### PR TITLE
feat: Add MCP roots support to aether and mcp-lexicon

### DIFF
--- a/packages/aether-acp/src/session.rs
+++ b/packages/aether-acp/src/session.rs
@@ -48,6 +48,7 @@ impl Session {
 
         let config_str = mcp_config_path.to_str().ok_or("Invalid MCP config path")?;
         let tasks_project_path = project_path.clone();
+        let roots_path = project_path.clone();
 
         debug!("Creating ACP-enabled CodingMcp and PluginsMcp");
         let McpSpawnResult {
@@ -102,6 +103,7 @@ impl Session {
                     .boxed()
                 }),
             )
+            .with_roots(vec![roots_path])
             .from_json_file(config_str)
             .await?
             .spawn()

--- a/packages/aether/src/mcp/client.rs
+++ b/packages/aether/src/mcp/client.rs
@@ -4,30 +4,35 @@ use rmcp::{
     handler::client::progress::ProgressDispatcher,
     model::{
         ClientInfo, CreateElicitationRequestParam, CreateElicitationResult, ElicitationAction,
-        ErrorData, ProgressNotificationParam,
+        ErrorData, ListRootsResult, ProgressNotificationParam,
     },
     service::{NotificationContext, RequestContext},
 };
 use std::result::Result;
-use tokio::sync::{mpsc, oneshot};
+use std::sync::Arc;
+use tokio::sync::{mpsc, oneshot, RwLock};
 
-use crate::mcp::ElicitationRequest;
+use crate::mcp::{ElicitationRequest, Root};
 
 pub struct McpClient {
     client_info: ClientInfo,
     pub progress_dispatcher: ProgressDispatcher,
     elicitation_sender: mpsc::Sender<ElicitationRequest>,
+    /// Roots advertised to MCP servers
+    roots: Arc<RwLock<Vec<Root>>>,
 }
 
 impl McpClient {
     pub fn new(
         client_info: ClientInfo,
         elicitation_sender: mpsc::Sender<ElicitationRequest>,
+        roots: Arc<RwLock<Vec<Root>>>,
     ) -> Self {
         Self {
             client_info,
             progress_dispatcher: ProgressDispatcher::new(),
             elicitation_sender,
+            roots,
         }
     }
 }
@@ -70,5 +75,17 @@ impl ClientHandler for McpClient {
                 content: None,
             }),
         }
+    }
+
+    async fn list_roots(
+        &self,
+        _context: RequestContext<RoleClient>,
+    ) -> Result<ListRootsResult, ErrorData> {
+        let roots = self.roots.read().await;
+        let rmcp_roots = roots.iter().map(|r| r.clone().into()).collect();
+
+        Ok(ListRootsResult {
+            roots: rmcp_roots,
+        })
     }
 }

--- a/packages/aether/src/mcp/client.rs
+++ b/packages/aether/src/mcp/client.rs
@@ -12,7 +12,8 @@ use std::result::Result;
 use std::sync::Arc;
 use tokio::sync::{mpsc, oneshot, RwLock};
 
-use crate::mcp::{ElicitationRequest, Root};
+use crate::mcp::ElicitationRequest;
+use rmcp::model::Root;
 
 pub struct McpClient {
     client_info: ClientInfo,
@@ -82,10 +83,9 @@ impl ClientHandler for McpClient {
         _context: RequestContext<RoleClient>,
     ) -> Result<ListRootsResult, ErrorData> {
         let roots = self.roots.read().await;
-        let rmcp_roots = roots.iter().map(|r| r.clone().into()).collect();
 
         Ok(ListRootsResult {
-            roots: rmcp_roots,
+            roots: roots.clone(),
         })
     }
 }

--- a/packages/aether/src/mcp/manager.rs
+++ b/packages/aether/src/mcp/manager.rs
@@ -1,12 +1,12 @@
 use crate::{
     llm::ToolDefinition,
-    mcp::{McpError, Result, config::McpServerConfig},
+    mcp::{McpError, Result, Root, config::McpServerConfig},
 };
 use rmcp::{
     RoleClient, ServiceExt,
     model::{
         ClientCapabilities, ClientInfo, CreateElicitationRequestParam, CreateElicitationResult,
-        ElicitationAction, ElicitationCapability, Implementation, Tool as RmcpTool,
+        ElicitationAction, Implementation, Tool as RmcpTool,
     },
     serve_client,
     service::RunningService,
@@ -17,7 +17,7 @@ use std::collections::HashMap;
 
 use crate::{mcp::client::McpClient, transport::create_in_memory_transport};
 use std::sync::Arc;
-use tokio::sync::{mpsc, oneshot};
+use tokio::sync::{mpsc, oneshot, RwLock};
 use tokio::{process::Command, task::JoinHandle};
 
 const SERVERNAME_DELIMITER: &str = "__";
@@ -41,6 +41,8 @@ pub struct McpManager {
     tool_definitions: Vec<ToolDefinition>,
     client_info: ClientInfo,
     elicitation_sender: mpsc::Sender<ElicitationRequest>,
+    /// Roots shared with all MCP clients
+    roots: Arc<RwLock<Vec<Root>>>,
 }
 
 impl McpManager {
@@ -51,12 +53,10 @@ impl McpManager {
             tool_definitions: Vec::new(),
             client_info: ClientInfo {
                 protocol_version: Default::default(),
-                capabilities: ClientCapabilities {
-                    elicitation: Some(ElicitationCapability {
-                        schema_validation: Some(true),
-                    }),
-                    ..ClientCapabilities::default()
-                },
+                capabilities: ClientCapabilities::builder()
+                    .enable_elicitation()
+                    .enable_roots()
+                    .build(),
                 client_info: Implementation {
                     name: "aether".to_string(),
                     version: "0.1.0".to_string(),
@@ -66,11 +66,16 @@ impl McpManager {
                 },
             },
             elicitation_sender,
+            roots: Arc::new(RwLock::new(Vec::new())),
         }
     }
 
     fn create_mcp_client(&self) -> McpClient {
-        McpClient::new(self.client_info.clone(), self.elicitation_sender.clone())
+        McpClient::new(
+            self.client_info.clone(),
+            self.elicitation_sender.clone(),
+            Arc::clone(&self.roots),
+        )
     }
 
     pub async fn add_mcps(&mut self, configs: Vec<McpServerConfig>) -> Result<()> {
@@ -383,6 +388,40 @@ impl McpManager {
         }
 
         Ok(())
+    }
+
+    /// Set the roots advertised to MCP servers.
+    ///
+    /// This updates the roots and sends notifications to all connected servers
+    /// that support the roots/list_changed notification.
+    pub async fn set_roots(&mut self, new_roots: Vec<Root>) -> Result<()> {
+        // Update stored roots
+        {
+            let mut roots = self.roots.write().await;
+            *roots = new_roots;
+        }
+
+        // Notify all connected servers
+        self.notify_roots_changed().await;
+
+        Ok(())
+    }
+
+    /// Send roots/list_changed notification to all connected servers.
+    ///
+    /// This prompts servers to re-request the roots via the roots/list endpoint.
+    /// Servers that don't support roots will simply ignore the notification.
+    async fn notify_roots_changed(&self) {
+        for (server_name, server_conn) in &self.servers {
+            // Try to send notification - servers that don't support roots will ignore it
+            if let Err(e) = server_conn.client.notify_roots_list_changed().await {
+                // Only log errors for debugging; it's expected that some servers may not support roots
+                eprintln!(
+                    "Note: server '{}' did not accept roots notification: {}",
+                    server_name, e
+                );
+            }
+        }
     }
 }
 

--- a/packages/aether/src/mcp/manager.rs
+++ b/packages/aether/src/mcp/manager.rs
@@ -1,12 +1,12 @@
 use crate::{
     llm::ToolDefinition,
-    mcp::{McpError, Result, Root, config::McpServerConfig},
+    mcp::{McpError, Result, config::McpServerConfig},
 };
 use rmcp::{
     RoleClient, ServiceExt,
     model::{
         ClientCapabilities, ClientInfo, CreateElicitationRequestParam, CreateElicitationResult,
-        ElicitationAction, Implementation, Tool as RmcpTool,
+        ElicitationAction, Implementation, Root, Tool as RmcpTool,
     },
     serve_client,
     service::RunningService,

--- a/packages/aether/src/mcp/mcp_builder.rs
+++ b/packages/aether/src/mcp/mcp_builder.rs
@@ -1,8 +1,8 @@
 use crate::llm::ToolDefinition;
 
 use super::{
-    ElicitationRequest, McpError, McpManager, McpServerConfig, ParseError, RawMcpConfig, Root,
-    ServerFactory, ServerInstructions,
+    ElicitationRequest, McpError, McpManager, McpServerConfig, ParseError, RawMcpConfig,
+    ServerFactory, ServerInstructions, root_from_path,
     run_mcp_task::{McpCommand, run_mcp_task},
 };
 use std::collections::HashMap;
@@ -89,10 +89,10 @@ impl McpBuilder {
 
         // Set workspace roots if provided
         if !self.roots.is_empty() {
-            let roots: Vec<Root> = self
+            let roots = self
                 .roots
                 .into_iter()
-                .map(|path| Root::from_path(path, None))
+                .map(|path| root_from_path(path, None))
                 .collect();
             mcp_manager.set_roots(roots).await?;
         }

--- a/packages/aether/src/mcp/mcp_builder.rs
+++ b/packages/aether/src/mcp/mcp_builder.rs
@@ -1,11 +1,12 @@
 use crate::llm::ToolDefinition;
 
 use super::{
-    ElicitationRequest, McpError, McpManager, McpServerConfig, ParseError, RawMcpConfig,
+    ElicitationRequest, McpError, McpManager, McpServerConfig, ParseError, RawMcpConfig, Root,
     ServerFactory, ServerInstructions,
     run_mcp_task::{McpCommand, run_mcp_task},
 };
 use std::collections::HashMap;
+use std::path::PathBuf;
 use tokio::{
     sync::mpsc::{self, Sender},
     task::JoinHandle,
@@ -27,6 +28,7 @@ pub struct McpBuilder {
     mcp_configs: Vec<McpServerConfig>,
     factories: HashMap<String, ServerFactory>,
     mcp_channel_capacity: usize,
+    roots: Vec<PathBuf>,
 }
 
 impl Default for McpBuilder {
@@ -35,6 +37,7 @@ impl Default for McpBuilder {
             mcp_configs: Vec::new(),
             factories: HashMap::new(),
             mcp_channel_capacity: 1000,
+            roots: Vec::new(),
         }
     }
 }
@@ -58,6 +61,16 @@ impl McpBuilder {
         self
     }
 
+    /// Set workspace roots that will be advertised to MCP servers.
+    ///
+    /// These roots are passed to the MCP client via the roots protocol,
+    /// allowing servers to dynamically receive workspace information without
+    /// relying solely on CLI arguments.
+    pub fn with_roots(mut self, roots: Vec<PathBuf>) -> Self {
+        self.roots = roots;
+        self
+    }
+
     pub async fn from_json_file(mut self, path: &str) -> Result<Self, ParseError> {
         let raw_config = RawMcpConfig::from_json_file(path)?;
         let mcp_configs = raw_config.into_configs(&self.factories).await?;
@@ -73,6 +86,17 @@ impl McpBuilder {
 
         let mut mcp_manager = McpManager::new(elicitation_tx);
         mcp_manager.add_mcps(self.mcp_configs).await?;
+
+        // Set workspace roots if provided
+        if !self.roots.is_empty() {
+            let roots: Vec<Root> = self
+                .roots
+                .into_iter()
+                .map(|path| Root::from_path(path, None))
+                .collect();
+            mcp_manager.set_roots(roots).await?;
+        }
+
         let tool_definitions = mcp_manager.tool_definitions();
         let instructions = mcp_manager.server_instructions();
         let mcp_handle = tokio::spawn(run_mcp_task(mcp_manager, mcp_command_rx));

--- a/packages/aether/src/mcp/mod.rs
+++ b/packages/aether/src/mcp/mod.rs
@@ -5,6 +5,7 @@ pub mod error;
 pub mod manager;
 pub mod mcp_builder;
 pub mod oauth_integration;
+pub mod roots;
 pub mod run_mcp_task;
 pub mod variables;
 
@@ -12,4 +13,5 @@ pub use config::*;
 pub use error::{McpError, Result};
 pub use manager::{ElicitationRequest, McpManager, ServerInstructions};
 pub use mcp_builder::*;
+pub use roots::Root;
 pub use variables::{VarError, expand_env_vars};

--- a/packages/aether/src/mcp/mod.rs
+++ b/packages/aether/src/mcp/mod.rs
@@ -13,5 +13,8 @@ pub use config::*;
 pub use error::{McpError, Result};
 pub use manager::{ElicitationRequest, McpManager, ServerInstructions};
 pub use mcp_builder::*;
-pub use roots::Root;
+pub use roots::root_from_path;
 pub use variables::{VarError, expand_env_vars};
+
+// Re-export rmcp's Root type for convenience
+pub use rmcp::model::Root;

--- a/packages/aether/src/mcp/roots.rs
+++ b/packages/aether/src/mcp/roots.rs
@@ -1,0 +1,177 @@
+use rmcp::model::Root as RmcpRoot;
+use std::path::PathBuf;
+
+/// A root directory exposed to MCP servers.
+///
+/// Represents a workspace root that MCP servers can access. The MCP protocol
+/// uses file:// URIs to identify roots, and clients advertise these roots to
+/// servers during initialization or via dynamic updates.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Root {
+    /// The file:// URI for the root (e.g., "file:///home/user/project")
+    pub uri: String,
+    /// Human-readable display name for the root (optional)
+    pub name: Option<String>,
+}
+
+impl Root {
+    /// Create a Root from a PathBuf.
+    ///
+    /// The path is converted to an absolute file:// URI. On Unix systems, this
+    /// is straightforward. On Windows, drive letters are converted to the
+    /// appropriate URI format (e.g., C:\ becomes file:///C:/).
+    ///
+    /// # Example
+    /// ```
+    /// use std::path::PathBuf;
+    /// use aether::mcp::Root;
+    ///
+    /// let root = Root::from_path(
+    ///     PathBuf::from("/home/user/project"),
+    ///     Some("My Project".to_string())
+    /// );
+    /// assert_eq!(root.uri, "file:///home/user/project");
+    /// assert_eq!(root.name, Some("My Project".to_string()));
+    /// ```
+    pub fn from_path(path: PathBuf, name: Option<String>) -> Self {
+        let uri = path_to_file_uri(&path);
+        Self { uri, name }
+    }
+
+    /// Extract the file path from this root's URI.
+    ///
+    /// Returns None if the URI is malformed or not a file:// URI.
+    pub fn to_path(&self) -> Option<PathBuf> {
+        file_uri_to_path(&self.uri)
+    }
+}
+
+/// Convert an rmcp Root to our Root type.
+impl From<RmcpRoot> for Root {
+    fn from(root: RmcpRoot) -> Self {
+        Self {
+            uri: root.uri.to_string(),
+            name: root.name,
+        }
+    }
+}
+
+/// Convert our Root to rmcp Root.
+impl From<Root> for RmcpRoot {
+    fn from(root: Root) -> Self {
+        RmcpRoot {
+            uri: root.uri.into(),
+            name: root.name,
+        }
+    }
+}
+
+/// Convert a PathBuf to a file:// URI string.
+///
+/// This function handles platform-specific path formats:
+/// - Unix: /home/user/project -> file:///home/user/project
+/// - Windows: C:\Users\user\project -> file:///C:/Users/user/project
+fn path_to_file_uri(path: &PathBuf) -> String {
+    #[cfg(unix)]
+    {
+        format!("file://{}", path.display())
+    }
+
+    #[cfg(windows)]
+    {
+        // Convert Windows paths to URI format
+        let path_str = path.display().to_string().replace('\\', "/");
+        format!("file:///{}", path_str)
+    }
+
+    #[cfg(not(any(unix, windows)))]
+    {
+        // Fallback for other platforms
+        format!("file://{}", path.display())
+    }
+}
+
+/// Convert a file:// URI to a PathBuf.
+///
+/// Returns None if the URI is not a valid file:// URI.
+fn file_uri_to_path(uri: &str) -> Option<PathBuf> {
+    let uri = uri.strip_prefix("file://")?;
+
+    #[cfg(unix)]
+    {
+        Some(PathBuf::from(uri))
+    }
+
+    #[cfg(windows)]
+    {
+        // Strip leading / and convert back to Windows format
+        let path_str = uri.strip_prefix('/')?.replace('/', "\\");
+        Some(PathBuf::from(path_str))
+    }
+
+    #[cfg(not(any(unix, windows)))]
+    {
+        Some(PathBuf::from(uri))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_root_from_path() {
+        let path = PathBuf::from("/home/user/project");
+        let root = Root::from_path(path, Some("Test Project".to_string()));
+
+        assert_eq!(root.uri, "file:///home/user/project");
+        assert_eq!(root.name, Some("Test Project".to_string()));
+    }
+
+    #[test]
+    fn test_root_to_path() {
+        let root = Root {
+            uri: "file:///home/user/project".to_string(),
+            name: None,
+        };
+
+        let path = root.to_path();
+        assert_eq!(path, Some(PathBuf::from("/home/user/project")));
+    }
+
+    #[test]
+    fn test_root_roundtrip() {
+        let original_path = PathBuf::from("/tmp/test");
+        let root = Root::from_path(original_path.clone(), None);
+        let recovered_path = root.to_path();
+
+        assert_eq!(Some(original_path), recovered_path);
+    }
+
+    #[test]
+    fn test_rmcp_root_conversion() {
+        let our_root = Root {
+            uri: "file:///home/user/project".to_string(),
+            name: Some("Test".to_string()),
+        };
+
+        let rmcp_root: RmcpRoot = our_root.clone().into();
+        assert_eq!(rmcp_root.uri.as_str(), "file:///home/user/project");
+        assert_eq!(rmcp_root.name, Some("Test".to_string()));
+
+        let converted_back: Root = rmcp_root.into();
+        assert_eq!(converted_back, our_root);
+    }
+
+    #[test]
+    fn test_path_with_spaces() {
+        let path = PathBuf::from("/home/user/my project");
+        let root = Root::from_path(path.clone(), None);
+
+        // The URI should preserve spaces (not percent-encoded in this simple implementation)
+        assert_eq!(root.uri, "file:///home/user/my project");
+
+        let recovered = root.to_path();
+        assert_eq!(recovered, Some(path));
+    }
+}

--- a/packages/aether/src/mcp/roots.rs
+++ b/packages/aether/src/mcp/roots.rs
@@ -1,77 +1,12 @@
-use rmcp::model::Root as RmcpRoot;
+use rmcp::model::Root;
 use std::path::PathBuf;
-
-/// A root directory exposed to MCP servers.
-///
-/// Represents a workspace root that MCP servers can access. The MCP protocol
-/// uses file:// URIs to identify roots, and clients advertise these roots to
-/// servers during initialization or via dynamic updates.
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub struct Root {
-    /// The file:// URI for the root (e.g., "file:///home/user/project")
-    pub uri: String,
-    /// Human-readable display name for the root (optional)
-    pub name: Option<String>,
-}
-
-impl Root {
-    /// Create a Root from a PathBuf.
-    ///
-    /// The path is converted to an absolute file:// URI. On Unix systems, this
-    /// is straightforward. On Windows, drive letters are converted to the
-    /// appropriate URI format (e.g., C:\ becomes file:///C:/).
-    ///
-    /// # Example
-    /// ```
-    /// use std::path::PathBuf;
-    /// use aether::mcp::Root;
-    ///
-    /// let root = Root::from_path(
-    ///     PathBuf::from("/home/user/project"),
-    ///     Some("My Project".to_string())
-    /// );
-    /// assert_eq!(root.uri, "file:///home/user/project");
-    /// assert_eq!(root.name, Some("My Project".to_string()));
-    /// ```
-    pub fn from_path(path: PathBuf, name: Option<String>) -> Self {
-        let uri = path_to_file_uri(&path);
-        Self { uri, name }
-    }
-
-    /// Extract the file path from this root's URI.
-    ///
-    /// Returns None if the URI is malformed or not a file:// URI.
-    pub fn to_path(&self) -> Option<PathBuf> {
-        file_uri_to_path(&self.uri)
-    }
-}
-
-/// Convert an rmcp Root to our Root type.
-impl From<RmcpRoot> for Root {
-    fn from(root: RmcpRoot) -> Self {
-        Self {
-            uri: root.uri.to_string(),
-            name: root.name,
-        }
-    }
-}
-
-/// Convert our Root to rmcp Root.
-impl From<Root> for RmcpRoot {
-    fn from(root: Root) -> Self {
-        RmcpRoot {
-            uri: root.uri.into(),
-            name: root.name,
-        }
-    }
-}
 
 /// Convert a PathBuf to a file:// URI string.
 ///
 /// This function handles platform-specific path formats:
 /// - Unix: /home/user/project -> file:///home/user/project
 /// - Windows: C:\Users\user\project -> file:///C:/Users/user/project
-fn path_to_file_uri(path: &PathBuf) -> String {
+pub fn path_to_file_uri(path: &PathBuf) -> String {
     #[cfg(unix)]
     {
         format!("file://{}", path.display())
@@ -91,27 +26,26 @@ fn path_to_file_uri(path: &PathBuf) -> String {
     }
 }
 
-/// Convert a file:// URI to a PathBuf.
+/// Create a Root from a PathBuf.
 ///
-/// Returns None if the URI is not a valid file:// URI.
-fn file_uri_to_path(uri: &str) -> Option<PathBuf> {
-    let uri = uri.strip_prefix("file://")?;
-
-    #[cfg(unix)]
-    {
-        Some(PathBuf::from(uri))
-    }
-
-    #[cfg(windows)]
-    {
-        // Strip leading / and convert back to Windows format
-        let path_str = uri.strip_prefix('/')?.replace('/', "\\");
-        Some(PathBuf::from(path_str))
-    }
-
-    #[cfg(not(any(unix, windows)))]
-    {
-        Some(PathBuf::from(uri))
+/// The path is converted to an absolute file:// URI.
+///
+/// # Example
+/// ```
+/// use std::path::PathBuf;
+/// use aether::mcp::root_from_path;
+///
+/// let root = root_from_path(
+///     PathBuf::from("/home/user/project"),
+///     Some("My Project".to_string())
+/// );
+/// assert_eq!(root.uri.as_str(), "file:///home/user/project");
+/// ```
+pub fn root_from_path(path: PathBuf, name: Option<String>) -> Root {
+    let uri = path_to_file_uri(&path);
+    Root {
+        uri: uri.into(),
+        name,
     }
 }
 
@@ -120,58 +54,36 @@ mod tests {
     use super::*;
 
     #[test]
+    fn test_path_to_file_uri() {
+        let path = PathBuf::from("/home/user/project");
+        let uri = path_to_file_uri(&path);
+        assert_eq!(uri, "file:///home/user/project");
+    }
+
+    #[test]
     fn test_root_from_path() {
         let path = PathBuf::from("/home/user/project");
-        let root = Root::from_path(path, Some("Test Project".to_string()));
+        let root = root_from_path(path, Some("Test Project".to_string()));
 
-        assert_eq!(root.uri, "file:///home/user/project");
+        assert_eq!(root.uri.as_str(), "file:///home/user/project");
         assert_eq!(root.name, Some("Test Project".to_string()));
     }
 
     #[test]
-    fn test_root_to_path() {
-        let root = Root {
-            uri: "file:///home/user/project".to_string(),
-            name: None,
-        };
+    fn test_root_from_path_no_name() {
+        let path = PathBuf::from("/tmp/test");
+        let root = root_from_path(path, None);
 
-        let path = root.to_path();
-        assert_eq!(path, Some(PathBuf::from("/home/user/project")));
-    }
-
-    #[test]
-    fn test_root_roundtrip() {
-        let original_path = PathBuf::from("/tmp/test");
-        let root = Root::from_path(original_path.clone(), None);
-        let recovered_path = root.to_path();
-
-        assert_eq!(Some(original_path), recovered_path);
-    }
-
-    #[test]
-    fn test_rmcp_root_conversion() {
-        let our_root = Root {
-            uri: "file:///home/user/project".to_string(),
-            name: Some("Test".to_string()),
-        };
-
-        let rmcp_root: RmcpRoot = our_root.clone().into();
-        assert_eq!(rmcp_root.uri.as_str(), "file:///home/user/project");
-        assert_eq!(rmcp_root.name, Some("Test".to_string()));
-
-        let converted_back: Root = rmcp_root.into();
-        assert_eq!(converted_back, our_root);
+        assert_eq!(root.uri.as_str(), "file:///tmp/test");
+        assert_eq!(root.name, None);
     }
 
     #[test]
     fn test_path_with_spaces() {
         let path = PathBuf::from("/home/user/my project");
-        let root = Root::from_path(path.clone(), None);
+        let root = root_from_path(path, None);
 
         // The URI should preserve spaces (not percent-encoded in this simple implementation)
-        assert_eq!(root.uri, "file:///home/user/my project");
-
-        let recovered = root.to_path();
-        assert_eq!(recovered, Some(path));
+        assert_eq!(root.uri.as_str(), "file:///home/user/my project");
     }
 }

--- a/packages/mcp-lexicon/src/coding/mod.rs
+++ b/packages/mcp-lexicon/src/coding/mod.rs
@@ -108,10 +108,8 @@ pub struct CodingMcp<T: CodingTools = DefaultCodingTools> {
     tools: T,
     web_fetcher: WebFetcher,
     web_searcher: Option<WebSearcher<BraveSearchClient>>,
-    /// Workspace roots provided via MCP protocol
+    /// Workspace roots (from MCP protocol or CLI args)
     roots: RwLock<Vec<PathBuf>>,
-    /// Fallback workspace root from CLI args (used when no protocol roots provided)
-    fallback_root_dir: Option<PathBuf>,
 }
 
 #[tool_handler(router = self.tool_router)]
@@ -144,7 +142,6 @@ impl CodingMcp<DefaultCodingTools> {
             web_fetcher: WebFetcher::new(),
             web_searcher: WebSearcher::try_new().ok(),
             roots: RwLock::new(Vec::new()),
-            fallback_root_dir: None,
         }
     }
 }
@@ -161,13 +158,12 @@ impl<T: CodingTools + 'static> CodingMcp<T> {
             web_fetcher: WebFetcher::new(),
             web_searcher: WebSearcher::try_new().ok(),
             roots: RwLock::new(Vec::new()),
-            fallback_root_dir: None,
         }
     }
 
-    /// Set workspace roots via MCP protocol.
+    /// Set workspace roots.
     ///
-    /// These roots take precedence over the fallback root directory.
+    /// Can be used to set roots from MCP protocol or CLI arguments.
     /// The first root is used as the primary workspace root.
     ///
     /// # Note
@@ -177,33 +173,25 @@ impl<T: CodingTools + 'static> CodingMcp<T> {
         self
     }
 
-    /// Set the fallback workspace root directory.
+    /// Set the workspace root directory from a single path.
     ///
-    /// This path is used when no roots are provided via the MCP protocol.
-    /// It is communicated to LLMs via the server instructions,
-    /// helping them use correct absolute paths when calling file tools.
+    /// Convenience method that wraps the path in a Vec and calls with_roots().
+    /// Typically used with CLI arguments like --root-dir.
     ///
     /// # Note
     /// This is a builder method - call it before using the server.
-    pub fn with_root_dir(mut self, root_dir: PathBuf) -> Self {
-        self.fallback_root_dir = Some(root_dir);
-        self
+    pub fn with_root_dir(self, root_dir: PathBuf) -> Self {
+        self.with_roots(vec![root_dir])
     }
 
     /// Get the current workspace root.
     ///
-    /// Checks protocol roots first, then falls back to CLI argument.
     /// Returns the first root if multiple are provided.
     fn get_workspace_root(&self) -> Option<PathBuf> {
-        // Try protocol roots first
-        if let Ok(roots) = self.roots.try_read() {
-            if let Some(first_root) = roots.first() {
-                return Some(first_root.clone());
-            }
-        }
-
-        // Fall back to CLI argument
-        self.fallback_root_dir.clone()
+        self.roots
+            .try_read()
+            .ok()
+            .and_then(|roots| roots.first().cloned())
     }
 
     fn build_instructions(&self) -> String {

--- a/packages/mcp-lexicon/src/coding/mod.rs
+++ b/packages/mcp-lexicon/src/coding/mod.rs
@@ -108,8 +108,10 @@ pub struct CodingMcp<T: CodingTools = DefaultCodingTools> {
     tools: T,
     web_fetcher: WebFetcher,
     web_searcher: Option<WebSearcher<BraveSearchClient>>,
-    /// Workspace root directory - communicated to LLMs via server instructions
-    root_dir: Option<PathBuf>,
+    /// Workspace roots provided via MCP protocol
+    roots: RwLock<Vec<PathBuf>>,
+    /// Fallback workspace root from CLI args (used when no protocol roots provided)
+    fallback_root_dir: Option<PathBuf>,
 }
 
 #[tool_handler(router = self.tool_router)]
@@ -141,7 +143,8 @@ impl CodingMcp<DefaultCodingTools> {
             tools: DefaultCodingTools::new(),
             web_fetcher: WebFetcher::new(),
             web_searcher: WebSearcher::try_new().ok(),
-            root_dir: None,
+            roots: RwLock::new(Vec::new()),
+            fallback_root_dir: None,
         }
     }
 }
@@ -157,20 +160,50 @@ impl<T: CodingTools + 'static> CodingMcp<T> {
             tools,
             web_fetcher: WebFetcher::new(),
             web_searcher: WebSearcher::try_new().ok(),
-            root_dir: None,
+            roots: RwLock::new(Vec::new()),
+            fallback_root_dir: None,
         }
     }
 
-    /// Set the workspace root directory.
+    /// Set workspace roots via MCP protocol.
     ///
-    /// This path is communicated to LLMs via the server instructions,
+    /// These roots take precedence over the fallback root directory.
+    /// The first root is used as the primary workspace root.
+    ///
+    /// # Note
+    /// This is a builder method - call it before using the server.
+    pub fn with_roots(mut self, roots: Vec<PathBuf>) -> Self {
+        self.roots = RwLock::new(roots);
+        self
+    }
+
+    /// Set the fallback workspace root directory.
+    ///
+    /// This path is used when no roots are provided via the MCP protocol.
+    /// It is communicated to LLMs via the server instructions,
     /// helping them use correct absolute paths when calling file tools.
     ///
     /// # Note
     /// This is a builder method - call it before using the server.
     pub fn with_root_dir(mut self, root_dir: PathBuf) -> Self {
-        self.root_dir = Some(root_dir);
+        self.fallback_root_dir = Some(root_dir);
         self
+    }
+
+    /// Get the current workspace root.
+    ///
+    /// Checks protocol roots first, then falls back to CLI argument.
+    /// Returns the first root if multiple are provided.
+    fn get_workspace_root(&self) -> Option<PathBuf> {
+        // Try protocol roots first
+        if let Ok(roots) = self.roots.try_read() {
+            if let Some(first_root) = roots.first() {
+                return Some(first_root.clone());
+            }
+        }
+
+        // Fall back to CLI argument
+        self.fallback_root_dir.clone()
     }
 
     fn build_instructions(&self) -> String {
@@ -201,7 +234,7 @@ impl<T: CodingTools + 'static> CodingMcp<T> {
 - **File names** (find *.test.ts): `find`
 "#;
 
-        match &self.root_dir {
+        match self.get_workspace_root() {
             Some(root) => format!(
                 r#"{}
 

--- a/packages/mcp-lexicon/src/plugins/server.rs
+++ b/packages/mcp-lexicon/src/plugins/server.rs
@@ -99,15 +99,6 @@ impl PluginsMcp {
         self
     }
 
-    /// Get the current base directory (first root).
-    fn get_base_dir(&self) -> PathBuf {
-        self.roots
-            .try_read()
-            .ok()
-            .and_then(|roots| roots.first().cloned())
-            .unwrap_or_else(|| PathBuf::from("."))
-    }
-
     fn build_instructions(&self) -> String {
         let mut instructions = include_str!("./instructions.md").to_string();
 

--- a/packages/mcp-lexicon/src/plugins/server.rs
+++ b/packages/mcp-lexicon/src/plugins/server.rs
@@ -60,10 +60,8 @@ pub struct PluginsMcp {
     skills_info: Vec<SkillMetadata>,
     agents_info: Vec<SubAgentInfo>,
     tool_router: ToolRouter<Self>,
-    /// Workspace roots provided via MCP protocol
+    /// Workspace roots (from MCP protocol or CLI args)
     roots: Arc<RwLock<Vec<PathBuf>>>,
-    /// Fallback base directory from CLI args
-    fallback_base_dir: Option<PathBuf>,
 }
 
 impl PluginsMcp {
@@ -81,8 +79,7 @@ impl PluginsMcp {
             skills_info,
             agents_info,
             tool_router: Self::tool_router(),
-            roots: Arc::new(RwLock::new(Vec::new())),
-            fallback_base_dir: Some(base_dir),
+            roots: Arc::new(RwLock::new(vec![base_dir])),
         }
     }
 
@@ -94,28 +91,20 @@ impl PluginsMcp {
         Ok(Self::new(base_dir))
     }
 
-    /// Set workspace roots via MCP protocol.
+    /// Set workspace roots.
     ///
-    /// These roots take precedence over the fallback base directory.
+    /// Can be used to set roots from MCP protocol or to override CLI arguments.
     pub fn with_roots(mut self, roots: Vec<PathBuf>) -> Self {
         self.roots = Arc::new(RwLock::new(roots));
         self
     }
 
-    /// Get the current base directory.
-    ///
-    /// Checks protocol roots first, then falls back to CLI argument.
+    /// Get the current base directory (first root).
     fn get_base_dir(&self) -> PathBuf {
-        // Try protocol roots first
-        if let Ok(roots) = self.roots.try_read() {
-            if let Some(first_root) = roots.first() {
-                return first_root.clone();
-            }
-        }
-
-        // Fall back to CLI argument or current directory
-        self.fallback_base_dir
-            .clone()
+        self.roots
+            .try_read()
+            .ok()
+            .and_then(|roots| roots.first().cloned())
             .unwrap_or_else(|| PathBuf::from("."))
     }
 

--- a/packages/mcp-lexicon/src/plugins/server.rs
+++ b/packages/mcp-lexicon/src/plugins/server.rs
@@ -17,6 +17,7 @@ use rmcp::{
 use std::collections::HashMap;
 use std::path::PathBuf;
 use std::sync::Arc;
+use tokio::sync::RwLock;
 use tracing::error;
 
 /// Callback type for reporting agent progress during subagent execution.
@@ -59,6 +60,10 @@ pub struct PluginsMcp {
     skills_info: Vec<SkillMetadata>,
     agents_info: Vec<SubAgentInfo>,
     tool_router: ToolRouter<Self>,
+    /// Workspace roots provided via MCP protocol
+    roots: Arc<RwLock<Vec<PathBuf>>>,
+    /// Fallback base directory from CLI args
+    fallback_base_dir: Option<PathBuf>,
 }
 
 impl PluginsMcp {
@@ -76,6 +81,8 @@ impl PluginsMcp {
             skills_info,
             agents_info,
             tool_router: Self::tool_router(),
+            roots: Arc::new(RwLock::new(Vec::new())),
+            fallback_base_dir: Some(base_dir),
         }
     }
 
@@ -85,6 +92,31 @@ impl PluginsMcp {
         let parsed_args = PluginsMcpArgs::from_args(args)?;
         let base_dir = parsed_args.base_dir.unwrap_or_else(|| PathBuf::from("."));
         Ok(Self::new(base_dir))
+    }
+
+    /// Set workspace roots via MCP protocol.
+    ///
+    /// These roots take precedence over the fallback base directory.
+    pub fn with_roots(mut self, roots: Vec<PathBuf>) -> Self {
+        self.roots = Arc::new(RwLock::new(roots));
+        self
+    }
+
+    /// Get the current base directory.
+    ///
+    /// Checks protocol roots first, then falls back to CLI argument.
+    fn get_base_dir(&self) -> PathBuf {
+        // Try protocol roots first
+        if let Ok(roots) = self.roots.try_read() {
+            if let Some(first_root) = roots.first() {
+                return first_root.clone();
+            }
+        }
+
+        // Fall back to CLI argument or current directory
+        self.fallback_base_dir
+            .clone()
+            .unwrap_or_else(|| PathBuf::from("."))
     }
 
     fn build_instructions(&self) -> String {

--- a/packages/mcp-lexicon/src/tasks/server.rs
+++ b/packages/mcp-lexicon/src/tasks/server.rs
@@ -45,10 +45,8 @@ impl TasksMcpArgs {
 pub struct TasksMcp {
     task_store: Mutex<TaskStore>,
     tool_router: ToolRouter<Self>,
-    /// Workspace roots provided via MCP protocol
+    /// Workspace roots (from MCP protocol or CLI args)
     roots: Arc<RwLock<Vec<PathBuf>>>,
-    /// Fallback base directory from CLI args
-    fallback_base_dir: Option<PathBuf>,
 }
 
 impl TasksMcp {
@@ -59,8 +57,7 @@ impl TasksMcp {
         Self {
             task_store: Mutex::new(TaskStore::new(base_dir.join(".aether-tasks"))),
             tool_router: Self::tool_router(),
-            roots: Arc::new(RwLock::new(Vec::new())),
-            fallback_base_dir: Some(base_dir),
+            roots: Arc::new(RwLock::new(vec![base_dir])),
         }
     }
 
@@ -72,28 +69,20 @@ impl TasksMcp {
         Ok(Self::new(parsed_args.dir))
     }
 
-    /// Set workspace roots via MCP protocol.
+    /// Set workspace roots.
     ///
-    /// These roots take precedence over the fallback base directory.
+    /// Can be used to set roots from MCP protocol or to override CLI arguments.
     pub fn with_roots(mut self, roots: Vec<PathBuf>) -> Self {
         self.roots = Arc::new(RwLock::new(roots));
         self
     }
 
-    /// Get the current base directory for task storage.
-    ///
-    /// Checks protocol roots first, then falls back to CLI argument.
+    /// Get the current base directory for task storage (first root).
     fn get_base_dir(&self) -> PathBuf {
-        // Try protocol roots first
-        if let Ok(roots) = self.roots.try_read() {
-            if let Some(first_root) = roots.first() {
-                return first_root.clone();
-            }
-        }
-
-        // Fall back to CLI argument or current directory
-        self.fallback_base_dir
-            .clone()
+        self.roots
+            .try_read()
+            .ok()
+            .and_then(|roots| roots.first().cloned())
             .unwrap_or_else(|| PathBuf::from("."))
     }
 }

--- a/packages/mcp-lexicon/src/tasks/server.rs
+++ b/packages/mcp-lexicon/src/tasks/server.rs
@@ -9,7 +9,6 @@ use rmcp::{
     tool, tool_handler, tool_router,
 };
 use std::path::PathBuf;
-use std::sync::Arc;
 use tokio::sync::{Mutex, RwLock};
 
 use crate::tasks::{
@@ -46,7 +45,7 @@ pub struct TasksMcp {
     task_store: Mutex<TaskStore>,
     tool_router: ToolRouter<Self>,
     /// Workspace roots (from MCP protocol or CLI args)
-    roots: Arc<RwLock<Vec<PathBuf>>>,
+    roots: RwLock<Vec<PathBuf>>,
 }
 
 impl TasksMcp {
@@ -57,7 +56,7 @@ impl TasksMcp {
         Self {
             task_store: Mutex::new(TaskStore::new(base_dir.join(".aether-tasks"))),
             tool_router: Self::tool_router(),
-            roots: Arc::new(RwLock::new(vec![base_dir])),
+            roots: RwLock::new(vec![base_dir]),
         }
     }
 
@@ -73,17 +72,8 @@ impl TasksMcp {
     ///
     /// Can be used to set roots from MCP protocol or to override CLI arguments.
     pub fn with_roots(mut self, roots: Vec<PathBuf>) -> Self {
-        self.roots = Arc::new(RwLock::new(roots));
+        self.roots = RwLock::new(roots);
         self
-    }
-
-    /// Get the current base directory for task storage (first root).
-    fn get_base_dir(&self) -> PathBuf {
-        self.roots
-            .try_read()
-            .ok()
-            .and_then(|roots| roots.first().cloned())
-            .unwrap_or_else(|| PathBuf::from("."))
     }
 }
 

--- a/packages/mcp-lexicon/src/tasks/server.rs
+++ b/packages/mcp-lexicon/src/tasks/server.rs
@@ -9,7 +9,8 @@ use rmcp::{
     tool, tool_handler, tool_router,
 };
 use std::path::PathBuf;
-use tokio::sync::Mutex;
+use std::sync::Arc;
+use tokio::sync::{Mutex, RwLock};
 
 use crate::tasks::{
     TaskCreateInput, TaskCreateOutput, TaskGetInput, TaskGetOutput, TaskListInput, TaskListOutput,
@@ -44,6 +45,10 @@ impl TasksMcpArgs {
 pub struct TasksMcp {
     task_store: Mutex<TaskStore>,
     tool_router: ToolRouter<Self>,
+    /// Workspace roots provided via MCP protocol
+    roots: Arc<RwLock<Vec<PathBuf>>>,
+    /// Fallback base directory from CLI args
+    fallback_base_dir: Option<PathBuf>,
 }
 
 impl TasksMcp {
@@ -54,6 +59,8 @@ impl TasksMcp {
         Self {
             task_store: Mutex::new(TaskStore::new(base_dir.join(".aether-tasks"))),
             tool_router: Self::tool_router(),
+            roots: Arc::new(RwLock::new(Vec::new())),
+            fallback_base_dir: Some(base_dir),
         }
     }
 
@@ -63,6 +70,31 @@ impl TasksMcp {
     pub fn from_args(args: Vec<String>) -> Result<Self, String> {
         let parsed_args = TasksMcpArgs::from_args(args)?;
         Ok(Self::new(parsed_args.dir))
+    }
+
+    /// Set workspace roots via MCP protocol.
+    ///
+    /// These roots take precedence over the fallback base directory.
+    pub fn with_roots(mut self, roots: Vec<PathBuf>) -> Self {
+        self.roots = Arc::new(RwLock::new(roots));
+        self
+    }
+
+    /// Get the current base directory for task storage.
+    ///
+    /// Checks protocol roots first, then falls back to CLI argument.
+    fn get_base_dir(&self) -> PathBuf {
+        // Try protocol roots first
+        if let Ok(roots) = self.roots.try_read() {
+            if let Some(first_root) = roots.first() {
+                return first_root.clone();
+            }
+        }
+
+        // Fall back to CLI argument or current directory
+        self.fallback_base_dir
+            .clone()
+            .unwrap_or_else(|| PathBuf::from("."))
     }
 }
 


### PR DESCRIPTION
Implements MCP roots protocol in both the aether MCP client and
mcp-lexicon servers (coding, plugins, tasks). This allows servers
to receive workspace root directories dynamically via the MCP protocol
instead of relying solely on CLI arguments.

Changes:
- Created new roots module in aether package with Root type and
  path-to-URI conversion utilities
- Updated McpClient to store and serve roots via list_roots() handler
- Enabled roots capability in McpManager's ClientCapabilities
- Added set_roots() method to McpManager for dynamic root updates
- Added roots support to CodingMcp, PluginsMcp, and TasksMcp servers
- Each server now has with_roots() builder method and falls back to
  CLI args when no protocol roots are provided
- All existing tests pass, new unit tests added for roots module

Backward compatible: CLI arguments (--root-dir, --dir) still work as
fallback when no protocol roots are provided.

Related to: JOS-58