### PR TITLE
fix: Enable token usage tracking for OpenRouter provider

### DIFF
--- a/packages/aether-desktop/src/acp_agent.rs
+++ b/packages/aether-desktop/src/acp_agent.rs
@@ -584,9 +584,10 @@ fn map_acp_event_to_agent_events(agent_id: &str, event: AcpEvent) -> Vec<AgentEv
             }
             // Skip tool calls with empty names (partial streaming updates)
             if let AgentMessage::ToolCall { ref request, .. } = event
-                && request.name.is_empty() {
-                    return vec![];
-                }
+                && request.name.is_empty()
+            {
+                return vec![];
+            }
             vec![AgentEvent::SubAgentProgress {
                 agent_id: agent_id.to_string(),
                 parent_tool_id,

--- a/packages/aether-desktop/src/components/tool_call_display.rs
+++ b/packages/aether-desktop/src/components/tool_call_display.rs
@@ -127,25 +127,26 @@ fn build_tool_display(
     // If we have sub-agent streams but no display_meta yet (tool still pending),
     // show the streams directly
     if let Some(ref streams) = sub_agent_streams
-        && !streams.streams.is_empty() {
-            return (
-                None,
-                rsx! {
-                    div {
-                        class: "flex flex-col gap-1",
-                        for (id, stream) in streams.streams.iter() {
-                            SubAgentStreamInline {
-                                key: "{id}",
-                                stream_id: id.clone(),
-                                agent_name: stream.agent_name.clone(),
-                                messages: stream.messages.clone(),
-                                is_complete: stream.is_complete,
-                            }
+        && !streams.streams.is_empty()
+    {
+        return (
+            None,
+            rsx! {
+                div {
+                    class: "flex flex-col gap-1",
+                    for (id, stream) in streams.streams.iter() {
+                        SubAgentStreamInline {
+                            key: "{id}",
+                            stream_id: id.clone(),
+                            agent_name: stream.agent_name.clone(),
+                            messages: stream.messages.clone(),
+                            is_complete: stream.is_complete,
                         }
                     }
-                },
-            );
-        }
+                }
+            },
+        );
+    }
 
     if *status == ToolCallStatus::Pending {
         return (None, render_raw_content(display_content));

--- a/packages/aether/src/llm/openai_compatible/streaming.rs
+++ b/packages/aether/src/llm/openai_compatible/streaming.rs
@@ -3,6 +3,7 @@ use crate::llm::openai_compatible::types::ChatCompletionStreamResponse;
 use crate::llm::{LlmError, LlmResponseStream};
 use async_openai::{Client, config::OpenAIConfig, types::chat::CreateChatCompletionRequest};
 use async_stream;
+use serde::Serialize;
 use tokio_stream::StreamExt;
 
 /// Creates a streaming response for OpenAI-compatible APIs.
@@ -12,13 +13,22 @@ pub fn create_custom_stream(
     client: &Client<OpenAIConfig>,
     request: CreateChatCompletionRequest,
 ) -> LlmResponseStream {
+    create_custom_stream_generic(client, request)
+}
+
+/// Generic streaming function that accepts any serializable request type.
+/// This enables providers to use custom request types while reusing the streaming logic.
+pub fn create_custom_stream_generic<R: Serialize + Send + 'static>(
+    client: &Client<OpenAIConfig>,
+    request: R,
+) -> LlmResponseStream {
     let client = client.clone();
 
     Box::pin(async_stream::stream! {
         // Create the stream - need await so we must use async_stream
         let stream = match client
             .chat()
-            .create_stream_byot::<CreateChatCompletionRequest, ChatCompletionStreamResponse>(request)
+            .create_stream_byot::<R, ChatCompletionStreamResponse>(request)
             .await {
             Ok(stream) => stream,
             Err(e) => {
@@ -27,7 +37,7 @@ pub fn create_custom_stream(
             }
         };
 
-        // Map to standard opneai types
+        // Map to standard OpenAI types
         let mapped_stream = stream.map(|result| {
             result
                 .map(|response| response.into())

--- a/packages/aether/src/llm/openrouter/mod.rs
+++ b/packages/aether/src/llm/openrouter/mod.rs
@@ -1,3 +1,5 @@
 mod provider;
+mod types;
 
 pub use provider::*;
+pub use types::*;

--- a/packages/aether/src/llm/openrouter/provider.rs
+++ b/packages/aether/src/llm/openrouter/provider.rs
@@ -1,6 +1,10 @@
-use async_openai::{Client, config::OpenAIConfig, types::chat::ChatCompletionStreamOptions};
+use async_openai::{Client, config::OpenAIConfig};
+use async_stream;
+use tokio_stream::StreamExt;
 
-use crate::llm::openai_compatible::{build_chat_request, create_custom_stream};
+use crate::llm::openai::process_completion_stream;
+use crate::llm::openai_compatible::{build_chat_request, types::ChatCompletionStreamResponse};
+use crate::llm::openrouter::types::OpenRouterChatRequest;
 use crate::llm::{
     Context, LlmError, LlmResponseStream, ProviderFactory, Result, StreamingModelProvider,
 };
@@ -62,13 +66,31 @@ impl ProviderFactory for OpenRouterProvider {
 
 impl StreamingModelProvider for OpenRouterProvider {
     fn stream_response(&self, context: &Context) -> LlmResponseStream {
-        let mut request = build_chat_request(&self.model, context);
-        request.stream_options = Some(ChatCompletionStreamOptions {
-            include_usage: Some(true),
-            include_obfuscation: None,
-        });
+        let request: OpenRouterChatRequest = build_chat_request(&self.model, context).into();
+        let client = self.client.clone();
 
-        create_custom_stream(&self.client, request)
+        Box::pin(async_stream::stream! {
+            let stream = match client
+                .chat()
+                .create_stream_byot::<OpenRouterChatRequest, ChatCompletionStreamResponse>(request)
+                .await {
+                Ok(stream) => stream,
+                Err(e) => {
+                    yield Err(LlmError::ApiRequest(e.to_string()));
+                    return;
+                }
+            };
+
+            let mapped_stream = stream.map(|result| {
+                result
+                    .map(|response| response.into())
+                    .map_err(|e| LlmError::ApiError(e.to_string()))
+            });
+
+            for await item in process_completion_stream(mapped_stream) {
+                yield item;
+            }
+        })
     }
 
     fn display_name(&self) -> String {

--- a/packages/aether/src/llm/openrouter/provider.rs
+++ b/packages/aether/src/llm/openrouter/provider.rs
@@ -1,9 +1,14 @@
 use async_openai::{Client, config::OpenAIConfig};
+<<<<<<< HEAD
 use async_stream;
 use tokio_stream::StreamExt;
 
 use crate::llm::openai::process_completion_stream;
 use crate::llm::openai_compatible::{build_chat_request, types::ChatCompletionStreamResponse};
+=======
+
+use crate::llm::openai_compatible::{build_chat_request, streaming::create_custom_stream_generic};
+>>>>>>> 516877e (refactor: DRY up OpenRouter provider and make streaming more generic)
 use crate::llm::openrouter::types::OpenRouterChatRequest;
 use crate::llm::{
     Context, LlmError, LlmResponseStream, ProviderFactory, Result, StreamingModelProvider,
@@ -66,31 +71,11 @@ impl ProviderFactory for OpenRouterProvider {
 
 impl StreamingModelProvider for OpenRouterProvider {
     fn stream_response(&self, context: &Context) -> LlmResponseStream {
+        // Build base request and convert to OpenRouter-specific format
+        // The From trait automatically adds usage tracking parameters
+        // See: https://openrouter.ai/docs/use-cases/usage-accounting
         let request: OpenRouterChatRequest = build_chat_request(&self.model, context).into();
-        let client = self.client.clone();
-
-        Box::pin(async_stream::stream! {
-            let stream = match client
-                .chat()
-                .create_stream_byot::<OpenRouterChatRequest, ChatCompletionStreamResponse>(request)
-                .await {
-                Ok(stream) => stream,
-                Err(e) => {
-                    yield Err(LlmError::ApiRequest(e.to_string()));
-                    return;
-                }
-            };
-
-            let mapped_stream = stream.map(|result| {
-                result
-                    .map(|response| response.into())
-                    .map_err(|e| LlmError::ApiError(e.to_string()))
-            });
-
-            for await item in process_completion_stream(mapped_stream) {
-                yield item;
-            }
-        })
+        create_custom_stream_generic(&self.client, request)
     }
 
     fn display_name(&self) -> String {

--- a/packages/aether/src/llm/openrouter/provider.rs
+++ b/packages/aether/src/llm/openrouter/provider.rs
@@ -1,18 +1,9 @@
-use async_openai::{Client, config::OpenAIConfig};
-<<<<<<< HEAD
-use async_stream;
-use tokio_stream::StreamExt;
-
-use crate::llm::openai::process_completion_stream;
-use crate::llm::openai_compatible::{build_chat_request, types::ChatCompletionStreamResponse};
-=======
-
 use crate::llm::openai_compatible::{build_chat_request, streaming::create_custom_stream_generic};
->>>>>>> 516877e (refactor: DRY up OpenRouter provider and make streaming more generic)
 use crate::llm::openrouter::types::OpenRouterChatRequest;
 use crate::llm::{
     Context, LlmError, LlmResponseStream, ProviderFactory, Result, StreamingModelProvider,
 };
+use async_openai::{Client, config::OpenAIConfig};
 
 pub struct OpenRouterProvider {
     client: Client<OpenAIConfig>,

--- a/packages/aether/src/llm/openrouter/types.rs
+++ b/packages/aether/src/llm/openrouter/types.rs
@@ -46,27 +46,25 @@ pub struct OpenRouterChatRequest {
 }
 
 impl From<CreateChatCompletionRequest> for OpenRouterChatRequest {
-    fn from(req: CreateChatCompletionRequest) -> Self {
+    fn from(request: CreateChatCompletionRequest) -> Self {
         Self {
-            model: req.model,
-            messages: req.messages,
-            stream: req.stream,
-            tools: req.tools,
-            tool_choice: req.tool_choice,
-            temperature: req.temperature,
-            top_p: req.top_p,
-            max_completion_tokens: req.max_completion_tokens,
-            presence_penalty: req.presence_penalty,
-            frequency_penalty: req.frequency_penalty,
-            stop: req.stop,
-            response_format: req.response_format,
-            // OpenRouter-specific: enable usage tracking in streaming responses
-            // See: https://openrouter.ai/docs/use-cases/usage-accounting
+            model: request.model,
+            messages: request.messages,
+            stream: request.stream,
+            tools: request.tools,
+            tool_choice: request.tool_choice,
+            temperature: request.temperature,
+            top_p: request.top_p,
+            max_completion_tokens: request.max_completion_tokens,
             stream_options: Some(ChatCompletionStreamOptions {
                 include_usage: Some(true),
                 include_obfuscation: None,
             }),
             usage: Some(OpenRouterUsage { include: true }),
+            presence_penalty: request.presence_penalty,
+            frequency_penalty: request.frequency_penalty,
+            stop: request.stop,
+            response_format: request.response_format,
         }
     }
 }

--- a/packages/aether/src/llm/openrouter/types.rs
+++ b/packages/aether/src/llm/openrouter/types.rs
@@ -1,0 +1,72 @@
+use async_openai::types::chat::{
+    ChatCompletionRequestMessage, ChatCompletionStreamOptions, ChatCompletionToolChoiceOption,
+    ChatCompletionTools, CreateChatCompletionRequest, ResponseFormat, StopConfiguration,
+};
+use serde::{Deserialize, Serialize};
+
+/// OpenRouter-specific usage configuration
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct OpenRouterUsage {
+    #[serde(rename = "include")]
+    pub include: bool,
+}
+
+/// Custom request type for OpenRouter that includes the usage parameter
+///
+/// OpenRouter requires a specific `usage` parameter in the request body to enable
+/// token usage tracking. See: https://openrouter.ai/docs/use-cases/usage-accounting
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct OpenRouterChatRequest {
+    pub model: String,
+    pub messages: Vec<ChatCompletionRequestMessage>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub stream: Option<bool>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub tools: Option<Vec<ChatCompletionTools>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub tool_choice: Option<ChatCompletionToolChoiceOption>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub temperature: Option<f32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub top_p: Option<f32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub max_completion_tokens: Option<u32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub stream_options: Option<ChatCompletionStreamOptions>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub usage: Option<OpenRouterUsage>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub presence_penalty: Option<f32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub frequency_penalty: Option<f32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub stop: Option<StopConfiguration>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub response_format: Option<ResponseFormat>,
+}
+
+impl From<CreateChatCompletionRequest> for OpenRouterChatRequest {
+    fn from(req: CreateChatCompletionRequest) -> Self {
+        Self {
+            model: req.model,
+            messages: req.messages,
+            stream: req.stream,
+            tools: req.tools,
+            tool_choice: req.tool_choice,
+            temperature: req.temperature,
+            top_p: req.top_p,
+            max_completion_tokens: req.max_completion_tokens,
+            presence_penalty: req.presence_penalty,
+            frequency_penalty: req.frequency_penalty,
+            stop: req.stop,
+            response_format: req.response_format,
+            // OpenRouter-specific: enable usage tracking in streaming responses
+            // See: https://openrouter.ai/docs/use-cases/usage-accounting
+            stream_options: Some(ChatCompletionStreamOptions {
+                include_usage: Some(true),
+                include_obfuscation: None,
+            }),
+            usage: Some(OpenRouterUsage { include: true }),
+        }
+    }
+}

--- a/packages/aether/src/mcp/oauth_integration.rs
+++ b/packages/aether/src/mcp/oauth_integration.rs
@@ -52,13 +52,14 @@ pub async fn perform_oauth_flow<H: OAuthHandler>(
 ) -> Result<OAuthHelperResult, OAuthError> {
     // Try to load existing credentials first
     if let Some(auth_manager) = create_auth_manager_from_store(server_id, base_url).await?
-        && let Ok(access_token) = auth_manager.get_access_token().await {
-            return Ok(OAuthHelperResult {
-                access_token: access_token.clone(),
-                auth_header: format!("Bearer {access_token}"),
-            });
-        }
-        // Token might be expired and refresh failed, continue to new auth flow
+        && let Ok(access_token) = auth_manager.get_access_token().await
+    {
+        return Ok(OAuthHelperResult {
+            access_token: access_token.clone(),
+            auth_header: format!("Bearer {access_token}"),
+        });
+    }
+    // Token might be expired and refresh failed, continue to new auth flow
 
     // No stored credentials or they're invalid, start new OAuth flow
     let credential_store = create_credential_store(server_id)?;

--- a/packages/aether/tests/llm.rs
+++ b/packages/aether/tests/llm.rs
@@ -2,6 +2,9 @@ mod llm {
     mod openai {
         mod streaming_tests;
     }
+    mod openrouter {
+        mod usage_tests;
+    }
     mod z_ai {
         mod types_tests;
     }

--- a/packages/aether/tests/llm/openrouter/usage_tests.rs
+++ b/packages/aether/tests/llm/openrouter/usage_tests.rs
@@ -1,9 +1,9 @@
+use aether::llm::LlmResponse;
+use aether::llm::openai::streaming::process_completion_stream;
 use aether::llm::openai_compatible::types::{
     ChatCompletionStreamChoice, ChatCompletionStreamResponse, ChatCompletionStreamResponseDelta,
     Usage,
 };
-use aether::llm::openai::streaming::process_completion_stream;
-use aether::llm::LlmResponse;
 use async_openai::types::chat::Role;
 use tokio_stream::StreamExt;
 

--- a/packages/aether/tests/llm/openrouter/usage_tests.rs
+++ b/packages/aether/tests/llm/openrouter/usage_tests.rs
@@ -1,0 +1,215 @@
+use aether::llm::openai_compatible::types::{
+    ChatCompletionStreamChoice, ChatCompletionStreamResponse, ChatCompletionStreamResponseDelta,
+    Usage,
+};
+use aether::llm::openai::streaming::process_completion_stream;
+use aether::llm::LlmResponse;
+use async_openai::types::chat::Role;
+use tokio_stream::StreamExt;
+
+/// Test that OpenRouter usage data is correctly extracted from stream responses
+#[tokio::test]
+async fn test_openrouter_usage_extraction() {
+    // Create a stream response that includes usage data, similar to what OpenRouter returns
+    let stream_items = vec![
+        // First chunk with content
+        Ok::<ChatCompletionStreamResponse, std::io::Error>(ChatCompletionStreamResponse {
+            id: "gen-123".to_string(),
+            choices: vec![ChatCompletionStreamChoice {
+                index: 0,
+                delta: ChatCompletionStreamResponseDelta {
+                    role: Some(Role::Assistant),
+                    content: Some("Hello".to_string()),
+                    tool_calls: None,
+                },
+                finish_reason: None,
+                logprobs: None,
+            }],
+            created: 1234567890,
+            model: "openai/gpt-3.5-turbo".to_string(),
+            system_fingerprint: None,
+            object: "chat.completion.chunk".to_string(),
+            usage: None,
+        }),
+        // Second chunk with more content
+        Ok::<ChatCompletionStreamResponse, std::io::Error>(ChatCompletionStreamResponse {
+            id: "gen-123".to_string(),
+            choices: vec![ChatCompletionStreamChoice {
+                index: 0,
+                delta: ChatCompletionStreamResponseDelta {
+                    role: None,
+                    content: Some(" world".to_string()),
+                    tool_calls: None,
+                },
+                finish_reason: None,
+                logprobs: None,
+            }],
+            created: 1234567890,
+            model: "openai/gpt-3.5-turbo".to_string(),
+            system_fingerprint: None,
+            object: "chat.completion.chunk".to_string(),
+            usage: None,
+        }),
+        // Final chunk with usage data
+        Ok::<ChatCompletionStreamResponse, std::io::Error>(ChatCompletionStreamResponse {
+            id: "gen-123".to_string(),
+            choices: vec![ChatCompletionStreamChoice {
+                index: 0,
+                delta: ChatCompletionStreamResponseDelta {
+                    role: None,
+                    content: None,
+                    tool_calls: None,
+                },
+                finish_reason: Some(aether::llm::openai_compatible::types::FinishReason::Stop),
+                logprobs: None,
+            }],
+            created: 1234567890,
+            model: "openai/gpt-3.5-turbo".to_string(),
+            system_fingerprint: None,
+            object: "chat.completion.chunk".to_string(),
+            usage: Some(Usage {
+                prompt_tokens: 10,
+                completion_tokens: 20,
+                total_tokens: 30,
+            }),
+        }),
+    ];
+
+    // Convert to standard OpenAI format and process
+    let stream = tokio_stream::iter(
+        stream_items
+            .into_iter()
+            .map(|r| r.map(|response| response.into())),
+    );
+    let mut processed_stream = Box::pin(process_completion_stream(stream));
+
+    let mut events = Vec::new();
+    while let Some(event) = processed_stream.next().await {
+        events.push(event.unwrap());
+    }
+
+    // Verify we got usage data
+    let usage_events: Vec<_> = events
+        .iter()
+        .filter_map(|e| match e {
+            LlmResponse::Usage {
+                input_tokens,
+                output_tokens,
+            } => Some((input_tokens, output_tokens)),
+            _ => None,
+        })
+        .collect();
+
+    assert_eq!(usage_events.len(), 1, "Should have exactly one usage event");
+    assert_eq!(*usage_events[0].0, 10, "Input tokens should be 10");
+    assert_eq!(*usage_events[0].1, 20, "Output tokens should be 20");
+}
+
+/// Test that negative token counts are handled correctly
+#[tokio::test]
+async fn test_openrouter_negative_token_handling() {
+    // OpenRouter sometimes returns negative token counts
+    // Our conversion should handle this by clamping to 0
+    let stream_items = vec![Ok::<ChatCompletionStreamResponse, std::io::Error>(
+        ChatCompletionStreamResponse {
+            id: "gen-123".to_string(),
+            choices: vec![ChatCompletionStreamChoice {
+                index: 0,
+                delta: ChatCompletionStreamResponseDelta {
+                    role: None,
+                    content: None,
+                    tool_calls: None,
+                },
+                finish_reason: Some(aether::llm::openai_compatible::types::FinishReason::Stop),
+                logprobs: None,
+            }],
+            created: 1234567890,
+            model: "openai/gpt-3.5-turbo".to_string(),
+            system_fingerprint: None,
+            object: "chat.completion.chunk".to_string(),
+            usage: Some(Usage {
+                prompt_tokens: -5, // Negative value
+                completion_tokens: 10,
+                total_tokens: 5,
+            }),
+        },
+    )];
+
+    let stream = tokio_stream::iter(
+        stream_items
+            .into_iter()
+            .map(|r| r.map(|response| response.into())),
+    );
+    let mut processed_stream = Box::pin(process_completion_stream(stream));
+
+    let mut events = Vec::new();
+    while let Some(event) = processed_stream.next().await {
+        events.push(event.unwrap());
+    }
+
+    // Verify negative tokens are clamped to 0
+    let usage_events: Vec<_> = events
+        .iter()
+        .filter_map(|e| match e {
+            LlmResponse::Usage {
+                input_tokens,
+                output_tokens,
+            } => Some((input_tokens, output_tokens)),
+            _ => None,
+        })
+        .collect();
+
+    assert_eq!(usage_events.len(), 1);
+    assert_eq!(
+        *usage_events[0].0, 0,
+        "Negative input tokens should be clamped to 0"
+    );
+    assert_eq!(*usage_events[0].1, 10, "Output tokens should be 10");
+}
+
+/// Test that the OpenRouterChatRequest serializes the usage parameter correctly
+#[test]
+fn test_openrouter_request_serialization() {
+    use aether::llm::openrouter::{OpenRouterChatRequest, OpenRouterUsage};
+    use async_openai::types::chat::{
+        ChatCompletionRequestMessage, ChatCompletionRequestUserMessage,
+        ChatCompletionRequestUserMessageContent,
+    };
+    use serde_json;
+
+    let request = OpenRouterChatRequest {
+        model: "openai/gpt-3.5-turbo".to_string(),
+        messages: vec![ChatCompletionRequestMessage::User(
+            ChatCompletionRequestUserMessage {
+                content: ChatCompletionRequestUserMessageContent::Text("Hello".to_string()),
+                name: None,
+            },
+        )],
+        stream: Some(true),
+        tools: None,
+        tool_choice: None,
+        temperature: None,
+        top_p: None,
+        max_completion_tokens: None,
+        stream_options: None,
+        usage: Some(OpenRouterUsage { include: true }),
+        presence_penalty: None,
+        frequency_penalty: None,
+        stop: None,
+        response_format: None,
+    };
+
+    let json = serde_json::to_value(&request).unwrap();
+
+    // Verify the usage parameter is serialized correctly
+    assert_eq!(
+        json["usage"]["include"],
+        serde_json::Value::Bool(true),
+        "Usage parameter should be serialized with include: true"
+    );
+    assert_eq!(
+        json["model"],
+        serde_json::Value::String("openai/gpt-3.5-turbo".to_string()),
+        "Model should be serialized correctly"
+    );
+}


### PR DESCRIPTION
OpenRouter requires a specific `usage` parameter in the request body
to enable token usage tracking, separate from the OpenAI-standard
`stream_options.include_usage` parameter.

Changes:
- Created custom OpenRouterChatRequest type that includes the usage parameter
- Added OpenRouterUsage configuration struct
- Modified OpenRouterProvider to use the custom request type with usage: { include: true }
- Created dedicated streaming function for OpenRouter requests
- Added comprehensive tests for usage extraction and serialization
- Verified negative token count handling (clamped to 0)

This fix enables the context usage progress bar in aether-desktop to
work correctly with OpenRouter models, matching the functionality
already working with Z.ai and other providers.

Fixes: JOS-62