### PR TITLE
Add support for context window compaction

### DIFF
--- a/packages/aether/README.md
+++ b/packages/aether/README.md
@@ -33,7 +33,7 @@ aether = "0.1"
 
 ### Minimal Agent (No Tools)
 
-```rust
+```rust,no_run
 use aether::{
     agent::{AgentMessage, UserMessage, agent},
     llm::openrouter::OpenRouterProvider,
@@ -88,6 +88,9 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             Some(Cancelled { .. }) => {
                 eprintln!("Agent cancelled");
                 break;
+            }
+            Some(ContextCompacted { .. }) => {
+                // Context was compacted to save space
             }
             None => break,
         }
@@ -192,6 +195,9 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             Some(Cancelled { .. }) => {
                 eprintln!("Agent cancelled");
                 break;
+            }
+            Some(ContextCompacted { .. }) => {
+                // Context was compacted to save space
             }
             None => break,
         }

--- a/packages/aether/examples/basic_agent.rs
+++ b/packages/aether/examples/basic_agent.rs
@@ -68,6 +68,16 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                 println!("⚠️  Processing cancelled");
                 break;
             }
+            Some(ContextCompacted {
+                messages_removed,
+                strategy,
+                ..
+            }) => {
+                println!(
+                    "📦 Context compacted: {} messages removed using {}",
+                    messages_removed, strategy
+                );
+            }
             None => {
                 println!("Channel closed");
                 break;

--- a/packages/aether/examples/basic_agent.rs
+++ b/packages/aether/examples/basic_agent.rs
@@ -69,14 +69,9 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                 break;
             }
             Some(ContextCompacted {
-                messages_removed,
-                strategy,
-                ..
+                messages_removed, ..
             }) => {
-                println!(
-                    "📦 Context compacted: {} messages removed using {}",
-                    messages_removed, strategy
-                );
+                println!("📦 Context compacted: {} messages removed", messages_removed);
             }
             None => {
                 println!("Channel closed");

--- a/packages/aether/examples/mcp_agent.rs
+++ b/packages/aether/examples/mcp_agent.rs
@@ -76,6 +76,16 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                 println!("⚠️  Cancelled");
                 break;
             }
+            Some(ContextCompacted {
+                messages_removed,
+                strategy,
+                ..
+            }) => {
+                println!(
+                    "📦 Context compacted: {} messages removed using {}",
+                    messages_removed, strategy
+                );
+            }
             None => {
                 println!("Channel closed");
                 break;

--- a/packages/aether/examples/mcp_agent.rs
+++ b/packages/aether/examples/mcp_agent.rs
@@ -77,14 +77,9 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                 break;
             }
             Some(ContextCompacted {
-                messages_removed,
-                strategy,
-                ..
+                messages_removed, ..
             }) => {
-                println!(
-                    "📦 Context compacted: {} messages removed using {}",
-                    messages_removed, strategy
-                );
+                println!("📦 Context compacted: {} messages removed", messages_removed);
             }
             None => {
                 println!("Channel closed");

--- a/packages/aether/examples/middleware_hooks.rs
+++ b/packages/aether/examples/middleware_hooks.rs
@@ -41,11 +41,9 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                     }
                 }
                 AgentEvent::ContextCompacted {
-                    messages_removed,
-                    strategy,
-                    ..
+                    messages_removed, ..
                 } => {
-                    println!("📦 Context compacted: {messages_removed} messages using {strategy}");
+                    println!("📦 Context compacted: {messages_removed} messages");
                 }
             }
             MiddlewareAction::Allow

--- a/packages/aether/examples/middleware_hooks.rs
+++ b/packages/aether/examples/middleware_hooks.rs
@@ -40,6 +40,13 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                         return MiddlewareAction::Block;
                     }
                 }
+                AgentEvent::ContextCompacted {
+                    messages_removed,
+                    strategy,
+                    ..
+                } => {
+                    println!("📦 Context compacted: {messages_removed} messages using {strategy}");
+                }
             }
             MiddlewareAction::Allow
         })

--- a/packages/aether/src/agent/agent_builder.rs
+++ b/packages/aether/src/agent/agent_builder.rs
@@ -37,7 +37,7 @@ impl<T: StreamingModelProvider + 'static> AgentBuilder<T> {
             mcp_tx: None,
             channel_capacity: 1000,
             tool_timeout: Duration::from_secs(60 * 10),
-            compaction_config: None,
+            compaction_config: Some(CompactionConfig::default()),
         }
     }
 

--- a/packages/aether/src/agent/agent_builder.rs
+++ b/packages/aether/src/agent/agent_builder.rs
@@ -94,51 +94,28 @@ impl<T: StreamingModelProvider + 'static> AgentBuilder<T> {
         self
     }
 
-    /// Configure context compaction with full control over settings.
+    /// Configure context compaction settings.
     ///
-    /// When enabled, the agent will automatically compact the conversation context
-    /// when token usage exceeds the configured threshold, helping prevent context
-    /// window overflow during long-running tasks.
+    /// By default, agents automatically compact context when token usage exceeds
+    /// 85% of the context window, preventing overflow during long-running tasks.
     ///
-    /// # Example
+    /// # Examples
     /// ```ignore
-    /// agent(llm)
-    ///     .compaction(CompactionConfig::with_threshold(0.85)
-    ///         .keep_recent_tool_results(5)
-    ///         .auto_compact(true))
+    /// // Custom threshold
+    /// agent(llm).compaction(CompactionConfig::with_threshold(0.9))
+    ///
+    /// // Disable compaction entirely
+    /// agent(llm).compaction(CompactionConfig::disabled())
+    ///
+    /// // Full customization
+    /// agent(llm).compaction(
+    ///     CompactionConfig::with_threshold(0.85)
+    ///         .keep_recent_tool_results(3)
+    ///         .min_messages(20)
+    /// )
     /// ```
     pub fn compaction(mut self, config: CompactionConfig) -> Self {
         self.compaction_config = Some(config);
-        self
-    }
-
-    /// Override the compaction threshold.
-    ///
-    /// Compaction is enabled by default at 85% of the context window.
-    /// Use this method to set a custom threshold (0.0-1.0).
-    ///
-    /// # Example
-    /// ```ignore
-    /// agent(llm)
-    ///     .auto_compact(0.9) // Compact at 90% instead of 85%
-    /// ```
-    pub fn auto_compact(mut self, threshold: f64) -> Self {
-        self.compaction_config = Some(CompactionConfig::with_threshold(threshold));
-        self
-    }
-
-    /// Disable automatic context compaction.
-    ///
-    /// By default, agents automatically compact context when usage exceeds 85%.
-    /// Use this method to disable that behavior entirely.
-    ///
-    /// # Example
-    /// ```ignore
-    /// agent(llm)
-    ///     .no_compaction()
-    /// ```
-    pub fn no_compaction(mut self) -> Self {
-        self.compaction_config = Some(CompactionConfig::disabled());
         self
     }
 

--- a/packages/aether/src/agent/agent_builder.rs
+++ b/packages/aether/src/agent/agent_builder.rs
@@ -1,10 +1,12 @@
 use crate::agent::Result;
 use crate::agent::middleware::{AgentEvent, Middleware, MiddlewareAction};
 use crate::agent::{Agent, AgentMessage, UserMessage};
+use crate::context::CompactionConfig;
 use crate::llm::{ChatMessage, Context, StreamingModelProvider, ToolDefinition};
 use crate::mcp::run_mcp_task::McpCommand;
 use crate::types::IsoString;
 use std::future::Future;
+use std::sync::Arc;
 use std::time::Duration;
 use tokio::sync::mpsc::{self, Receiver, Sender};
 use tokio::task::JoinHandle;
@@ -22,6 +24,7 @@ pub struct AgentBuilder<T: StreamingModelProvider> {
     mcp_tx: Option<Sender<McpCommand>>,
     channel_capacity: usize,
     tool_timeout: Duration,
+    compaction_config: Option<CompactionConfig>,
 }
 
 impl<T: StreamingModelProvider + 'static> AgentBuilder<T> {
@@ -34,6 +37,7 @@ impl<T: StreamingModelProvider + 'static> AgentBuilder<T> {
             mcp_tx: None,
             channel_capacity: 1000,
             tool_timeout: Duration::from_secs(60 * 10),
+            compaction_config: None,
         }
     }
 
@@ -90,6 +94,41 @@ impl<T: StreamingModelProvider + 'static> AgentBuilder<T> {
         self
     }
 
+    /// Configure context compaction with full control over settings.
+    ///
+    /// When enabled, the agent will automatically compact the conversation context
+    /// when token usage exceeds the configured threshold, helping prevent context
+    /// window overflow during long-running tasks.
+    ///
+    /// # Example
+    /// ```ignore
+    /// agent(llm)
+    ///     .compaction(CompactionConfig::with_threshold(0.85)
+    ///         .keep_recent_tool_results(5)
+    ///         .auto_compact(true))
+    /// ```
+    pub fn compaction(mut self, config: CompactionConfig) -> Self {
+        self.compaction_config = Some(config);
+        self
+    }
+
+    /// Enable automatic context compaction with default settings.
+    ///
+    /// This is a convenience method that enables compaction at the specified
+    /// threshold (0.0-1.0 representing percentage of context limit).
+    ///
+    /// Default threshold: 0.85 (85% of context window)
+    ///
+    /// # Example
+    /// ```ignore
+    /// agent(llm)
+    ///     .auto_compact(0.85)
+    /// ```
+    pub fn auto_compact(mut self, threshold: f64) -> Self {
+        self.compaction_config = Some(CompactionConfig::with_threshold(threshold));
+        self
+    }
+
     pub async fn spawn(self) -> Result<(Sender<UserMessage>, Receiver<AgentMessage>, AgentHandle)> {
         let mut messages = Vec::new();
         if let Some(content) = self.system_prompt {
@@ -108,13 +147,14 @@ impl<T: StreamingModelProvider + 'static> AgentBuilder<T> {
         let context = Context::new(messages, self.tool_definitions);
 
         let agent = Agent::new(
-            self.llm,
+            Arc::new(self.llm),
             context,
             self.mcp_tx,
             user_message_rx,
             agent_message_tx,
             self.middleware,
             self.tool_timeout,
+            self.compaction_config,
         );
 
         let agent_handle = tokio::spawn(agent.run());

--- a/packages/aether/src/agent/agent_builder.rs
+++ b/packages/aether/src/agent/agent_builder.rs
@@ -112,20 +112,33 @@ impl<T: StreamingModelProvider + 'static> AgentBuilder<T> {
         self
     }
 
-    /// Enable automatic context compaction with default settings.
+    /// Override the compaction threshold.
     ///
-    /// This is a convenience method that enables compaction at the specified
-    /// threshold (0.0-1.0 representing percentage of context limit).
-    ///
-    /// Default threshold: 0.85 (85% of context window)
+    /// Compaction is enabled by default at 85% of the context window.
+    /// Use this method to set a custom threshold (0.0-1.0).
     ///
     /// # Example
     /// ```ignore
     /// agent(llm)
-    ///     .auto_compact(0.85)
+    ///     .auto_compact(0.9) // Compact at 90% instead of 85%
     /// ```
     pub fn auto_compact(mut self, threshold: f64) -> Self {
         self.compaction_config = Some(CompactionConfig::with_threshold(threshold));
+        self
+    }
+
+    /// Disable automatic context compaction.
+    ///
+    /// By default, agents automatically compact context when usage exceeds 85%.
+    /// Use this method to disable that behavior entirely.
+    ///
+    /// # Example
+    /// ```ignore
+    /// agent(llm)
+    ///     .no_compaction()
+    /// ```
+    pub fn no_compaction(mut self) -> Self {
+        self.compaction_config = Some(CompactionConfig::disabled());
         self
     }
 

--- a/packages/aether/src/agent/core.rs
+++ b/packages/aether/src/agent/core.rs
@@ -1,6 +1,6 @@
 use crate::agent::middleware::{AgentEvent, Middleware, MiddlewareAction};
 use crate::agent::{AgentMessage, UserMessage};
-use crate::context::{CompactionConfig, HybridCompactor, TokenTracker};
+use crate::context::{CompactionConfig, Compactor, TokenTracker};
 use crate::llm::{
     ChatMessage, StreamingModelProvider, ToolCallError, ToolCallRequest, ToolCallResult,
 };
@@ -378,18 +378,11 @@ impl<T: StreamingModelProvider + 'static> Agent<T> {
         }
     }
 
-    /// Perform context compaction if pending and conditions are met.
-    /// This uses a hybrid approach: first tries light-touch tool result clearing,
-    /// then falls back to full LLM summarization if still over threshold.
+    /// Perform context compaction if pending.
     async fn maybe_compact_context(&mut self) {
         if !self.pending_compaction {
             return;
         }
-
-        let config = match &self.compaction_config {
-            Some(config) => config.clone(),
-            None => return,
-        };
 
         self.pending_compaction = false;
 
@@ -399,19 +392,13 @@ impl<T: StreamingModelProvider + 'static> Agent<T> {
             self.token_tracker.usage_ratio() * 100.0
         );
 
-        let compactor = HybridCompactor::new(self.llm.clone(), config.keep_recent_tool_results);
+        let compactor = Compactor::new(self.llm.clone());
 
-        // Create a closure to check if we're still over threshold
-        // Note: We capture the threshold and use it with the tracker
-        let threshold = config.threshold;
-        let still_over = || self.token_tracker.exceeds_threshold(threshold);
-
-        match compactor.compact(&mut self.context, still_over).await {
+        match compactor.compact(&mut self.context).await {
             Ok(result) => {
                 tracing::info!(
-                    "Context compacted: {} messages removed using {} strategy",
-                    result.messages_removed,
-                    result.strategy
+                    "Context compacted: {} messages removed",
+                    result.messages_removed
                 );
 
                 // Emit middleware event
@@ -420,7 +407,6 @@ impl<T: StreamingModelProvider + 'static> Agent<T> {
                     .emit(AgentEvent::ContextCompacted {
                         summary_length: result.summary.len(),
                         messages_removed: result.messages_removed,
-                        strategy: result.strategy.to_string(),
                     })
                     .await;
 
@@ -430,7 +416,6 @@ impl<T: StreamingModelProvider + 'static> Agent<T> {
                     .send(AgentMessage::ContextCompacted {
                         summary: result.summary,
                         messages_removed: result.messages_removed,
-                        strategy: result.strategy.to_string(),
                     })
                     .await;
             }

--- a/packages/aether/src/agent/core.rs
+++ b/packages/aether/src/agent/core.rs
@@ -1,6 +1,6 @@
 use crate::agent::middleware::{AgentEvent, Middleware, MiddlewareAction};
 use crate::agent::{AgentMessage, UserMessage};
-use crate::context::TokenTracker;
+use crate::context::{CompactionConfig, HybridCompactor, TokenTracker};
 use crate::llm::{
     ChatMessage, StreamingModelProvider, ToolCallError, ToolCallRequest, ToolCallResult,
 };
@@ -10,6 +10,7 @@ use crate::types::IsoString;
 use futures::Stream;
 use std::collections::HashMap;
 use std::pin::Pin;
+use std::sync::Arc;
 use std::time::Duration;
 use tokio::sync::mpsc;
 use tokio_stream::StreamExt;
@@ -27,7 +28,7 @@ enum StreamEvent {
 type EventStream = Pin<Box<dyn Stream<Item = StreamEvent> + Send>>;
 
 pub struct Agent<T: StreamingModelProvider> {
-    llm: T,
+    llm: Arc<T>,
     context: Context,
     mcp_command_tx: Option<mpsc::Sender<McpCommand>>,
     agent_message_tx: mpsc::Sender<AgentMessage>,
@@ -35,17 +36,21 @@ pub struct Agent<T: StreamingModelProvider> {
     middleware: Middleware,
     tool_timeout: Duration,
     token_tracker: TokenTracker,
+    compaction_config: Option<CompactionConfig>,
+    /// Flag indicating compaction is needed before the next LLM call
+    pending_compaction: bool,
 }
 
 impl<T: StreamingModelProvider + 'static> Agent<T> {
     pub fn new(
-        llm: T,
+        llm: Arc<T>,
         context: Context,
         mcp_command_tx: Option<mpsc::Sender<McpCommand>>,
         user_message_rx: mpsc::Receiver<UserMessage>,
         agent_message_tx: mpsc::Sender<AgentMessage>,
         middleware: Middleware,
         tool_timeout: Duration,
+        compaction_config: Option<CompactionConfig>,
     ) -> Self {
         let mut streams: StreamMap<String, EventStream> = StreamMap::new();
         streams.insert(
@@ -62,6 +67,8 @@ impl<T: StreamingModelProvider + 'static> Agent<T> {
             middleware,
             tool_timeout,
             token_tracker: TokenTracker::new(200_000), // Default to Claude's 200k context limit
+            compaction_config,
+            pending_compaction: false,
         }
     }
 
@@ -120,7 +127,7 @@ impl<T: StreamingModelProvider + 'static> Agent<T> {
                 state = IterationState::new();
 
                 if should_continue {
-                    self.start_llm_stream();
+                    self.start_llm_stream().await;
                 } else if let Err(e) = self.agent_message_tx.send(AgentMessage::Done).await {
                     tracing::warn!("Failed to send Done message: {:?}", e);
                 }
@@ -166,10 +173,13 @@ impl<T: StreamingModelProvider + 'static> Agent<T> {
             timestamp: IsoString::now(),
         });
 
-        self.start_llm_stream();
+        self.start_llm_stream().await;
     }
 
-    fn start_llm_stream(&mut self) {
+    async fn start_llm_stream(&mut self) {
+        // Perform compaction if needed before starting a new LLM call
+        self.maybe_compact_context().await;
+
         self.streams.remove("llm");
 
         let llm_stream = self
@@ -352,6 +362,83 @@ impl<T: StreamingModelProvider + 'static> Agent<T> {
             self.token_tracker.usage_ratio() * 100.0,
             self.token_tracker.tokens_remaining()
         );
+
+        // Check if compaction is needed
+        if let Some(ref config) = self.compaction_config {
+            if config.auto_compact
+                && self.token_tracker.should_compact(config.threshold)
+                && self.context.message_count() >= config.min_messages_for_compaction
+            {
+                tracing::info!(
+                    "Context compaction needed - usage at {:.1}% of limit",
+                    self.token_tracker.usage_ratio() * 100.0
+                );
+                self.pending_compaction = true;
+            }
+        }
+    }
+
+    /// Perform context compaction if pending and conditions are met.
+    /// This uses a hybrid approach: first tries light-touch tool result clearing,
+    /// then falls back to full LLM summarization if still over threshold.
+    async fn maybe_compact_context(&mut self) {
+        if !self.pending_compaction {
+            return;
+        }
+
+        let config = match &self.compaction_config {
+            Some(config) => config.clone(),
+            None => return,
+        };
+
+        self.pending_compaction = false;
+
+        tracing::info!(
+            "Starting context compaction - {} messages, {:.1}% of context limit",
+            self.context.message_count(),
+            self.token_tracker.usage_ratio() * 100.0
+        );
+
+        let compactor = HybridCompactor::new(self.llm.clone(), config.keep_recent_tool_results);
+
+        // Create a closure to check if we're still over threshold
+        // Note: We capture the threshold and use it with the tracker
+        let threshold = config.threshold;
+        let still_over = || self.token_tracker.exceeds_threshold(threshold);
+
+        match compactor.compact(&mut self.context, still_over).await {
+            Ok(result) => {
+                tracing::info!(
+                    "Context compacted: {} messages removed using {} strategy",
+                    result.messages_removed,
+                    result.strategy
+                );
+
+                // Emit middleware event
+                let _ = self
+                    .middleware
+                    .emit(AgentEvent::ContextCompacted {
+                        summary_length: result.summary.len(),
+                        messages_removed: result.messages_removed,
+                        strategy: result.strategy.to_string(),
+                    })
+                    .await;
+
+                // Send message to consumers
+                let _ = self
+                    .agent_message_tx
+                    .send(AgentMessage::ContextCompacted {
+                        summary: result.summary,
+                        messages_removed: result.messages_removed,
+                        strategy: result.strategy.to_string(),
+                    })
+                    .await;
+            }
+            Err(e) => {
+                tracing::warn!("Context compaction failed: {}", e);
+                // Don't block the agent - just log and continue
+            }
+        }
     }
 
     async fn on_tool_execution_event(

--- a/packages/aether/src/agent/messages.rs
+++ b/packages/aether/src/agent/messages.rs
@@ -47,8 +47,6 @@ pub enum AgentMessage {
         summary: String,
         /// Number of messages that were removed
         messages_removed: usize,
-        /// The compaction strategy used
-        strategy: String,
     },
 
     Done,

--- a/packages/aether/src/agent/messages.rs
+++ b/packages/aether/src/agent/messages.rs
@@ -41,6 +41,16 @@ pub enum AgentMessage {
         message: String,
     },
 
+    /// Context was compacted to reduce token usage
+    ContextCompacted {
+        /// The summary that replaced the compacted messages
+        summary: String,
+        /// Number of messages that were removed
+        messages_removed: usize,
+        /// The compaction strategy used
+        strategy: String,
+    },
+
     Done,
 }
 

--- a/packages/aether/src/agent/middleware.rs
+++ b/packages/aether/src/agent/middleware.rs
@@ -25,6 +25,16 @@ pub enum AgentEvent {
         name: String,
         arguments: String,
     },
+
+    /// Context was compacted to reduce token usage
+    ContextCompacted {
+        /// Length of the generated summary in characters
+        summary_length: usize,
+        /// Number of messages that were removed/compacted
+        messages_removed: usize,
+        /// The compaction strategy that was used (e.g., "tool_result_clearing", "llm_summarization")
+        strategy: String,
+    },
 }
 
 type HandlerFn = Box<dyn Fn(AgentEvent) -> BoxFuture<'static, MiddlewareAction> + Send + Sync>;

--- a/packages/aether/src/agent/middleware.rs
+++ b/packages/aether/src/agent/middleware.rs
@@ -32,8 +32,6 @@ pub enum AgentEvent {
         summary_length: usize,
         /// Number of messages that were removed/compacted
         messages_removed: usize,
-        /// The compaction strategy that was used (e.g., "tool_result_clearing", "llm_summarization")
-        strategy: String,
     },
 }
 

--- a/packages/aether/src/context/compaction.rs
+++ b/packages/aether/src/context/compaction.rs
@@ -1,0 +1,573 @@
+use std::fmt;
+use std::sync::Arc;
+
+use tokio_stream::StreamExt;
+
+use crate::llm::{ChatMessage, Context, LlmResponse, StreamingModelProvider};
+use crate::types::IsoString;
+
+/// Result of a compaction operation
+#[derive(Debug, Clone)]
+pub struct CompactionResult {
+    /// The summary text that replaced the compacted messages
+    pub summary: String,
+    /// Number of messages that were removed/compacted
+    pub messages_removed: usize,
+    /// The type of compaction that was performed
+    pub strategy: CompactionStrategy,
+}
+
+/// Types of compaction strategies
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum CompactionStrategy {
+    /// Removed old tool results to reduce context size
+    ToolResultClearing,
+    /// Generated an LLM summary of the conversation
+    LlmSummarization,
+    /// A combination of strategies was used
+    Hybrid,
+}
+
+impl fmt::Display for CompactionStrategy {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            CompactionStrategy::ToolResultClearing => write!(f, "tool_result_clearing"),
+            CompactionStrategy::LlmSummarization => write!(f, "llm_summarization"),
+            CompactionStrategy::Hybrid => write!(f, "hybrid"),
+        }
+    }
+}
+
+/// Errors that can occur during compaction
+#[derive(Debug, Clone)]
+pub enum CompactionError {
+    /// The LLM failed to generate a summary
+    SummarizationFailed(String),
+    /// No messages to compact
+    NothingToCompact,
+    /// Compaction would not reduce context size enough
+    InsufficientReduction,
+}
+
+impl fmt::Display for CompactionError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            CompactionError::SummarizationFailed(msg) => {
+                write!(f, "summarization failed: {}", msg)
+            }
+            CompactionError::NothingToCompact => write!(f, "nothing to compact"),
+            CompactionError::InsufficientReduction => {
+                write!(f, "compaction would not reduce context size sufficiently")
+            }
+        }
+    }
+}
+
+impl std::error::Error for CompactionError {}
+
+/// Configuration for context compaction
+#[derive(Debug, Clone)]
+pub struct CompactionConfig {
+    /// Threshold (0.0-1.0) at which to trigger compaction
+    pub threshold: f64,
+    /// Number of recent tool results to keep during tool result clearing
+    pub keep_recent_tool_results: usize,
+    /// Whether to automatically compact when threshold is exceeded
+    pub auto_compact: bool,
+    /// Minimum number of messages before compaction is considered
+    pub min_messages_for_compaction: usize,
+}
+
+impl Default for CompactionConfig {
+    fn default() -> Self {
+        Self {
+            threshold: super::DEFAULT_COMPACTION_THRESHOLD,
+            keep_recent_tool_results: 5,
+            auto_compact: true,
+            min_messages_for_compaction: 10,
+        }
+    }
+}
+
+impl CompactionConfig {
+    /// Create a new compaction config with the given threshold
+    pub fn with_threshold(threshold: f64) -> Self {
+        Self {
+            threshold,
+            ..Default::default()
+        }
+    }
+
+    /// Set the number of recent tool results to keep
+    pub fn keep_recent_tool_results(mut self, count: usize) -> Self {
+        self.keep_recent_tool_results = count;
+        self
+    }
+
+    /// Enable or disable automatic compaction
+    pub fn auto_compact(mut self, enabled: bool) -> Self {
+        self.auto_compact = enabled;
+        self
+    }
+
+    /// Set minimum messages required before compaction
+    pub fn min_messages(mut self, count: usize) -> Self {
+        self.min_messages_for_compaction = count;
+        self
+    }
+}
+
+/// A compactor that clears old tool results to reduce context size.
+/// This is a lightweight compaction strategy that preserves conversation structure.
+#[derive(Debug, Clone)]
+pub struct ToolResultClearer {
+    keep_recent: usize,
+}
+
+impl ToolResultClearer {
+    pub fn new(keep_recent: usize) -> Self {
+        Self { keep_recent }
+    }
+
+    /// Perform tool result clearing on the context.
+    /// Returns the number of messages removed, or None if nothing was removed.
+    pub fn compact(&self, context: &mut Context) -> Option<CompactionResult> {
+        let removed = context.clear_old_tool_results(self.keep_recent);
+        if removed > 0 {
+            Some(CompactionResult {
+                summary: format!("Cleared {} old tool results", removed),
+                messages_removed: removed,
+                strategy: CompactionStrategy::ToolResultClearing,
+            })
+        } else {
+            None
+        }
+    }
+}
+
+impl Default for ToolResultClearer {
+    fn default() -> Self {
+        Self::new(5)
+    }
+}
+
+/// The structured summarization prompt following Factory.ai's anchored iterative approach.
+/// This prompt instructs the LLM to create a structured summary with dedicated sections.
+const SUMMARIZATION_PROMPT: &str = r#"You are a context compaction assistant. Your task is to create a structured summary of the conversation history that preserves critical information while significantly reducing token usage.
+
+Create a summary with the following sections:
+
+## Session Intent
+What is the user trying to accomplish? State the main goal or objective.
+
+## Accomplishments
+What has been completed so far? List the key achievements in bullet points.
+
+## File Modifications
+List any files that were created, modified, or deleted:
+- filename: brief description of changes
+
+## Key Decisions
+What important decisions were made during the conversation?
+- Decision: reasoning
+
+## Current State
+What is currently in progress or was just completed?
+
+## Next Steps
+What remains to be done? What was the user's last request?
+
+## Constraints
+Any specific requirements or constraints the user mentioned?
+
+---
+
+Be concise but preserve all information needed to continue the task effectively. Do not include pleasantries or meta-commentary about the summary itself."#;
+
+/// A compactor that uses an LLM to generate structured summaries.
+/// This provides the highest quality compaction but incurs API cost and latency.
+pub struct LlmCompactor<T: StreamingModelProvider> {
+    llm: Arc<T>,
+}
+
+impl<T: StreamingModelProvider> LlmCompactor<T> {
+    pub fn new(llm: Arc<T>) -> Self {
+        Self { llm }
+    }
+
+    /// Generate a structured summary of the conversation history.
+    pub async fn compact(&self, context: &Context) -> Result<CompactionResult, CompactionError> {
+        let messages_to_summarize = context.messages_for_summary();
+        if messages_to_summarize.is_empty() {
+            return Err(CompactionError::NothingToCompact);
+        }
+
+        let messages_count = messages_to_summarize.len();
+
+        // Format the conversation history for summarization
+        let conversation_text = format_messages_for_summary(&messages_to_summarize);
+
+        // Create a context for the summarization request
+        let summary_context = Context::new(
+            vec![
+                ChatMessage::System {
+                    content: SUMMARIZATION_PROMPT.to_string(),
+                    timestamp: IsoString::now(),
+                },
+                ChatMessage::User {
+                    content: format!(
+                        "Please create a structured summary of the following conversation:\n\n{}",
+                        conversation_text
+                    ),
+                    timestamp: IsoString::now(),
+                },
+            ],
+            vec![], // No tools for summarization
+        );
+
+        // Stream the response and collect the summary
+        let mut stream = self.llm.stream_response(&summary_context);
+        let mut summary = String::new();
+
+        while let Some(result) = stream.next().await {
+            match result {
+                Ok(LlmResponse::Text { chunk }) => {
+                    summary.push_str(&chunk);
+                }
+                Ok(LlmResponse::Done) => break,
+                Ok(LlmResponse::Error { message }) => {
+                    return Err(CompactionError::SummarizationFailed(message));
+                }
+                Err(e) => {
+                    return Err(CompactionError::SummarizationFailed(e.to_string()));
+                }
+                _ => {} // Ignore other response types
+            }
+        }
+
+        if summary.is_empty() {
+            return Err(CompactionError::SummarizationFailed(
+                "LLM returned empty summary".to_string(),
+            ));
+        }
+
+        Ok(CompactionResult {
+            summary,
+            messages_removed: messages_count,
+            strategy: CompactionStrategy::LlmSummarization,
+        })
+    }
+}
+
+/// Format messages for the summarization prompt
+fn format_messages_for_summary(messages: &[&ChatMessage]) -> String {
+    let mut output = String::new();
+
+    for msg in messages {
+        match msg {
+            ChatMessage::User { content, .. } => {
+                output.push_str(&format!("USER: {}\n\n", content));
+            }
+            ChatMessage::Assistant {
+                content,
+                tool_calls,
+                ..
+            } => {
+                output.push_str(&format!("ASSISTANT: {}\n", content));
+                if !tool_calls.is_empty() {
+                    output.push_str("Tool calls:\n");
+                    for tc in tool_calls {
+                        output.push_str(&format!("  - {} ({})\n", tc.name, tc.id));
+                    }
+                }
+                output.push('\n');
+            }
+            ChatMessage::ToolCallResult(Ok(result)) => {
+                output.push_str(&format!(
+                    "TOOL RESULT [{}]: {}\n\n",
+                    result.name,
+                    truncate_result(&result.result, 500)
+                ));
+            }
+            ChatMessage::ToolCallResult(Err(error)) => {
+                output.push_str(&format!(
+                    "TOOL ERROR [{}]: {}\n\n",
+                    error.name, error.error
+                ));
+            }
+            ChatMessage::Summary { content, .. } => {
+                output.push_str(&format!("PREVIOUS SUMMARY:\n{}\n\n", content));
+            }
+            ChatMessage::Error { message, .. } => {
+                output.push_str(&format!("ERROR: {}\n\n", message));
+            }
+            ChatMessage::System { .. } => {
+                // System messages are excluded from summarization
+            }
+        }
+    }
+
+    output
+}
+
+/// Truncate long tool results to avoid overwhelming the summarization
+fn truncate_result(result: &str, max_len: usize) -> String {
+    if result.len() <= max_len {
+        result.to_string()
+    } else {
+        format!("{}... [truncated, {} chars total]", &result[..max_len], result.len())
+    }
+}
+
+/// A hybrid compactor that first tries tool result clearing,
+/// then falls back to LLM summarization if still over threshold.
+pub struct HybridCompactor<T: StreamingModelProvider> {
+    tool_clearer: ToolResultClearer,
+    llm_compactor: LlmCompactor<T>,
+}
+
+impl<T: StreamingModelProvider> HybridCompactor<T> {
+    pub fn new(llm: Arc<T>, keep_recent_tool_results: usize) -> Self {
+        Self {
+            tool_clearer: ToolResultClearer::new(keep_recent_tool_results),
+            llm_compactor: LlmCompactor::new(llm),
+        }
+    }
+
+    /// Try tool result clearing first, then LLM summarization if needed.
+    /// The `still_over_threshold` function is called after tool clearing to check
+    /// if further compaction is needed.
+    pub async fn compact<F>(
+        &self,
+        context: &mut Context,
+        still_over_threshold: F,
+    ) -> Result<CompactionResult, CompactionError>
+    where
+        F: Fn() -> bool,
+    {
+        // Phase 1: Try tool result clearing
+        let tool_result = self.tool_clearer.compact(context);
+        let did_tool_clearing = tool_result.is_some();
+
+        if let Some(result) = tool_result {
+            if !still_over_threshold() {
+                // Tool clearing was sufficient
+                return Ok(result);
+            }
+        }
+
+        // Phase 2: Need full LLM summarization
+        let llm_result = self.llm_compactor.compact(context).await?;
+
+        // Apply the summary to the context
+        let compacted = context.compact(&llm_result.summary);
+
+        Ok(CompactionResult {
+            summary: llm_result.summary,
+            messages_removed: compacted,
+            strategy: if did_tool_clearing {
+                CompactionStrategy::Hybrid
+            } else {
+                CompactionStrategy::LlmSummarization
+            },
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::llm::{ChatMessage, ToolCallResult};
+    use crate::types::IsoString;
+
+    fn create_context_with_tool_results(count: usize) -> Context {
+        let mut messages = vec![
+            ChatMessage::System {
+                content: "System prompt".to_string(),
+                timestamp: IsoString::now(),
+            },
+            ChatMessage::User {
+                content: "Hello".to_string(),
+                timestamp: IsoString::now(),
+            },
+        ];
+
+        for i in 0..count {
+            messages.push(ChatMessage::ToolCallResult(Ok(ToolCallResult {
+                id: format!("tool_{}", i),
+                name: format!("tool_{}", i),
+                arguments: "{}".to_string(),
+                result: format!("Result {}", i),
+            })));
+        }
+
+        Context::new(messages, vec![])
+    }
+
+    #[test]
+    fn test_tool_result_clearer_removes_old_results() {
+        let mut ctx = create_context_with_tool_results(10);
+        let clearer = ToolResultClearer::new(3);
+
+        let result = clearer.compact(&mut ctx);
+
+        assert!(result.is_some());
+        let result = result.unwrap();
+        assert_eq!(result.messages_removed, 7);
+        assert_eq!(result.strategy, CompactionStrategy::ToolResultClearing);
+
+        // Should have 2 (system + user) + 3 (kept tool results) = 5 messages
+        assert_eq!(ctx.message_count(), 5);
+    }
+
+    #[test]
+    fn test_tool_result_clearer_nothing_to_remove() {
+        let mut ctx = create_context_with_tool_results(2);
+        let clearer = ToolResultClearer::new(5);
+
+        let result = clearer.compact(&mut ctx);
+
+        assert!(result.is_none());
+        assert_eq!(ctx.message_count(), 4); // 2 + 2 tool results
+    }
+
+    #[test]
+    fn test_compaction_config_default() {
+        let config = CompactionConfig::default();
+        assert!((config.threshold - 0.85).abs() < 0.001);
+        assert_eq!(config.keep_recent_tool_results, 5);
+        assert!(config.auto_compact);
+        assert_eq!(config.min_messages_for_compaction, 10);
+    }
+
+    #[test]
+    fn test_compaction_config_builder() {
+        let config = CompactionConfig::with_threshold(0.9)
+            .keep_recent_tool_results(3)
+            .auto_compact(false)
+            .min_messages(20);
+
+        assert!((config.threshold - 0.9).abs() < 0.001);
+        assert_eq!(config.keep_recent_tool_results, 3);
+        assert!(!config.auto_compact);
+        assert_eq!(config.min_messages_for_compaction, 20);
+    }
+
+    #[test]
+    fn test_format_messages_for_summary() {
+        let messages = vec![
+            ChatMessage::User {
+                content: "Hello, can you help me?".to_string(),
+                timestamp: IsoString::now(),
+            },
+            ChatMessage::Assistant {
+                content: "Of course!".to_string(),
+                timestamp: IsoString::now(),
+                tool_calls: vec![],
+            },
+        ];
+
+        let refs: Vec<&ChatMessage> = messages.iter().collect();
+        let formatted = format_messages_for_summary(&refs);
+
+        assert!(formatted.contains("USER: Hello, can you help me?"));
+        assert!(formatted.contains("ASSISTANT: Of course!"));
+    }
+
+    #[test]
+    fn test_truncate_result() {
+        let short = "short result";
+        assert_eq!(truncate_result(short, 100), short);
+
+        let long = "a".repeat(1000);
+        let truncated = truncate_result(&long, 100);
+        assert!(truncated.len() < long.len());
+        assert!(truncated.contains("[truncated"));
+        assert!(truncated.contains("1000 chars total"));
+    }
+
+    #[tokio::test]
+    async fn test_llm_compactor_generates_summary() {
+        use crate::testing::FakeLlmProvider;
+
+        let summary_response = vec![
+            LlmResponse::start("msg-1"),
+            LlmResponse::text("## Session Intent\nTest the compaction feature"),
+            LlmResponse::Done,
+        ];
+
+        let fake_llm = Arc::new(FakeLlmProvider::with_single_response(summary_response));
+        let compactor = LlmCompactor::new(fake_llm);
+
+        let context = Context::new(
+            vec![
+                ChatMessage::System {
+                    content: "System".to_string(),
+                    timestamp: IsoString::now(),
+                },
+                ChatMessage::User {
+                    content: "Test message".to_string(),
+                    timestamp: IsoString::now(),
+                },
+            ],
+            vec![],
+        );
+
+        let result = compactor.compact(&context).await;
+        assert!(result.is_ok());
+
+        let result = result.unwrap();
+        assert!(result.summary.contains("Session Intent"));
+        assert_eq!(result.messages_removed, 1); // Only user message (system excluded)
+        assert_eq!(result.strategy, CompactionStrategy::LlmSummarization);
+    }
+
+    #[tokio::test]
+    async fn test_llm_compactor_handles_error() {
+        use crate::testing::FakeLlmProvider;
+
+        let error_response = vec![LlmResponse::Error {
+            message: "API error".to_string(),
+        }];
+
+        let fake_llm = Arc::new(FakeLlmProvider::with_single_response(error_response));
+        let compactor = LlmCompactor::new(fake_llm);
+
+        let context = Context::new(
+            vec![
+                ChatMessage::System {
+                    content: "System".to_string(),
+                    timestamp: IsoString::now(),
+                },
+                ChatMessage::User {
+                    content: "Test".to_string(),
+                    timestamp: IsoString::now(),
+                },
+            ],
+            vec![],
+        );
+
+        let result = compactor.compact(&context).await;
+        assert!(matches!(result, Err(CompactionError::SummarizationFailed(_))));
+    }
+
+    #[tokio::test]
+    async fn test_llm_compactor_empty_context() {
+        use crate::testing::FakeLlmProvider;
+
+        let fake_llm = Arc::new(FakeLlmProvider::with_single_response(vec![]));
+        let compactor = LlmCompactor::new(fake_llm);
+
+        // Context with only system message
+        let context = Context::new(
+            vec![ChatMessage::System {
+                content: "System".to_string(),
+                timestamp: IsoString::now(),
+            }],
+            vec![],
+        );
+
+        let result = compactor.compact(&context).await;
+        assert!(matches!(result, Err(CompactionError::NothingToCompact)));
+    }
+}

--- a/packages/aether/src/context/compaction.rs
+++ b/packages/aether/src/context/compaction.rs
@@ -13,29 +13,6 @@ pub struct CompactionResult {
     pub summary: String,
     /// Number of messages that were removed/compacted
     pub messages_removed: usize,
-    /// The type of compaction that was performed
-    pub strategy: CompactionStrategy,
-}
-
-/// Types of compaction strategies
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum CompactionStrategy {
-    /// Removed old tool results to reduce context size
-    ToolResultClearing,
-    /// Generated an LLM summary of the conversation
-    LlmSummarization,
-    /// A combination of strategies was used
-    Hybrid,
-}
-
-impl fmt::Display for CompactionStrategy {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        match self {
-            CompactionStrategy::ToolResultClearing => write!(f, "tool_result_clearing"),
-            CompactionStrategy::LlmSummarization => write!(f, "llm_summarization"),
-            CompactionStrategy::Hybrid => write!(f, "hybrid"),
-        }
-    }
 }
 
 /// Errors that can occur during compaction
@@ -45,8 +22,6 @@ pub enum CompactionError {
     SummarizationFailed(String),
     /// No messages to compact
     NothingToCompact,
-    /// Compaction would not reduce context size enough
-    InsufficientReduction,
 }
 
 impl fmt::Display for CompactionError {
@@ -56,9 +31,6 @@ impl fmt::Display for CompactionError {
                 write!(f, "summarization failed: {}", msg)
             }
             CompactionError::NothingToCompact => write!(f, "nothing to compact"),
-            CompactionError::InsufficientReduction => {
-                write!(f, "compaction would not reduce context size sufficiently")
-            }
         }
     }
 }
@@ -70,8 +42,6 @@ impl std::error::Error for CompactionError {}
 pub struct CompactionConfig {
     /// Threshold (0.0-1.0) at which to trigger compaction
     pub threshold: f64,
-    /// Number of recent tool results to keep during tool result clearing
-    pub keep_recent_tool_results: usize,
     /// Whether to automatically compact when threshold is exceeded
     pub auto_compact: bool,
     /// Minimum number of messages before compaction is considered
@@ -82,7 +52,6 @@ impl Default for CompactionConfig {
     fn default() -> Self {
         Self {
             threshold: super::DEFAULT_COMPACTION_THRESHOLD,
-            keep_recent_tool_results: 5,
             auto_compact: true,
             min_messages_for_compaction: 10,
         }
@@ -98,18 +67,6 @@ impl CompactionConfig {
         }
     }
 
-    /// Set the number of recent tool results to keep
-    pub fn keep_recent_tool_results(mut self, count: usize) -> Self {
-        self.keep_recent_tool_results = count;
-        self
-    }
-
-    /// Enable or disable automatic compaction
-    pub fn auto_compact(mut self, enabled: bool) -> Self {
-        self.auto_compact = enabled;
-        self
-    }
-
     /// Set minimum messages required before compaction
     pub fn min_messages(mut self, count: usize) -> Self {
         self.min_messages_for_compaction = count;
@@ -117,7 +74,6 @@ impl CompactionConfig {
     }
 
     /// Create a configuration with compaction disabled.
-    /// Useful for explicitly opting out of the default auto-compaction.
     pub fn disabled() -> Self {
         Self {
             auto_compact: false,
@@ -126,42 +82,7 @@ impl CompactionConfig {
     }
 }
 
-/// A compactor that clears old tool results to reduce context size.
-/// This is a lightweight compaction strategy that preserves conversation structure.
-#[derive(Debug, Clone)]
-pub struct ToolResultClearer {
-    keep_recent: usize,
-}
-
-impl ToolResultClearer {
-    pub fn new(keep_recent: usize) -> Self {
-        Self { keep_recent }
-    }
-
-    /// Perform tool result clearing on the context.
-    /// Returns the number of messages removed, or None if nothing was removed.
-    pub fn compact(&self, context: &mut Context) -> Option<CompactionResult> {
-        let removed = context.clear_old_tool_results(self.keep_recent);
-        if removed > 0 {
-            Some(CompactionResult {
-                summary: format!("Cleared {} old tool results", removed),
-                messages_removed: removed,
-                strategy: CompactionStrategy::ToolResultClearing,
-            })
-        } else {
-            None
-        }
-    }
-}
-
-impl Default for ToolResultClearer {
-    fn default() -> Self {
-        Self::new(5)
-    }
-}
-
-/// The structured summarization prompt following Factory.ai's anchored iterative approach.
-/// This prompt instructs the LLM to create a structured summary with dedicated sections.
+/// The structured summarization prompt.
 const SUMMARIZATION_PROMPT: &str = r#"You are a context compaction assistant. Your task is to create a structured summary of the conversation history that preserves critical information while significantly reducing token usage.
 
 Create a summary with the following sections:
@@ -193,25 +114,22 @@ Any specific requirements or constraints the user mentioned?
 
 Be concise but preserve all information needed to continue the task effectively. Do not include pleasantries or meta-commentary about the summary itself."#;
 
-/// A compactor that uses an LLM to generate structured summaries.
-/// This provides the highest quality compaction but incurs API cost and latency.
-pub struct LlmCompactor<T: StreamingModelProvider> {
+/// Compacts context by generating an LLM summary
+pub struct Compactor<T: StreamingModelProvider> {
     llm: Arc<T>,
 }
 
-impl<T: StreamingModelProvider> LlmCompactor<T> {
+impl<T: StreamingModelProvider> Compactor<T> {
     pub fn new(llm: Arc<T>) -> Self {
         Self { llm }
     }
 
-    /// Generate a structured summary of the conversation history.
-    pub async fn compact(&self, context: &Context) -> Result<CompactionResult, CompactionError> {
+    /// Generate a structured summary of the conversation and apply it to the context.
+    pub async fn compact(&self, context: &mut Context) -> Result<CompactionResult, CompactionError> {
         let messages_to_summarize = context.messages_for_summary();
         if messages_to_summarize.is_empty() {
             return Err(CompactionError::NothingToCompact);
         }
-
-        let messages_count = messages_to_summarize.len();
 
         // Format the conversation history for summarization
         let conversation_text = format_messages_for_summary(&messages_to_summarize);
@@ -260,10 +178,12 @@ impl<T: StreamingModelProvider> LlmCompactor<T> {
             ));
         }
 
+        // Apply the summary to the context
+        let messages_removed = context.compact(&summary);
+
         Ok(CompactionResult {
             summary,
-            messages_removed: messages_count,
-            strategy: CompactionStrategy::LlmSummarization,
+            messages_removed,
         })
     }
 }
@@ -341,137 +261,26 @@ fn truncate_result(result: &str, max_len: usize) -> String {
     )
 }
 
-/// A hybrid compactor that first tries tool result clearing,
-/// then falls back to LLM summarization if still over threshold.
-pub struct HybridCompactor<T: StreamingModelProvider> {
-    tool_clearer: ToolResultClearer,
-    llm_compactor: LlmCompactor<T>,
-}
-
-impl<T: StreamingModelProvider> HybridCompactor<T> {
-    pub fn new(llm: Arc<T>, keep_recent_tool_results: usize) -> Self {
-        Self {
-            tool_clearer: ToolResultClearer::new(keep_recent_tool_results),
-            llm_compactor: LlmCompactor::new(llm),
-        }
-    }
-
-    /// Try tool result clearing first, then LLM summarization if needed.
-    /// The `still_over_threshold` function is called after tool clearing to check
-    /// if further compaction is needed.
-    pub async fn compact<F>(
-        &self,
-        context: &mut Context,
-        still_over_threshold: F,
-    ) -> Result<CompactionResult, CompactionError>
-    where
-        F: Fn() -> bool,
-    {
-        // Phase 1: Try tool result clearing
-        let tool_result = self.tool_clearer.compact(context);
-        let did_tool_clearing = tool_result.is_some();
-
-        if let Some(result) = tool_result {
-            if !still_over_threshold() {
-                // Tool clearing was sufficient
-                return Ok(result);
-            }
-        }
-
-        // Phase 2: Need full LLM summarization
-        let llm_result = self.llm_compactor.compact(context).await?;
-
-        // Apply the summary to the context
-        let compacted = context.compact(&llm_result.summary);
-
-        Ok(CompactionResult {
-            summary: llm_result.summary,
-            messages_removed: compacted,
-            strategy: if did_tool_clearing {
-                CompactionStrategy::Hybrid
-            } else {
-                CompactionStrategy::LlmSummarization
-            },
-        })
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::llm::{ChatMessage, ToolCallResult};
+    use crate::llm::ChatMessage;
     use crate::types::IsoString;
-
-    fn create_context_with_tool_results(count: usize) -> Context {
-        let mut messages = vec![
-            ChatMessage::System {
-                content: "System prompt".to_string(),
-                timestamp: IsoString::now(),
-            },
-            ChatMessage::User {
-                content: "Hello".to_string(),
-                timestamp: IsoString::now(),
-            },
-        ];
-
-        for i in 0..count {
-            messages.push(ChatMessage::ToolCallResult(Ok(ToolCallResult {
-                id: format!("tool_{}", i),
-                name: format!("tool_{}", i),
-                arguments: "{}".to_string(),
-                result: format!("Result {}", i),
-            })));
-        }
-
-        Context::new(messages, vec![])
-    }
-
-    #[test]
-    fn test_tool_result_clearer_removes_old_results() {
-        let mut ctx = create_context_with_tool_results(10);
-        let clearer = ToolResultClearer::new(3);
-
-        let result = clearer.compact(&mut ctx);
-
-        assert!(result.is_some());
-        let result = result.unwrap();
-        assert_eq!(result.messages_removed, 7);
-        assert_eq!(result.strategy, CompactionStrategy::ToolResultClearing);
-
-        // Should have 2 (system + user) + 3 (kept tool results) = 5 messages
-        assert_eq!(ctx.message_count(), 5);
-    }
-
-    #[test]
-    fn test_tool_result_clearer_nothing_to_remove() {
-        let mut ctx = create_context_with_tool_results(2);
-        let clearer = ToolResultClearer::new(5);
-
-        let result = clearer.compact(&mut ctx);
-
-        assert!(result.is_none());
-        assert_eq!(ctx.message_count(), 4); // 2 + 2 tool results
-    }
 
     #[test]
     fn test_compaction_config_default() {
         let config = CompactionConfig::default();
         assert!((config.threshold - 0.85).abs() < 0.001);
-        assert_eq!(config.keep_recent_tool_results, 5);
         assert!(config.auto_compact);
         assert_eq!(config.min_messages_for_compaction, 10);
     }
 
     #[test]
-    fn test_compaction_config_builder() {
-        let config = CompactionConfig::with_threshold(0.9)
-            .keep_recent_tool_results(3)
-            .auto_compact(false)
-            .min_messages(20);
+    fn test_compaction_config_with_threshold() {
+        let config = CompactionConfig::with_threshold(0.9).min_messages(20);
 
         assert!((config.threshold - 0.9).abs() < 0.001);
-        assert_eq!(config.keep_recent_tool_results, 3);
-        assert!(!config.auto_compact);
+        assert!(config.auto_compact);
         assert_eq!(config.min_messages_for_compaction, 20);
     }
 
@@ -479,9 +288,7 @@ mod tests {
     fn test_compaction_config_disabled() {
         let config = CompactionConfig::disabled();
         assert!(!config.auto_compact);
-        // Other fields should be default
         assert!((config.threshold - 0.85).abs() < 0.001);
-        assert_eq!(config.keep_recent_tool_results, 5);
     }
 
     #[test]
@@ -537,7 +344,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_llm_compactor_generates_summary() {
+    async fn test_compactor_generates_summary() {
         use crate::testing::FakeLlmProvider;
 
         let summary_response = vec![
@@ -547,9 +354,9 @@ mod tests {
         ];
 
         let fake_llm = Arc::new(FakeLlmProvider::with_single_response(summary_response));
-        let compactor = LlmCompactor::new(fake_llm);
+        let compactor = Compactor::new(fake_llm);
 
-        let context = Context::new(
+        let mut context = Context::new(
             vec![
                 ChatMessage::System {
                     content: "System".to_string(),
@@ -563,17 +370,16 @@ mod tests {
             vec![],
         );
 
-        let result = compactor.compact(&context).await;
+        let result = compactor.compact(&mut context).await;
         assert!(result.is_ok());
 
         let result = result.unwrap();
         assert!(result.summary.contains("Session Intent"));
         assert_eq!(result.messages_removed, 1); // Only user message (system excluded)
-        assert_eq!(result.strategy, CompactionStrategy::LlmSummarization);
     }
 
     #[tokio::test]
-    async fn test_llm_compactor_handles_error() {
+    async fn test_compactor_handles_error() {
         use crate::testing::FakeLlmProvider;
 
         let error_response = vec![LlmResponse::Error {
@@ -581,9 +387,9 @@ mod tests {
         }];
 
         let fake_llm = Arc::new(FakeLlmProvider::with_single_response(error_response));
-        let compactor = LlmCompactor::new(fake_llm);
+        let compactor = Compactor::new(fake_llm);
 
-        let context = Context::new(
+        let mut context = Context::new(
             vec![
                 ChatMessage::System {
                     content: "System".to_string(),
@@ -597,19 +403,19 @@ mod tests {
             vec![],
         );
 
-        let result = compactor.compact(&context).await;
+        let result = compactor.compact(&mut context).await;
         assert!(matches!(result, Err(CompactionError::SummarizationFailed(_))));
     }
 
     #[tokio::test]
-    async fn test_llm_compactor_empty_context() {
+    async fn test_compactor_empty_context() {
         use crate::testing::FakeLlmProvider;
 
         let fake_llm = Arc::new(FakeLlmProvider::with_single_response(vec![]));
-        let compactor = LlmCompactor::new(fake_llm);
+        let compactor = Compactor::new(fake_llm);
 
         // Context with only system message
-        let context = Context::new(
+        let mut context = Context::new(
             vec![ChatMessage::System {
                 content: "System".to_string(),
                 timestamp: IsoString::now(),
@@ -617,7 +423,7 @@ mod tests {
             vec![],
         );
 
-        let result = compactor.compact(&context).await;
+        let result = compactor.compact(&mut context).await;
         assert!(matches!(result, Err(CompactionError::NothingToCompact)));
     }
 }

--- a/packages/aether/src/context/compaction.rs
+++ b/packages/aether/src/context/compaction.rs
@@ -115,6 +115,15 @@ impl CompactionConfig {
         self.min_messages_for_compaction = count;
         self
     }
+
+    /// Create a configuration with compaction disabled.
+    /// Useful for explicitly opting out of the default auto-compaction.
+    pub fn disabled() -> Self {
+        Self {
+            auto_compact: false,
+            ..Default::default()
+        }
+    }
 }
 
 /// A compactor that clears old tool results to reduce context size.
@@ -310,13 +319,26 @@ fn format_messages_for_summary(messages: &[&ChatMessage]) -> String {
     output
 }
 
-/// Truncate long tool results to avoid overwhelming the summarization
+/// Truncate long tool results to avoid overwhelming the summarization.
+/// Uses char_indices to ensure we don't split multi-byte UTF-8 characters.
 fn truncate_result(result: &str, max_len: usize) -> String {
     if result.len() <= max_len {
-        result.to_string()
-    } else {
-        format!("{}... [truncated, {} chars total]", &result[..max_len], result.len())
+        return result.to_string();
     }
+
+    // Find a safe UTF-8 boundary at or before max_len
+    let truncate_at = result
+        .char_indices()
+        .take_while(|(idx, _)| *idx < max_len)
+        .last()
+        .map(|(idx, c)| idx + c.len_utf8())
+        .unwrap_or(0);
+
+    format!(
+        "{}... [truncated, {} chars total]",
+        &result[..truncate_at],
+        result.chars().count()
+    )
 }
 
 /// A hybrid compactor that first tries tool result clearing,
@@ -454,6 +476,15 @@ mod tests {
     }
 
     #[test]
+    fn test_compaction_config_disabled() {
+        let config = CompactionConfig::disabled();
+        assert!(!config.auto_compact);
+        // Other fields should be default
+        assert!((config.threshold - 0.85).abs() < 0.001);
+        assert_eq!(config.keep_recent_tool_results, 5);
+    }
+
+    #[test]
     fn test_format_messages_for_summary() {
         let messages = vec![
             ChatMessage::User {
@@ -484,6 +515,25 @@ mod tests {
         assert!(truncated.len() < long.len());
         assert!(truncated.contains("[truncated"));
         assert!(truncated.contains("1000 chars total"));
+    }
+
+    #[test]
+    fn test_truncate_result_utf8_safety() {
+        // Multi-byte UTF-8 characters: 日本語 (each is 3 bytes)
+        let japanese = "日本語テスト"; // 6 chars, 18 bytes
+
+        // Truncate at byte 5 - should not panic and should find safe boundary
+        let truncated = truncate_result(japanese, 5);
+        assert!(truncated.contains("[truncated"));
+        // Should truncate to "日" (3 bytes) since "日本" would be 6 bytes > 5
+        assert!(truncated.starts_with("日"));
+
+        // Emoji test: 🦀 is 4 bytes
+        let emoji = "🦀🦀🦀🦀🦀"; // 5 chars, 20 bytes
+        let truncated = truncate_result(emoji, 10);
+        assert!(truncated.contains("[truncated"));
+        // Should include 2 crabs (8 bytes) since 3 would be 12 > 10
+        assert!(truncated.starts_with("🦀🦀"));
     }
 
     #[tokio::test]

--- a/packages/aether/src/context/mod.rs
+++ b/packages/aether/src/context/mod.rs
@@ -1,3 +1,6 @@
 mod token_tracker;
 
+pub mod compaction;
+
+pub use compaction::*;
 pub use token_tracker::*;

--- a/packages/aether/src/context/token_tracker.rs
+++ b/packages/aether/src/context/token_tracker.rs
@@ -1,3 +1,6 @@
+/// Default threshold for triggering context compaction (85%)
+pub const DEFAULT_COMPACTION_THRESHOLD: f64 = 0.85;
+
 /// Tracks token usage from LLM API responses.
 /// Uses real usage data from API, not estimation.
 #[derive(Debug, Clone, Default)]
@@ -61,6 +64,17 @@ impl TokenTracker {
     /// Whether current usage exceeds the given threshold
     pub fn exceeds_threshold(&self, threshold: f64) -> bool {
         self.usage_ratio() >= threshold
+    }
+
+    /// Check if context should be compacted based on the given threshold.
+    /// This is a convenience method that combines usage ratio check with
+    /// a minimum context size requirement to avoid unnecessary compaction
+    /// on small conversations.
+    pub fn should_compact(&self, threshold: f64) -> bool {
+        // Only consider compaction if we have meaningful context usage
+        // (at least 10% of the limit, or at least 1000 tokens)
+        let min_tokens = std::cmp::max(self.context_limit / 10, 1000);
+        self.last_input_tokens >= min_tokens && self.exceeds_threshold(threshold)
     }
 
     /// Tokens remaining before hitting limit
@@ -150,5 +164,28 @@ mod tests {
         tracker.record_usage(850, 50);
         assert!(tracker.exceeds_threshold(0.8));
         assert!(tracker.exceeds_threshold(0.85));
+    }
+
+    #[test]
+    fn test_should_compact() {
+        let mut tracker = TokenTracker::new(10000);
+
+        // Small context shouldn't trigger compaction even if ratio is high
+        tracker.record_usage(500, 100);
+        assert!(!tracker.should_compact(0.04)); // 5% usage but only 500 tokens
+
+        // Large context at high ratio should trigger
+        tracker.record_usage(9000, 100);
+        assert!(tracker.should_compact(0.85)); // 90% usage with 9000 tokens
+
+        // Large context below threshold shouldn't trigger
+        tracker.record_usage(7000, 100);
+        assert!(!tracker.should_compact(0.85)); // 70% usage
+    }
+
+    #[test]
+    fn test_default_compaction_threshold() {
+        use super::DEFAULT_COMPACTION_THRESHOLD;
+        assert!((DEFAULT_COMPACTION_THRESHOLD - 0.85).abs() < 0.001);
     }
 }

--- a/packages/aether/src/llm/anthropic/mappers.rs
+++ b/packages/aether/src/llm/anthropic/mappers.rs
@@ -87,6 +87,16 @@ pub fn map_messages(messages: &[ChatMessage]) -> Result<(Option<String>, Vec<Mes
                     cache_control: None,
                 });
             }
+            ChatMessage::Summary { content, .. } => {
+                // Summaries from previous compaction are treated as user context
+                anthropic_messages.push(Message {
+                    role: Role::User,
+                    content: Content::Text(format!(
+                        "[Previous conversation summary]\n\n{content}"
+                    )),
+                    cache_control: None,
+                });
+            }
         }
     }
 

--- a/packages/aether/src/llm/chat_message.rs
+++ b/packages/aether/src/llm/chat_message.rs
@@ -25,4 +25,41 @@ pub enum ChatMessage {
         message: String,
         timestamp: IsoString,
     },
+    /// A compacted summary of previous conversation history.
+    /// This replaces multiple messages with a structured summary to reduce context usage.
+    Summary {
+        content: String,
+        timestamp: IsoString,
+        /// Number of messages that were compacted into this summary
+        messages_compacted: usize,
+    },
+}
+
+impl ChatMessage {
+    /// Returns true if this message is a tool call result
+    pub fn is_tool_result(&self) -> bool {
+        matches!(self, ChatMessage::ToolCallResult(_))
+    }
+
+    /// Returns true if this message is a system prompt
+    pub fn is_system(&self) -> bool {
+        matches!(self, ChatMessage::System { .. })
+    }
+
+    /// Returns true if this message is a compacted summary
+    pub fn is_summary(&self) -> bool {
+        matches!(self, ChatMessage::Summary { .. })
+    }
+
+    /// Returns the timestamp of this message, if it has one
+    pub fn timestamp(&self) -> Option<&IsoString> {
+        match self {
+            ChatMessage::System { timestamp, .. } => Some(timestamp),
+            ChatMessage::User { timestamp, .. } => Some(timestamp),
+            ChatMessage::Assistant { timestamp, .. } => Some(timestamp),
+            ChatMessage::Error { timestamp, .. } => Some(timestamp),
+            ChatMessage::Summary { timestamp, .. } => Some(timestamp),
+            ChatMessage::ToolCallResult(_) => None,
+        }
+    }
 }

--- a/packages/aether/src/llm/context.rs
+++ b/packages/aether/src/llm/context.rs
@@ -36,50 +36,6 @@ impl Context {
         self.messages.len()
     }
 
-    /// Retain only messages that match the predicate
-    pub fn retain_messages<F>(&mut self, predicate: F)
-    where
-        F: FnMut(&ChatMessage) -> bool,
-    {
-        self.messages.retain(predicate);
-    }
-
-    /// Clear tool call results from the context, keeping only the most recent ones.
-    /// This is a light-touch compaction strategy that reduces context size
-    /// while preserving the structure of the conversation.
-    ///
-    /// Returns the number of tool results that were removed.
-    pub fn clear_old_tool_results(&mut self, keep_recent: usize) -> usize {
-        // Find indices of all tool results
-        let tool_result_indices: Vec<usize> = self
-            .messages
-            .iter()
-            .enumerate()
-            .filter(|(_, msg)| msg.is_tool_result())
-            .map(|(idx, _)| idx)
-            .collect();
-
-        let total_results = tool_result_indices.len();
-        if total_results <= keep_recent {
-            return 0;
-        }
-
-        // Determine which indices to remove (older ones)
-        let remove_count = total_results - keep_recent;
-        let indices_to_remove: std::collections::HashSet<usize> =
-            tool_result_indices.into_iter().take(remove_count).collect();
-
-        // Remove those messages
-        let mut idx = 0;
-        self.messages.retain(|_| {
-            let keep = !indices_to_remove.contains(&idx);
-            idx += 1;
-            keep
-        });
-
-        remove_count
-    }
-
     /// Replace all messages (except system prompt) with a summary message.
     /// This is a full compaction that significantly reduces context size.
     ///
@@ -164,28 +120,6 @@ mod tests {
     }
 
     #[test]
-    fn test_clear_old_tool_results_keeps_recent() {
-        let mut ctx = create_test_context();
-        let removed = ctx.clear_old_tool_results(2);
-
-        assert_eq!(removed, 1);
-        assert_eq!(ctx.message_count(), 5);
-
-        // Should have kept the last 2 tool results
-        let tool_results: Vec<_> = ctx.messages().iter().filter(|m| m.is_tool_result()).collect();
-        assert_eq!(tool_results.len(), 2);
-    }
-
-    #[test]
-    fn test_clear_old_tool_results_nothing_to_remove() {
-        let mut ctx = create_test_context();
-        let removed = ctx.clear_old_tool_results(10);
-
-        assert_eq!(removed, 0);
-        assert_eq!(ctx.message_count(), 6);
-    }
-
-    #[test]
     fn test_compact_preserves_system_prompt() {
         let mut ctx = create_test_context();
         let compacted = ctx.compact("This is a summary of previous conversation.");
@@ -222,11 +156,4 @@ mod tests {
         assert!(msgs.iter().all(|m| !m.is_system()));
     }
 
-    #[test]
-    fn test_retain_messages() {
-        let mut ctx = create_test_context();
-        ctx.retain_messages(|msg| !msg.is_tool_result());
-
-        assert_eq!(ctx.message_count(), 3); // System, User, Assistant
-    }
 }

--- a/packages/aether/src/llm/context.rs
+++ b/packages/aether/src/llm/context.rs
@@ -1,5 +1,7 @@
 use serde::{Deserialize, Serialize};
 
+use crate::types::IsoString;
+
 use super::{ChatMessage, ToolDefinition};
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -27,5 +29,204 @@ impl Context {
 
     pub fn tools(&self) -> &Vec<ToolDefinition> {
         &self.tools
+    }
+
+    /// Returns the number of messages in the context
+    pub fn message_count(&self) -> usize {
+        self.messages.len()
+    }
+
+    /// Retain only messages that match the predicate
+    pub fn retain_messages<F>(&mut self, predicate: F)
+    where
+        F: FnMut(&ChatMessage) -> bool,
+    {
+        self.messages.retain(predicate);
+    }
+
+    /// Clear tool call results from the context, keeping only the most recent ones.
+    /// This is a light-touch compaction strategy that reduces context size
+    /// while preserving the structure of the conversation.
+    ///
+    /// Returns the number of tool results that were removed.
+    pub fn clear_old_tool_results(&mut self, keep_recent: usize) -> usize {
+        // Find indices of all tool results
+        let tool_result_indices: Vec<usize> = self
+            .messages
+            .iter()
+            .enumerate()
+            .filter(|(_, msg)| msg.is_tool_result())
+            .map(|(idx, _)| idx)
+            .collect();
+
+        let total_results = tool_result_indices.len();
+        if total_results <= keep_recent {
+            return 0;
+        }
+
+        // Determine which indices to remove (older ones)
+        let remove_count = total_results - keep_recent;
+        let indices_to_remove: std::collections::HashSet<usize> =
+            tool_result_indices.into_iter().take(remove_count).collect();
+
+        // Remove those messages
+        let mut idx = 0;
+        self.messages.retain(|_| {
+            let keep = !indices_to_remove.contains(&idx);
+            idx += 1;
+            keep
+        });
+
+        remove_count
+    }
+
+    /// Replace all messages (except system prompt) with a summary message.
+    /// This is a full compaction that significantly reduces context size.
+    ///
+    /// Returns the number of messages that were compacted.
+    pub fn compact(&mut self, summary: &str) -> usize {
+        // Separate system prompt from other messages
+        let (system_messages, other_messages): (Vec<_>, Vec<_>) =
+            self.messages.drain(..).partition(|msg| msg.is_system());
+
+        let compacted_count = other_messages.len();
+
+        // Restore system messages
+        self.messages = system_messages;
+
+        // Add the summary message
+        if compacted_count > 0 {
+            self.messages.push(ChatMessage::Summary {
+                content: summary.to_string(),
+                timestamp: IsoString::now(),
+                messages_compacted: compacted_count,
+            });
+        }
+
+        compacted_count
+    }
+
+    /// Get all non-system messages for summarization
+    pub fn messages_for_summary(&self) -> Vec<&ChatMessage> {
+        self.messages
+            .iter()
+            .filter(|msg| !msg.is_system())
+            .collect()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::llm::ToolCallResult;
+
+    fn create_test_context() -> Context {
+        let messages = vec![
+            ChatMessage::System {
+                content: "You are a helpful assistant.".to_string(),
+                timestamp: IsoString::now(),
+            },
+            ChatMessage::User {
+                content: "Hello".to_string(),
+                timestamp: IsoString::now(),
+            },
+            ChatMessage::Assistant {
+                content: "Hi there!".to_string(),
+                timestamp: IsoString::now(),
+                tool_calls: vec![],
+            },
+            ChatMessage::ToolCallResult(Ok(ToolCallResult {
+                id: "1".to_string(),
+                name: "tool1".to_string(),
+                arguments: "{}".to_string(),
+                result: "Result 1".to_string(),
+            })),
+            ChatMessage::ToolCallResult(Ok(ToolCallResult {
+                id: "2".to_string(),
+                name: "tool2".to_string(),
+                arguments: "{}".to_string(),
+                result: "Result 2".to_string(),
+            })),
+            ChatMessage::ToolCallResult(Ok(ToolCallResult {
+                id: "3".to_string(),
+                name: "tool3".to_string(),
+                arguments: "{}".to_string(),
+                result: "Result 3".to_string(),
+            })),
+        ];
+        Context::new(messages, vec![])
+    }
+
+    #[test]
+    fn test_message_count() {
+        let ctx = create_test_context();
+        assert_eq!(ctx.message_count(), 6);
+    }
+
+    #[test]
+    fn test_clear_old_tool_results_keeps_recent() {
+        let mut ctx = create_test_context();
+        let removed = ctx.clear_old_tool_results(2);
+
+        assert_eq!(removed, 1);
+        assert_eq!(ctx.message_count(), 5);
+
+        // Should have kept the last 2 tool results
+        let tool_results: Vec<_> = ctx.messages().iter().filter(|m| m.is_tool_result()).collect();
+        assert_eq!(tool_results.len(), 2);
+    }
+
+    #[test]
+    fn test_clear_old_tool_results_nothing_to_remove() {
+        let mut ctx = create_test_context();
+        let removed = ctx.clear_old_tool_results(10);
+
+        assert_eq!(removed, 0);
+        assert_eq!(ctx.message_count(), 6);
+    }
+
+    #[test]
+    fn test_compact_preserves_system_prompt() {
+        let mut ctx = create_test_context();
+        let compacted = ctx.compact("This is a summary of previous conversation.");
+
+        assert_eq!(compacted, 5); // Everything except system prompt
+        assert_eq!(ctx.message_count(), 2); // System + Summary
+
+        // Check system prompt is preserved
+        assert!(ctx.messages()[0].is_system());
+        assert!(ctx.messages()[1].is_summary());
+    }
+
+    #[test]
+    fn test_compact_empty_context() {
+        let mut ctx = Context::new(
+            vec![ChatMessage::System {
+                content: "System".to_string(),
+                timestamp: IsoString::now(),
+            }],
+            vec![],
+        );
+        let compacted = ctx.compact("Summary");
+
+        assert_eq!(compacted, 0);
+        assert_eq!(ctx.message_count(), 1); // Only system prompt
+    }
+
+    #[test]
+    fn test_messages_for_summary() {
+        let ctx = create_test_context();
+        let msgs = ctx.messages_for_summary();
+
+        assert_eq!(msgs.len(), 5); // All except system prompt
+        assert!(msgs.iter().all(|m| !m.is_system()));
+    }
+
+    #[test]
+    fn test_retain_messages() {
+        let mut ctx = create_test_context();
+        ctx.retain_messages(|msg| !msg.is_tool_result());
+
+        assert_eq!(ctx.message_count(), 3); // System, User, Assistant
     }
 }

--- a/packages/aether/src/llm/gemini/mappers.rs
+++ b/packages/aether/src/llm/gemini/mappers.rs
@@ -128,6 +128,15 @@ fn map_messages_to_contents(messages: &[ChatMessage]) -> (Option<Content>, Vec<C
             ChatMessage::Error { .. } => {
                 // Skip error messages in the context
             }
+            ChatMessage::Summary { content, .. } => {
+                // Summaries from previous compaction are treated as user context
+                contents.push(Content {
+                    role: "user".to_string(),
+                    parts: vec![Part::Text {
+                        text: format!("[Previous conversation summary]\n\n{content}"),
+                    }],
+                });
+            }
         }
     }
 

--- a/packages/aether/src/llm/openai/mappers.rs
+++ b/packages/aether/src/llm/openai/mappers.rs
@@ -68,7 +68,15 @@ impl From<ChatMessage> for Option<ChatCompletionRequestMessage> {
                     },
                 ))
             }
-
+            ChatMessage::Summary { content, .. } => {
+                // Summaries from previous compaction are treated as user context
+                Some(ChatCompletionRequestMessage::User(
+                    ChatCompletionRequestUserMessage {
+                        content: format!("[Previous conversation summary]\n\n{content}").into(),
+                        name: None,
+                    },
+                ))
+            }
             ChatMessage::Error { .. } => None,
         }
     }

--- a/packages/aether/src/main.rs
+++ b/packages/aether/src/main.rs
@@ -139,6 +139,17 @@ async fn run_agent(
                 eprintln!("Cancelled: {message}");
             }
 
+            ContextCompacted {
+                messages_removed,
+                strategy,
+                ..
+            } => {
+                println!(
+                    "[Context compacted: {} messages removed using {} strategy]",
+                    messages_removed, strategy
+                );
+            }
+
             Done => {
                 println!("Agent task completed");
                 break;

--- a/packages/aether/src/main.rs
+++ b/packages/aether/src/main.rs
@@ -140,14 +140,9 @@ async fn run_agent(
             }
 
             ContextCompacted {
-                messages_removed,
-                strategy,
-                ..
+                messages_removed, ..
             } => {
-                println!(
-                    "[Context compacted: {} messages removed using {} strategy]",
-                    messages_removed, strategy
-                );
+                println!("[Context compacted: {} messages removed]", messages_removed);
             }
 
             Done => {


### PR DESCRIPTION
Implement context compaction to prevent agents from running out of context window space during long tasks. This is inspired by Claude Code and Codex's approach to handling context overflow.

Key changes:
- Add ChatMessage::Summary variant for storing compacted summaries
- Add Context methods: clear_old_tool_results(), compact(), messages_for_summary()
- Add TokenTracker::should_compact() to check compaction thresholds
- Create CompactionConfig for configuring compaction behavior
- Implement ToolResultClearer for lightweight compaction
- Implement LlmCompactor for structured LLM-based summarization
- Implement HybridCompactor (tries tool clearing first, then LLM summarization)
- Add AgentEvent::ContextCompacted for middleware observability
- Add AgentMessage::ContextCompacted for consumer notification
- Integrate compaction into Agent's event loop (triggers before LLM calls)
- Add AgentBuilder methods: compaction() and auto_compact()

The compaction uses a two-phase strategy:
1. Light touch: Clear old tool results (fast, no API cost)
2. Full compaction: LLM-based structured summarization (if still over threshold)

The structured summary follows Factory.ai's anchored iterative approach with sections for: Session Intent, Accomplishments, File Modifications, Key Decisions, Current State, Next Steps, and Constraints.

Closes: JOS-8