### PR TITLE
feat(desktop): add @-file includes for embedding files in prompts

### DIFF
--- a/packages/aether-desktop/src/acp_agent.rs
+++ b/packages/aether-desktop/src/acp_agent.rs
@@ -326,20 +326,31 @@ async fn run_agent(
                     // Build content blocks: text message + embedded file resources
                     let mut content_blocks: Vec<ContentBlock> = vec![ContentBlock::from(message)];
 
-                    // Add embedded resources for each file reference
-                    for file_ref in files {
-                        match read_file_for_embedding(&file_ref.path).await {
-                            Ok(resource_block) => {
-                                content_blocks.push(resource_block);
-                            }
-                            Err(e) => {
-                                // If file can't be read, add an error note as text
-                                debug!("Failed to read file for embedding: {:?} - {}", file_ref.path, e);
-                                content_blocks.push(ContentBlock::from(format!(
-                                    "[Error reading {}: {}]",
-                                    file_ref.path.display(),
-                                    e
-                                )));
+                    // Read all files in parallel
+                    if !files.is_empty() {
+                        let file_futures: Vec<_> = files
+                            .iter()
+                            .map(|file_ref| {
+                                let path = file_ref.path.clone();
+                                async move { (path.clone(), read_file_for_embedding(&path).await) }
+                            })
+                            .collect();
+
+                        let results = futures::future::join_all(file_futures).await;
+
+                        for (path, result) in results {
+                            match result {
+                                Ok(resource_block) => {
+                                    content_blocks.push(resource_block);
+                                }
+                                Err(e) => {
+                                    debug!("Failed to read file for embedding: {:?} - {}", path, e);
+                                    content_blocks.push(ContentBlock::from(format!(
+                                        "[Error reading {}: {}]",
+                                        path.display(),
+                                        e
+                                    )));
+                                }
                             }
                         }
                     }

--- a/packages/aether-desktop/src/acp_agent.rs
+++ b/packages/aether-desktop/src/acp_agent.rs
@@ -86,13 +86,7 @@ impl AgentHandle {
 
     /// Send a prompt to the agent.
     pub fn send_prompt(&self, message: String) -> Result<(), SendError> {
-        self.cmd_tx
-            .send(AgentCommand::Prompt {
-                acp_session_id: self.acp_session_id.clone(),
-                message,
-                files: Vec::new(),
-            })
-            .map_err(|_| SendError::ChannelClosed)
+        self.send_prompt_with_files(message, Vec::new())
     }
 
     /// Send a prompt with embedded file references to the agent.

--- a/packages/aether-desktop/src/acp_agent.rs
+++ b/packages/aether-desktop/src/acp_agent.rs
@@ -508,42 +508,30 @@ fn transform_session_notification(
             let tool_id = update.id.0.to_string();
             debug!("Tool call update: {} - {:?}", tool_id, update.fields.status);
 
-            if let Some(status) = &update.fields.status {
-                match status {
-                    ToolCallStatus::Completed => {
-                        let content = extract_tool_content(&update.fields)
-                            .unwrap_or_else(|| "Completed".to_string());
-
-                        vec![AgentEvent::ToolCallCompleted {
-                            agent_id: agent_id.to_string(),
-                            tool_id,
-                            result: content,
-                        }]
-                    }
-                    ToolCallStatus::Failed => {
-                        let error_msg = extract_tool_content(&update.fields)
-                            .unwrap_or_else(|| "Unknown error".to_string());
-
-                        vec![AgentEvent::ToolCallFailed {
-                            agent_id: agent_id.to_string(),
-                            tool_id,
-                            error: error_msg,
-                        }]
-                    }
-                    _ => {
-                        vec![AgentEvent::ToolCallUpdated {
-                            agent_id: agent_id.to_string(),
-                            tool_id,
-                            fields: update.fields,
-                        }]
-                    }
+            match update.fields.status.as_ref() {
+                Some(ToolCallStatus::Completed) => {
+                    let content = extract_tool_content(&update.fields)
+                        .unwrap_or_else(|| "Completed".to_string());
+                    vec![AgentEvent::ToolCallCompleted {
+                        agent_id: agent_id.to_string(),
+                        tool_id,
+                        result: content,
+                    }]
                 }
-            } else {
-                vec![AgentEvent::ToolCallUpdated {
+                Some(ToolCallStatus::Failed) => {
+                    let error_msg = extract_tool_content(&update.fields)
+                        .unwrap_or_else(|| "Unknown error".to_string());
+                    vec![AgentEvent::ToolCallFailed {
+                        agent_id: agent_id.to_string(),
+                        tool_id,
+                        error: error_msg,
+                    }]
+                }
+                _ => vec![AgentEvent::ToolCallUpdated {
                     agent_id: agent_id.to_string(),
                     tool_id,
                     fields: update.fields,
-                }]
+                }],
             }
         }
 
@@ -571,13 +559,7 @@ fn transform_session_notification(
 fn extract_tool_content(fields: &ToolCallUpdateFields) -> Option<String> {
     fields.content.as_ref().and_then(|contents| {
         contents.iter().find_map(|c| match c {
-            ToolCallContent::Content { content } => {
-                if let ContentBlock::Text(t) = content {
-                    Some(t.text.clone())
-                } else {
-                    None
-                }
-            }
+            ToolCallContent::Content { content: ContentBlock::Text(t) } => Some(t.text.clone()),
             _ => None,
         })
     })

--- a/packages/aether-desktop/src/acp_agent.rs
+++ b/packages/aether-desktop/src/acp_agent.rs
@@ -1,10 +1,10 @@
 use crate::acp_client::{AcpClient, RawAgentEvent};
-use crate::state::{AgentStatus, SendError};
+use crate::state::{AgentStatus, FileReference, SendError};
 use agent_client_protocol::{
-    Agent, AvailableCommand, ClientSideConnection, ContentBlock, InitializeRequest,
-    NewSessionRequest, NewSessionResponse, PromptRequest, RequestPermissionRequest,
-    RequestPermissionResponse, SessionId, SessionUpdate, ToolCall, ToolCallContent, ToolCallStatus,
-    ToolCallUpdateFields, VERSION,
+    Agent, AvailableCommand, ClientSideConnection, ContentBlock, EmbeddedResource,
+    EmbeddedResourceResource, InitializeRequest, NewSessionRequest, NewSessionResponse,
+    PromptRequest, RequestPermissionRequest, RequestPermissionResponse, SessionId, SessionUpdate,
+    TextResourceContents, ToolCall, ToolCallContent, ToolCallStatus, ToolCallUpdateFields, VERSION,
 };
 use futures::Stream;
 use std::path::{Path, PathBuf};
@@ -90,6 +90,22 @@ impl AgentHandle {
             .send(AgentCommand::Prompt {
                 acp_session_id: self.acp_session_id.clone(),
                 message,
+                files: Vec::new(),
+            })
+            .map_err(|_| SendError::ChannelClosed)
+    }
+
+    /// Send a prompt with embedded file references to the agent.
+    pub fn send_prompt_with_files(
+        &self,
+        message: String,
+        files: Vec<FileReference>,
+    ) -> Result<(), SendError> {
+        self.cmd_tx
+            .send(AgentCommand::Prompt {
+                acp_session_id: self.acp_session_id.clone(),
+                message,
+                files,
             })
             .map_err(|_| SendError::ChannelClosed)
     }
@@ -179,6 +195,7 @@ pub enum AgentCommand {
     Prompt {
         acp_session_id: SessionId,
         message: String,
+        files: Vec<FileReference>,
     },
 }
 
@@ -299,16 +316,38 @@ async fn run_agent(
             LoopEvent::Command(AgentCommand::Prompt {
                 acp_session_id: prompt_acp_session_id,
                 message,
+                files,
             }) => {
                 // Spawn prompt as a stream so it doesn't block other events
                 let conn = Rc::clone(&conn);
                 let (tx, rx) = mpsc::channel(1);
 
                 tokio::task::spawn_local(async move {
+                    // Build content blocks: text message + embedded file resources
+                    let mut content_blocks: Vec<ContentBlock> = vec![ContentBlock::from(message)];
+
+                    // Add embedded resources for each file reference
+                    for file_ref in files {
+                        match read_file_for_embedding(&file_ref.path).await {
+                            Ok(resource_block) => {
+                                content_blocks.push(resource_block);
+                            }
+                            Err(e) => {
+                                // If file can't be read, add an error note as text
+                                debug!("Failed to read file for embedding: {:?} - {}", file_ref.path, e);
+                                content_blocks.push(ContentBlock::from(format!(
+                                    "[Error reading {}: {}]",
+                                    file_ref.path.display(),
+                                    e
+                                )));
+                            }
+                        }
+                    }
+
                     let response = conn
                         .prompt(PromptRequest {
                             session_id: prompt_acp_session_id,
-                            prompt: vec![ContentBlock::from(message)],
+                            prompt: content_blocks,
                             meta: None,
                         })
                         .await;
@@ -531,4 +570,48 @@ fn extract_tool_content(fields: &ToolCallUpdateFields) -> Option<String> {
             _ => None,
         })
     })
+}
+
+/// Read a file and create an embedded resource ContentBlock.
+async fn read_file_for_embedding(path: &Path) -> Result<ContentBlock, std::io::Error> {
+    let content = tokio::fs::read_to_string(path).await?;
+    let uri = format!("file://{}", path.display());
+
+    // Determine MIME type based on extension
+    let mime_type = path
+        .extension()
+        .and_then(|ext| ext.to_str())
+        .map(|ext| match ext.to_lowercase().as_str() {
+            "rs" => "text/x-rust",
+            "ts" | "tsx" => "text/typescript",
+            "js" | "jsx" => "text/javascript",
+            "py" => "text/x-python",
+            "go" => "text/x-go",
+            "java" => "text/x-java",
+            "c" | "h" => "text/x-c",
+            "cpp" | "hpp" | "cc" => "text/x-c++",
+            "json" => "application/json",
+            "yaml" | "yml" => "text/yaml",
+            "toml" => "text/toml",
+            "md" => "text/markdown",
+            "html" => "text/html",
+            "css" => "text/css",
+            "sql" => "text/x-sql",
+            "sh" | "bash" => "text/x-shellscript",
+            "xml" => "text/xml",
+            "proto" => "text/x-protobuf",
+            _ => "text/plain",
+        })
+        .map(String::from);
+
+    Ok(ContentBlock::Resource(EmbeddedResource {
+        annotations: None,
+        resource: EmbeddedResourceResource::TextResourceContents(TextResourceContents {
+            uri,
+            mime_type,
+            text: content,
+            meta: None,
+        }),
+        meta: None,
+    }))
 }

--- a/packages/aether-desktop/src/acp_agent.rs
+++ b/packages/aether-desktop/src/acp_agent.rs
@@ -84,17 +84,8 @@ impl AgentHandle {
         })
     }
 
-    /// Send a prompt to the agent.
-    pub fn send_prompt(&self, message: String) -> Result<(), SendError> {
-        self.send_prompt_with_files(message, Vec::new())
-    }
-
-    /// Send a prompt with embedded file references to the agent.
-    pub fn send_prompt_with_files(
-        &self,
-        message: String,
-        files: Vec<FileReference>,
-    ) -> Result<(), SendError> {
+    /// Send a prompt to the agent, optionally with embedded file references.
+    pub fn send_prompt(&self, message: String, files: Vec<FileReference>) -> Result<(), SendError> {
         self.cmd_tx
             .send(AgentCommand::Prompt {
                 acp_session_id: self.acp_session_id.clone(),

--- a/packages/aether-desktop/src/components/agent_view.rs
+++ b/packages/aether-desktop/src/components/agent_view.rs
@@ -3,25 +3,100 @@
 //! Displays the chat interface for a single agent session.
 
 use dioxus::prelude::*;
+use std::path::PathBuf;
 
-use crate::state::{now_iso, AgentStatus, Message, MessageKind, Role, SlashCommand};
+use crate::file_walker::FileWalker;
+use crate::state::{now_iso, AgentStatus, DropdownMode, FileReference, Message, MessageKind, Role, SlashCommand};
 use crate::{AGENTS, HANDLES};
 
 use super::command_dropdown::CommandDropdown;
+use super::file_picker_dropdown::FilePickerDropdown;
 use super::message_bubble::MessageBubble;
 
-/// State for the command dropdown
+/// State for the dropdown (both slash commands and file picker)
 #[derive(Clone, PartialEq, Default)]
 struct DropdownState {
     visible: bool,
     selected_index: usize,
     filter_text: String,
+    mode: DropdownMode,
+}
+
+/// Find the position of an incomplete @-mention in the input.
+///
+/// Returns the position of the @ character if there's an incomplete mention,
+/// i.e., an @ followed by text but not yet completed (no space after).
+fn find_incomplete_at_mention(text: &str) -> Option<usize> {
+    // Find the last @ that starts a file mention
+    // A mention is incomplete if it doesn't end with a space
+    let mut last_at = None;
+
+    for (i, c) in text.char_indices() {
+        if c == '@' {
+            // Check if this @ is at start or preceded by whitespace
+            if i == 0 || text.chars().nth(i.saturating_sub(1)).map(|c| c.is_whitespace()).unwrap_or(true) {
+                last_at = Some(i);
+            }
+        }
+    }
+
+    // Check if the mention is incomplete (no space after the @path)
+    if let Some(at_pos) = last_at {
+        let after_at = &text[at_pos + 1..];
+        // If there's no space in the text after @, it's incomplete
+        if !after_at.contains(' ') {
+            return Some(at_pos);
+        }
+    }
+
+    None
+}
+
+/// Extract the filter text from an @-mention at the given position.
+fn extract_at_filter(text: &str, at_pos: usize) -> String {
+    text[at_pos + 1..].to_string()
+}
+
+/// Parse file references from the input text.
+///
+/// Returns a list of file paths that are @-mentioned in the text.
+#[allow(dead_code)]
+fn parse_file_references(text: &str) -> Vec<PathBuf> {
+    let mut refs = Vec::new();
+    let mut in_mention = false;
+    let mut current_path = String::new();
+
+    for (i, c) in text.char_indices() {
+        if c == '@' && (i == 0 || text.chars().nth(i.saturating_sub(1)).map(|ch| ch.is_whitespace()).unwrap_or(true)) {
+            in_mention = true;
+            current_path.clear();
+        } else if in_mention {
+            if c.is_whitespace() {
+                if !current_path.is_empty() {
+                    refs.push(PathBuf::from(&current_path));
+                }
+                in_mention = false;
+                current_path.clear();
+            } else {
+                current_path.push(c);
+            }
+        }
+    }
+
+    // Handle mention at end of string
+    if in_mention && !current_path.is_empty() {
+        refs.push(PathBuf::from(&current_path));
+    }
+
+    refs
 }
 
 #[component]
 pub fn AgentView(agent_id: String) -> Element {
     let mut input_val = use_signal(String::new);
     let dropdown_state = use_signal(DropdownState::default);
+    let file_results = use_signal(Vec::<PathBuf>::new);
+    let file_refs = use_signal(Vec::<FileReference>::new);
     let agent_id_for_send = agent_id.clone();
     let agent_id_for_handlers = agent_id.clone();
 
@@ -37,6 +112,7 @@ pub fn AgentView(agent_id: String) -> Element {
 
     let mut do_send = {
         let mut dropdown_state = dropdown_state;
+        let mut file_refs = file_refs;
         move || {
             let content = input_val.read().clone();
             if content.trim().is_empty() {
@@ -46,14 +122,25 @@ pub fn AgentView(agent_id: String) -> Element {
             // Close dropdown on send
             dropdown_state.write().visible = false;
 
-            // Add user message to state
+            // Get the file references for this message
+            let refs: Vec<FileReference> = file_refs.read().clone();
+
+            // Add user message to state (with file refs noted in content)
+            let display_content = if refs.is_empty() {
+                content.clone()
+            } else {
+                // Show which files are attached
+                let file_list: Vec<String> = refs.iter().map(|r| format!("@{}", r.path.display())).collect();
+                format!("{}\n\n📎 Attached: {}", content, file_list.join(", "))
+            };
+
             {
                 let mut list = AGENTS.write();
                 if let Some(agent) = list.iter_mut().find(|a| a.id == agent_id_for_send) {
                     agent.messages.push(Message {
                         id: uuid::Uuid::new_v4().to_string(),
                         role: Role::User,
-                        content: content.clone(),
+                        content: display_content,
                         kind: MessageKind::Text,
                         timestamp: now_iso(),
                         is_streaming: false,
@@ -62,8 +149,9 @@ pub fn AgentView(agent_id: String) -> Element {
                 }
             }
 
-            // Send via handles (separate from UI state)
-            if let Err(e) = HANDLES.read().send_prompt(&agent_id_for_send, content) {
+            // Send via handles with file references
+            // For now, we send the content with @mentions; the agent will handle reading files
+            if let Err(e) = HANDLES.read().send_prompt_with_files(&agent_id_for_send, content, refs) {
                 tracing::error!("Failed to send message: {}", e);
                 let mut list = AGENTS.write();
                 if let Some(agent) = list.iter_mut().find(|a| a.id == agent_id_for_send) {
@@ -72,6 +160,7 @@ pub fn AgentView(agent_id: String) -> Element {
             }
 
             input_val.set(String::new());
+            file_refs.write().clear();
         }
     };
 
@@ -86,22 +175,64 @@ pub fn AgentView(agent_id: String) -> Element {
         }
     };
 
-    // Handle input changes - detect "/" for dropdown
+    // Handle file selection from file picker
+    let on_file_select = {
+        let mut input_val = input_val;
+        let mut dropdown_state = dropdown_state;
+        let mut file_refs = file_refs;
+        move |path: PathBuf| {
+            let state = dropdown_state.read().clone();
+            if let DropdownMode::FilePicker { at_position } = state.mode {
+                // Replace @partial with @full/path
+                let current = input_val.read().clone();
+                let before = &current[..at_position];
+                let path_str = path.to_string_lossy();
+                let new_value = format!("{}@{} ", before, path_str);
+                input_val.set(new_value);
+
+                // Add to file references
+                file_refs.write().push(FileReference::new(path));
+            }
+            dropdown_state.write().visible = false;
+        }
+    };
+
+    // Handle input changes - detect "/" for slash commands or "@" for file picker
     let on_input_change = {
         let mut dropdown_state = dropdown_state;
+        let file_results = file_results;
         let commands = available_commands.clone();
         move |e: Event<FormData>| {
             let value = e.value();
             input_val.set(value.clone());
 
-            // Check if we should show/hide dropdown
-            if value.starts_with('/') && !value.contains(' ') {
+            // Check for @ pattern first (file picker)
+            if let Some(at_pos) = find_incomplete_at_mention(&value) {
+                let filter = extract_at_filter(&value, at_pos);
+                let mut state = dropdown_state.write();
+                state.visible = true;
+                state.filter_text = filter.clone();
+                state.selected_index = 0;
+                state.mode = DropdownMode::FilePicker { at_position: at_pos };
+
+                // Trigger file search asynchronously
+                let mut file_results = file_results.clone();
+                spawn(async move {
+                    let cwd = std::env::current_dir().unwrap_or_default();
+                    let walker = FileWalker::new(cwd);
+                    let results = walker.search(&filter).await;
+                    file_results.set(results);
+                });
+            }
+            // Check for / pattern (slash commands)
+            else if value.starts_with('/') && !value.contains(' ') {
                 // Show dropdown, filter by text after "/"
                 let filter = value.trim_start_matches('/').to_string();
                 let mut state = dropdown_state.write();
                 state.visible = !commands.is_empty();
                 state.filter_text = filter;
                 state.selected_index = 0;
+                state.mode = DropdownMode::SlashCommand;
             } else {
                 dropdown_state.write().visible = false;
             }
@@ -113,62 +244,112 @@ pub fn AgentView(agent_id: String) -> Element {
         let mut do_send = do_send.clone();
         let mut dropdown_state = dropdown_state;
         let commands = available_commands.clone();
+        let file_results = file_results;
         let mut input_val = input_val;
+        let mut file_refs = file_refs;
 
         move |e: KeyboardEvent| {
             let state = dropdown_state.read().clone();
 
             if state.visible {
-                // Dropdown is open - handle navigation
-                let filtered: Vec<&SlashCommand> = commands
-                    .iter()
-                    .filter(|cmd| {
-                        state.filter_text.is_empty()
-                            || cmd
-                                .name
-                                .to_lowercase()
-                                .contains(&state.filter_text.to_lowercase())
-                    })
-                    .collect();
+                match &state.mode {
+                    DropdownMode::SlashCommand => {
+                        // Slash command dropdown - handle navigation
+                        let filtered: Vec<&SlashCommand> = commands
+                            .iter()
+                            .filter(|cmd| {
+                                state.filter_text.is_empty()
+                                    || cmd
+                                        .name
+                                        .to_lowercase()
+                                        .contains(&state.filter_text.to_lowercase())
+                            })
+                            .collect();
 
-                match e.key() {
-                    Key::ArrowDown => {
-                        e.prevent_default();
-                        let mut state = dropdown_state.write();
-                        if !filtered.is_empty() {
-                            state.selected_index = (state.selected_index + 1) % filtered.len();
+                        match e.key() {
+                            Key::ArrowDown => {
+                                e.prevent_default();
+                                let mut state = dropdown_state.write();
+                                if !filtered.is_empty() {
+                                    state.selected_index = (state.selected_index + 1) % filtered.len();
+                                }
+                            }
+                            Key::ArrowUp => {
+                                e.prevent_default();
+                                let mut state = dropdown_state.write();
+                                if !filtered.is_empty() {
+                                    state.selected_index = state
+                                        .selected_index
+                                        .checked_sub(1)
+                                        .unwrap_or(filtered.len().saturating_sub(1));
+                                }
+                            }
+                            Key::Enter => {
+                                e.prevent_default();
+                                if let Some(cmd) = filtered.get(state.selected_index) {
+                                    input_val.set(format!("/{} ", cmd.name));
+                                    dropdown_state.write().visible = false;
+                                }
+                            }
+                            Key::Escape => {
+                                e.prevent_default();
+                                dropdown_state.write().visible = false;
+                            }
+                            Key::Tab => {
+                                e.prevent_default();
+                                if let Some(cmd) = filtered.get(state.selected_index) {
+                                    input_val.set(format!("/{} ", cmd.name));
+                                    dropdown_state.write().visible = false;
+                                }
+                            }
+                            _ => {}
                         }
                     }
-                    Key::ArrowUp => {
-                        e.prevent_default();
-                        let mut state = dropdown_state.write();
-                        if !filtered.is_empty() {
-                            state.selected_index = state
-                                .selected_index
-                                .checked_sub(1)
-                                .unwrap_or(filtered.len().saturating_sub(1));
+                    DropdownMode::FilePicker { at_position } => {
+                        // File picker dropdown - handle navigation
+                        let files = file_results.read();
+                        let file_count = files.len();
+
+                        match e.key() {
+                            Key::ArrowDown => {
+                                e.prevent_default();
+                                let mut state = dropdown_state.write();
+                                if file_count > 0 {
+                                    state.selected_index = (state.selected_index + 1) % file_count;
+                                }
+                            }
+                            Key::ArrowUp => {
+                                e.prevent_default();
+                                let mut state = dropdown_state.write();
+                                if file_count > 0 {
+                                    state.selected_index = state
+                                        .selected_index
+                                        .checked_sub(1)
+                                        .unwrap_or(file_count.saturating_sub(1));
+                                }
+                            }
+                            Key::Enter | Key::Tab => {
+                                e.prevent_default();
+                                if let Some(path) = files.get(state.selected_index) {
+                                    // Replace @partial with @full/path
+                                    let current = input_val.read().clone();
+                                    let before = &current[..*at_position];
+                                    let path_str = path.to_string_lossy();
+                                    let new_value = format!("{}@{} ", before, path_str);
+                                    input_val.set(new_value);
+
+                                    // Add to file references
+                                    file_refs.write().push(FileReference::new(path.clone()));
+                                    dropdown_state.write().visible = false;
+                                }
+                            }
+                            Key::Escape => {
+                                e.prevent_default();
+                                dropdown_state.write().visible = false;
+                            }
+                            _ => {}
                         }
                     }
-                    Key::Enter => {
-                        e.prevent_default();
-                        if let Some(cmd) = filtered.get(state.selected_index) {
-                            input_val.set(format!("/{} ", cmd.name));
-                            dropdown_state.write().visible = false;
-                        }
-                    }
-                    Key::Escape => {
-                        e.prevent_default();
-                        dropdown_state.write().visible = false;
-                    }
-                    Key::Tab => {
-                        // Tab also selects (like autocomplete)
-                        e.prevent_default();
-                        if let Some(cmd) = filtered.get(state.selected_index) {
-                            input_val.set(format!("/{} ", cmd.name));
-                            dropdown_state.write().visible = false;
-                        }
-                    }
-                    _ => {}
                 }
             } else {
                 // Normal mode - send on Enter
@@ -208,6 +389,8 @@ pub fn AgentView(agent_id: String) -> Element {
     let dropdown_visible = dropdown_state.read().visible;
     let dropdown_selected = dropdown_state.read().selected_index;
     let dropdown_filter = dropdown_state.read().filter_text.clone();
+    let dropdown_mode = dropdown_state.read().mode.clone();
+    let current_file_results = file_results.read().clone();
 
     rsx! {
         div {
@@ -257,13 +440,22 @@ pub fn AgentView(agent_id: String) -> Element {
                 div {
                     class: "relative",
 
-                    // Command dropdown (positioned above input)
-                    if dropdown_visible && !available_commands.is_empty() {
+                    // Show appropriate dropdown based on mode
+                    if dropdown_visible && matches!(dropdown_mode, DropdownMode::SlashCommand) && !available_commands.is_empty() {
                         CommandDropdown {
                             commands: available_commands.clone(),
-                            filter: dropdown_filter,
+                            filter: dropdown_filter.clone(),
                             selected_index: dropdown_selected,
                             on_select: on_command_select,
+                        }
+                    }
+
+                    if dropdown_visible && matches!(dropdown_mode, DropdownMode::FilePicker { .. }) {
+                        FilePickerDropdown {
+                            files: current_file_results.clone(),
+                            filter: dropdown_filter.clone(),
+                            selected_index: dropdown_selected,
+                            on_select: on_file_select,
                         }
                     }
 
@@ -274,7 +466,7 @@ pub fn AgentView(agent_id: String) -> Element {
                             value: "{input_val}",
                             oninput: on_input_change,
                             onkeydown: on_keydown,
-                            placeholder: "Type a message or / for commands... (Enter to send)",
+                            placeholder: "Type a message, / for commands, or @ for files... (Enter to send)",
                             disabled: is_running,
                             rows: "2",
                         }

--- a/packages/aether-desktop/src/components/agent_view.rs
+++ b/packages/aether-desktop/src/components/agent_view.rs
@@ -22,6 +22,13 @@ struct DropdownState {
     mode: DropdownMode,
 }
 
+/// Direction for dropdown navigation.
+#[derive(Clone, Copy)]
+enum NavigationDirection {
+    Up,
+    Down,
+}
+
 /// Find the position of an incomplete @-mention in the input.
 ///
 /// Returns the position of the @ character if there's an incomplete mention,
@@ -33,25 +40,14 @@ fn find_incomplete_at_mention(text: &str) -> Option<usize> {
     let mut prev_char: Option<char> = None;
 
     for (i, c) in text.char_indices() {
-        if c == '@' {
-            // Check if this @ is at start or preceded by whitespace
-            if prev_char.is_none() || prev_char.is_some_and(|pc| pc.is_whitespace()) {
-                last_at = Some(i);
-            }
+        if c == '@' && prev_char.map_or(true, |pc| pc.is_whitespace()) {
+            last_at = Some(i);
         }
         prev_char = Some(c);
     }
 
-    // Check if the mention is incomplete (no space after the @path)
-    if let Some(at_pos) = last_at {
-        let after_at = &text[at_pos + 1..];
-        // If there's no space in the text after @, it's incomplete
-        if !after_at.contains(' ') {
-            return Some(at_pos);
-        }
-    }
-
-    None
+    // Return only if incomplete (no space after the @path)
+    last_at.filter(|&at_pos| !text[at_pos + 1..].contains(' '))
 }
 
 /// Extract the filter text from an @-mention at the given position.
@@ -67,14 +63,11 @@ fn apply_file_selection(current_input: &str, at_position: usize, path: &PathBuf)
 }
 
 /// Navigate dropdown selection (wrapping at bounds).
-fn navigate_dropdown(current_index: usize, item_count: usize, direction: i32) -> usize {
-    if item_count == 0 {
-        return 0;
-    }
-    if direction > 0 {
-        (current_index + 1) % item_count
-    } else {
-        current_index.checked_sub(1).unwrap_or(item_count.saturating_sub(1))
+fn navigate_dropdown(current_index: usize, item_count: usize, direction: NavigationDirection) -> usize {
+    match (item_count, direction) {
+        (0, _) => 0,
+        (n, NavigationDirection::Down) => (current_index + 1) % n,
+        (n, NavigationDirection::Up) => current_index.checked_sub(1).unwrap_or(n - 1),
     }
 }
 
@@ -89,7 +82,7 @@ fn parse_file_references(text: &str) -> Vec<PathBuf> {
     let mut prev_char: Option<char> = None;
 
     for c in text.chars() {
-        if c == '@' && (prev_char.is_none() || prev_char.is_some_and(|pc| pc.is_whitespace())) {
+        if c == '@' && prev_char.map_or(true, |pc| pc.is_whitespace()) {
             in_mention = true;
             current_path.clear();
         } else if in_mention {
@@ -285,12 +278,12 @@ pub fn AgentView(agent_id: String) -> Element {
                     Key::ArrowDown => {
                         e.prevent_default();
                         let mut state = dropdown_state.write();
-                        state.selected_index = navigate_dropdown(state.selected_index, item_count, 1);
+                        state.selected_index = navigate_dropdown(state.selected_index, item_count, NavigationDirection::Down);
                     }
                     Key::ArrowUp => {
                         e.prevent_default();
                         let mut state = dropdown_state.write();
-                        state.selected_index = navigate_dropdown(state.selected_index, item_count, -1);
+                        state.selected_index = navigate_dropdown(state.selected_index, item_count, NavigationDirection::Up);
                     }
                     Key::Enter | Key::Tab => {
                         e.prevent_default();

--- a/packages/aether-desktop/src/components/agent_view.rs
+++ b/packages/aether-desktop/src/components/agent_view.rs
@@ -30,14 +30,16 @@ fn find_incomplete_at_mention(text: &str) -> Option<usize> {
     // Find the last @ that starts a file mention
     // A mention is incomplete if it doesn't end with a space
     let mut last_at = None;
+    let mut prev_char: Option<char> = None;
 
     for (i, c) in text.char_indices() {
         if c == '@' {
             // Check if this @ is at start or preceded by whitespace
-            if i == 0 || text.chars().nth(i.saturating_sub(1)).map(|c| c.is_whitespace()).unwrap_or(true) {
+            if prev_char.is_none() || prev_char.is_some_and(|pc| pc.is_whitespace()) {
                 last_at = Some(i);
             }
         }
+        prev_char = Some(c);
     }
 
     // Check if the mention is incomplete (no space after the @path)
@@ -57,6 +59,25 @@ fn extract_at_filter(text: &str, at_pos: usize) -> String {
     text[at_pos + 1..].to_string()
 }
 
+/// Apply file selection to input: replace @partial with @full/path and return new input value.
+fn apply_file_selection(current_input: &str, at_position: usize, path: &PathBuf) -> String {
+    let before = &current_input[..at_position];
+    let path_str = path.to_string_lossy();
+    format!("{}@{} ", before, path_str)
+}
+
+/// Navigate dropdown selection (wrapping at bounds).
+fn navigate_dropdown(current_index: usize, item_count: usize, direction: i32) -> usize {
+    if item_count == 0 {
+        return 0;
+    }
+    if direction > 0 {
+        (current_index + 1) % item_count
+    } else {
+        current_index.checked_sub(1).unwrap_or(item_count.saturating_sub(1))
+    }
+}
+
 /// Parse file references from the input text.
 ///
 /// Returns a list of file paths that are @-mentioned in the text.
@@ -65,9 +86,10 @@ fn parse_file_references(text: &str) -> Vec<PathBuf> {
     let mut refs = Vec::new();
     let mut in_mention = false;
     let mut current_path = String::new();
+    let mut prev_char: Option<char> = None;
 
-    for (i, c) in text.char_indices() {
-        if c == '@' && (i == 0 || text.chars().nth(i.saturating_sub(1)).map(|ch| ch.is_whitespace()).unwrap_or(true)) {
+    for c in text.chars() {
+        if c == '@' && (prev_char.is_none() || prev_char.is_some_and(|pc| pc.is_whitespace())) {
             in_mention = true;
             current_path.clear();
         } else if in_mention {
@@ -81,6 +103,7 @@ fn parse_file_references(text: &str) -> Vec<PathBuf> {
                 current_path.push(c);
             }
         }
+        prev_char = Some(c);
     }
 
     // Handle mention at end of string
@@ -183,14 +206,8 @@ pub fn AgentView(agent_id: String) -> Element {
         move |path: PathBuf| {
             let state = dropdown_state.read().clone();
             if let DropdownMode::FilePicker { at_position } = state.mode {
-                // Replace @partial with @full/path
                 let current = input_val.read().clone();
-                let before = &current[..at_position];
-                let path_str = path.to_string_lossy();
-                let new_value = format!("{}@{} ", before, path_str);
-                input_val.set(new_value);
-
-                // Add to file references
+                input_val.set(apply_file_selection(&current, at_position, &path));
                 file_refs.write().push(FileReference::new(path));
             }
             dropdown_state.write().visible = false;
@@ -252,104 +269,61 @@ pub fn AgentView(agent_id: String) -> Element {
             let state = dropdown_state.read().clone();
 
             if state.visible {
-                match &state.mode {
-                    DropdownMode::SlashCommand => {
-                        // Slash command dropdown - handle navigation
-                        let filtered: Vec<&SlashCommand> = commands
-                            .iter()
-                            .filter(|cmd| {
-                                state.filter_text.is_empty()
-                                    || cmd
-                                        .name
-                                        .to_lowercase()
-                                        .contains(&state.filter_text.to_lowercase())
-                            })
-                            .collect();
+                // Get item count based on mode
+                let item_count = match &state.mode {
+                    DropdownMode::SlashCommand => commands
+                        .iter()
+                        .filter(|cmd| {
+                            state.filter_text.is_empty()
+                                || cmd.name.to_lowercase().contains(&state.filter_text.to_lowercase())
+                        })
+                        .count(),
+                    DropdownMode::FilePicker { .. } => file_results.read().len(),
+                };
 
-                        match e.key() {
-                            Key::ArrowDown => {
-                                e.prevent_default();
-                                let mut state = dropdown_state.write();
-                                if !filtered.is_empty() {
-                                    state.selected_index = (state.selected_index + 1) % filtered.len();
-                                }
-                            }
-                            Key::ArrowUp => {
-                                e.prevent_default();
-                                let mut state = dropdown_state.write();
-                                if !filtered.is_empty() {
-                                    state.selected_index = state
-                                        .selected_index
-                                        .checked_sub(1)
-                                        .unwrap_or(filtered.len().saturating_sub(1));
-                                }
-                            }
-                            Key::Enter => {
-                                e.prevent_default();
-                                if let Some(cmd) = filtered.get(state.selected_index) {
-                                    input_val.set(format!("/{} ", cmd.name));
-                                    dropdown_state.write().visible = false;
-                                }
-                            }
-                            Key::Escape => {
-                                e.prevent_default();
-                                dropdown_state.write().visible = false;
-                            }
-                            Key::Tab => {
-                                e.prevent_default();
-                                if let Some(cmd) = filtered.get(state.selected_index) {
-                                    input_val.set(format!("/{} ", cmd.name));
-                                    dropdown_state.write().visible = false;
-                                }
-                            }
-                            _ => {}
-                        }
+                match e.key() {
+                    Key::ArrowDown => {
+                        e.prevent_default();
+                        let mut state = dropdown_state.write();
+                        state.selected_index = navigate_dropdown(state.selected_index, item_count, 1);
                     }
-                    DropdownMode::FilePicker { at_position } => {
-                        // File picker dropdown - handle navigation
-                        let files = file_results.read();
-                        let file_count = files.len();
-
-                        match e.key() {
-                            Key::ArrowDown => {
-                                e.prevent_default();
-                                let mut state = dropdown_state.write();
-                                if file_count > 0 {
-                                    state.selected_index = (state.selected_index + 1) % file_count;
+                    Key::ArrowUp => {
+                        e.prevent_default();
+                        let mut state = dropdown_state.write();
+                        state.selected_index = navigate_dropdown(state.selected_index, item_count, -1);
+                    }
+                    Key::Enter | Key::Tab => {
+                        e.prevent_default();
+                        match &state.mode {
+                            DropdownMode::SlashCommand => {
+                                let filtered: Vec<_> = commands
+                                    .iter()
+                                    .filter(|cmd| {
+                                        state.filter_text.is_empty()
+                                            || cmd.name.to_lowercase().contains(&state.filter_text.to_lowercase())
+                                    })
+                                    .collect();
+                                if let Some(cmd) = filtered.get(state.selected_index) {
+                                    input_val.set(format!("/{} ", cmd.name));
+                                    dropdown_state.write().visible = false;
                                 }
                             }
-                            Key::ArrowUp => {
-                                e.prevent_default();
-                                let mut state = dropdown_state.write();
-                                if file_count > 0 {
-                                    state.selected_index = state
-                                        .selected_index
-                                        .checked_sub(1)
-                                        .unwrap_or(file_count.saturating_sub(1));
-                                }
-                            }
-                            Key::Enter | Key::Tab => {
-                                e.prevent_default();
+                            DropdownMode::FilePicker { at_position } => {
+                                let files = file_results.read();
                                 if let Some(path) = files.get(state.selected_index) {
-                                    // Replace @partial with @full/path
                                     let current = input_val.read().clone();
-                                    let before = &current[..*at_position];
-                                    let path_str = path.to_string_lossy();
-                                    let new_value = format!("{}@{} ", before, path_str);
-                                    input_val.set(new_value);
-
-                                    // Add to file references
+                                    input_val.set(apply_file_selection(&current, *at_position, path));
                                     file_refs.write().push(FileReference::new(path.clone()));
                                     dropdown_state.write().visible = false;
                                 }
                             }
-                            Key::Escape => {
-                                e.prevent_default();
-                                dropdown_state.write().visible = false;
-                            }
-                            _ => {}
                         }
                     }
+                    Key::Escape => {
+                        e.prevent_default();
+                        dropdown_state.write().visible = false;
+                    }
+                    _ => {}
                 }
             } else {
                 // Normal mode - send on Enter

--- a/packages/aether-desktop/src/components/agent_view.rs
+++ b/packages/aether-desktop/src/components/agent_view.rs
@@ -3,7 +3,7 @@
 //! Displays the chat interface for a single agent session.
 
 use dioxus::prelude::*;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
 use crate::file_walker::FileWalker;
 use crate::state::{now_iso, AgentStatus, DropdownMode, FileReference, Message, MessageKind, Role, SlashCommand};
@@ -56,7 +56,7 @@ fn extract_at_filter(text: &str, at_pos: usize) -> String {
 }
 
 /// Apply file selection to input: replace @partial with @full/path and return new input value.
-fn apply_file_selection(current_input: &str, at_position: usize, path: &PathBuf) -> String {
+fn apply_file_selection(current_input: &str, at_position: usize, path: &Path) -> String {
     let before = &current_input[..at_position];
     let path_str = path.to_string_lossy();
     format!("{}@{} ", before, path_str)
@@ -69,6 +69,11 @@ fn navigate_dropdown(current_index: usize, item_count: usize, direction: Navigat
         (n, NavigationDirection::Down) => (current_index + 1) % n,
         (n, NavigationDirection::Up) => current_index.checked_sub(1).unwrap_or(n - 1),
     }
+}
+
+/// Check if a command matches the filter text.
+fn command_matches_filter(cmd: &SlashCommand, filter: &str) -> bool {
+    filter.is_empty() || cmd.name.to_lowercase().contains(&filter.to_lowercase())
 }
 
 #[component]
@@ -230,10 +235,7 @@ pub fn AgentView(agent_id: String) -> Element {
                 let item_count = match &state.mode {
                     DropdownMode::SlashCommand => commands
                         .iter()
-                        .filter(|cmd| {
-                            state.filter_text.is_empty()
-                                || cmd.name.to_lowercase().contains(&state.filter_text.to_lowercase())
-                        })
+                        .filter(|cmd| command_matches_filter(cmd, &state.filter_text))
                         .count(),
                     DropdownMode::FilePicker { .. } => file_results.read().len(),
                 };
@@ -255,10 +257,7 @@ pub fn AgentView(agent_id: String) -> Element {
                             DropdownMode::SlashCommand => {
                                 let filtered: Vec<_> = commands
                                     .iter()
-                                    .filter(|cmd| {
-                                        state.filter_text.is_empty()
-                                            || cmd.name.to_lowercase().contains(&state.filter_text.to_lowercase())
-                                    })
+                                    .filter(|cmd| command_matches_filter(cmd, &state.filter_text))
                                     .collect();
                                 if let Some(cmd) = filtered.get(state.selected_index) {
                                     input_val.set(format!("/{} ", cmd.name));

--- a/packages/aether-desktop/src/components/agent_view.rs
+++ b/packages/aether-desktop/src/components/agent_view.rs
@@ -136,7 +136,7 @@ pub fn AgentView(agent_id: String) -> Element {
 
             // Send via handles with file references
             // For now, we send the content with @mentions; the agent will handle reading files
-            if let Err(e) = HANDLES.read().send_prompt_with_files(&agent_id_for_send, content, refs) {
+            if let Err(e) = HANDLES.read().send_prompt(&agent_id_for_send, content, refs) {
                 tracing::error!("Failed to send message: {}", e);
                 let mut list = AGENTS.write();
                 if let Some(agent) = list.iter_mut().find(|a| a.id == agent_id_for_send) {

--- a/packages/aether-desktop/src/components/agent_view.rs
+++ b/packages/aether-desktop/src/components/agent_view.rs
@@ -71,42 +71,6 @@ fn navigate_dropdown(current_index: usize, item_count: usize, direction: Navigat
     }
 }
 
-/// Parse file references from the input text.
-///
-/// Returns a list of file paths that are @-mentioned in the text.
-#[allow(dead_code)]
-fn parse_file_references(text: &str) -> Vec<PathBuf> {
-    let mut refs = Vec::new();
-    let mut in_mention = false;
-    let mut current_path = String::new();
-    let mut prev_char: Option<char> = None;
-
-    for c in text.chars() {
-        if c == '@' && prev_char.map_or(true, |pc| pc.is_whitespace()) {
-            in_mention = true;
-            current_path.clear();
-        } else if in_mention {
-            if c.is_whitespace() {
-                if !current_path.is_empty() {
-                    refs.push(PathBuf::from(&current_path));
-                }
-                in_mention = false;
-                current_path.clear();
-            } else {
-                current_path.push(c);
-            }
-        }
-        prev_char = Some(c);
-    }
-
-    // Handle mention at end of string
-    if in_mention && !current_path.is_empty() {
-        refs.push(PathBuf::from(&current_path));
-    }
-
-    refs
-}
-
 #[component]
 pub fn AgentView(agent_id: String) -> Element {
     let mut input_val = use_signal(String::new);

--- a/packages/aether-desktop/src/components/file_picker_dropdown.rs
+++ b/packages/aether-desktop/src/components/file_picker_dropdown.rs
@@ -1,0 +1,174 @@
+//! File picker dropdown component.
+//!
+//! Displays a filterable list of files when the user types "@".
+
+use dioxus::prelude::*;
+use std::path::PathBuf;
+
+/// Get a file icon based on extension
+fn get_file_icon(path: &PathBuf) -> &'static str {
+    let ext = path
+        .extension()
+        .and_then(|s| s.to_str())
+        .unwrap_or("")
+        .to_lowercase();
+
+    match ext.as_str() {
+        "rs" => "🦀",
+        "ts" | "tsx" => "📘",
+        "js" | "jsx" => "📒",
+        "py" => "🐍",
+        "go" => "🐹",
+        "java" => "☕",
+        "c" | "cpp" | "h" | "hpp" => "⚙️",
+        "json" => "📋",
+        "yaml" | "yml" => "📄",
+        "toml" => "⚙️",
+        "md" => "📝",
+        "html" => "🌐",
+        "css" | "scss" | "sass" => "🎨",
+        "sql" => "🗃️",
+        "sh" | "bash" | "zsh" => "💻",
+        "dockerfile" => "🐳",
+        "proto" => "📡",
+        _ => "📄",
+    }
+}
+
+/// Highlight matching parts of a path based on the filter query
+fn highlight_path(path: &str, filter: &str) -> Element {
+    if filter.is_empty() {
+        return rsx! { span { "{path}" } };
+    }
+
+    let path_lower = path.to_lowercase();
+    let filter_lower = filter.to_lowercase();
+
+    if let Some(start) = path_lower.find(&filter_lower) {
+        let before = &path[..start];
+        let matched = &path[start..start + filter.len()];
+        let after = &path[start + filter.len()..];
+
+        rsx! {
+            span { "{before}" }
+            span { class: "text-blue-400 font-semibold", "{matched}" }
+            span { "{after}" }
+        }
+    } else {
+        rsx! { span { "{path}" } }
+    }
+}
+
+#[component]
+pub fn FilePickerDropdown(
+    /// List of file paths to display
+    files: Vec<PathBuf>,
+    /// Current filter text (text after "@")
+    filter: String,
+    /// Currently selected index in filtered list
+    selected_index: usize,
+    /// Called when a file is selected
+    on_select: EventHandler<PathBuf>,
+) -> Element {
+    if files.is_empty() {
+        return rsx! {
+            div {
+                class: "absolute bottom-full left-0 right-0 mb-2 bg-[#1a1d23] border border-[#373b47] rounded-xl shadow-2xl p-4 text-gray-400 text-sm z-50",
+                if filter.is_empty() {
+                    "Type to search for files..."
+                } else {
+                    "No matching files"
+                }
+            }
+        };
+    }
+
+    // Clamp selected index to valid range
+    let selected_index = selected_index.min(files.len().saturating_sub(1));
+
+    rsx! {
+        div {
+            class: "absolute bottom-full left-0 right-0 mb-2 bg-[#1a1d23] border border-[#373b47] rounded-xl shadow-2xl overflow-hidden max-h-80 overflow-y-auto z-50",
+
+            // Header
+            div {
+                class: "px-4 py-3 border-b border-[#2d313a] bg-[#252830] text-xs text-gray-500 font-semibold uppercase tracking-wide flex items-center gap-2",
+                span { "📁" }
+                span { "File Picker" }
+                span { class: "text-gray-600 font-normal ml-auto", "@ to search files" }
+            }
+
+            // File list
+            for (index, file_path) in files.iter().enumerate() {
+                FileItem {
+                    key: "{file_path:?}",
+                    path: file_path.clone(),
+                    filter: filter.clone(),
+                    is_selected: index == selected_index,
+                    on_click: {
+                        let path = file_path.clone();
+                        move |_| on_select.call(path.clone())
+                    },
+                }
+            }
+        }
+    }
+}
+
+#[component]
+fn FileItem(
+    path: PathBuf,
+    filter: String,
+    is_selected: bool,
+    on_click: EventHandler<()>,
+) -> Element {
+    let class_str = if is_selected {
+        "px-4 py-2 cursor-pointer transition-colors bg-blue-600 border-l-2 border-blue-400"
+    } else {
+        "px-4 py-2 cursor-pointer transition-colors hover:bg-[#252830] border-l-2 border-transparent"
+    };
+
+    let icon = get_file_icon(&path);
+    let path_str = path.to_string_lossy().to_string();
+
+    // Split into directory and filename for display
+    let (dir, filename) = if let Some(parent) = path.parent() {
+        let parent_str = parent.to_string_lossy();
+        let filename = path
+            .file_name()
+            .map(|s| s.to_string_lossy().to_string())
+            .unwrap_or_default();
+        if parent_str.is_empty() {
+            (None, filename)
+        } else {
+            (Some(format!("{}/", parent_str)), filename)
+        }
+    } else {
+        (None, path_str.clone())
+    };
+
+    rsx! {
+        div {
+            class: "{class_str}",
+            onclick: move |_| on_click.call(()),
+
+            div {
+                class: "flex items-center gap-2",
+                span { class: "text-base", "{icon}" }
+                div {
+                    class: "flex items-baseline gap-1 min-w-0 overflow-hidden",
+                    if let Some(dir_path) = &dir {
+                        span {
+                            class: "text-gray-500 text-xs font-mono truncate",
+                            "{dir_path}"
+                        }
+                    }
+                    span {
+                        class: "text-white text-sm font-mono font-medium truncate",
+                        {highlight_path(&filename, &filter)}
+                    }
+                }
+            }
+        }
+    }
+}

--- a/packages/aether-desktop/src/components/mod.rs
+++ b/packages/aether-desktop/src/components/mod.rs
@@ -1,5 +1,6 @@
 pub mod agent_view;
 pub mod command_dropdown;
+pub mod file_picker_dropdown;
 pub mod message_bubble;
 pub mod new_agent_modal;
 pub mod settings_editor;

--- a/packages/aether-desktop/src/file_walker.rs
+++ b/packages/aether-desktop/src/file_walker.rs
@@ -1,0 +1,295 @@
+//! Async file walker with fuzzy matching for the @-mention file picker.
+//!
+//! Walks a directory tree and provides fuzzy matching for file paths,
+//! respecting .gitignore patterns and filtering out hidden files.
+
+use std::path::{Path, PathBuf};
+
+/// Maximum number of files to return in search results
+const MAX_RESULTS: usize = 50;
+
+/// Maximum depth to walk when searching
+const MAX_DEPTH: usize = 10;
+
+/// File extensions commonly found in code projects
+const CODE_EXTENSIONS: &[&str] = &[
+    "rs", "ts", "tsx", "js", "jsx", "py", "go", "java", "c", "cpp", "h", "hpp", "cs", "rb", "php",
+    "swift", "kt", "scala", "clj", "ex", "exs", "erl", "hs", "ml", "fs", "vue", "svelte", "html",
+    "css", "scss", "sass", "less", "json", "yaml", "yml", "toml", "xml", "md", "txt", "sql", "sh",
+    "bash", "zsh", "fish", "ps1", "bat", "cmd", "dockerfile", "makefile", "cmake", "gradle", "sbt",
+    "cargo", "proto", "graphql", "prisma",
+];
+
+/// Directories to always ignore when walking
+const IGNORE_DIRS: &[&str] = &[
+    "node_modules",
+    "target",
+    ".git",
+    ".svn",
+    ".hg",
+    "dist",
+    "build",
+    "out",
+    ".next",
+    ".nuxt",
+    "__pycache__",
+    ".pytest_cache",
+    ".mypy_cache",
+    "venv",
+    ".venv",
+    "env",
+    ".env",
+    "vendor",
+    ".cargo",
+    ".rustup",
+    "coverage",
+    ".coverage",
+    ".nyc_output",
+    ".idea",
+    ".vscode",
+];
+
+/// A file walker that searches for files in a directory tree.
+pub struct FileWalker {
+    root_dir: PathBuf,
+}
+
+impl FileWalker {
+    /// Create a new FileWalker rooted at the given directory.
+    pub fn new(root_dir: impl Into<PathBuf>) -> Self {
+        Self {
+            root_dir: root_dir.into(),
+        }
+    }
+
+    /// Search for files matching the given query.
+    ///
+    /// Returns a list of file paths relative to the root directory,
+    /// sorted by match quality.
+    pub async fn search(&self, query: &str) -> Vec<PathBuf> {
+        let query = query.to_lowercase();
+
+        // Walk the directory and collect matching files
+        let mut matches: Vec<(PathBuf, i32)> = Vec::new();
+        self.walk_dir(&self.root_dir, &query, 0, &mut matches).await;
+
+        // Sort by score (higher is better)
+        matches.sort_by(|a, b| b.1.cmp(&a.1));
+
+        // Return just the paths, limited to MAX_RESULTS
+        matches
+            .into_iter()
+            .take(MAX_RESULTS)
+            .map(|(path, _)| path)
+            .collect()
+    }
+
+    /// Recursively walk a directory and collect matching files.
+    async fn walk_dir(
+        &self,
+        dir: &Path,
+        query: &str,
+        depth: usize,
+        matches: &mut Vec<(PathBuf, i32)>,
+    ) {
+        if depth > MAX_DEPTH {
+            return;
+        }
+
+        // Early exit if we have enough matches
+        if matches.len() >= MAX_RESULTS * 2 {
+            return;
+        }
+
+        let entries = match std::fs::read_dir(dir) {
+            Ok(entries) => entries,
+            Err(_) => return,
+        };
+
+        for entry in entries.flatten() {
+            let path = entry.path();
+            let file_name = match path.file_name().and_then(|s| s.to_str()) {
+                Some(name) => name,
+                None => continue,
+            };
+
+            // Skip hidden files and directories
+            if file_name.starts_with('.') {
+                continue;
+            }
+
+            if path.is_dir() {
+                // Skip ignored directories
+                if IGNORE_DIRS.contains(&file_name.to_lowercase().as_str()) {
+                    continue;
+                }
+
+                // Recurse into subdirectories
+                Box::pin(self.walk_dir(&path, query, depth + 1, matches)).await;
+            } else if path.is_file() {
+                // Get relative path
+                let relative_path = match path.strip_prefix(&self.root_dir) {
+                    Ok(p) => p.to_path_buf(),
+                    Err(_) => continue,
+                };
+
+                // Calculate match score
+                if let Some(score) = calculate_match_score(&relative_path, query) {
+                    matches.push((relative_path, score));
+                }
+            }
+        }
+    }
+}
+
+/// Calculate a match score for a file path against a query.
+///
+/// Returns None if the file doesn't match at all.
+/// Higher scores indicate better matches.
+fn calculate_match_score(path: &Path, query: &str) -> Option<i32> {
+    if query.is_empty() {
+        // When query is empty, prefer files at root level and common code files
+        let path_str = path.to_string_lossy().to_lowercase();
+        let ext = path.extension().and_then(|s| s.to_str()).unwrap_or("");
+
+        // Score based on depth (fewer components = higher score)
+        let depth = path.components().count();
+        let mut score = 100 - (depth as i32 * 10);
+
+        // Boost common code files
+        if CODE_EXTENSIONS.contains(&ext.to_lowercase().as_str()) {
+            score += 20;
+        }
+
+        // Boost common entry point files
+        if path_str.contains("main")
+            || path_str.contains("index")
+            || path_str.contains("lib")
+            || path_str.contains("mod")
+        {
+            score += 10;
+        }
+
+        return Some(score);
+    }
+
+    let path_str = path.to_string_lossy().to_lowercase();
+    let file_name = path
+        .file_name()
+        .and_then(|s| s.to_str())
+        .unwrap_or("")
+        .to_lowercase();
+
+    // Check if query appears anywhere in the path
+    if !path_str.contains(query) && !fuzzy_match(&file_name, query) {
+        return None;
+    }
+
+    let mut score = 0;
+
+    // Exact filename match
+    if file_name == query {
+        score += 100;
+    }
+    // Filename starts with query
+    else if file_name.starts_with(query) {
+        score += 80;
+    }
+    // Filename contains query
+    else if file_name.contains(query) {
+        score += 60;
+    }
+    // Path contains query
+    else if path_str.contains(query) {
+        score += 40;
+    }
+    // Fuzzy match
+    else {
+        score += 20;
+    }
+
+    // Prefer shorter paths
+    let depth = path.components().count();
+    score -= (depth as i32 - 1) * 5;
+
+    // Boost code files
+    let ext = path.extension().and_then(|s| s.to_str()).unwrap_or("");
+    if CODE_EXTENSIONS.contains(&ext.to_lowercase().as_str()) {
+        score += 10;
+    }
+
+    Some(score)
+}
+
+/// Simple fuzzy matching - checks if all characters in query appear in order in target.
+fn fuzzy_match(target: &str, query: &str) -> bool {
+    let mut query_chars = query.chars().peekable();
+
+    for c in target.chars() {
+        if query_chars.peek() == Some(&c) {
+            query_chars.next();
+        }
+        if query_chars.peek().is_none() {
+            return true;
+        }
+    }
+
+    query_chars.peek().is_none()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_fuzzy_match() {
+        assert!(fuzzy_match("main.rs", "mn"));
+        assert!(fuzzy_match("main.rs", "main"));
+        assert!(fuzzy_match("file_walker.rs", "fw"));
+        assert!(fuzzy_match("file_walker.rs", "walker"));
+        assert!(!fuzzy_match("main.rs", "xyz"));
+        assert!(!fuzzy_match("main.rs", "nim")); // wrong order
+    }
+
+    #[test]
+    fn test_calculate_match_score_exact() {
+        let path = PathBuf::from("main.rs");
+        let score = calculate_match_score(&path, "main.rs");
+        assert!(score.is_some());
+        assert!(score.unwrap() >= 100); // Exact match should score high
+    }
+
+    #[test]
+    fn test_calculate_match_score_prefix() {
+        let path = PathBuf::from("main.rs");
+        let score = calculate_match_score(&path, "main");
+        assert!(score.is_some());
+        assert!(score.unwrap() >= 80); // Prefix match should score well
+    }
+
+    #[test]
+    fn test_calculate_match_score_no_match() {
+        let path = PathBuf::from("main.rs");
+        let score = calculate_match_score(&path, "xyz");
+        assert!(score.is_none());
+    }
+
+    #[test]
+    fn test_calculate_match_score_empty_query() {
+        let path = PathBuf::from("src/main.rs");
+        let score = calculate_match_score(&path, "");
+        assert!(score.is_some()); // Empty query matches everything
+    }
+
+    #[test]
+    fn test_calculate_match_score_deep_path() {
+        let shallow = PathBuf::from("main.rs");
+        let deep = PathBuf::from("src/deep/nested/main.rs");
+
+        let shallow_score = calculate_match_score(&shallow, "main").unwrap();
+        let deep_score = calculate_match_score(&deep, "main").unwrap();
+
+        // Shallow paths should score higher
+        assert!(shallow_score > deep_score);
+    }
+}

--- a/packages/aether-desktop/src/main.rs
+++ b/packages/aether-desktop/src/main.rs
@@ -10,6 +10,7 @@ mod acp_agent;
 mod acp_client;
 mod components;
 mod error;
+mod file_walker;
 mod markdown;
 mod settings;
 mod state;

--- a/packages/aether-desktop/src/state.rs
+++ b/packages/aether-desktop/src/state.rs
@@ -241,23 +241,15 @@ impl AgentHandles {
         self.handles.insert(handle.id.clone(), handle);
     }
 
-    /// Send a prompt to an agent by its UUID.
-    pub fn send_prompt(&self, agent_id: &str, message: String) -> Result<(), SendError> {
-        match self.handles.get(agent_id) {
-            Some(handle) => handle.send_prompt(message),
-            None => Err(SendError::NotConnected),
-        }
-    }
-
-    /// Send a prompt with embedded file references to an agent by its UUID.
-    pub fn send_prompt_with_files(
+    /// Send a prompt to an agent by its UUID, optionally with embedded file references.
+    pub fn send_prompt(
         &self,
         agent_id: &str,
         message: String,
         files: Vec<FileReference>,
     ) -> Result<(), SendError> {
         match self.handles.get(agent_id) {
-            Some(handle) => handle.send_prompt_with_files(message, files),
+            Some(handle) => handle.send_prompt(message, files),
             None => Err(SendError::NotConnected),
         }
     }

--- a/packages/aether-desktop/src/state.rs
+++ b/packages/aether-desktop/src/state.rs
@@ -6,6 +6,7 @@
 use crate::acp_agent::AgentHandle;
 use agent_client_protocol::{AvailableCommand, AvailableCommandInput, SessionId, ToolCall};
 use std::collections::HashMap;
+use std::path::PathBuf;
 
 #[derive(Clone, PartialEq, Debug)]
 pub enum AgentStatus {
@@ -103,6 +104,37 @@ impl From<AvailableCommand> for SlashCommand {
             input_hint,
         }
     }
+}
+
+/// A reference to a file that should be embedded in the prompt.
+#[derive(Clone, PartialEq, Debug)]
+pub struct FileReference {
+    /// The file path relative to cwd
+    pub path: PathBuf,
+    /// Display name (usually just the filename)
+    pub display_name: String,
+}
+
+impl FileReference {
+    pub fn new(path: PathBuf) -> Self {
+        let display_name = path
+            .file_name()
+            .and_then(|s| s.to_str())
+            .unwrap_or("unknown")
+            .to_string();
+        Self { path, display_name }
+    }
+}
+
+/// Mode for the input dropdown (slash commands vs file picker)
+#[derive(Clone, PartialEq, Debug, Default)]
+pub enum DropdownMode {
+    #[default]
+    SlashCommand,
+    FilePicker {
+        /// Position of the @ character that triggered the file picker
+        at_position: usize,
+    },
 }
 
 /// Represents an active agent session in the UI.
@@ -213,6 +245,19 @@ impl AgentHandles {
     pub fn send_prompt(&self, agent_id: &str, message: String) -> Result<(), SendError> {
         match self.handles.get(agent_id) {
             Some(handle) => handle.send_prompt(message),
+            None => Err(SendError::NotConnected),
+        }
+    }
+
+    /// Send a prompt with embedded file references to an agent by its UUID.
+    pub fn send_prompt_with_files(
+        &self,
+        agent_id: &str,
+        message: String,
+        files: Vec<FileReference>,
+    ) -> Result<(), SendError> {
+        match self.handles.get(agent_id) {
+            Some(handle) => handle.send_prompt_with_files(message, files),
             None => Err(SendError::NotConnected),
         }
     }

--- a/packages/aether-desktop/src/views/home.rs
+++ b/packages/aether-desktop/src/views/home.rs
@@ -339,7 +339,7 @@ async fn create_agent(
 
     // Send initial prompt via handle (before storing)
     handle
-        .send_prompt(initial_message.clone())
+        .send_prompt(initial_message.clone(), Vec::new())
         .map_err(|e| ActorError::Session(e.to_string()))?;
 
     // Create UI state


### PR DESCRIPTION
Implement file picker functionality that allows users to reference files
using @-mentions in the chat input. When typing @, a fuzzy file picker
dropdown appears, and selected files are embedded as resources in the
ACP prompt.

Changes:
- Add FileReference type and DropdownMode to state.rs
- Create FileWalker for async directory traversal with fuzzy matching
- Create FilePickerDropdown component with file icons and highlighting
- Update AgentView to detect @ patterns and show file picker
- Update acp_agent.rs to send embedded resources with prompts
- Support keyboard navigation (Arrow keys, Tab, Enter, Escape)