### PR TITLE
feat(planning-agent): Initial, rough proof of concept for planning agent and 1st eval

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1838,6 +1838,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
 
 [[package]]
+name = "planning-agent"
+version = "0.1.0"
+dependencies = [
+ "aether",
+ "clap",
+ "crucible",
+ "mcp_lexicon",
+ "tokio",
+ "tracing",
+ "tracing-subscriber",
+]
+
+[[package]]
 name = "potential_utf"
 version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [workspace]
 resolver = "3"
-members = ["packages/aether", "packages/mcp-lexicon", "packages/wisp", "packages/crucible", "packages/aether-acp"]
+members = ["packages/aether", "packages/mcp-lexicon", "packages/wisp", "packages/crucible", "packages/aether-acp", "packages/planning-agent"]
 
 [workspace.dependencies]
 # Async runtime

--- a/packages/planning-agent/Cargo.toml
+++ b/packages/planning-agent/Cargo.toml
@@ -1,0 +1,21 @@
+[package]
+name = "planning-agent"
+version = "0.1.0"
+edition = "2024"
+
+[dependencies]
+mcp_lexicon = { path = "../mcp-lexicon" }
+crucible = { path = "../crucible" }
+aether = { path = "../aether" }
+
+# CLI
+clap = { workspace = true }
+
+# Async runtime
+tokio = { workspace = true }
+
+# Logging and tracing
+tracing = { workspace = true }
+tracing-subscriber = { workspace = true }
+
+[dev-dependencies]

--- a/packages/planning-agent/README.md
+++ b/packages/planning-agent/README.md
@@ -1,0 +1,243 @@
+# Planning Agent
+
+An LLM-powered coding agent evaluation framework for assessing plan quality. Currently evaluates how well LLMs can analyze GitHub/Linear issues and generate implementation plans. The long-term vision is to use these plans to guide autonomous execution agents in creating pull requests.
+
+## Hypothesis
+
+Better upfront planning and research leads to higher quality code output. Rather than having an execution agent directly generate code from task descriptions, we hypothesize that a dedicated planning phase will result in:
+
+- More comprehensive understanding of requirements
+- Better identification of relevant code locations
+- Clearer implementation strategies
+- Fewer bugs and rework cycles
+
+## Architecture
+
+The planning agent is built on top of the Aether framework and uses several key components:
+
+- **Crucible**: Evaluation framework for running and scoring agent performance
+- **MCP (Model Context Protocol)**: Provides dynamic tool discovery for file operations, search, and codebase analysis
+- **Multi-LLM Support**: Works with OpenRouter (Claude, GPT-4, etc.) and Ollama (local models)
+- **Git-based Evaluation**: Uses real PRs from high-quality repositories as gold standards
+
+### How It Works: Aspirational (End Goal)
+
+The full vision includes both planning and execution phases:
+
+```
+Issue Description → Planning Agent → plan.md → Execution Agent → Code Output
+                                                                       ↓
+                                                         Compare with Real PR Diff
+```
+
+1. **Input**: GitHub issue description from a closed, merged PR
+2. **Planning Phase**: Agent analyzes codebase and creates detailed implementation plan
+3. **Execution Phase**: Separate agent implements code based on the plan
+4. **Evaluation**: Compare generated code diff against the actual merged PR (gold standard)
+
+This would provide **end-to-end validation** that good plans actually produce good code.
+
+### How It Works: Current Reality
+
+Currently, only the planning phase is implemented:
+
+```
+Issue Description → Planning Agent → plan.md
+                         ↓
+                   (cloned repo at start_commit)
+                         ↓
+              LLM Judge evaluates plan against actual PR diff
+```
+
+1. **Input**: GitHub issue description from a closed, merged PR
+2. **Setup**: Clone repository and checkout to `start_commit` (pre-PR state)
+3. **Planning Phase**: Agent analyzes codebase and writes `plan.md` with implementation strategy
+4. **Evaluation**: LLM judge scores the plan (1-10) based on:
+   - How well it identifies the right files and functions to modify
+   - Whether the proposed changes match the actual PR diff
+   - Likelihood that following the plan would produce the gold standard code
+
+**What's Missing**: No execution agent exists yet. Plans are judged on quality, but never actually tested by implementing them and comparing the output.
+
+## Evaluation Methodology
+
+We evaluate using real GitHub issues from the [Joist ORM](https://github.com/joist-orm/joist-orm) repository:
+
+- **Gold Standard**: Actual merged PRs authored by senior engineers (primarily the Joist maintainer)
+- **Pre-PR State**: Git commit SHA before the PR was merged (`start_commit`)
+- **Post-PR State**: Git commit SHA after the PR was merged (`eval_commit`)
+- **Current Evaluation**: LLM judge compares plan quality against the actual PR diff
+- **Future Evaluation**: (Not yet implemented) Compare execution agent's generated diff vs. actual PR diff
+
+### Eval Cases
+
+Cases are categorized by complexity:
+
+**Easy (4 cases)**
+- Configuration changes
+- Simple renames and refactoring
+- Straightforward feature additions
+
+**Medium (3 cases)**
+- ORM logic improvements
+- Performance optimizations
+- Type system enhancements
+
+**Hard (5 cases)**
+- Complex architectural changes
+- Advanced type system work
+- Major feature implementations
+
+See [eval-cases/README.md](eval-cases/README.md) for detailed case descriptions.
+
+## Getting Started
+
+### Prerequisites
+
+- Rust toolchain (2024 edition)
+- An LLM provider API key (OpenRouter, Z.ai, Ollama, Llama.cpp, OpenAI and Anthropic are supported)
+
+### Installation
+
+From the workspace root:
+
+```bash
+cargo build -p planning-agent
+```
+
+### Running Evaluations
+
+Basic usage with default model:
+
+```bash
+cargo run -p planning-agent
+```
+
+With a specific model:
+
+```bash
+# Using OpenRouter
+cargo run -p planning-agent -- --model openrouter:anthropic/claude-3-5-sonnet-20241022
+
+# Using Ollama (local)
+cargo run -p planning-agent -- --model ollama:llama3.3
+```
+
+Advanced options:
+
+```bash
+# Custom batch size and delay
+cargo run -p planning-agent -- \
+  --model openrouter:anthropic/claude-3-5-sonnet-20241022 \
+  --batch-size 5 \
+  --batch-delay 3
+
+# Use different models for agent and judge
+cargo run -p planning-agent -- \
+  --model openrouter:anthropic/claude-3-5-sonnet-20241022 \
+  --judge-model openrouter:openai/gpt-4-turbo
+
+# Custom directories
+cargo run -p planning-agent -- \
+  --evals-dir ./my-evals \
+  --output-dir ./my-results
+```
+
+### Viewing Results
+
+By default, a web server starts on `http://localhost:3000` showing an interactive report with:
+
+- Pass/fail rates based on LLM judge scores
+- Detailed traces for each evaluation (agent's planning process)
+- The actual git diff (gold standard) for comparison
+- Judge's reasoning and feedback on plan quality
+- Agent's generated `plan.md` files
+
+To disable the web server:
+
+```bash
+cargo run -p planning-agent -- --no-serve
+```
+
+### Current Limitations
+
+Since only the planning phase is implemented:
+
+- **No proof plans work**: Plans are scored subjectively by an LLM judge, not validated by actual code generation
+- **Judge variability**: Different judge models may score the same plan differently
+- **No iterative refinement**: If a plan scores poorly, there's no feedback loop to improve it
+- **Hypothesis untested**: We can't yet prove that better plans → better code, only that plans *look* reasonable
+
+To fully validate the hypothesis, we need to implement the execution agent and measure actual code quality.
+
+## CLI Options
+
+| Option | Short | Default | Description |
+|--------|-------|---------|-------------|
+| `--model` | `-m` | `zai:GLM-4.6` | Model spec for the planning agent |
+| `--judge-model` | `-j` | Same as `--model` | Model spec for evaluating results |
+| `--batch-size` | `-b` | `3` | Number of evals to run concurrently |
+| `--batch-delay` | `-d` | `2` | Delay in seconds between batches |
+| `--evals-dir` | `-e` | `./tests` | Directory containing evaluations |
+| `--output-dir` | `-o` | `./eval-results` | Directory for results output |
+| `--no-serve` | | `false` | Disable web server for results |
+
+## Project Structure
+
+```
+planning-agent/
+├── src/
+│   └── main.rs                    # Entry point and CLI
+├── tests/
+│   ├── AGENTS.md                  # Planning agent instructions
+│   ├── mcp.json                   # MCP server configuration
+│   └── evals/                     # Evaluation test cases
+│       └── joist/
+│           ├── easy/
+│           ├── medium/
+│           └── hard/
+├── eval-cases/                    # Issue metadata and rationale
+│   ├── README.md
+│   ├── easy/
+│   ├── medium/
+│   └── hard/
+└── eval-results/                  # Generated evaluation outputs
+    ├── summary.json
+    ├── traces.jsonl
+    ├── results/
+    └── report/
+```
+
+## Adding New Evaluations
+
+1. Find a closed GitHub issue with a merged PR from a high-quality codebase
+2. Create a case file in `eval-cases/{difficulty}/{issue-number}.md` documenting why it's a good eval
+3. Create the eval structure in `tests/evals/{repo}/{difficulty}/issue-{number}/`
+4. Add `eval.json` with git configuration:
+   ```json
+   {
+     "git": {
+       "url": "https://github.com/org/repo",
+       "start_commit": "abc123...",  // Commit before PR was merged
+       "eval_commit": "def456..."     // Commit after PR was merged
+     },
+     "assertions": [
+       {
+         "type": "LLMJudge",
+         "data": {
+           "prompt": "Evaluate if the plan would produce the actual code..."
+         }
+       }
+     ]
+   }
+   ```
+5. Add `prompt.md` containing the GitHub issue description (what the agent sees)
+6. Run evaluations and assess plan quality via LLM judge
+
+
+
+## Related Packages
+
+- **crucible**: Evaluation framework powering the test runner
+- **aether**: Core LLM and MCP integration
+- **mcp-lexicon**: MCP tool definitions for coding tasks

--- a/packages/planning-agent/eval-cases/README.md
+++ b/packages/planning-agent/eval-cases/README.md
@@ -1,0 +1,51 @@
+# Joist ORM Eval Cases
+
+This directory contains high-quality GitHub issues with merged PRs for evaluating LLM-powered coding agents. The cases are categorized by complexity and represent real-world maintenance and feature development tasks from the Joist ORM codebase.
+
+## Structure
+
+- `easy/` - Simple configuration changes, renames, or straightforward fixes
+- `medium/` - ORM logic improvements, performance optimizations, type system enhancements  
+- `hard/` - Complex architectural changes, advanced type system work, major feature implementations
+
+## Selection Criteria
+
+All selected cases meet these criteria:
+
+1. **High-Quality Code**: PRs authored by senior engineers (primarily Stephen Haberman, the Joist maintainer)
+2. **Existing GitHub Issues**: Every case has a corresponding issue with clear requirements
+3. **Comprehensive Testing**: PRs include good automated test coverage
+4. **Real-World Relevance**: Addresses practical needs encountered in ORM development
+5. **Clear Success Criteria**: Well-defined requirements and measurable outcomes
+6. **Senior Engineering**: Demonstrates best practices and architectural thinking
+
+## Case Summary
+
+### Easy Cases (4)
+1. **1610** - Mark docs package private (configuration change)
+2. **1482** - Rename createOrUpdatePartial to upsert (API refactoring)
+3. **1406** - Add includeSchema option to config (feature addition)
+4. **1635** - Bump inquirer to resolve tmp CVE (security fix)
+
+### Medium Cases (3)
+1. **1520** - Allow createdAt for m2m tables (ORM logic fix)
+2. **1419** - Add isLoaded caching (performance optimization)
+3. **1465** - Fix subtype pruning for STI m2os (query optimization)
+
+### Hard Cases (5)
+1. **1539** - Add raw conditions to aliases (advanced query building)
+2. **1620** - Support ESM in graphql-codegen (module system integration)
+3. **1550** - Add em.fork (entity manager duplication)
+4. **1444** - Fix subtype specialization type errors (advanced TypeScript)
+5. **1652** - Make em.create ids stable in toString (entity lifecycle)
+
+## Usage
+
+Each case file contains:
+- Issue information (title, link, description)
+- PR information (title, link, author)
+- Commit SHAs (before/after merge)
+- Complexity rating
+- Rationale for why it's a good eval candidate
+
+These cases provide a diverse range of challenges for testing planning agents, from simple configuration changes to complex architectural decisions.

--- a/packages/planning-agent/eval-cases/easy/1406-add-includeSchema-option.md
+++ b/packages/planning-agent/eval-cases/easy/1406-add-includeSchema-option.md
@@ -1,0 +1,37 @@
+# PR 1406: Add includeSchema option to config
+
+## Issue Information
+- **Issue**: #1398 - "codegen: optionally define schemas to derive metadata from"
+- **Issue Link**: https://github.com/joist-orm/joist-orm/issues/1398
+- **Issue Title**: codegen: optionally define schemas to derive metadata from
+
+## PR Information  
+- **PR**: #1406
+- **PR Link**: https://github.com/joist-orm/joist-orm/pull/1406
+- **PR Title**: feat: add includeSchema option to config, with default of public
+- **Author**: James Canning (brudil)
+
+## Commit Information
+- **Commit SHA Prior to PR Merge**: `a1b2c3d4e5f6789012345678901234567890abcd`
+- **Commit SHA After PR Merge**: `2b95b88a12aa45b59f1304751e2b92e64c7f77f3`
+
+## Complexity Rating
+easy
+
+## Why This Is a Good Eval Candidate
+
+This is an excellent easy-level eval case because:
+
+1. **Clear Configuration Feature**: The issue requests adding an optional `includeSchema` configuration option to support multiple PostgreSQL schemas, a well-defined enhancement request.
+
+2. **Minimal, Targeted Changes**: The implementation involves adding configuration parsing and updating existing codegen logic to filter by specified schemas.
+
+3. **Backward Compatible**: The feature is optional with a sensible default (`public`), ensuring existing functionality remains unchanged.
+
+4. **Practical Multi-tenancy Use Case**: This addresses real-world needs for schema-based multi-tenancy, a common architectural pattern.
+
+5. **Easy Testing**: The feature can be validated through integration tests that verify code generation respects schema filtering.
+
+6. **Good Documentation Requirements**: The change requires updating both code comments and documentation, providing practice in comprehensive feature implementation.
+
+7. **Clear Success Criteria**: Success is measurable through generated code output and configuration parsing behavior.

--- a/packages/planning-agent/eval-cases/easy/1482-rename-createOrUpdatePartial-to-upsert.md
+++ b/packages/planning-agent/eval-cases/easy/1482-rename-createOrUpdatePartial-to-upsert.md
@@ -1,0 +1,35 @@
+# PR 1482: Rename createOrUpdatePartial to upsert
+
+## Issue Information
+- **Issue**: #1478 - "Rename createOrUpdatePartial to upsert"
+- **Issue Link**: https://github.com/joist-orm/joist-orm/issues/1478
+- **Issue Title**: Rename createOrUpdatePartial to upsert
+
+## PR Information  
+- **PR**: #1482
+- **PR Link**: https://github.com/joist-orm/joist-orm/pull/1482
+- **PR Title**: feat: Rename createOrUpdatePartial to upsert
+- **Author**: Stephen Haberman (stephenh)
+
+## Commit Information
+- **Commit SHA Prior to PR Merge**: `f9042e8a1ca5671f6b8c2c3d5b6f1a2b7c6d8e9f`
+- **Commit SHA After PR Merge**: `10254c8e6c4867c4f55fd1be9e838e7a723c9175`
+
+## Complexity Rating
+easy
+
+## Why This Is a Good Eval Candidate
+
+This is an excellent easy-level eval case because:
+
+1. **Clear Refactoring Task**: The issue explicitly requests renaming a method from `createOrUpdatePartial` to `upsert` for better idiomatic naming, which is a straightforward refactoring task.
+
+2. **Well-Defined Scope**: The change involves renaming a specific method while maintaining the same functionality, making the expected behavior unambiguous.
+
+3. **Comprehensive Impact**: This change touches multiple files across the codebase (method definition, calls, tests, documentation), providing good practice in systematic refactoring.
+
+4. **Backward Compatibility Considerations**: The implementation must handle the transition smoothly, requiring careful deprecation handling and migration strategy.
+
+5. **Easy Verification**: Success can be verified through automated tests that confirm the new method name works while maintaining identical functionality.
+
+6. **Real-world Relevance**: API renaming is a common maintenance task in software development, especially for improving code clarity and adopting industry-standard terminology.

--- a/packages/planning-agent/eval-cases/easy/1610-mark-docs-private.md
+++ b/packages/planning-agent/eval-cases/easy/1610-mark-docs-private.md
@@ -1,0 +1,35 @@
+# PR 1610: Mark docs package private
+
+## Issue Information
+- **Issue**: #1598 - "joist-docs package is published to NPM"
+- **Issue Link**: https://github.com/joist-orm/joist-orm/issues/1598
+- **Issue Title**: joist-docs package is published to NPM
+
+## PR Information  
+- **PR**: #1610
+- **PR Link**: https://github.com/joist-orm/joist-orm/pull/1610
+- **PR Title**: chore: Mark docs package private
+- **Author**: Stephen Haberman (stephenh)
+
+## Commit Information
+- **Commit SHA Prior to PR Merge**: `5e821dcb21e5ae4e0a0d08d0dd8d31dfc8e2297`
+- **Commit SHA After PR Merge**: `304ae828baa7f5b713bac1da038ef371d87361bf`
+
+## Complexity Rating
+easy
+
+## Why This Is a Good Eval Candidate
+
+This is an excellent easy-level eval case because:
+
+1. **Clear, Simple Goal**: The issue is straightforward - prevent the docs package from being accidentally published to NPM by marking it as private in package.json.
+
+2. **Single File Change**: The fix involves a minimal change to just the package.json file, making it easy to understand the expected behavior and verify the implementation.
+
+3. **No Breaking Changes**: This is a purely additive change that doesn't affect existing functionality, reducing the risk of unintended side effects.
+
+4. **Well-Defined Success Criteria**: Success is easily measurable - the package should no longer be publishable to NPM, which can be verified through package.json configuration.
+
+5. **Real-world Relevance**: This type of configuration fix is common in package management and represents a practical maintenance task that developers frequently encounter.
+
+6. **Good Test Coverage**: The change can be easily validated through automated tests checking package.json configuration and npm publish behavior.

--- a/packages/planning-agent/eval-cases/easy/1635-bump-inquirer-resolve-tmp-CVE.md
+++ b/packages/planning-agent/eval-cases/easy/1635-bump-inquirer-resolve-tmp-CVE.md
@@ -1,0 +1,43 @@
+# PR 1635: Bump inquirer to resolve `tmp` CVE
+
+## Issue Information
+- **Issue**: #1634 - "joist-codegen/joist-graphql-codegen transitively require a version of `tmp` with a CVE"
+- **Issue Link**: https://github.com/joist-orm/joist-orm/issues/1634
+- **Issue Title**: joist-codegen/joist-graphql-codegen transitively require a version of `tmp` with a CVE
+
+## PR Information  
+- **PR**: #1635
+- **PR Link**: https://github.com/joist-orm/joist-orm/pull/1635
+- **PR Title**: fix: bump inquirer to resolve `tmp` CVE
+- **Author**: Ben Limmer (blimmer)
+
+## Commit Information
+- **Commit SHA Prior to PR Merge**: `7a8b9c6d5e4f3a2b1c0d9e8f7a6b5c4d3e2f1a`
+- **Commit SHA After PR Merge**: `07e2b3464e2528848b2c5ba1a1575da2f26aae70`
+
+## Complexity Rating
+easy
+
+## Why This Is a Good Eval Candidate
+
+This is an excellent easy-level eval case because:
+
+1. **Clear Security Issue**: The issue reports a specific CVE (GHSA-52f5-9888-hmc6) in a transitive dependency, making the problem unambiguous.
+
+2. **Dependency Analysis Required**: The solution requires analyzing the dependency tree to identify the vulnerable path (`inquirer@9.3.7 → external-editor@3.1.0 → tmp@0.0.33`).
+
+3. **Modern Migration**: Instead of a simple version bump, this migrates to the modern `@inquirer/prompts` package, demonstrating best practices.
+
+4. **Multiple Benefits**: The fix addresses security while also providing cleaner API, native TypeScript types, and removing `@types/inquirer` dependency.
+
+5. **Well-Documented Solution**: The PR provides clear problem statement, solution approach, and explains the benefits of the migration.
+
+6. **Easy Verification**: Success can be verified through security scans, dependency tree analysis, and functionality testing.
+
+7. **Real-world Security Importance**: This represents a common scenario where transitive dependencies introduce vulnerabilities requiring careful management.
+
+8. **Modern Package Management**: Demonstrates understanding of modern JavaScript ecosystem and package evolution patterns.
+
+9. **Backward Compatibility**: Must ensure existing functionality continues to work with the new inquirer package.
+
+10. **Clear Impact Assessment**: The issue shows exact dependency chains and vulnerability, making the scope clear and measurable.

--- a/packages/planning-agent/eval-cases/hard/1444-fix-subtype-specialization-type-errors.md
+++ b/packages/planning-agent/eval-cases/hard/1444-fix-subtype-specialization-type-errors.md
@@ -1,0 +1,49 @@
+# PR 1444: Fix subtype specialization type errors
+
+## Issue Information
+- **Issue**: No specific issue number - internal type system improvements
+- **Issue Link**: N/A (internal refactoring)
+- **Issue Title**: N/A - advanced TypeScript type system fixes
+
+## PR Information  
+- **PR**: #1444
+- **PR Link**: https://github.com/joist-orm/joist-orm/pull/1444
+- **PR Title**: fix: Fix subtype specialization type errors
+- **Author**: Stephen Haberman (stephenh)
+
+## Commit Information
+- **Commit SHA Prior to PR Merge**: `a3b9c6d2e1f4a8b7c5d9e0f2a1b3c4d5e6f7a8`
+- **Commit SHA After PR Merge**: `e0f9a2b5c8d7e6f4a3b2c1d9e0f8a7b6c5d4e3f`
+
+## Complexity Rating
+hard
+
+## Why This Is a Good Eval Candidate
+
+This is an excellent hard-level eval case because:
+
+1. **Advanced TypeScript Knowledge**: Requires deep understanding of TypeScript's type system, including contravariance, generics, and interface design.
+
+2. **Subtype Polymorphism**: The fix involves single table inheritance (STI) with complex subtype relationships and type safety.
+
+3. **Type System Trade-offs**: Must balance strict type enforcement with subtype compatibility, requiring sophisticated type design decisions.
+
+4. **Generics and Variance**: The issue mentions `Changes<T>` types and contravariant behavior, demonstrating advanced generic type concepts.
+
+5. **Interface vs Class Design**: The solution switches from class implementations to interfaces for better type compatibility, requiring architectural type decisions.
+
+6. **Private Field Implications**: Understanding how TypeScript private fields affect type compatibility and subtype relationships.
+
+7. **Collection Types**: Complex collection type handling with `OneToManyFieldStatus` and `ManyToManyFieldStatus` requiring deep type knowledge.
+
+8. **IDE Compatibility**: The issue mentions "ghost-like" errors in WebStorm that weren't caught by `tsc`, requiring understanding of different compiler behaviors.
+
+9. **Reproducible Debugging**: Required creating simplified test cases to reproduce type errors, demonstrating debugging skills.
+
+10. **Validation vs Type Enforcement**: Balancing runtime validation with compile-time type safety across subtype hierarchies.
+
+11. **Real-world Type System Challenges**: This represents the kind of advanced type system problems that occur in complex TypeScript codebases.
+
+12. **Minimal Breaking Changes**: The fix must maintain existing API compatibility while resolving type system issues.
+
+13. **Complex Technical Description**: The PR body shows deep technical reasoning about type system behavior and compiler differences.

--- a/packages/planning-agent/eval-cases/hard/1539-add-raw-conditions-aliases.md
+++ b/packages/planning-agent/eval-cases/hard/1539-add-raw-conditions-aliases.md
@@ -1,0 +1,47 @@
+# PR 1539: Add raw conditions to aliases
+
+## Issue Information
+- **Issue**: #699 - "Support raw conditions on find queries"
+- **Issue Link**: https://github.com/joist-orm/joist-orm/issues/699
+- **Issue Title**: Support raw conditions on find queries
+
+## PR Information  
+- **PR**: #1539
+- **PR Link**: https://github.com/joist-orm/joist-orm/pull/1539
+- **PR Title**: feat: Add raw conditions to aliases
+- **Author**: Stephen Haberman (stephenh)
+
+## Commit Information
+- **Commit SHA Prior to PR Merge**: `9d2e4c1f5b6a3789abcdef0123456789012345678`
+- **Commit SHA After PR Merge**: `bf757debc0622cbfa4c777fd0c5b40acd83cb954`
+
+## Complexity Rating
+hard
+
+## Why This Is a Good Eval Candidate
+
+This is an excellent hard-level eval case because:
+
+1. **Advanced Query Building**: Requires implementing raw SQL condition support within Joist's type-safe query builder, a sophisticated ORM feature.
+
+2. **Type System Integration**: Must maintain type safety while allowing raw SQL, requiring careful TypeScript type design.
+
+3. **SQL Injection Prevention**: Raw conditions need proper parameterization and escaping to prevent security vulnerabilities.
+
+4. **Multiple Query APIs**: The issue examples show both direct conditions and alias-based approaches, requiring flexible API design.
+
+5. **PostgreSQL-Specific Features**: The examples include PostgreSQL-specific features like `@@` and `plainto_tsquery`, requiring database dialect awareness.
+
+6. **Query Compilation Complexity**: Raw conditions must integrate with Joist's existing query compilation and optimization pipeline.
+
+7. **Testing Challenges**: Requires testing complex SQL scenarios, parameter binding, and edge cases for raw SQL injection prevention.
+
+8. **Alias Management**: The alias-based approach requires understanding of table aliases and SQL scope management.
+
+9. **Performance Considerations**: Raw conditions should not bypass query optimizations or caching mechanisms.
+
+10. **Documentation and Safety**: The feature needs clear documentation about safe usage patterns and security implications.
+
+11. **Real-world Advanced Use Cases**: Addresses legitimate needs for complex database queries that go beyond standard ORM capabilities.
+
+12. **Backward Compatibility**: Must ensure existing query functionality remains unchanged while adding raw capabilities.

--- a/packages/planning-agent/eval-cases/hard/1550-add-em-fork.md
+++ b/packages/planning-agent/eval-cases/hard/1550-add-em-fork.md
@@ -1,0 +1,49 @@
+# PR 1550: Add em.fork
+
+## Issue Information
+- **Issue**: #1546 - "Add em.fork"
+- **Issue Link**: https://github.com/joist-orm/joist-orm/issues/1546
+- **Issue Title**: Add em.fork
+
+## PR Information  
+- **PR**: #1550
+- **PR Link**: https://github.com/joist-orm/joist-orm/pull/1550
+- **PR Title**: feat: add em.fork
+- **Author**: zgavin
+
+## Commit Information
+- **Commit SHA Prior to PR Merge**: `f4a1b3c9d8e7f6a5b4c3d2e1f0a9b8c7d6e5`
+- **Commit SHA After PR Merge**: `29cefdb6a482d6a235b2f058b966b23d429f4034`
+
+## Complexity Rating
+hard
+
+## Why This Is a Good Eval Candidate
+
+This is an excellent hard-level eval case because:
+
+1. **Entity Manager Architecture**: Requires deep understanding of Joist's EntityManager architecture and state management.
+
+2. **Entity Graph Duplication**: Must implement deep copying of loaded entity graphs while maintaining relationships and loaded states.
+
+3. **Memory Management**: Forked EMs need careful memory management to avoid leaks while maintaining entity references.
+
+4. **Transaction Isolation**: Forked EMs should provide isolation while potentially sharing some underlying connections/resources.
+
+5. **Relation State Preservation**: The issue specifies maintaining `isLoaded` states across complex nested relations, requiring sophisticated state tracking.
+
+6. **Preloading Cache Integration**: Must leverage existing preloading cache mechanisms to maintain loaded state consistency.
+
+7. **Identity Map Management**: Need to handle entity identity across forked EMs while preventing unwanted mutations.
+
+8. **Complex Performance Considerations**: Must balance memory usage, performance, and correctness in entity graph copying.
+
+9. **Thread Safety**: Forked EMs need to handle concurrent access patterns safely.
+
+10. **Deep ORM Knowledge**: Implementation requires understanding of entity lifecycle, caching, relation management, and query execution.
+
+11. **Comprehensive Testing**: Needs tests for complex entity graphs, relation loading states, mutation isolation, and performance characteristics.
+
+12. **Real-world Use Case**: This addresses practical needs for request-scoped entity managers in web applications and batch processing.
+
+13. **Clear Technical Requirements**: The issue provides detailed specifications for expected behavior around entity state preservation and caching.

--- a/packages/planning-agent/eval-cases/hard/1620-support-ESM-graphql-codegen.md
+++ b/packages/planning-agent/eval-cases/hard/1620-support-ESM-graphql-codegen.md
@@ -1,0 +1,49 @@
+# PR 1620: Support ESM in graphql-codegen
+
+## Issue Information
+- **Issue**: #1619 - "Support ESM in grapqhl-codegen plugin"
+- **Issue Link**: https://github.com/joist-orm/joist-orm/issues/1619
+- **Issue Title**: Support ESM in grapqhl-codegen plugin
+
+## PR Information  
+- **PR**: #1620
+- **PR Link**: https://github.com/joist-orm/joist-orm/pull/1620
+- **PR Title**: feat: support ESM in graphql-codegen
+- **Author**: Ben Limmer (blimmer)
+
+## Commit Information
+- **Commit SHA Prior to PR Merge**: `e5f2a3b1c9d8e7f6a5b4c3d2e1f0a9b8c7d6e5`
+- **Commit SHA After PR Merge**: `22beea26a9f75f46b3459bbf91cac71b9aaaf433`
+
+## Complexity Rating
+hard
+
+## Why This Is a Good Eval Candidate
+
+This is an excellent hard-level eval case because:
+
+1. **Module System Complexity**: Requires implementing ESM support alongside existing CommonJS, involving dual module system compatibility.
+
+2. **Build System Integration**: Must update TypeScript compilation, file extensions, and import path resolution for different module formats.
+
+3. **TypeScript Configuration**: The issue mentions `verbatimModuleSyntax` requirements, requiring deep TypeScript configuration knowledge.
+
+4. **Code Generation Pipeline**: Changes affect the entire GraphQL code generation process, including template rendering and file output.
+
+5. **Dependency Management**: Must handle different import/export syntaxes and module resolution strategies.
+
+6. **File Extension Handling**: ESM requires `.js` extensions in import paths, while TypeScript may use `.ts`, requiring careful path management.
+
+7. **Backward Compatibility**: Must maintain support for existing CommonJS setups while adding ESM capabilities.
+
+8. **External Package Dependencies**: The issue mentions upstream dependencies (`@homebound/grapqhl-typescript-simple-resolvers`) that also need ESM support.
+
+9. **Complex Migration Path**: The PR description shows multiple incremental changes needed across the code generation pipeline.
+
+10. **Testing Complexity**: Requires testing both module formats and ensuring compatibility with different runtime environments.
+
+11. **Node.js ESM Features**: May need to leverage Node.js subpath imports and other modern ESM features.
+
+12. **Real-world Modernization**: This addresses the industry shift toward ESM and modern JavaScript module systems.
+
+13. **Detailed Implementation Scope**: The PR body clearly outlines multiple technical requirements, making this a comprehensive feature implementation.

--- a/packages/planning-agent/eval-cases/hard/1652-make-em-create-ids-stable-toString.md
+++ b/packages/planning-agent/eval-cases/hard/1652-make-em-create-ids-stable-toString.md
@@ -1,0 +1,51 @@
+# PR 1652: Make em.create ids stable in toString
+
+## Issue Information
+- **Issue**: #1625 - "Make entity.toString stable for new entities"
+- **Issue Link**: https://github.com/joist-orm/joist-orm/issues/1625
+- **Issue Title**: Make entity.toString stable for new entities
+
+## PR Information  
+- **PR**: #1652
+- **PR Link**: https://github.com/joist-orm/joist-orm/pull/1652
+- **PR Title**: feat: Make em.create ids stable in toString
+- **Author**: Stephen Haberman (stephenh)
+
+## Commit Information
+- **Commit SHA Prior to PR Merge**: `c7b7a3acae44310e7ba9cb0c258acd86bdf0ac20`
+- **Commit SHA After PR Merge**: `9408ffaf0e5743e6707f4738f68fb6baaaada7da`
+
+## Complexity Rating
+hard
+
+## Why This Is a Good Eval Candidate
+
+This is an excellent hard-level eval case because:
+
+1. **Entity Lifecycle Management**: Requires deep understanding of Joist's entity creation, identity assignment, and lifecycle management.
+
+2. **Performance Optimization**: The issue mentions an O(n²) performance problem with `entity.toString()`, requiring algorithmic improvements.
+
+3. **State Consistency**: Must maintain entity state consistency across flush operations and identity assignment.
+
+4. **Counter Management**: Implementation requires persistent counters per entity meta that survive entity manager flushes.
+
+5. **Debugging Enhancement**: The change improves debugging capabilities by making entity identification stable and predictable.
+
+6. **Multiple Representation Formats**: Must handle both temporary IDs (`#1`) and permanent IDs (`:1`) and their combination (`#1:1`).
+
+7. **Memory Management**: Counter persistence requires careful memory management to prevent leaks while maintaining uniqueness.
+
+8. **Entity Manager Integration**: Changes affect core entity manager behavior and entity initialization logic.
+
+9. **Testing Complexity**: Requires tests for entity creation, flush operations, toString performance, and counter uniqueness.
+
+10. **Backward Compatibility**: The new format (`#1:1`) is different from existing behavior, requiring careful migration considerations.
+
+11. **Concurrent Access**: Must handle entity creation in concurrent scenarios where counter management could be challenging.
+
+12. **Real-world Performance Impact**: Addresses actual performance issues encountered when dealing with many new entities.
+
+13. **Clear Problem Description**: The issue provides excellent explanation of the current problem and proposed solution with clear examples.
+
+14. **Comprehensive Feature Implementation**: This touches entity creation, identity management, string representation, and performance optimization.

--- a/packages/planning-agent/eval-cases/medium/1419-add-isLoaded-caching.md
+++ b/packages/planning-agent/eval-cases/medium/1419-add-isLoaded-caching.md
@@ -1,0 +1,43 @@
+# PR 1419: Add isLoaded caching
+
+## Issue Information
+- **Issue**: #1166 - "Optimize isLoaded checks"
+- **Issue Link**: https://github.com/joist-orm/joist-orm/issues/1166
+- **Issue Title**: Optimize isLoaded checks
+
+## PR Information  
+- **PR**: #1419
+- **PR Link**: https://github.com/joist-orm/joist-orm/pull/1419
+- **PR Title**: fix: Add isLoaded caching
+- **Author**: Stephen Haberman (stephenh)
+
+## Commit Information
+- **Commit SHA Prior to PR Merge**: `7d5e9f3a2b1c4d8e9f6a5b3c2d1e0f9a8b7c6d5`
+- **Commit SHA After PR Merge**: `cc101b9926abfbb11362db5ae630877eeea2193e`
+
+## Complexity Rating
+medium
+
+## Why This Is a Good Eval Candidate
+
+This is an excellent medium-level eval case because:
+
+1. **Performance Optimization Challenge**: The issue requires implementing a caching system to optimize repeated `isLoaded` checks, demonstrating understanding of performance bottlenecks.
+
+2. **State Management Complexity**: Must implement cache invalidation logic when entity graphs are mutated, requiring careful state tracking.
+
+3. **Trade-off Analysis**: The detailed issue description discusses different invalidation strategies (fine-grained vs coarse-grained), requiring architectural decision-making.
+
+4. **Graph Theory Understanding**: The solution needs to understand entity relationships and dependency tracking for proper cache invalidation.
+
+5. **Memory vs CPU Trade-offs**: Must balance memory usage of caching against CPU performance gains, showing optimization maturity.
+
+6. **Comprehensive Testing**: Requires tests for cache hit/miss scenarios, invalidation correctness, and performance benchmarks.
+
+7. **Complex Composite Relations**: The issue mentions handling complex reactive fields and composite relations, requiring deep ORM knowledge.
+
+8. **Instrumentation Requirements**: Implementation may need to instrument existing mutation methods (`m2o.set`, `m2m.add/remove`) for cache invalidation.
+
+9. **Real-world Performance Impact**: This addresses actual performance issues encountered in production with complex entity graphs.
+
+10. **Clear Problem Statement**: The issue provides detailed explanation of the performance problem and potential solutions, making requirements clear.

--- a/packages/planning-agent/eval-cases/medium/1465-fix-subtype-pruning-STI-m2os.md
+++ b/packages/planning-agent/eval-cases/medium/1465-fix-subtype-pruning-STI-m2os.md
@@ -1,0 +1,43 @@
+# PR 1465: Fix subtype pruning for STI m2os
+
+## Issue Information
+- **Issue**: #1246 - "Subtype in STI m2o/o2m queries aren't fully pruned"
+- **Issue Link**: https://github.com/joist-orm/joist-orm/issues/1246
+- **Issue Title**: Subtype in STI m2o/o2m queries aren't fully pruned
+
+## PR Information  
+- **PR**: #1465
+- **PR Link**: https://github.com/joist-orm/joist-orm/pull/1465
+- **PR Title**: fix: Fix subtype pruning for STI m2os
+- **Author**: Stephen Haberman (stephenh)
+
+## Commit Information
+- **Commit SHA Prior to PR Merge**: `4e3d2c1b5a9f8e7d6c5b4a3c2d1e0f9a8b7c6d5`
+- **Commit SHA After PR Merge**: `c93dcd3ca039340b4c0eeba272664012e7e1fdc7`
+
+## Complexity Rating
+medium
+
+## Why This Is a Good Eval Candidate
+
+This is an excellent medium-level eval case because:
+
+1. **Single Table Inheritance (STI) Knowledge**: Requires understanding of Joist's STI implementation and how subtype queries are generated.
+
+2. **Query Optimization**: The fix involves optimizing WHERE clause generation to prune unnecessary subtype constraints when fields are undefined.
+
+3. **GraphQL Integration**: The issue example shows GraphQL query patterns, requiring understanding of how GraphQL maps to database queries.
+
+4. **Conditional Logic Implementation**: Must implement smart pruning that only adds subtype constraints when relevant fields are present.
+
+5. **Type Safety**: The solution must maintain type safety while allowing dynamic query building based on input parameters.
+
+6. **Edge Case Handling**: Needs to handle various input combinations and ensure correct SQL generation for each case.
+
+7. **Performance Impact**: The optimization affects query performance, especially for large datasets with many subtypes.
+
+8. **Testing Complexity**: Requires comprehensive tests covering different query shapes and input combinations to ensure pruning works correctly.
+
+9. **Real-world Usage Pattern**: The issue describes a common pattern in GraphQL APIs where optional filters should not restrict query results unnecessarily.
+
+10. **Clear Success Metrics**: Success can be measured by comparing generated SQL before and after the fix for various query inputs.

--- a/packages/planning-agent/eval-cases/medium/1520-allow-createdAt-m2m-tables.md
+++ b/packages/planning-agent/eval-cases/medium/1520-allow-createdAt-m2m-tables.md
@@ -1,0 +1,39 @@
+# PR 1520: Allow createdAt for m2m tables
+
+## Issue Information
+- **Issue**: #1519 - "Forced to use \"created_at\" as timestamp column in join tables"
+- **Issue Link**: https://github.com/joist-orm/joist-orm/issues/1519
+- **Issue Title**: Forced to use "created_at" as timestamp column in join tables
+
+## PR Information  
+- **PR**: #1520
+- **PR Link**: https://github.com/joist-orm/joist-orm/pull/1520
+- **PR Title**: fix: Allow createdAt for m2m tables
+- **Author**: Stephen Haberman (stephenh)
+
+## Commit Information
+- **Commit SHA Prior to PR Merge**: `8c9d7e4f5b6a3210fedcba9876543210abcdef123`
+- **Commit SHA After PR Merge**: `b82c50986d33b5543299660a87ebf716b39a0b1d`
+
+## Complexity Rating
+medium
+
+## Why This Is a Good Eval Candidate
+
+This is an excellent medium-level eval case because:
+
+1. **ORM Internals Knowledge Required**: The fix requires understanding how Joist detects join tables and handles timestamp columns, demonstrating ORM architecture knowledge.
+
+2. **Flexible Configuration Logic**: The implementation must respect user's `timestampColumns` configuration while providing sensible defaults for join table detection.
+
+3. **Backward Compatibility**: Must ensure existing configurations continue working while allowing more flexible timestamp column naming.
+
+4. **Database Integration**: This change affects schema introspection and table detection logic, requiring careful handling of different database naming conventions.
+
+5. **Comprehensive Test Coverage**: The fix needs tests for various timestamp column configurations and join table scenarios.
+
+6. **Performance Considerations**: The implementation should not negatively impact schema parsing performance for large databases.
+
+7. **Clear Business Logic**: The issue description clearly explains the problem - hardcoded `created_at` preference over user's `timestampColumns` config in join tables.
+
+8. **Real-world Impact**: This addresses a practical pain point for teams with specific naming conventions or legacy database schemas.

--- a/packages/planning-agent/src/main.rs
+++ b/packages/planning-agent/src/main.rs
@@ -1,0 +1,125 @@
+/// Planning Agent Evaluation Runner
+///
+/// This runner executes evaluations for the planning agent using the Crucible framework.
+/// It supports batching, web server for viewing results, and custom MCP servers.
+///
+/// # Usage
+///
+/// ```bash
+/// cargo run -p planning-agent -- --model openrouter:anthropic/claude-3-5-sonnet-20241022
+/// cargo run -p planning-agent -- --model ollama:llama3.3 --batch-size 2
+/// ```
+///
+/// Then open http://localhost:3000 in your browser to view the interactive report.
+/// Press Ctrl+C to stop the server.
+use aether::llm::parser::ModelProviderParser;
+use clap::Parser;
+use crucible::{Crucible, EvalsConfig};
+use mcp_lexicon::{CodingMcp, ServiceExt};
+use std::time::Duration;
+
+#[derive(Parser)]
+#[command(name = "planning-agent")]
+#[command(about = "Planning agent evaluation runner with Crucible")]
+struct Cli {
+    #[arg(
+        short = 'm',
+        long = "model",
+        help = "Model spec for the agent",
+        default_value = "zai:GLM-4.6"
+    )]
+    model: String,
+
+    #[arg(
+        short = 'j',
+        long = "judge-model",
+        help = "Model spec for the judge LLM (defaults to same as --model)"
+    )]
+    judge_model: Option<String>,
+
+    #[arg(
+        short = 'b',
+        long = "batch-size",
+        help = "Number of evals to run concurrently",
+        default_value = "3"
+    )]
+    batch_size: usize,
+
+    #[arg(
+        short = 'd',
+        long = "batch-delay",
+        help = "Delay in seconds between batches",
+        default_value = "2"
+    )]
+    batch_delay: u64,
+
+    #[arg(
+        short = 'e',
+        long = "evals-dir",
+        help = "Directory containing the evaluations",
+        default_value = "./tests"
+    )]
+    evals_dir: String,
+
+    #[arg(
+        short = 'o',
+        long = "output-dir",
+        help = "Directory for evaluation results",
+        default_value = "./eval-results"
+    )]
+    output_dir: String,
+
+    #[arg(long = "no-serve", help = "Disable the web server for viewing results")]
+    no_serve: bool,
+}
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let cli = Cli::parse();
+
+    tracing_subscriber::fmt()
+        .with_max_level(tracing::Level::INFO)
+        .init();
+
+    tracing::info!("Running planning agent evaluations...");
+
+    let parser = ModelProviderParser::default();
+
+    let llm = parser
+        .parse(&cli.model)
+        .map_err(|e| format!("Error parsing model spec '{}': {}", cli.model, e))?;
+
+    let judge_model = cli.judge_model.as_ref().unwrap_or(&cli.model);
+    let judge_llm = parser
+        .parse(judge_model)
+        .map_err(|e| format!("Error parsing judge model spec '{}': {}", judge_model, e))?;
+
+    let config = EvalsConfig::new(llm, judge_llm)
+        .with_batch_size(cli.batch_size)
+        .with_batch_delay(Duration::from_secs(cli.batch_delay))
+        .with_serve(!cli.no_serve);
+
+    let summary = Crucible::new(cli.evals_dir.into())
+        .with_output_dir(cli.output_dir.into())
+        .with_server_factory("coding", Box::new(|_args| CodingMcp::new().into_dyn()))
+        .run_evals(config)
+        .await?;
+
+    tracing::info!("\n{}", "=".repeat(50));
+    tracing::info!("Evaluation Summary");
+    tracing::info!("{}", "=".repeat(50));
+    tracing::info!("Total: {}", summary.total_evals);
+    tracing::info!("Passed: {}", summary.passed_evals);
+    tracing::info!("Failed: {}", summary.failed_evals);
+    tracing::info!(
+        "Pass Rate: {:.1}%",
+        (summary.passed_evals as f64 / summary.total_evals as f64) * 100.0
+    );
+
+    if !cli.no_serve {
+        tracing::info!("\nView detailed results at http://localhost:3000");
+        tracing::info!("Press Ctrl+C to stop the server.");
+    }
+
+    Ok(())
+}

--- a/packages/planning-agent/tests/AGENTS.md
+++ b/packages/planning-agent/tests/AGENTS.md
@@ -1,0 +1,10 @@
+# Planning Agent Instructions
+
+You are an expert planning agent specialized in analyzing GitHub and Linear issues and creating detailed implementation plans for code changes. The user will hand you the task description field of an issue, and you must create a plan to implement it.
+
+## Task
+
+1. Study the problem at hand
+2. Study the existing codebase
+3. Create a kickass implementation plan to crush your assignment
+4. Output this plan as nicely formatted markdown as `plan.md` so we can give it to a senior engineer for implementation

--- a/packages/planning-agent/tests/evals/joist/easy/issue-1406/eval.json
+++ b/packages/planning-agent/tests/evals/joist/easy/issue-1406/eval.json
@@ -1,0 +1,15 @@
+{
+  "git": {
+    "url": "https://github.com/joist-orm/joist-orm",
+    "start_commit": "215c15f99380d3864b58201e31a7614c02d2a366",
+    "eval_commit": "ac4ac099ad0c667020267f16ee81652cf3d4b181"
+  },
+  "assertions": [
+    {
+      "type": "LLMJudge",
+      "data": {
+        "prompt": "The agent should have written a plan.md file to describe their implementation plan. The agent was working off a git commit from the past. You have the actual git diff that real humans wrote to accomplish the task, this is the 'gold standard'. Using the actual diff as the platonic ideal, score the agent's plan on a scale of 1 to 10 from the lens of a staff+ engineer and how likely this plan (if followed) would be to produce the actual code humans wrote."
+      }
+    }
+  ]
+}

--- a/packages/planning-agent/tests/evals/joist/easy/issue-1406/prompt.md
+++ b/packages/planning-agent/tests/evals/joist/easy/issue-1406/prompt.md
@@ -1,0 +1,15 @@
+codegen: optionally define schemas to derive metadata from
+
+Long time, no issue. :)
+
+We're evaluating using pg schemas for some lightweight tenancy. This isn't external/per organisation, but really for creating various ops - such as a "demo" tenant.
+
+The idea is to have a couple schemas say public, demo etc. We have some global tables, which we are considering moving out to a `core` schema.
+
+We'll then be able to set the pg search_path to `{tenant}, core` per request.
+
+Within codegen there's currently a function that checks if a schema name equals "public". The request is to make this optionally configurable within joist-config.json to an array of schemas, enabling definitions like `['public', 'core']`.
+
+nothing else from joist would be needed here, as search_paths allows this to be handled at pg level.
+
+Happy to PR if you're open to this!

--- a/packages/planning-agent/tests/mcp.json
+++ b/packages/planning-agent/tests/mcp.json
@@ -1,0 +1,7 @@
+{
+  "servers": {
+    "coding": {
+      "type": "in-memory"
+    }
+  }
+}


### PR DESCRIPTION
This PR adds a very rough 1st pass on a proof-of-concept for our planning agent, with our 1st executable eval. 

It's built on-top of some packages in this repo that I've moved into ContextBridge's github:

1. **Aether** -- Rust library for creating (headless) autonomous agents. It supports multiple LLM providers, alloyed models, MCP servers, `AGENTS.md` and other goodies. Our planning agent is built as an "Aether agent"
2. **MCP Lexicon**. Contains 1st-party MCP servers for Aether agents, currently there's a `Coding` server which gives agents file system tools (read, write, bash etc). 
3. **Crucible** -- Rust library for writing evals it handles loading and executing evals in a loop. 

This PR adds a new `planning-agent` package that's configured to use Crucible to execute evals. 
