### PR TITLE
fix(aether-cli): Crashes due to tokio stdin surfacing eagin and acp t…

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -55,6 +55,7 @@ dependencies = [
  "aether-wisp",
  "agent-client-protocol",
  "async-trait",
+ "blocking",
  "clap",
  "crossterm",
  "dirs",
@@ -494,6 +495,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "async-channel"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "924ed96dd52d1b75e9c1a3e6275715fd320f5f9439fb5a4a11fa51f4221158d2"
+dependencies = [
+ "concurrent-queue",
+ "event-listener-strategy",
+ "futures-core",
+ "pin-project-lite",
+]
+
+[[package]]
 name = "async-openai"
 version = "0.38.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -553,6 +566,12 @@ dependencies = [
  "quote",
  "syn",
 ]
+
+[[package]]
+name = "async-task"
+version = "4.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b75356056920673b02621b35afd0f7dda9306d03c79a30f5c56c44cf256e3de"
 
 [[package]]
 name = "async-trait"
@@ -1127,6 +1146,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "blocking"
+version = "1.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e83f8d02be6967315521be875afa792a316e28d57b5a2d401897e2a7921b7f21"
+dependencies = [
+ "async-channel",
+ "async-task",
+ "futures-io",
+ "futures-lite",
+ "piper",
+]
+
+[[package]]
 name = "bs58"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1300,6 +1332,15 @@ checksum = "ba5a308b75df32fe02788e748662718f03fde005016435c444eea572398219fd"
 dependencies = [
  "bytes",
  "memchr",
+]
+
+[[package]]
+name = "concurrent-queue"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ca0197aee26d1ae37445ee532fefce43251d24cc7c166799f4d46817f1d3973"
+dependencies = [
+ "crossbeam-utils",
 ]
 
 [[package]]
@@ -1825,6 +1866,27 @@ checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "event-listener"
+version = "5.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e13b66accf52311f30a0db42147dadea9850cb48cd070028831ae5f5d4b856ab"
+dependencies = [
+ "concurrent-queue",
+ "parking",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "event-listener-strategy"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8be9f3dfaaffdae2972880079a491a1a8bb7cbed0b8dd7a347f668b4150a3b93"
+dependencies = [
+ "event-listener",
+ "pin-project-lite",
 ]
 
 [[package]]
@@ -3401,6 +3463,17 @@ name = "pin-utils"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
+
+[[package]]
+name = "piper"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c835479a4443ded371d6c535cbfd8d31ad92c5d23ae9770a61bc155e4992a3c1"
+dependencies = [
+ "atomic-waker",
+ "fastrand",
+ "futures-io",
+]
 
 [[package]]
 name = "pkg-config"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,6 +39,7 @@ tokio = { version = "^1.52.3", features = ["full"] }
 tokio-stream = { version = "^0.1.18", features = ["io-util"] }
 tokio-util = "^0.7.18"
 futures = "^0.3.32"
+blocking = "1.6.2"
 async-stream = "^0.3.6"
 eventsource-stream = "^0.2"
 

--- a/packages/aether-cli/Cargo.toml
+++ b/packages/aether-cli/Cargo.toml
@@ -42,7 +42,8 @@ agent-client-protocol = { workspace = true }
 aether-lspd = { path = "../aether-lspd", version = "0.1.14" }
 rmcp = { workspace = true }
 tokio = { workspace = true }
-tokio-util = { workspace = true, features = ["compat"] }
+tokio-util = { workspace = true }
+blocking = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 async-trait = { workspace = true }

--- a/packages/aether-cli/src/acp/mod.rs
+++ b/packages/aether-cli/src/acp/mod.rs
@@ -7,19 +7,20 @@ pub(crate) mod session;
 pub(crate) mod session_manager;
 pub(crate) mod session_registry;
 pub(crate) mod session_store;
+pub(crate) mod stdio;
 pub mod testing;
 
 pub use mappers::map_mcp_prompt_to_available_command;
 pub use session_manager::SessionManager;
 
+use crate::acp::handlers::acp_agent_builder;
+use crate::acp::stdio::Stdio;
 use crate::provider_connection_args::ProviderConnectionArgs;
 use crate::settings_args::SettingsSourceArgs;
-use agent_client_protocol::{self as acp, ByteStreams};
+use agent_client_protocol as acp;
 use llm::ReasoningEffort;
 use std::sync::Arc;
 use std::{fs::create_dir_all, path::PathBuf};
-use tokio::io::{stdin, stdout};
-use tokio_util::compat::{TokioAsyncReadCompatExt, TokioAsyncWriteCompatExt};
 use tracing::info;
 use tracing_appender::rolling::daily;
 use tracing_subscriber::EnvFilter;
@@ -110,9 +111,7 @@ pub async fn run_acp(args: AcpArgs) -> Result<AcpRunOutcome, AcpRunError> {
         provider_connections,
     }));
 
-    let transport = ByteStreams::new(stdout().compat_write(), stdin().compat());
-    let connect_result = handlers::acp_agent_builder(manager.clone()).connect_to(transport).await;
-
+    let connect_result = acp_agent_builder(manager.clone()).connect_to(Stdio::new()).await;
     manager.shutdown_all_sessions().await;
 
     match connect_result {

--- a/packages/aether-cli/src/acp/stdio.rs
+++ b/packages/aether-cli/src/acp/stdio.rs
@@ -1,0 +1,36 @@
+//! Stdio transport for Aether's ACP server.
+//!
+//! Why this exists: `tokio::io::stdin()`'s nonblocking compat adapter can
+//! surface `EAGAIN`/`WouldBlock` on terminal stdio, which the ACP JSON-RPC
+//! transport actor treats as a fatal `Internal error` and kills the session.
+//! `blocking::Unblock` runs synchronous `std::io` reads/writes on a thread
+//! pool against the blocking handles, so the readiness error never occurs.
+//!
+//! Vendored from the upstream `agent-client-protocol::Stdio` which hasn't
+//! published a new version of the SDK with this inside yet.
+//!
+//! TODO: Delete this once the SDK ships an equivalent transport.
+
+use agent_client_protocol::{ByteStreams, ConnectTo, Error, Role};
+use blocking::Unblock;
+use std::io::{stdin, stdout};
+
+pub struct Stdio;
+
+impl Stdio {
+    pub fn new() -> Self {
+        Self
+    }
+}
+
+impl Default for Stdio {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl<T: Role> ConnectTo<T> for Stdio {
+    async fn connect_to(self, client: impl ConnectTo<T::Counterpart>) -> Result<(), Error> {
+        ConnectTo::<T>::connect_to(ByteStreams::new(Unblock::new(stdout()), Unblock::new(stdin())), client).await
+    }
+}


### PR DESCRIPTION
This PR fixes a bug where using `tokio::io::stdin()` with the ACP SDK's transport would lead to surfacing `EAGAIN` (resource is temporarily unavailable) and if we hit that the transport would treat that as fatal. 

The end result is the user would see the aether agent + wisp tui just die, which was very frustrating. 

This fix grabs the newer transport code out of the ACP SDK as they haven't yet released it. Once they do, we should be able to drop code in here and just import from the SDK. 