### PR TITLE
feat: add token tracking infrastructure

### DIFF
--- a/packages/aether/examples/anthropic_test.rs
+++ b/packages/aether/examples/anthropic_test.rs
@@ -172,6 +172,15 @@ async fn main() -> Result<(), Box<dyn Error>> {
                 println!("\n❌ Error: {message}");
                 break;
             }
+            LlmResponse::Usage {
+                input_tokens,
+                output_tokens,
+            } => {
+                println!(
+                    "\n📊 Token usage - input: {}, output: {}",
+                    input_tokens, output_tokens
+                );
+            }
         }
     }
 

--- a/packages/aether/src/agent/core.rs
+++ b/packages/aether/src/agent/core.rs
@@ -300,6 +300,19 @@ impl<T: StreamingModelProvider + 'static> Agent<T> {
                     .send(AgentMessage::Error { message })
                     .await;
             }
+
+            Usage {
+                input_tokens,
+                output_tokens,
+            } => {
+                // Token usage information from API response
+                // This is tracked for context management but doesn't require action in the agent loop
+                tracing::debug!(
+                    "Token usage - input: {}, output: {}",
+                    input_tokens,
+                    output_tokens
+                );
+            }
         }
     }
 

--- a/packages/aether/src/agent/core.rs
+++ b/packages/aether/src/agent/core.rs
@@ -1,5 +1,6 @@
 use crate::agent::middleware::{AgentEvent, Middleware, MiddlewareAction};
 use crate::agent::{AgentMessage, UserMessage};
+use crate::context::TokenTracker;
 use crate::llm::{
     ChatMessage, StreamingModelProvider, ToolCallError, ToolCallRequest, ToolCallResult,
 };
@@ -33,6 +34,7 @@ pub struct Agent<T: StreamingModelProvider> {
     streams: StreamMap<String, EventStream>,
     middleware: Middleware,
     tool_timeout: Duration,
+    token_tracker: TokenTracker,
 }
 
 impl<T: StreamingModelProvider + 'static> Agent<T> {
@@ -59,11 +61,17 @@ impl<T: StreamingModelProvider + 'static> Agent<T> {
             streams,
             middleware,
             tool_timeout,
+            token_tracker: TokenTracker::new(200_000), // Default to Claude's 200k context limit
         }
     }
 
     pub fn current_model_display_name(&self) -> String {
         self.llm.display_name()
+    }
+
+    /// Get a reference to the token tracker
+    pub fn token_tracker(&self) -> &TokenTracker {
+        &self.token_tracker
     }
 
     pub async fn run(mut self) {
@@ -305,12 +313,14 @@ impl<T: StreamingModelProvider + 'static> Agent<T> {
                 input_tokens,
                 output_tokens,
             } => {
-                // Token usage information from API response
-                // This is tracked for context management but doesn't require action in the agent loop
+                // Record token usage for context management
+                self.token_tracker.record_usage(input_tokens, output_tokens);
                 tracing::debug!(
-                    "Token usage - input: {}, output: {}",
+                    "Token usage - input: {}, output: {}, ratio: {:.2}%, remaining: {}",
                     input_tokens,
-                    output_tokens
+                    output_tokens,
+                    self.token_tracker.usage_ratio() * 100.0,
+                    self.token_tracker.tokens_remaining()
                 );
             }
         }

--- a/packages/aether/src/context/mod.rs
+++ b/packages/aether/src/context/mod.rs
@@ -1,0 +1,3 @@
+mod token_tracker;
+
+pub use token_tracker::*;

--- a/packages/aether/src/context/token_tracker.rs
+++ b/packages/aether/src/context/token_tracker.rs
@@ -1,0 +1,161 @@
+/// Tracks token usage from LLM API responses.
+/// Uses real usage data from API, not estimation.
+#[derive(Debug, Clone, Default)]
+pub struct TokenTracker {
+    /// Total input tokens across all API calls
+    total_input_tokens: u64,
+    /// Total output tokens across all API calls
+    total_output_tokens: u64,
+    /// Input tokens from the most recent API call (current context size)
+    last_input_tokens: u32,
+    /// Configured context limit for the current provider
+    context_limit: u32,
+}
+
+impl TokenTracker {
+    pub fn new(context_limit: u32) -> Self {
+        Self {
+            total_input_tokens: 0,
+            total_output_tokens: 0,
+            last_input_tokens: 0,
+            context_limit,
+        }
+    }
+
+    // Factory methods for common context limits
+    pub fn claude_opus() -> Self {
+        Self::new(200_000)
+    }
+
+    pub fn claude_sonnet() -> Self {
+        Self::new(200_000)
+    }
+
+    pub fn claude_haiku() -> Self {
+        Self::new(200_000)
+    }
+
+    pub fn gpt4o() -> Self {
+        Self::new(128_000)
+    }
+
+    pub fn gpt4o_mini() -> Self {
+        Self::new(128_000)
+    }
+
+    /// Record usage from an LLM API response
+    pub fn record_usage(&mut self, input_tokens: u32, output_tokens: u32) {
+        self.total_input_tokens += input_tokens as u64;
+        self.total_output_tokens += output_tokens as u64;
+        self.last_input_tokens = input_tokens;
+    }
+
+    /// Current context usage as a ratio (0.0 - 1.0)
+    pub fn usage_ratio(&self) -> f64 {
+        if self.context_limit == 0 {
+            return 0.0;
+        }
+        self.last_input_tokens as f64 / self.context_limit as f64
+    }
+
+    /// Whether current usage exceeds the given threshold
+    pub fn exceeds_threshold(&self, threshold: f64) -> bool {
+        self.usage_ratio() >= threshold
+    }
+
+    /// Tokens remaining before hitting limit
+    pub fn tokens_remaining(&self) -> u32 {
+        self.context_limit.saturating_sub(self.last_input_tokens)
+    }
+
+    /// Get the context limit
+    pub fn context_limit(&self) -> u32 {
+        self.context_limit
+    }
+
+    /// Get last recorded input tokens (current context size)
+    pub fn last_input_tokens(&self) -> u32 {
+        self.last_input_tokens
+    }
+
+    /// Get total input tokens across all calls
+    pub fn total_input_tokens(&self) -> u64 {
+        self.total_input_tokens
+    }
+
+    /// Get total output tokens across all calls
+    pub fn total_output_tokens(&self) -> u64 {
+        self.total_output_tokens
+    }
+
+    /// Reset the last input tokens (e.g., after compaction)
+    /// Note: This doesn't truly reset - the next API call will provide real usage
+    pub fn reset_for_compaction(&mut self) {
+        // We don't actually reset last_input_tokens here because
+        // the next API call will give us the real post-compaction usage
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_usage_tracking() {
+        let mut tracker = TokenTracker::new(1000);
+
+        tracker.record_usage(500, 100);
+        assert_eq!(tracker.usage_ratio(), 0.5);
+        assert!(!tracker.exceeds_threshold(0.85));
+
+        tracker.record_usage(900, 50);
+        assert_eq!(tracker.usage_ratio(), 0.9);
+        assert!(tracker.exceeds_threshold(0.85));
+    }
+
+    #[test]
+    fn test_tokens_remaining() {
+        let mut tracker = TokenTracker::new(1000);
+        tracker.record_usage(700, 50);
+        assert_eq!(tracker.tokens_remaining(), 300);
+    }
+
+    #[test]
+    fn test_cumulative_totals() {
+        let mut tracker = TokenTracker::new(1000);
+        tracker.record_usage(100, 50);
+        tracker.record_usage(200, 60);
+
+        assert_eq!(tracker.total_input_tokens(), 300);
+        assert_eq!(tracker.total_output_tokens(), 110);
+        assert_eq!(tracker.last_input_tokens(), 200); // Only last call
+    }
+
+    #[test]
+    fn test_zero_context_limit() {
+        let tracker = TokenTracker::new(0);
+        assert_eq!(tracker.usage_ratio(), 0.0);
+    }
+
+    #[test]
+    fn test_factory_methods() {
+        assert_eq!(TokenTracker::claude_opus().context_limit(), 200_000);
+        assert_eq!(TokenTracker::claude_sonnet().context_limit(), 200_000);
+        assert_eq!(TokenTracker::claude_haiku().context_limit(), 200_000);
+        assert_eq!(TokenTracker::gpt4o().context_limit(), 128_000);
+        assert_eq!(TokenTracker::gpt4o_mini().context_limit(), 128_000);
+    }
+
+    #[test]
+    fn test_exceeds_threshold() {
+        let mut tracker = TokenTracker::new(1000);
+
+        tracker.record_usage(500, 100);
+        assert!(!tracker.exceeds_threshold(0.6));
+        assert!(tracker.exceeds_threshold(0.5));
+
+        tracker.record_usage(850, 50);
+        assert!(tracker.exceeds_threshold(0.8));
+        assert!(tracker.exceeds_threshold(0.85));
+    }
+}

--- a/packages/aether/src/context/token_tracker.rs
+++ b/packages/aether/src/context/token_tracker.rs
@@ -87,13 +87,6 @@ impl TokenTracker {
     pub fn total_output_tokens(&self) -> u64 {
         self.total_output_tokens
     }
-
-    /// Reset the last input tokens (e.g., after compaction)
-    /// Note: This doesn't truly reset - the next API call will provide real usage
-    pub fn reset_for_compaction(&mut self) {
-        // We don't actually reset last_input_tokens here because
-        // the next API call will give us the real post-compaction usage
-    }
 }
 
 #[cfg(test)]

--- a/packages/aether/src/lib.rs
+++ b/packages/aether/src/lib.rs
@@ -2,6 +2,7 @@
 
 pub mod agent;
 pub mod auth;
+pub mod context;
 pub mod fs;
 pub mod llm;
 pub mod mcp;

--- a/packages/aether/src/llm/anthropic/streaming.rs
+++ b/packages/aether/src/llm/anthropic/streaming.rs
@@ -70,14 +70,9 @@ fn process_stream_event(
 ) -> Result<Option<LlmResponse>> {
     use StreamEvent::*;
     match event {
-        MessageStart { data: start_data } => {
+        MessageStart { data: _start_data } => {
             debug!("Message started");
-            // Emit usage from message_start event
-            let usage = &start_data.message.usage;
-            Ok(Some(LlmResponse::Usage {
-                input_tokens: usage.input_tokens,
-                output_tokens: usage.output_tokens,
-            }))
+            Ok(None)
         }
 
         ContentBlockStart { data: start_data } => match start_data.content_block {
@@ -147,10 +142,10 @@ fn process_stream_event(
 
         MessageDelta { data: delta_data } => {
             debug!("Message delta received");
-            // Emit cumulative output_tokens if available
+            // Emit complete usage at message completion
             if let Some(usage) = &delta_data.delta.usage {
                 Ok(Some(LlmResponse::Usage {
-                    input_tokens: 0, // Already reported in message_start
+                    input_tokens: usage.input_tokens,
                     output_tokens: usage.output_tokens,
                 }))
             } else {
@@ -188,6 +183,7 @@ mod tests {
             "data: {\"type\": \"content_block_delta\", \"index\": 0, \"delta\": {\"type\": \"text_delta\", \"text\": \"Hello\"}}".to_string(),
             "data: {\"type\": \"content_block_delta\", \"index\": 0, \"delta\": {\"type\": \"text_delta\", \"text\": \" world\"}}".to_string(),
             "data: {\"type\": \"content_block_stop\", \"index\": 0}".to_string(),
+            "data: {\"type\": \"message_delta\", \"delta\": {\"stop_reason\": \"end_turn\", \"stop_sequence\": null, \"usage\": {\"input_tokens\": 10, \"output_tokens\": 25}}}".to_string(),
             "data: {\"type\": \"message_stop\"}".to_string(),
         ];
 
@@ -200,9 +196,9 @@ mod tests {
         }
 
         assert!(matches!(responses[0], LlmResponse::Start { .. }));
-        assert!(matches!(responses[1], LlmResponse::Usage { input_tokens: 10, output_tokens: 0 }));
-        assert!(matches!(responses[2], LlmResponse::Text { ref chunk } if chunk == "Hello"));
-        assert!(matches!(responses[3], LlmResponse::Text { ref chunk } if chunk == " world"));
+        assert!(matches!(responses[1], LlmResponse::Text { ref chunk } if chunk == "Hello"));
+        assert!(matches!(responses[2], LlmResponse::Text { ref chunk } if chunk == " world"));
+        assert!(matches!(responses[3], LlmResponse::Usage { input_tokens: 10, output_tokens: 25 }));
         assert!(matches!(responses[4], LlmResponse::Done));
     }
 
@@ -213,6 +209,7 @@ mod tests {
             "data: {\"type\": \"content_block_start\", \"index\": 0, \"content_block\": {\"type\": \"tool_use\", \"id\": \"tool_123\", \"name\": \"search\"}}".to_string(),
             "data: {\"type\": \"content_block_delta\", \"index\": 0, \"delta\": {\"type\": \"input_json_delta\", \"partial_json\": \"{\\\"query\\\":\\\"test\\\"}\"}".to_string(),
             "data: {\"type\": \"content_block_stop\", \"index\": 0}".to_string(),
+            "data: {\"type\": \"message_delta\", \"delta\": {\"stop_reason\": \"tool_use\", \"stop_sequence\": null, \"usage\": {\"input_tokens\": 10, \"output_tokens\": 15}}}".to_string(),
             "data: {\"type\": \"message_stop\"}".to_string(),
         ];
 
@@ -225,13 +222,13 @@ mod tests {
         }
 
         assert!(matches!(responses[0], LlmResponse::Start { .. }));
-        assert!(matches!(responses[1], LlmResponse::Usage { input_tokens: 10, output_tokens: 0 }));
         assert!(
-            matches!(responses[2], LlmResponse::ToolRequestStart { ref id, ref name } if id == "tool_123" && name == "search")
+            matches!(responses[1], LlmResponse::ToolRequestStart { ref id, ref name } if id == "tool_123" && name == "search")
         );
         assert!(
-            matches!(responses[3], LlmResponse::ToolRequestComplete { ref tool_call } if tool_call.id == "tool_123" && tool_call.name == "search")
+            matches!(responses[2], LlmResponse::ToolRequestComplete { ref tool_call } if tool_call.id == "tool_123" && tool_call.name == "search")
         );
+        assert!(matches!(responses[3], LlmResponse::Usage { input_tokens: 10, output_tokens: 15 }));
         assert!(matches!(responses[4], LlmResponse::Done));
     }
 

--- a/packages/aether/src/llm/anthropic/streaming.rs
+++ b/packages/aether/src/llm/anthropic/streaming.rs
@@ -70,9 +70,14 @@ fn process_stream_event(
 ) -> Result<Option<LlmResponse>> {
     use StreamEvent::*;
     match event {
-        MessageStart { data: _start_data } => {
+        MessageStart { data: start_data } => {
             debug!("Message started");
-            Ok(None)
+            // Emit usage from message_start event
+            let usage = &start_data.message.usage;
+            Ok(Some(LlmResponse::Usage {
+                input_tokens: usage.input_tokens,
+                output_tokens: usage.output_tokens,
+            }))
         }
 
         ContentBlockStart { data: start_data } => match start_data.content_block {
@@ -140,9 +145,17 @@ fn process_stream_event(
             }
         }
 
-        MessageDelta { data: _delta_data } => {
+        MessageDelta { data: delta_data } => {
             debug!("Message delta received");
-            Ok(None)
+            // Emit cumulative output_tokens if available
+            if let Some(usage) = &delta_data.delta.usage {
+                Ok(Some(LlmResponse::Usage {
+                    input_tokens: 0, // Already reported in message_start
+                    output_tokens: usage.output_tokens,
+                }))
+            } else {
+                Ok(None)
+            }
         }
 
         MessageStop { data: _stop_data } => {
@@ -187,9 +200,10 @@ mod tests {
         }
 
         assert!(matches!(responses[0], LlmResponse::Start { .. }));
-        assert!(matches!(responses[1], LlmResponse::Text { ref chunk } if chunk == "Hello"));
-        assert!(matches!(responses[2], LlmResponse::Text { ref chunk } if chunk == " world"));
-        assert!(matches!(responses[3], LlmResponse::Done));
+        assert!(matches!(responses[1], LlmResponse::Usage { input_tokens: 10, output_tokens: 0 }));
+        assert!(matches!(responses[2], LlmResponse::Text { ref chunk } if chunk == "Hello"));
+        assert!(matches!(responses[3], LlmResponse::Text { ref chunk } if chunk == " world"));
+        assert!(matches!(responses[4], LlmResponse::Done));
     }
 
     #[tokio::test]
@@ -211,13 +225,14 @@ mod tests {
         }
 
         assert!(matches!(responses[0], LlmResponse::Start { .. }));
+        assert!(matches!(responses[1], LlmResponse::Usage { input_tokens: 10, output_tokens: 0 }));
         assert!(
-            matches!(responses[1], LlmResponse::ToolRequestStart { ref id, ref name } if id == "tool_123" && name == "search")
+            matches!(responses[2], LlmResponse::ToolRequestStart { ref id, ref name } if id == "tool_123" && name == "search")
         );
         assert!(
-            matches!(responses[2], LlmResponse::ToolRequestComplete { ref tool_call } if tool_call.id == "tool_123" && tool_call.name == "search")
+            matches!(responses[3], LlmResponse::ToolRequestComplete { ref tool_call } if tool_call.id == "tool_123" && tool_call.name == "search")
         );
-        assert!(matches!(responses[3], LlmResponse::Done));
+        assert!(matches!(responses[4], LlmResponse::Done));
     }
 
     #[tokio::test]

--- a/packages/aether/src/llm/llm_response.rs
+++ b/packages/aether/src/llm/llm_response.rs
@@ -12,6 +12,7 @@ pub enum LlmResponse {
     ToolRequestComplete { tool_call: ToolCallRequest },
     Done,
     Error { message: String },
+    Usage { input_tokens: u32, output_tokens: u32 },
 }
 
 impl LlmResponse {
@@ -48,6 +49,13 @@ impl LlmResponse {
                 name: name.to_string(),
                 arguments: arguments.to_string(),
             },
+        }
+    }
+
+    pub fn usage(input_tokens: u32, output_tokens: u32) -> Self {
+        Self::Usage {
+            input_tokens,
+            output_tokens,
         }
     }
 }

--- a/packages/aether/src/llm/openai/streaming.rs
+++ b/packages/aether/src/llm/openai/streaming.rs
@@ -22,6 +22,14 @@ pub fn process_completion_stream<E: Into<LlmError> + Send>(
         while let Some(result) = stream.next().await {
             match result {
                 Ok(mut response) => {
+                    // Emit usage information if available
+                    if let Some(usage) = response.usage {
+                        yield Ok(LlmResponse::Usage {
+                            input_tokens: usage.prompt_tokens,
+                            output_tokens: usage.completion_tokens,
+                        });
+                    }
+
                     if let Some(choice) = response.choices.pop() {
                         let delta = choice.delta;
 


### PR DESCRIPTION
This commit implements the token tracking foundation that will be used
for context compaction. It adds the ability to track real token usage
from LLM API responses.

Changes:
- Add Usage variant to LlmResponse enum for token data
- Create new context module with TokenTracker struct
- TokenTracker records actual usage from API responses (not estimation)
- Anthropic streaming now emits Usage events from message_start and message_delta
- OpenAI-compatible streaming emits Usage events from response data
- Update agent core to handle Usage events with debug logging
- Add comprehensive unit tests for TokenTracker
- Update existing tests to account for new Usage variant

The TokenTracker includes:
- Factory methods for common model context limits (Claude, GPT-4o)
- Usage ratio calculation and threshold detection
- Tracking of cumulative and per-request token counts
- Tokens remaining calculation

Related to JOS-8a

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduces real token usage tracking and surfaces it through streaming events.
> 
> - **New `context` module** with `TokenTracker` to record actual API usage (totals, last input size), compute usage ratio/thresholds, tokens remaining, and factory methods for common models
> - **Extend `LlmResponse`** with `Usage { input_tokens, output_tokens }`
> - **Streaming updates**: Anthropic emits `Usage` on `message_start` and cumulative output on `message_delta`; OpenAI-compatible stream emits `Usage` from response `usage`
> - **Agent integration**: agent core consumes `Usage` events (debug logs) without altering control flow; example app prints token usage
> - **Plumbing/tests**: export `context` in lib; add comprehensive unit tests for `TokenTracker` and adjust existing streaming tests to account for `Usage` events
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b3151acaed86cf0ca625f197fd944267a1868076. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->