### PR TITLE
refactor: migrate Hook trait to async-trait crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2005,6 +2005,7 @@ version = "0.1.0"
 dependencies = [
  "aether",
  "anyhow",
+ "async-trait",
  "clap",
  "crucible",
  "futures",

--- a/packages/aether/src/tools/summarizer.rs
+++ b/packages/aether/src/tools/summarizer.rs
@@ -2,7 +2,7 @@ use crate::tools::Result;
 use std::future::Future;
 
 pub trait Summarizer {
-    fn summarize(&self, text: &str) -> impl Future<Output = Result<String>>;
+    fn summarize(&self, text: &str) -> impl Future<Output = Result<String>> + Send;
 }
 
 #[derive(Clone)]

--- a/packages/crucible/src/hooks.rs
+++ b/packages/crucible/src/hooks.rs
@@ -1,5 +1,6 @@
-use std::{path::PathBuf, pin::Pin};
+use std::path::PathBuf;
 
+use async_trait::async_trait;
 use crate::AgentRunnerMessage;
 
 pub struct HookInput {
@@ -10,17 +11,19 @@ pub struct HookInput {
 pub type HookResult = Result<(), Box<dyn std::error::Error>>;
 
 /// Trait for eval lifecycle hooks (useful for running setup functions)
+#[async_trait]
 pub trait Hook: Send + Sync {
-    fn run(&self, input: HookInput) -> Pin<Box<dyn Future<Output = HookResult> + Send>>;
+    async fn run(&self, input: HookInput) -> HookResult;
 }
 
 // Implement for closures that return futures
+#[async_trait]
 impl<F, Fut> Hook for F
 where
     F: Fn(HookInput) -> Fut + Send + Sync,
-    Fut: Future<Output = HookResult> + Send + 'static,
+    Fut: std::future::Future<Output = HookResult> + Send + 'static,
 {
-    fn run(&self, input: HookInput) -> Pin<Box<dyn Future<Output = HookResult> + Send>> {
-        Box::pin(self(input))
+    async fn run(&self, input: HookInput) -> HookResult {
+        self(input).await
     }
 }

--- a/packages/mcp-lexicon/src/plugins/server.rs
+++ b/packages/mcp-lexicon/src/plugins/server.rs
@@ -180,6 +180,7 @@ impl ServerHandler for PluginsMcp {
                 return Ok(ListPromptsResult {
                     prompts: Vec::new(),
                     next_cursor: None,
+                    meta: None,
                 });
             }
         };
@@ -195,6 +196,7 @@ impl ServerHandler for PluginsMcp {
         Ok(ListPromptsResult {
             prompts: commands,
             next_cursor: None,
+            meta: None,
         })
     }
 

--- a/packages/planning-agent/Cargo.toml
+++ b/packages/planning-agent/Cargo.toml
@@ -14,6 +14,7 @@ clap = { workspace = true }
 # Async runtime
 tokio = { workspace = true }
 futures = { workspace = true }
+async-trait = { workspace = true }
 
 # Logging and tracing
 tracing = { workspace = true }

--- a/packages/planning-agent/src/claude_code.rs
+++ b/packages/planning-agent/src/claude_code.rs
@@ -1,5 +1,6 @@
+use async_trait::async_trait;
 use crucible::hooks::{Hook, HookInput, HookResult};
-use std::{fs, pin::Pin, process::Stdio};
+use std::{fs, process::Stdio};
 use tokio::io::{AsyncBufReadExt, BufReader};
 
 /// Hook that reads a prompt file and executes it using Claude Code CLI
@@ -15,51 +16,49 @@ impl ClaudeCode {
     }
 }
 
+#[async_trait]
 impl Hook for ClaudeCode {
-    fn run(&self, input: HookInput) -> Pin<Box<dyn Future<Output = HookResult> + Send>> {
-        let plan_file = self.prompt_file.clone();
-        Box::pin(async move {
-            let plan_path = input.working_directory.join(&plan_file);
-            let plan_contents = fs::read_to_string(&plan_path)
-                .map_err(|e| format!("Failed to read {}: {}", plan_file, e))?;
+    async fn run(&self, input: HookInput) -> HookResult {
+        let plan_path = input.working_directory.join(&self.prompt_file);
+        let plan_contents = fs::read_to_string(&plan_path)
+            .map_err(|e| format!("Failed to read {}: {}", self.prompt_file, e))?;
 
-            tracing::info!("Starting Claude Code agent");
+        tracing::info!("Starting Claude Code agent");
 
-            let mut child = tokio::process::Command::new("claude")
-                .arg("-p")
-                .arg("--dangerously-skip-permissions")
-                .arg("--verbose")
-                .arg("--output-format")
-                .arg("stream-json")
-                .arg(format!("An engineer has produced this implementation plan: <plan>{}</plan>. Implement the feature per the plan.", plan_contents))
-                .current_dir(&input.working_directory)
-                .stdout(Stdio::piped())
-                .stderr(Stdio::piped())
-                .spawn()
-                .map_err(|e| format!("Failed to spawn claude CLI: {}", e))?;
+        let mut child = tokio::process::Command::new("claude")
+            .arg("-p")
+            .arg("--dangerously-skip-permissions")
+            .arg("--verbose")
+            .arg("--output-format")
+            .arg("stream-json")
+            .arg(format!("An engineer has produced this implementation plan: <plan>{}</plan>. Implement the feature per the plan.", plan_contents))
+            .current_dir(&input.working_directory)
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped())
+            .spawn()
+            .map_err(|e| format!("Failed to spawn claude CLI: {}", e))?;
 
-            if let Some(stdout) = child.stdout.take() {
-                let reader = BufReader::new(stdout);
-                let mut lines = reader.lines();
-                tokio::spawn(async move {
-                    while let Ok(Some(line)) = lines.next_line().await {
-                        tracing::info!("claude: {}", line);
-                    }
-                });
-            }
+        if let Some(stdout) = child.stdout.take() {
+            let reader = BufReader::new(stdout);
+            let mut lines = reader.lines();
+            tokio::spawn(async move {
+                while let Ok(Some(line)) = lines.next_line().await {
+                    tracing::info!("claude: {}", line);
+                }
+            });
+        }
 
-            let status = child
-                .wait()
-                .await
-                .map_err(|e| format!("Failed to wait for claude CLI: {}", e))?;
+        let status = child
+            .wait()
+            .await
+            .map_err(|e| format!("Failed to wait for claude CLI: {}", e))?;
 
-            if !status.success() {
-                return Err(format!("Claude CLI failed with status {}", status).into());
-            }
+        if !status.success() {
+            return Err(format!("Claude CLI failed with status {}", status).into());
+        }
 
-            tracing::info!("Claude Code successfully executed the plan");
+        tracing::info!("Claude Code successfully executed the plan");
 
-            Ok(())
-        })
+        Ok(())
     }
 }


### PR DESCRIPTION
The Hook trait is used as a trait object (Box<dyn Hook>) in the
evaluation system, which previously required the complex
Pin<Box<dyn Future>> return type pattern.

Migrated to use the async-trait crate which provides cleaner
async fn syntax while maintaining the same functionality. Updated
the ClaudeCode implementation and blanket impl for closures.

Also added missing Send bound to Summarizer trait and fixed
ListPromptsResult missing meta field.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Refactor hooks to async-trait and clean up async usage**
> 
> - Replace `Hook::run`'s `Pin<Box<Future>>` with `async fn run` using `async_trait`; update blanket impl for closures and the `ClaudeCode` hook accordingly
> - Add `async-trait` dependency in `planning-agent`
> - Add `+ Send` bound to `Summarizer::summarize` future in `aether`
> - Ensure `ListPromptsResult` sets `meta: None` in `mcp-lexicon`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4717a911559d5a7937e05c4b03238710a7ce924e. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->