### PR TITLE
feat: add Gemini provider with API key authentication

### DIFF
--- a/packages/aether/src/llm/gemini/mod.rs
+++ b/packages/aether/src/llm/gemini/mod.rs
@@ -1,0 +1,3 @@
+pub mod provider;
+
+pub use provider::GeminiProvider;

--- a/packages/aether/src/llm/gemini/provider.rs
+++ b/packages/aether/src/llm/gemini/provider.rs
@@ -1,0 +1,56 @@
+use async_openai::{Client, config::OpenAIConfig};
+
+use crate::llm::openai_compatible::{build_chat_request, create_custom_stream};
+use crate::llm::{
+    Context, LlmError, LlmResponseStream, ProviderFactory, Result, StreamingModelProvider,
+};
+
+pub struct GeminiProvider {
+    client: Client<OpenAIConfig>,
+    model: String,
+}
+
+impl GeminiProvider {
+    pub fn new(api_key: String, model: String) -> Result<Self> {
+        let config = OpenAIConfig::new()
+            .with_api_key(api_key)
+            .with_api_base("https://generativelanguage.googleapis.com/v1beta/openai/");
+
+        let client = Client::with_config(config);
+        Ok(Self { client, model })
+    }
+}
+
+impl ProviderFactory for GeminiProvider {
+    fn from_env() -> Result<Self> {
+        let api_key = std::env::var("GEMINI_API_KEY")
+            .map_err(|_| LlmError::MissingApiKey("GEMINI_API_KEY".to_string()))?;
+
+        let config = OpenAIConfig::new()
+            .with_api_key(api_key)
+            .with_api_base("https://generativelanguage.googleapis.com/v1beta/openai/");
+
+        let client = Client::with_config(config);
+
+        Ok(Self {
+            client,
+            model: String::new(),
+        })
+    }
+
+    fn with_model(mut self, model: &str) -> Self {
+        self.model = model.to_string();
+        self
+    }
+}
+
+impl StreamingModelProvider for GeminiProvider {
+    fn stream_response(&self, context: &Context) -> LlmResponseStream {
+        let request = build_chat_request(&self.model, context);
+        create_custom_stream(&self.client, request)
+    }
+
+    fn display_name(&self) -> String {
+        format!("Gemini ({})", self.model)
+    }
+}

--- a/packages/aether/src/llm/mod.rs
+++ b/packages/aether/src/llm/mod.rs
@@ -3,6 +3,7 @@ pub mod anthropic;
 mod chat_message;
 mod context;
 pub mod error;
+pub mod gemini;
 mod llm_response;
 pub mod local;
 pub mod openai;

--- a/packages/aether/src/llm/parser.rs
+++ b/packages/aether/src/llm/parser.rs
@@ -4,6 +4,7 @@ use crate::llm::{
     LlmError, ProviderFactory, StreamingModelProvider,
     alloyed::AlloyedModelProvider,
     anthropic::AnthropicProvider,
+    gemini::GeminiProvider,
     local::{llama_cpp::LlamaCppProvider, ollama::OllamaProvider},
     openrouter::OpenRouterProvider,
     z_ai::ZAiProvider,
@@ -28,6 +29,7 @@ impl Default for ModelProviderParser {
     fn default() -> Self {
         Self::new(HashMap::new())
             .with_provider::<AnthropicProvider>("anthropic")
+            .with_provider::<GeminiProvider>("gemini")
             .with_provider::<OpenRouterProvider>("openrouter")
             .with_provider::<OllamaProvider>("ollama")
             .with_provider::<ZAiProvider>("zai")
@@ -136,6 +138,20 @@ mod tests {
             let err = e.to_string();
             assert!(
                 err.contains("API") || err.contains("OPENROUTER"),
+                "Should fail on API key, not parsing"
+            );
+        }
+    }
+
+    #[test]
+    fn test_parse_gemini() {
+        let parser = ModelProviderParser::default();
+        let result = parser.parse("gemini:gemini-2.5-flash");
+        // Will fail without API key, but should parse successfully
+        if let Err(e) = result {
+            let err = e.to_string();
+            assert!(
+                err.contains("API") || err.contains("GEMINI"),
                 "Should fail on API key, not parsing"
             );
         }


### PR DESCRIPTION
Add GeminiProvider using the OpenAI-compatible API endpoint at
https://generativelanguage.googleapis.com/v1beta/openai/

This implementation:
- Reuses the existing openai_compatible module for request building and streaming
- Supports GEMINI_API_KEY environment variable
- Registers the "gemini" provider in the ModelProviderParser
- Includes tests for provider parsing

Supported models: gemini-2.5-pro, gemini-2.5-flash, gemini-3-pro-preview

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds Gemini support leveraging existing OpenAI-compatible infrastructure.
> 
> - New `GeminiProvider` using `async_openai` with base `https://generativelanguage.googleapis.com/v1beta/openai/`
> - Reuses `openai_compatible::build_chat_request` and `create_custom_stream` for chat streaming
> - Supports `GEMINI_API_KEY` via `ProviderFactory::from_env` and `with_model`
> - Registers `gemini` in `ModelProviderParser::default()` and exports via `llm/gemini`
> - Adds parser test `test_parse_gemini` to validate provider parsing
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3fd9fcd289fecc37ebaad3e87067386c3e05937f. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->