### PR TITLE
fix(wisp): More visible search bar in resume session

### DIFF
--- a/packages/tui/src/components/bordered_text_field.rs
+++ b/packages/tui/src/components/bordered_text_field.rs
@@ -21,11 +21,17 @@ pub struct BorderedTextField {
     pub inner: TextField,
     label: String,
     width: usize,
+    placeholder: Option<String>,
 }
 
 impl BorderedTextField {
     pub fn new(label: impl Into<String>, value: String) -> Self {
-        Self { inner: TextField::new(value), label: label.into(), width: 0 }
+        Self { inner: TextField::new(value), label: label.into(), width: 0, placeholder: None }
+    }
+
+    pub fn placeholder(mut self, placeholder: impl Into<String>) -> Self {
+        self.placeholder = Some(placeholder.into());
+        self
     }
 
     pub fn set_width(&mut self, width: usize) {
@@ -89,7 +95,10 @@ impl BorderedTextField {
         focused: bool,
     ) -> Line {
         let content_width = width.saturating_sub(HORIZONTAL_PADDING);
-        let inner_line = self.inner.render_field(context, focused).into_iter().next().unwrap_or_default();
+        let inner_line = self.placeholder.as_ref().filter(|_| self.inner.value.is_empty()).map_or_else(
+            || self.inner.render_field(context, focused).into_iter().next().unwrap_or_default(),
+            |placeholder| Line::with_style(placeholder.clone(), Style::fg(context.theme.muted())),
+        );
         let clipped = truncate_line(&inner_line, content_width);
 
         let mut row = Line::default();

--- a/packages/tui/tests/components/bordered_text_field.rs
+++ b/packages/tui/tests/components/bordered_text_field.rs
@@ -1,6 +1,6 @@
 use super::*;
 use crossterm::event::KeyCode;
-use tui::{BorderedTextField, Color};
+use tui::{BorderedTextField, Color, display_width_text};
 
 #[test]
 fn empty_focused_renders_heavy_box_with_label_and_cursor() {
@@ -8,14 +8,7 @@ fn empty_focused_renders_heavy_box_with_label_and_cursor() {
     let ctx = ViewContext::new((40, 10));
     let lines = field.render_field(&ctx, true);
     let term = render_lines(&lines, 40, 10);
-    assert_buffer_eq(
-        &term,
-        &[
-            "┏━ Name ━━━━━━━━━━━┓", //
-            "┃ ▏                ┃",
-            "┗━━━━━━━━━━━━━━━━━━┛",
-        ],
-    );
+    assert_buffer_eq(&term, &bordered_box("Name", "▏", 20, true));
 }
 
 #[test]
@@ -24,14 +17,7 @@ fn value_renders_inside_box() {
     let ctx = ViewContext::new((40, 10));
     let lines = field.render_field(&ctx, true);
     let term = render_lines(&lines, 40, 10);
-    assert_buffer_eq(
-        &term,
-        &[
-            "┏━ Name ━━━━━━━━━━━┓", //
-            "┃ my-agent▏        ┃",
-            "┗━━━━━━━━━━━━━━━━━━┛",
-        ],
-    );
+    assert_buffer_eq(&term, &bordered_box("Name", "my-agent▏", 20, true));
 }
 
 #[test]
@@ -41,20 +27,31 @@ fn unfocused_uses_light_box_and_dimmer_border_color() {
     let lines = field.render_field(&ctx, false);
 
     let term = render_lines(&lines, 40, 10);
-    assert_buffer_eq(
-        &term,
-        &[
-            "┌─ Name ───────────┐", //
-            "│ hello            │",
-            "└──────────────────┘",
-        ],
-    );
+    assert_buffer_eq(&term, &bordered_box("Name", "hello", 20, false));
 
     let theme = tui::Theme::default();
     let top_spans = lines[0].spans();
     assert_eq!(top_spans[0].style().fg, Some(theme.text_secondary()), "unfocused top border is text_secondary");
     let bottom_spans = lines[2].spans();
     assert_eq!(bottom_spans[0].style().fg, Some(theme.text_secondary()), "unfocused bottom border is text_secondary");
+}
+
+#[test]
+fn placeholder_renders_when_value_is_empty() {
+    let field = make_field("Name", "", 20).placeholder("placeholder");
+    let ctx = ViewContext::new((40, 10));
+    let lines = field.render_field(&ctx, false);
+    let term = render_lines(&lines, 40, 10);
+    assert_buffer_eq(&term, &bordered_box("Name", "placeholder", 20, false));
+}
+
+#[test]
+fn placeholder_does_not_render_when_value_is_non_empty() {
+    let field = make_field("Name", "hello", 20).placeholder("placeholder");
+    let ctx = ViewContext::new((40, 10));
+    let lines = field.render_field(&ctx, false);
+    let term = render_lines(&lines, 40, 10);
+    assert_buffer_eq(&term, &bordered_box("Name", "hello", 20, false));
 }
 
 #[test]
@@ -87,14 +84,7 @@ fn long_value_clips_at_inner_width() {
     let ctx = ViewContext::new((40, 10));
     let lines = field.render_field(&ctx, false);
     let term = render_lines(&lines, 40, 10);
-    assert_buffer_eq(
-        &term,
-        &[
-            "┌─ Name ───────────┐", //
-            "│ abcdefghijklmnop │",
-            "└──────────────────┘",
-        ],
-    );
+    assert_buffer_eq(&term, &bordered_box("Name", "abcdefghijklmnop", 20, false));
 }
 
 #[test]
@@ -154,6 +144,21 @@ fn border_color_is_not_affected_by_theme_bg() {
             assert_ne!(span.style().bg, Some(Color::Red), "unexpected red bg");
         }
     }
+}
+
+fn bordered_box(label: &str, content: &str, width: usize, focused: bool) -> [String; 3] {
+    let (top_left, top_right, bottom_left, bottom_right, horizontal, vertical) =
+        if focused { ("┏", "┓", "┗", "┛", "━", "┃") } else { ("┌", "┐", "└", "┘", "─", "│") };
+    let label_width = display_width_text(label);
+    let dash_cols = width.saturating_sub(label_width + 5);
+    let content_width = width.saturating_sub(4);
+    let pad_cols = content_width.saturating_sub(display_width_text(content));
+
+    [
+        format!("{top_left}{horizontal} {label} {}{top_right}", horizontal.repeat(dash_cols)),
+        format!("{vertical} {content}{} {vertical}", " ".repeat(pad_cols)),
+        format!("{bottom_left}{}{bottom_right}", horizontal.repeat(width.saturating_sub(2))),
+    ]
 }
 
 fn make_field(label: &str, value: &str, width: usize) -> BorderedTextField {

--- a/packages/wisp/src/components/session_picker.rs
+++ b/packages/wisp/src/components/session_picker.rs
@@ -2,8 +2,8 @@ use agent_client_protocol::schema as acp;
 use chrono::{DateTime, Utc};
 use std::path::PathBuf;
 use tui::{
-    Combobox, Component, Cursor, Event, Frame, Line, MouseEventKind, PickerMessage, Searchable, Style, ViewContext,
-    display_width_text, pad_text_to_width, truncate_text,
+    BorderedTextField, Combobox, Component, Cursor, Event, Frame, Line, MouseEventKind, PickerMessage, Searchable,
+    Style, ViewContext, display_width_text, pad_text_to_width, truncate_text,
 };
 
 #[derive(Clone)]
@@ -20,6 +20,7 @@ impl Searchable for SessionEntry {
 
 pub struct SessionPicker {
     combobox: Combobox<SessionEntry>,
+    has_sessions: bool,
 }
 
 pub enum SessionPickerMessage {
@@ -29,7 +30,8 @@ pub enum SessionPickerMessage {
 
 impl SessionPicker {
     pub fn new(sessions: Vec<SessionEntry>) -> Self {
-        Self { combobox: Combobox::new(sessions) }
+        let has_sessions = !sessions.is_empty();
+        Self { combobox: Combobox::new(sessions), has_sessions }
     }
 }
 
@@ -66,16 +68,18 @@ impl Component for SessionPicker {
     }
 
     fn render(&mut self, context: &ViewContext) -> Frame {
-        if self.combobox.is_empty() {
+        if !self.has_sessions {
             return Frame::new(vec![Line::new(String::new()), Line::new("  No previous sessions found.")]);
         }
 
         let now = Utc::now();
+        let search = search_box_frame(self.combobox.query(), context);
+        let mut list_lines = vec![Line::new(String::new())];
 
-        let mut lines = vec![Line::new(String::new())];
-        let header = format!("  Resume a previous session: {}", self.combobox.query());
-        lines.push(Line::new(&header));
-        lines.push(Line::new(String::new()));
+        if self.combobox.is_empty() {
+            list_lines.push(Line::new("  (no matching sessions)"));
+            return Frame::vstack([search, Frame::new(list_lines)]);
+        }
 
         let max_title_width = self
             .combobox
@@ -109,10 +113,27 @@ impl Component for SessionPicker {
                 line
             }
         });
-        lines.extend(item_lines);
-        let cursor = Cursor::visible(1, display_width_text(&header));
-        Frame::new(lines).with_cursor(cursor)
+        list_lines.extend(item_lines);
+        Frame::vstack([search, Frame::new(list_lines)])
     }
+}
+
+const SEARCH_BOX_MAX_WIDTH: usize = 56;
+const SEARCH_BOX_INDENT: u16 = 2;
+const SEARCH_LABEL: &str = "🔍 Search";
+const SEARCH_PLACEHOLDER: &str = "type to search title or path";
+
+fn search_box_frame(query: &str, context: &ViewContext) -> Frame {
+    let width = (context.size.width as usize).saturating_sub(usize::from(SEARCH_BOX_INDENT)).min(SEARCH_BOX_MAX_WIDTH);
+    let input_width = width.saturating_sub(4);
+    let visible_query = truncate_text(query, input_width);
+
+    let mut field = BorderedTextField::new(SEARCH_LABEL, query.to_string()).placeholder(SEARCH_PLACEHOLDER);
+    field.set_width(width);
+
+    Frame::new(field.render_field(context, false))
+        .with_cursor(Cursor::visible(1, 2 + display_width_text(&visible_query)))
+        .indent(SEARCH_BOX_INDENT)
 }
 
 fn display_title(info: &acp::SessionInfo) -> String {
@@ -165,6 +186,27 @@ mod tests {
         format_relative_time(iso, Utc::now())
     }
 
+    fn expected_picker_lines(rows: Vec<String>) -> Vec<String> {
+        let mut lines = Vec::from(rendered_search_box(SEARCH_PLACEHOLDER));
+        lines.push(String::new());
+        lines.extend(rows);
+        lines
+    }
+
+    fn rendered_search_box(content: &str) -> [String; 3] {
+        let indent = " ".repeat(usize::from(SEARCH_BOX_INDENT));
+        let width = (W as usize).saturating_sub(usize::from(SEARCH_BOX_INDENT)).min(SEARCH_BOX_MAX_WIDTH);
+        let dash_cols = width.saturating_sub(display_width_text(SEARCH_LABEL) + 5);
+        let content_width = width.saturating_sub(4);
+        let pad_cols = content_width.saturating_sub(display_width_text(content));
+
+        [
+            format!("{indent}┌─ {SEARCH_LABEL} {}┐", "─".repeat(dash_cols)),
+            format!("{indent}│ {content}{} │", " ".repeat(pad_cols)),
+            format!("{indent}└{}┘", "─".repeat(width.saturating_sub(2))),
+        ]
+    }
+
     #[test]
     fn empty_sessions_shows_message() {
         let mut picker = SessionPicker::new(vec![]);
@@ -173,21 +215,53 @@ mod tests {
     }
 
     #[test]
+    fn renders_search_box_when_query_empty() {
+        let mut picker = SessionPicker::new(sample_sessions());
+        let term = render_component(|ctx| picker.render(ctx), W, H);
+        let lines = term.get_lines();
+        assert!(lines.iter().any(|line| line.contains("🔍 Search")));
+        assert!(lines.iter().any(|line| line.contains("type to search title or path")));
+        assert!(!lines.iter().any(|line| line.contains("Resume a previous session")),);
+    }
+
+    #[tokio::test]
+    async fn query_displayed_in_search_box() {
+        let mut picker = SessionPicker::new(sample_sessions());
+        picker.on_event(&key(KeyCode::Char('f'))).await;
+        picker.on_event(&key(KeyCode::Char('i'))).await;
+        picker.on_event(&key(KeyCode::Char('x'))).await;
+        let term = render_component(|ctx| picker.render(ctx), W, H);
+        let lines = term.get_lines();
+        assert!(lines.iter().any(|line| line.contains("🔍 Search")));
+        assert!(lines.iter().any(|line| line.contains("│ fix")));
+        assert!(!lines.iter().any(|line| line.contains("type to search title or path")),);
+    }
+
+    #[tokio::test]
+    async fn no_matches_keeps_search_box_visible() {
+        let mut picker = SessionPicker::new(sample_sessions());
+        for ch in "zzzz".chars() {
+            picker.on_event(&key(KeyCode::Char(ch))).await;
+        }
+
+        let term = render_component(|ctx| picker.render(ctx), W, H);
+        let lines = term.get_lines();
+        assert!(lines.iter().any(|line| line.contains("🔍 Search")));
+        assert!(lines.iter().any(|line| line.contains("(no matching sessions)")),);
+        assert!(!lines.iter().any(|line| line.contains("No previous sessions found.")));
+    }
+
+    #[test]
     fn renders_titles_and_dates_with_first_selected() {
         let mut picker = SessionPicker::new(sample_sessions());
         let d1 = expected_date("2026-03-10T10:00:00Z");
         let d2 = expected_date("2026-03-09T10:00:00Z");
         let term = render_component(|ctx| picker.render(ctx), W, H);
-        assert_buffer_eq(
-            &term,
-            &[
-                "",
-                "  Resume a previous session:",
-                "",
-                &format!("  Fix the login page redirect bug   {d1}"),
-                &format!("  Add unit tests for session store  {d2}"),
-            ],
-        );
+        let expected = expected_picker_lines(vec![
+            format!("  Fix the login page redirect bug   {d1}"),
+            format!("  Add unit tests for session store  {d2}"),
+        ]);
+        assert_buffer_eq(&term, &expected);
     }
 
     #[tokio::test]
@@ -197,16 +271,11 @@ mod tests {
         let d1 = expected_date("2026-03-10T10:00:00Z");
         let d2 = expected_date("2026-03-09T10:00:00Z");
         let term = render_component(|ctx| picker.render(ctx), W, H);
-        assert_buffer_eq(
-            &term,
-            &[
-                "",
-                "  Resume a previous session:",
-                "",
-                &format!("  Fix the login page redirect bug   {d1}"),
-                &format!("  Add unit tests for session store  {d2}"),
-            ],
-        );
+        let expected = expected_picker_lines(vec![
+            format!("  Fix the login page redirect bug   {d1}"),
+            format!("  Add unit tests for session store  {d2}"),
+        ]);
+        assert_buffer_eq(&term, &expected);
     }
 
     #[tokio::test]
@@ -234,19 +303,6 @@ mod tests {
         assert_eq!(picker.combobox.selected_index(), 0);
     }
 
-    #[tokio::test]
-    async fn query_displayed_in_header() {
-        let mut picker = SessionPicker::new(sample_sessions());
-        picker.on_event(&key(KeyCode::Char('f'))).await;
-        picker.on_event(&key(KeyCode::Char('i'))).await;
-        picker.on_event(&key(KeyCode::Char('x'))).await;
-
-        let term = render_component(|ctx| picker.render(ctx), W, H);
-        let lines = term.get_lines();
-        let header = &lines[1];
-        assert!(header.contains("fix"), "header should contain query text, got: {header}");
-    }
-
     #[test]
     fn falls_back_to_cwd_basename_when_no_title() {
         let sessions = vec![SessionEntry(
@@ -256,6 +312,7 @@ mod tests {
         let mut picker = SessionPicker::new(sessions);
         let d = expected_date("2026-03-10T10:00:00Z");
         let term = render_component(|ctx| picker.render(ctx), W, H);
-        assert_buffer_eq(&term, &["", "  Resume a previous session:", "", &format!("  my-project  {d}")]);
+        let expected = expected_picker_lines(vec![format!("  my-project  {d}")]);
+        assert_buffer_eq(&term, &expected);
     }
 }

--- a/packages/wisp/src/docs/conversation_screen.md
+++ b/packages/wisp/src/docs/conversation_screen.md
@@ -13,7 +13,7 @@ The main chat UI screen.
 The screen can display one modal at a time:
 
 - **`ElicitationForm`** — agent-requested structured input (e.g. confirmation dialogs)
-- **`SessionPicker`** — list of previous sessions for `/resume`
+- **`SessionPicker`** — boxed fuzzy-search input for filtering previous `/resume` sessions by title/path
 
 # See also
 

--- a/packages/wisp/tests/app_tests/common.rs
+++ b/packages/wisp/tests/app_tests/common.rs
@@ -118,6 +118,13 @@ impl Renderer {
         Ok(())
     }
 
+    pub(super) fn on_sessions_listed(
+        &mut self,
+        sessions: Vec<acp::SessionInfo>,
+    ) -> Result<LoopAction, Box<dyn std::error::Error>> {
+        self.handle_acp_event(AcpEvent::SessionsListed { sessions })
+    }
+
     pub(super) fn on_prompt_done(&mut self) -> Result<(), Box<dyn std::error::Error>> {
         self.handle_acp_event(AcpEvent::PromptDone(acp::StopReason::EndTurn))?;
         Ok(())

--- a/packages/wisp/tests/app_tests/common.rs
+++ b/packages/wisp/tests/app_tests/common.rs
@@ -118,13 +118,6 @@ impl Renderer {
         Ok(())
     }
 
-    pub(super) fn on_sessions_listed(
-        &mut self,
-        sessions: Vec<acp::SessionInfo>,
-    ) -> Result<LoopAction, Box<dyn std::error::Error>> {
-        self.handle_acp_event(AcpEvent::SessionsListed { sessions })
-    }
-
     pub(super) fn on_prompt_done(&mut self) -> Result<(), Box<dyn std::error::Error>> {
         self.handle_acp_event(AcpEvent::PromptDone(acp::StopReason::EndTurn))?;
         Ok(())

--- a/packages/wisp/tests/app_tests/session_tests.rs
+++ b/packages/wisp/tests/app_tests/session_tests.rs
@@ -1,8 +1,33 @@
 use agent_client_protocol::schema as acp;
+use std::path::PathBuf;
 use tui::testing::{TestTerminal, assert_buffer_eq};
 use tui::{KeyCode, KeyEvent, KeyModifiers};
 
 use super::common::*;
+
+#[tokio::test]
+async fn test_resume_picker_shows_search_box_and_filters() {
+    let terminal = TestTerminal::new(TEST_WIDTH, 40);
+    let mut renderer = Renderer::new(terminal, TEST_AGENT.to_string(), &[], (TEST_WIDTH, 40));
+    renderer.initial_render().unwrap();
+
+    type_string(&mut renderer, "/resume").await;
+    press_enter(&mut renderer).await;
+    renderer
+        .on_sessions_listed(vec![
+            acp::SessionInfo::new("session-login", PathBuf::from("/repo/auth")).title("Fix login redirect".to_string()),
+            acp::SessionInfo::new("session-billing", PathBuf::from("/repo/billing"))
+                .title("Billing cleanup".to_string()),
+        ])
+        .unwrap();
+
+    assert_buffer_contains(renderer.writer(), "🔍 Search");
+    assert_buffer_contains(renderer.writer(), "type to search title or path");
+    assert_buffer_not_contains(renderer.writer(), "Resume a previous session");
+    type_string(&mut renderer, "login").await;
+    assert_buffer_contains(renderer.writer(), "Fix login redirect");
+    assert_buffer_not_contains(renderer.writer(), "Billing cleanup");
+}
 
 #[tokio::test]
 async fn test_prompt_done_clears_running_tool_spinner() {


### PR DESCRIPTION
Closes #50 by making the `/resume` session menu have a much nicer looking search bar. 