### PR TITLE
refactor(aether): Migrate error handling to thiserror

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -36,6 +36,7 @@ dependencies = [
  "serde_json",
  "sha2",
  "tempfile",
+ "thiserror 2.0.16",
  "tokio",
  "tokio-stream",
  "tokio-util",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,6 +40,7 @@ rand = "0.8"
 
 # Error handling
 color-eyre = "0.6.3"
+thiserror = "2.0"
 
 # File system and pattern matching
 glob = "0.3"

--- a/packages/aether/Cargo.toml
+++ b/packages/aether/Cargo.toml
@@ -24,6 +24,7 @@ regex = { workspace = true }
 sha2 = { workspace = true }
 base64 = { workspace = true }
 rand = { workspace = true }
+thiserror = { workspace = true }
 tempfile = { workspace = true }
 
 [[example]]

--- a/packages/aether/src/agent/error.rs
+++ b/packages/aether/src/agent/error.rs
@@ -1,42 +1,21 @@
-use std::fmt;
+use thiserror::Error;
 
 use crate::{llm, mcp};
 
-#[derive(Debug)]
+#[derive(Debug, Error)]
 pub enum AgentError {
     /// MCP manager operation failed
-    McpError(mcp::McpError),
+    #[error("MCP error: {0}")]
+    McpError(#[from] mcp::McpError),
     /// LLM provider error
-    LlmError(llm::LlmError),
+    #[error("LLM error: {0}")]
+    LlmError(#[from] llm::LlmError),
     /// IO error (file operations, etc.)
+    #[error("IO error: {0}")]
     IoError(String),
     /// Generic error for other cases
+    #[error("{0}")]
     Other(String),
-}
-
-impl fmt::Display for AgentError {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        match self {
-            AgentError::McpError(e) => write!(f, "MCP error: {e}"),
-            AgentError::LlmError(e) => write!(f, "LLM error: {e}"),
-            AgentError::IoError(msg) => write!(f, "IO error: {msg}"),
-            AgentError::Other(msg) => write!(f, "{msg}"),
-        }
-    }
-}
-
-impl std::error::Error for AgentError {}
-
-impl From<crate::mcp::McpError> for AgentError {
-    fn from(error: crate::mcp::McpError) -> Self {
-        AgentError::McpError(error)
-    }
-}
-
-impl From<crate::llm::LlmError> for AgentError {
-    fn from(error: crate::llm::LlmError) -> Self {
-        AgentError::LlmError(error)
-    }
 }
 
 pub type Result<T> = std::result::Result<T, AgentError>;

--- a/packages/aether/src/auth/mod.rs
+++ b/packages/aether/src/auth/mod.rs
@@ -1,4 +1,4 @@
-use std::fmt;
+use thiserror::Error;
 
 pub mod anthropic;
 pub mod store;
@@ -9,30 +9,21 @@ pub use anthropic::{
 };
 pub use store::{CredentialsStore, ProviderCredentials};
 
-#[derive(Debug)]
+#[derive(Debug, Error)]
 pub enum AuthError {
+    #[error("Home directory not set")]
     MissingHomeDir,
+    #[error("Auth IO error: {0}")]
     Io(String),
+    #[error("Auth JSON error: {0}")]
     Json(String),
+    #[error("Auth HTTP error: {0}")]
     Http(String),
+    #[error("Auth response error: {0}")]
     InvalidResponse(String),
+    #[error("{0}")]
     Other(String),
 }
-
-impl fmt::Display for AuthError {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        match self {
-            AuthError::MissingHomeDir => write!(f, "Home directory not set"),
-            AuthError::Io(msg) => write!(f, "Auth IO error: {msg}"),
-            AuthError::Json(msg) => write!(f, "Auth JSON error: {msg}"),
-            AuthError::Http(msg) => write!(f, "Auth HTTP error: {msg}"),
-            AuthError::InvalidResponse(msg) => write!(f, "Auth response error: {msg}"),
-            AuthError::Other(msg) => write!(f, "{msg}"),
-        }
-    }
-}
-
-impl std::error::Error for AuthError {}
 
 impl From<std::io::Error> for AuthError {
     fn from(error: std::io::Error) -> Self {

--- a/packages/aether/src/llm/anthropic/provider.rs
+++ b/packages/aether/src/llm/anthropic/provider.rs
@@ -239,22 +239,20 @@ impl AnthropicProvider {
 }
 
 impl ProviderFactory for AnthropicProvider {
-    fn from_env() -> std::result::Result<Self, Box<dyn std::error::Error>> {
+    fn from_env() -> Result<Self> {
         if let Ok(api_key) = env::var("ANTHROPIC_API_KEY") {
-            return Self::new(ProviderCredentials::api_key(&api_key))
-                .map_err(|e| Box::new(e) as Box<dyn std::error::Error>);
+            return Self::new(ProviderCredentials::api_key(&api_key));
         }
 
-        let store = load_credentials().map_err(auth_error_to_boxed)?;
+        let store = load_credentials().map_err(auth_error_to_llm)?;
         if let Some(credentials) = store.providers.get("anthropic") {
-            return Self::new(credentials.clone())
-                .map_err(|e| Box::new(e) as Box<dyn std::error::Error>);
+            return Self::new(credentials.clone());
         }
 
-        Err(Box::new(LlmError::Other(
+        Err(LlmError::Other(
             "No Anthropic credentials found. Run `wisp auth anthropic` or set ANTHROPIC_API_KEY."
                 .to_string(),
-        )))
+        ))
     }
 
     fn with_model(self, model: &str) -> Self {
@@ -346,10 +344,6 @@ fn format_headers(headers: &header::HeaderMap) -> String {
 
 fn auth_error_to_llm(error: AuthError) -> LlmError {
     LlmError::Other(error.to_string())
-}
-
-fn auth_error_to_boxed(error: AuthError) -> Box<dyn std::error::Error> {
-    Box::new(LlmError::Other(error.to_string()))
 }
 
 fn now_millis() -> u64 {

--- a/packages/aether/src/llm/error.rs
+++ b/packages/aether/src/llm/error.rs
@@ -1,49 +1,35 @@
-use std::fmt;
+use thiserror::Error;
 
-#[derive(Debug)]
+#[derive(Debug, Error)]
 pub enum LlmError {
     /// Environment variable not set or invalid
+    #[error("{0} environment variable not set")]
     MissingApiKey(String),
     /// Invalid API key format
+    #[error("Invalid API key: {0}")]
     InvalidApiKey(String),
     /// HTTP client creation failed
+    #[error("Failed to create HTTP client: {0}")]
     HttpClientCreation(String),
     /// API request failed
+    #[error("API request failed: {0}")]
     ApiRequest(String),
     /// API returned an error response
+    #[error("API error: {0}")]
     ApiError(String),
     /// IO error while reading stream
+    #[error("IO error reading stream: {0}")]
     IoError(String),
     /// JSON parsing/serialization error
+    #[error("JSON parsing error: {0}")]
     JsonParsing(String),
     /// Tool parameter parsing error
+    #[error("Failed to parse tool parameters for {tool_name}: {error}")]
     ToolParameterParsing { tool_name: String, error: String },
     /// Generic error for other cases
+    #[error("{0}")]
     Other(String),
 }
-
-impl fmt::Display for LlmError {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        match self {
-            LlmError::MissingApiKey(var) => write!(f, "{var} environment variable not set"),
-            LlmError::InvalidApiKey(msg) => write!(f, "Invalid API key: {msg}"),
-            LlmError::HttpClientCreation(msg) => write!(f, "Failed to create HTTP client: {msg}"),
-            LlmError::ApiRequest(msg) => write!(f, "API request failed: {msg}"),
-            LlmError::ApiError(msg) => write!(f, "API error: {msg}"),
-            LlmError::IoError(msg) => write!(f, "IO error reading stream: {msg}"),
-            LlmError::JsonParsing(msg) => write!(f, "JSON parsing error: {msg}"),
-            LlmError::ToolParameterParsing { tool_name, error } => {
-                write!(
-                    f,
-                    "Failed to parse tool parameters for {tool_name}: {error}"
-                )
-            }
-            LlmError::Other(msg) => write!(f, "{msg}"),
-        }
-    }
-}
-
-impl std::error::Error for LlmError {}
 
 impl From<reqwest::Error> for LlmError {
     fn from(error: reqwest::Error) -> Self {

--- a/packages/aether/src/llm/local/llama_cpp.rs
+++ b/packages/aether/src/llm/local/llama_cpp.rs
@@ -1,4 +1,6 @@
-use crate::llm::{ProviderFactory, local::util::get_local_config, openai::OpenAiChatProvider};
+use crate::llm::{
+    ProviderFactory, Result, local::util::get_local_config, openai::OpenAiChatProvider,
+};
 use async_openai::{Client, config::OpenAIConfig};
 
 pub struct LlamaCppProvider {
@@ -22,7 +24,7 @@ impl Default for LlamaCppProvider {
 }
 
 impl ProviderFactory for LlamaCppProvider {
-    fn from_env() -> std::result::Result<Self, Box<dyn std::error::Error>> {
+    fn from_env() -> Result<Self> {
         Ok(Self::default())
     }
 

--- a/packages/aether/src/llm/local/ollama.rs
+++ b/packages/aether/src/llm/local/ollama.rs
@@ -1,4 +1,6 @@
-use crate::llm::{ProviderFactory, local::util::get_local_config, openai::OpenAiChatProvider};
+use crate::llm::{
+    ProviderFactory, Result, local::util::get_local_config, openai::OpenAiChatProvider,
+};
 use async_openai::{Client, config::OpenAIConfig};
 
 pub struct OllamaProvider {
@@ -23,7 +25,7 @@ impl OllamaProvider {
 }
 
 impl ProviderFactory for OllamaProvider {
-    fn from_env() -> std::result::Result<Self, Box<dyn std::error::Error>> {
+    fn from_env() -> Result<Self> {
         Ok(Self {
             model: String::new(),
             client: Client::with_config(get_local_config("http://localhost:11434/v1")),

--- a/packages/aether/src/llm/openai_compatible/mod.rs
+++ b/packages/aether/src/llm/openai_compatible/mod.rs
@@ -9,5 +9,30 @@
 pub mod streaming;
 pub mod types;
 
+use async_openai::types::CreateChatCompletionRequest;
+
+use crate::llm::Context;
+use crate::llm::openai::mappers::{map_messages, map_tools};
+
 pub use streaming::create_custom_stream;
 pub use types::ChatCompletionStreamResponse;
+
+/// Build a chat completion request from a context
+///
+/// This is shared logic for OpenAI-compatible providers like OpenRouter and Z.ai.
+pub fn build_chat_request(model: &str, context: &Context) -> CreateChatCompletionRequest {
+    let messages = map_messages(context.messages());
+    let tools = if context.tools().is_empty() {
+        None
+    } else {
+        Some(map_tools(context.tools()))
+    };
+
+    CreateChatCompletionRequest {
+        model: model.to_string(),
+        messages,
+        stream: Some(true),
+        tools,
+        ..Default::default()
+    }
+}

--- a/packages/aether/src/llm/openrouter/provider.rs
+++ b/packages/aether/src/llm/openrouter/provider.rs
@@ -1,8 +1,6 @@
-use async_openai::types::CreateChatCompletionRequest;
 use async_openai::{Client, config::OpenAIConfig};
 
-use crate::llm::openai::mappers::{map_messages, map_tools};
-use crate::llm::openai_compatible::create_custom_stream;
+use crate::llm::openai_compatible::{build_chat_request, create_custom_stream};
 use crate::llm::{
     Context, LlmError, LlmResponseStream, ProviderFactory, Result, StreamingModelProvider,
 };
@@ -40,7 +38,7 @@ impl OpenRouterProvider {
 }
 
 impl ProviderFactory for OpenRouterProvider {
-    fn from_env() -> std::result::Result<Self, Box<dyn std::error::Error>> {
+    fn from_env() -> Result<Self> {
         let api_key = std::env::var("OPENROUTER_API_KEY")
             .map_err(|_| LlmError::MissingApiKey("OPENROUTER_API_KEY".to_string()))?;
 
@@ -64,21 +62,7 @@ impl ProviderFactory for OpenRouterProvider {
 
 impl StreamingModelProvider for OpenRouterProvider {
     fn stream_response(&self, context: &Context) -> LlmResponseStream {
-        let messages = map_messages(context.messages());
-        let tools = if context.tools().is_empty() {
-            None
-        } else {
-            Some(map_tools(context.tools()))
-        };
-
-        let request = CreateChatCompletionRequest {
-            model: self.model.clone(),
-            messages,
-            stream: Some(true),
-            tools,
-            ..Default::default()
-        };
-
+        let request = build_chat_request(&self.model, context);
         create_custom_stream(&self.client, request)
     }
 

--- a/packages/aether/src/llm/parser.rs
+++ b/packages/aether/src/llm/parser.rs
@@ -1,7 +1,7 @@
 use std::collections::HashMap;
 
 use crate::llm::{
-    ProviderFactory, StreamingModelProvider,
+    LlmError, ProviderFactory, StreamingModelProvider,
     alloyed::AlloyedModelProvider,
     anthropic::AnthropicProvider,
     local::{llama_cpp::LlamaCppProvider, ollama::OllamaProvider},
@@ -56,13 +56,10 @@ impl ModelProviderParser {
     /// - `"provider:model"` - Single provider (e.g., "anthropic:claude-3.5-sonnet")
     /// - `"provider1:model1,provider2:model2"` - Multiple providers create an AlloyedModelProvider
     ///
-    pub fn parse(
-        &self,
-        models_str: &str,
-    ) -> Result<Box<dyn StreamingModelProvider>, Box<dyn std::error::Error>> {
+    pub fn parse(&self, models_str: &str) -> crate::llm::Result<Box<dyn StreamingModelProvider>> {
         let provider_model_pairs: Vec<&str> = models_str.split(',').map(|s| s.trim()).collect();
         if provider_model_pairs.is_empty() {
-            return Err("No models provided".into());
+            return Err(LlmError::Other("No models provided".to_string()));
         }
 
         let mut providers = Vec::new();
@@ -77,7 +74,7 @@ impl ModelProviderParser {
             let factory = self
                 .factories
                 .get(provider_name)
-                .ok_or_else(|| format!("Unknown provider: {provider_name}"))?;
+                .ok_or_else(|| LlmError::Other(format!("Unknown provider: {provider_name}")))?;
 
             providers.push(factory(model)?);
         }
@@ -95,11 +92,8 @@ impl ModelProviderParser {
 /// Factory function type for creating model providers
 ///
 /// Takes a model name and returns a boxed StreamingModelProvider
-pub type CreateProviderFn = Box<
-    dyn Fn(&str) -> Result<Box<dyn StreamingModelProvider>, Box<dyn std::error::Error>>
-        + Send
-        + Sync,
->;
+pub type CreateProviderFn =
+    Box<dyn Fn(&str) -> crate::llm::Result<Box<dyn StreamingModelProvider>> + Send + Sync>;
 
 #[cfg(test)]
 mod tests {

--- a/packages/aether/src/llm/provider.rs
+++ b/packages/aether/src/llm/provider.rs
@@ -14,7 +14,7 @@ pub type LlmResponseStream = Pin<Box<dyn Stream<Item = LlmResult<LlmResponse>> +
 /// (Box<dyn StreamingModelProvider>) to work without construction methods.
 pub trait ProviderFactory: Sized {
     /// Create provider from environment variables and default configuration
-    fn from_env() -> Result<Self, Box<dyn std::error::Error>>;
+    fn from_env() -> super::Result<Self>;
 
     /// Set or update the model for this provider (builder pattern)
     fn with_model(self, model: &str) -> Self;

--- a/packages/aether/src/llm/z_ai/provider.rs
+++ b/packages/aether/src/llm/z_ai/provider.rs
@@ -1,7 +1,8 @@
-use crate::llm::openai::mappers::{map_messages, map_tools};
-use crate::llm::openai_compatible::create_custom_stream;
-use crate::llm::{Context, LlmError, LlmResponseStream, ProviderFactory, StreamingModelProvider};
-use async_openai::{Client, config::OpenAIConfig, types::CreateChatCompletionRequest};
+use crate::llm::openai_compatible::{build_chat_request, create_custom_stream};
+use crate::llm::{
+    Context, LlmError, LlmResponseStream, ProviderFactory, Result, StreamingModelProvider,
+};
+use async_openai::{Client, config::OpenAIConfig};
 
 pub struct ZAiProvider {
     client: Client<OpenAIConfig>,
@@ -27,7 +28,7 @@ impl ZAiProvider {
 }
 
 impl ProviderFactory for ZAiProvider {
-    fn from_env() -> std::result::Result<Self, Box<dyn std::error::Error>> {
+    fn from_env() -> Result<Self> {
         let api_key = std::env::var("ZAI_API_KEY")
             .map_err(|_| LlmError::MissingApiKey("ZAI_API_KEY".to_string()))?;
         Ok(Self::new(api_key))
@@ -40,21 +41,7 @@ impl ProviderFactory for ZAiProvider {
 
 impl StreamingModelProvider for ZAiProvider {
     fn stream_response(&self, context: &Context) -> LlmResponseStream {
-        let messages = map_messages(context.messages());
-        let tools = if context.tools().is_empty() {
-            None
-        } else {
-            Some(map_tools(context.tools()))
-        };
-
-        let request = CreateChatCompletionRequest {
-            model: self.model.clone(),
-            messages,
-            stream: Some(true),
-            tools,
-            ..Default::default()
-        };
-
+        let request = build_chat_request(&self.model, context);
         create_custom_stream(&self.client, request)
     }
 

--- a/packages/aether/src/mcp/error.rs
+++ b/packages/aether/src/mcp/error.rs
@@ -1,74 +1,54 @@
-use std::fmt;
+use thiserror::Error;
 
-#[derive(Debug)]
+#[derive(Debug, Error)]
 pub enum McpError {
     /// Tool not found in the registry
+    #[error("Tool not found: {0}")]
     ToolNotFound(String),
     /// Invalid tool name format (should be server__tool)
+    #[error("Invalid tool name format: {0}")]
     InvalidToolNameFormat(String),
     /// MCP server not found
+    #[error("Server not found: {0}")]
     ServerNotFound(String),
     /// Failed to execute tool on MCP server
+    #[error("Failed to execute tool {tool_name} on server {server_name}: {error}")]
     ToolExecutionFailed {
         tool_name: String,
         server_name: String,
         error: String,
     },
     /// Tool execution returned an error
+    #[error("Tool execution failed: {0}")]
     ToolExecutionError(String),
     /// Tool discovery failed
+    #[error("Tool discovery failed: {0}")]
     ToolDiscoveryFailed(String),
     /// Prompt not found in the registry
+    #[error("Prompt not found: {0}")]
     PromptNotFound(String),
     /// Prompt listing failed
+    #[error("Prompt listing failed: {0}")]
     PromptListFailed(String),
     /// Prompt retrieval failed
+    #[error("Prompt retrieval failed: {0}")]
     PromptGetFailed(String),
     /// Server connection failed
+    #[error("Connection failed: {0}")]
     ConnectionFailed(String),
     /// Server startup failed
+    #[error("Server startup failed: {0}")]
     ServerStartupFailed(String),
     /// Transport error
+    #[error("Transport error: {0}")]
     TransportError(String),
     /// JSON serialization/deserialization error
+    #[error("JSON error: {0}")]
     JsonError(String),
     /// Generic error for other cases
+    #[error("{0}")]
     Other(String),
 }
-
-impl fmt::Display for McpError {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        match self {
-            McpError::ToolNotFound(tool) => write!(f, "Tool not found: {tool}"),
-            McpError::InvalidToolNameFormat(name) => {
-                write!(f, "Invalid tool name format: {name}")
-            }
-            McpError::ServerNotFound(server) => write!(f, "Server not found: {server}"),
-            McpError::ToolExecutionFailed {
-                tool_name,
-                server_name,
-                error,
-            } => {
-                write!(
-                    f,
-                    "Failed to execute tool {tool_name} on server {server_name}: {error}"
-                )
-            }
-            McpError::ToolExecutionError(msg) => write!(f, "Tool execution failed: {msg}"),
-            McpError::ToolDiscoveryFailed(msg) => write!(f, "Tool discovery failed: {msg}"),
-            McpError::PromptNotFound(prompt) => write!(f, "Prompt not found: {prompt}"),
-            McpError::PromptListFailed(msg) => write!(f, "Prompt listing failed: {msg}"),
-            McpError::PromptGetFailed(msg) => write!(f, "Prompt retrieval failed: {msg}"),
-            McpError::ConnectionFailed(msg) => write!(f, "Connection failed: {msg}"),
-            McpError::ServerStartupFailed(msg) => write!(f, "Server startup failed: {msg}"),
-            McpError::TransportError(msg) => write!(f, "Transport error: {msg}"),
-            McpError::JsonError(msg) => write!(f, "JSON error: {msg}"),
-            McpError::Other(msg) => write!(f, "{msg}"),
-        }
-    }
-}
-
-impl std::error::Error for McpError {}
 
 impl From<serde_json::Error> for McpError {
     fn from(error: serde_json::Error) -> Self {

--- a/packages/aether/src/tools/error.rs
+++ b/packages/aether/src/tools/error.rs
@@ -1,29 +1,20 @@
-use std::fmt;
+use thiserror::Error;
 
-#[derive(Debug)]
+#[derive(Debug, Error)]
 pub enum ToolError {
     /// Tool execution failed
+    #[error("Tool execution failed: {0}")]
     ExecutionFailed(String),
     /// Tool configuration error
+    #[error("Tool configuration error: {0}")]
     ConfigurationError(String),
     /// IO error during tool operation
+    #[error("IO error: {0}")]
     IoError(String),
     /// Generic error for other cases
+    #[error("{0}")]
     Other(String),
 }
-
-impl fmt::Display for ToolError {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        match self {
-            ToolError::ExecutionFailed(msg) => write!(f, "Tool execution failed: {msg}"),
-            ToolError::ConfigurationError(msg) => write!(f, "Tool configuration error: {msg}"),
-            ToolError::IoError(msg) => write!(f, "IO error: {msg}"),
-            ToolError::Other(msg) => write!(f, "{msg}"),
-        }
-    }
-}
-
-impl std::error::Error for ToolError {}
 
 impl From<std::io::Error> for ToolError {
     fn from(error: std::io::Error) -> Self {

--- a/packages/wisp/src/cli.rs
+++ b/packages/wisp/src/cli.rs
@@ -57,7 +57,7 @@ impl Cli {
         &self,
     ) -> Result<Box<dyn StreamingModelProvider>, Box<dyn std::error::Error>> {
         let parser = ModelProviderParser::default();
-        parser.parse(&self.model)
+        Ok(parser.parse(&self.model)?)
     }
 }
 


### PR DESCRIPTION
## Summary

This PR implements the tech debt refactoring plan from Linear issue JOS-5:

- **Migrated all error types to use `thiserror`**: LlmError, McpError, AgentError, ToolError, and AuthError now use derive macros instead of manual Display implementations, reducing ~70% of error handling boilerplate
- **Improved ProviderFactory return type**: Changed from `Box<dyn std::error::Error>` to `LlmError`, enabling pattern matching on specific errors
- **DRY'd OpenAI-compatible provider logic**: Added shared `build_chat_request()` function used by OpenRouter and ZAi providers

**Net result:** 82 fewer lines of code while improving type safety and error handling.

## Test plan

- [x] All `cargo test -p aether` tests pass (91 tests)
- [x] All `cargo test --workspace` tests pass
- [x] `cargo clippy --workspace` shows no new warnings
- [x] `cargo fmt` applied

🤖 Generated with [Claude Code](https://claude.com/claude-code)