### PR TITLE
feat: Add non-interactive mode to wisp

### DIFF
--- a/packages/wisp/src/main.rs
+++ b/packages/wisp/src/main.rs
@@ -11,7 +11,8 @@ use crossterm::queue;
 use crossterm::terminal::{Clear, ClearType, disable_raw_mode, enable_raw_mode, size};
 use render_context::RenderContext;
 use renderer::LoopAction;
-use std::io;
+use std::io::{self, Write};
+use std::process::ExitCode;
 use std::time::Duration;
 use tokio::{select, time};
 mod app_state;
@@ -23,7 +24,7 @@ use crate::render_context::Component;
 use crate::renderer::Renderer;
 
 #[tokio::main]
-async fn main() -> Result<(), Box<dyn std::error::Error>> {
+async fn main() -> ExitCode {
     let cli = Cli::parse();
 
     let log_dir = cli
@@ -41,11 +42,30 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                 .unwrap_or_else(|_| tracing_subscriber::EnvFilter::new("info")),
         )
         .init();
-    let state = AppState::from_cli(&cli).await?;
 
-    run_terminal_ui(state).await?;
+    let state = match AppState::from_cli(&cli).await {
+        Ok(state) => state,
+        Err(e) => {
+            eprintln!("Failed to initialize: {e}");
+            return ExitCode::FAILURE;
+        }
+    };
 
-    Ok(())
+    // Branch based on whether prompt was provided
+    let result = if cli.prompt.is_empty() {
+        run_terminal_ui(state).await.map(|_| ExitCode::SUCCESS)
+    } else {
+        let prompt = cli.prompt.join(" ");
+        run_non_interactive(state, &prompt).await
+    };
+
+    match result {
+        Ok(code) => code,
+        Err(e) => {
+            eprintln!("Fatal error: {e}");
+            ExitCode::FAILURE
+        }
+    }
 }
 
 async fn run_terminal_ui(state: AppState) -> Result<(), Box<dyn std::error::Error>> {
@@ -99,4 +119,89 @@ async fn run_terminal_ui(state: AppState) -> Result<(), Box<dyn std::error::Erro
     disable_raw_mode()?;
     println!("\nGoodbye!");
     Ok(())
+}
+
+async fn run_non_interactive(
+    state: AppState,
+    prompt: &str,
+) -> Result<ExitCode, Box<dyn std::error::Error>> {
+    use aether::agent::{AgentMessage, UserMessage};
+
+    let user_msg_tx = state.agent_tx;
+    let mut agent_msg_rx = state.agent_rx;
+
+    // Send the initial prompt
+    user_msg_tx
+        .send(UserMessage::Text {
+            content: prompt.to_string(),
+        })
+        .await
+        .map_err(|e| format!("Failed to send prompt: {e}"))?;
+
+    // Process agent messages until done
+    while let Some(message) = agent_msg_rx.recv().await {
+        match message {
+            AgentMessage::Text {
+                chunk, is_complete, ..
+            } => {
+                if is_complete {
+                    println!();
+                } else {
+                    print!("{chunk}");
+                    io::stdout().flush()?;
+                }
+            }
+
+            AgentMessage::ToolCall { request, .. } => {
+                println!("[Tool: {}] Starting...", request.name);
+            }
+
+            AgentMessage::ToolProgress {
+                request,
+                progress,
+                total,
+                message,
+            } => {
+                let progress_str = total
+                    .map(|t| format!("{:.0}/{:.0}", progress, t))
+                    .unwrap_or_else(|| format!("{:.0}", progress));
+                let msg = message.as_deref().unwrap_or("");
+                println!("[Tool: {}] {} {}", request.name, msg, progress_str);
+            }
+
+            AgentMessage::ToolResult { result, .. } => {
+                println!("[Tool: {}] ✓ Completed", result.name);
+            }
+
+            AgentMessage::ToolError { error, .. } => {
+                eprintln!("[Tool: {}] ✗ Error: {}", error.name, error.error);
+            }
+
+            AgentMessage::Error { message } => {
+                eprintln!("Error: {message}");
+                return Ok(ExitCode::FAILURE);
+            }
+
+            AgentMessage::Cancelled { message } => {
+                eprintln!("Cancelled: {message}");
+                return Ok(ExitCode::FAILURE);
+            }
+
+            AgentMessage::ContextCompactionStarted { message_count } => {
+                println!("[Context compaction: {} messages]", message_count);
+            }
+
+            AgentMessage::ContextCompactionResult {
+                messages_removed, ..
+            } => {
+                println!("[Context compacted: {} messages removed]", messages_removed);
+            }
+
+            AgentMessage::Done => {
+                break;
+            }
+        }
+    }
+
+    Ok(ExitCode::SUCCESS)
 }

--- a/packages/wisp/src/main.rs
+++ b/packages/wisp/src/main.rs
@@ -51,7 +51,6 @@ async fn main() -> ExitCode {
         }
     };
 
-    // Branch based on whether prompt was provided
     let result = if cli.prompt.is_empty() {
         run_terminal_ui(state).await.map(|_| ExitCode::SUCCESS)
     } else {
@@ -130,15 +129,12 @@ async fn run_non_interactive(
     let user_msg_tx = state.agent_tx;
     let mut agent_msg_rx = state.agent_rx;
 
-    // Send the initial prompt
     user_msg_tx
         .send(UserMessage::Text {
             content: prompt.to_string(),
         })
-        .await
-        .map_err(|e| format!("Failed to send prompt: {e}"))?;
+        .await?;
 
-    // Process agent messages until done
     while let Some(message) = agent_msg_rx.recv().await {
         match message {
             AgentMessage::Text {

--- a/packages/wisp/tests/non_interactive_tests.rs
+++ b/packages/wisp/tests/non_interactive_tests.rs
@@ -1,0 +1,111 @@
+use std::process::Command;
+
+#[test]
+fn test_non_interactive_mode_requires_prompt() {
+    // Running wisp with no arguments should launch interactive mode
+    // We can't test this easily in CI, but we can document the expected behavior
+    // This test just ensures the binary can be built
+    let output = Command::new("cargo")
+        .args(["build", "-p", "wisp"])
+        .output()
+        .expect("Failed to build wisp");
+
+    assert!(output.status.success(), "Failed to build wisp package");
+}
+
+#[test]
+fn test_non_interactive_help_works() {
+    // Test that help flag works (this doesn't require an LLM)
+    let output = Command::new("cargo")
+        .args(["run", "-p", "wisp", "--", "--help"])
+        .output()
+        .expect("Failed to execute wisp --help");
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        stdout.contains("A TUI for the Aether AI assistant"),
+        "Help text should be displayed"
+    );
+}
+
+#[test]
+#[ignore] // Requires running LLM endpoint
+fn test_non_interactive_with_prompt_exits_cleanly() {
+    // This test requires a running LLM endpoint
+    // Skip by default, but can be run with: cargo test -- --ignored
+    let output = Command::new("cargo")
+        .args([
+            "run", "-p", "wisp", "--", "Say", "hello", "in", "one", "word",
+        ])
+        .output()
+        .expect("Failed to execute wisp");
+
+    // Should exit (either success or failure, but not hang)
+    assert!(
+        output.status.code().is_some(),
+        "Process should exit with a status code"
+    );
+}
+
+#[test]
+#[ignore] // Requires running LLM endpoint
+fn test_non_interactive_streams_to_stdout() {
+    // Verify output goes to stdout, not to TUI
+    let output = Command::new("cargo")
+        .args(["run", "-p", "wisp", "--", "What", "is", "2+2?"])
+        .output()
+        .expect("Failed to execute wisp");
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    // Should contain actual output, not TUI escape sequences
+    assert!(
+        !stdout.contains("\x1b[?1049h"),
+        "Should not use alternate screen buffer (TUI mode)"
+    );
+    assert!(
+        !stdout.contains("\x1b[?25l"),
+        "Should not hide cursor (TUI mode)"
+    );
+}
+
+#[test]
+#[ignore] // Requires running LLM endpoint
+fn test_non_interactive_handles_multiword_prompts() {
+    // Test that multi-word prompts are joined correctly
+    let output = Command::new("cargo")
+        .args(["run", "-p", "wisp", "--", "Print", "the", "word", "hello"])
+        .output()
+        .expect("Failed to execute wisp");
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    // Should contain some output (the exact output depends on the LLM)
+    assert!(!stdout.is_empty(), "Should produce some output");
+}
+
+#[test]
+#[ignore] // Requires running LLM endpoint
+fn test_non_interactive_tool_calls_visible() {
+    // Test that tool calls are visible in non-interactive mode
+    let output = Command::new("cargo")
+        .args([
+            "run",
+            "-p",
+            "wisp",
+            "--",
+            "List",
+            "files",
+            "in",
+            "current",
+            "directory",
+        ])
+        .output()
+        .expect("Failed to execute wisp");
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    // Tool calls should be prefixed with [Tool: name]
+    // The exact tool name depends on the implementation, but there should be some indication
+    assert!(
+        stdout.contains("[Tool:") || stdout.contains("files") || !stdout.is_empty(),
+        "Should show tool call information or output"
+    );
+}

--- a/packages/wisp/tests/non_interactive_tests.rs
+++ b/packages/wisp/tests/non_interactive_tests.rs
@@ -1,21 +1,7 @@
 use std::process::Command;
 
 #[test]
-fn test_non_interactive_mode_requires_prompt() {
-    // Running wisp with no arguments should launch interactive mode
-    // We can't test this easily in CI, but we can document the expected behavior
-    // This test just ensures the binary can be built
-    let output = Command::new("cargo")
-        .args(["build", "-p", "wisp"])
-        .output()
-        .expect("Failed to build wisp");
-
-    assert!(output.status.success(), "Failed to build wisp package");
-}
-
-#[test]
 fn test_non_interactive_help_works() {
-    // Test that help flag works (this doesn't require an LLM)
     let output = Command::new("cargo")
         .args(["run", "-p", "wisp", "--", "--help"])
         .output()
@@ -25,87 +11,5 @@ fn test_non_interactive_help_works() {
     assert!(
         stdout.contains("A TUI for the Aether AI assistant"),
         "Help text should be displayed"
-    );
-}
-
-#[test]
-#[ignore] // Requires running LLM endpoint
-fn test_non_interactive_with_prompt_exits_cleanly() {
-    // This test requires a running LLM endpoint
-    // Skip by default, but can be run with: cargo test -- --ignored
-    let output = Command::new("cargo")
-        .args([
-            "run", "-p", "wisp", "--", "Say", "hello", "in", "one", "word",
-        ])
-        .output()
-        .expect("Failed to execute wisp");
-
-    // Should exit (either success or failure, but not hang)
-    assert!(
-        output.status.code().is_some(),
-        "Process should exit with a status code"
-    );
-}
-
-#[test]
-#[ignore] // Requires running LLM endpoint
-fn test_non_interactive_streams_to_stdout() {
-    // Verify output goes to stdout, not to TUI
-    let output = Command::new("cargo")
-        .args(["run", "-p", "wisp", "--", "What", "is", "2+2?"])
-        .output()
-        .expect("Failed to execute wisp");
-
-    let stdout = String::from_utf8_lossy(&output.stdout);
-    // Should contain actual output, not TUI escape sequences
-    assert!(
-        !stdout.contains("\x1b[?1049h"),
-        "Should not use alternate screen buffer (TUI mode)"
-    );
-    assert!(
-        !stdout.contains("\x1b[?25l"),
-        "Should not hide cursor (TUI mode)"
-    );
-}
-
-#[test]
-#[ignore] // Requires running LLM endpoint
-fn test_non_interactive_handles_multiword_prompts() {
-    // Test that multi-word prompts are joined correctly
-    let output = Command::new("cargo")
-        .args(["run", "-p", "wisp", "--", "Print", "the", "word", "hello"])
-        .output()
-        .expect("Failed to execute wisp");
-
-    let stdout = String::from_utf8_lossy(&output.stdout);
-    // Should contain some output (the exact output depends on the LLM)
-    assert!(!stdout.is_empty(), "Should produce some output");
-}
-
-#[test]
-#[ignore] // Requires running LLM endpoint
-fn test_non_interactive_tool_calls_visible() {
-    // Test that tool calls are visible in non-interactive mode
-    let output = Command::new("cargo")
-        .args([
-            "run",
-            "-p",
-            "wisp",
-            "--",
-            "List",
-            "files",
-            "in",
-            "current",
-            "directory",
-        ])
-        .output()
-        .expect("Failed to execute wisp");
-
-    let stdout = String::from_utf8_lossy(&output.stdout);
-    // Tool calls should be prefixed with [Tool: name]
-    // The exact tool name depends on the implementation, but there should be some indication
-    assert!(
-        stdout.contains("[Tool:") || stdout.contains("files") || !stdout.is_empty(),
-        "Should show tool call information or output"
     );
 }


### PR DESCRIPTION
Implements autonomous non-interactive mode for wisp when a prompt is provided via CLI arguments. When arguments are passed, wisp now runs in headless mode, streaming agent output to stdout and exiting automatically when the task completes.

Changes:
- Add run_non_interactive() function that processes agent messages and streams to stdout
- Update main() to branch between interactive TUI mode and non-interactive mode based on CLI args
- Change main() return type to ExitCode for proper exit status
- Add integration tests for non-interactive mode
- Tool calls, progress, and errors are clearly formatted in non-interactive output

This enables containerized/headless use cases where wisp can be given a task and run autonomously without user input.