### PR TITLE
fix(llm): Use prompt caching on Bedrock models that support prompt caching

### DIFF
--- a/.aether/settings.json
+++ b/.aether/settings.json
@@ -4,16 +4,16 @@
   "agents": [
     {
       "name": "Planner",
-      "description": "Codex GPT-5.5 with high reasoning",
+      "description": "Codex GPT-5.5 with xhigh reasoning",
       "model": "codex:gpt-5.5",
-      "reasoningEffort": "high",
+      "reasoningEffort": "xhigh",
       "userInvocable": true
     },
     {
-      "name": "Builder",
-      "description": "Codex GPT-5.3 Codex with high reasoning",
-      "model": "codex:gpt-5.3-codex",
-      "reasoningEffort": "high",
+      "name": "Implementor",
+      "description": "Codex GPT-5.5 with medium reasoning",
+      "model": "codex:gpt-5.5",
+      "reasoningEffort": "medium",
       "userInvocable": true
     },
     {

--- a/packages/aether-cli/src/acp/model_config.rs
+++ b/packages/aether-cli/src/acp/model_config.rs
@@ -4,7 +4,7 @@ use aether_auth::OAuthCredentialStorage;
 use aether_core::agent_spec::AgentSpec;
 use agent_client_protocol::schema::{self as acp, SessionConfigOption, SessionConfigOptionCategory};
 use llm::ReasoningEffort;
-use llm::catalog::{BedrockModel, LlmModel};
+use llm::catalog::LlmModel;
 use std::collections::{BTreeMap, HashSet};
 
 fn needs_oauth_login(model: &LlmModel, store: &dyn OAuthCredentialStorage) -> bool {
@@ -29,12 +29,7 @@ pub(crate) fn unavailable_reason(model: &LlmModel, store: &dyn OAuthCredentialSt
 }
 
 pub(crate) fn model_exists(available: &[LlmModel], model_str: &str) -> bool {
-    model_str.split(',').map(str::trim).all(|part| {
-        if matches!(part.parse::<LlmModel>(), Ok(LlmModel::Bedrock(BedrockModel::Profile(_)))) {
-            return true;
-        }
-        available.iter().any(|m| m.to_string() == part)
-    })
+    model_str.split(',').map(str::trim).all(|part| available.iter().any(|m| m.to_string() == part))
 }
 
 pub(crate) fn effective_model<'a>(active_model: &'a str, pending_model: Option<&'a str>) -> &'a str {
@@ -262,13 +257,14 @@ mod tests {
     use aether_auth::FakeOAuthCredentialStore;
     use aether_core::agent_spec::{AgentSpecExposure, ToolFilter};
     use agent_client_protocol::schema::{SessionConfigKind, SessionConfigSelectOption, SessionConfigSelectOptions};
-    use llm::catalog::{AnthropicModel, DeepSeekModel, GeminiModel};
+    use llm::catalog::{AnthropicModel, BedrockFoundationModel, BedrockModel, DeepSeekModel, GeminiModel};
 
     fn test_models() -> Vec<LlmModel> {
         vec![
             LlmModel::Anthropic(AnthropicModel::ClaudeSonnet45),
             LlmModel::Anthropic(AnthropicModel::ClaudeOpus46),
             LlmModel::DeepSeek(DeepSeekModel::DeepseekChat),
+            LlmModel::Bedrock(BedrockModel::Foundation(BedrockFoundationModel::AnthropicClaudeSonnet4520250929V10)),
             LlmModel::Gemini(GeminiModel::Gemini25Pro),
         ]
     }
@@ -409,20 +405,13 @@ mod tests {
     }
 
     #[test]
-    fn model_exists_accepts_bedrock_inference_profile_arn() {
-        let models = test_models();
-        let arn = "bedrock:arn:aws:bedrock:us-west-2:000000000000:application-inference-profile/000000000000";
-        assert!(model_exists(&models, arn), "Bedrock inference-profile ARN should be accepted");
-    }
-
-    #[test]
-    fn validated_modes_from_specs_keeps_agent_with_bedrock_profile_arn() {
-        let arn = "bedrock:arn:aws:bedrock:us-west-2:000000000000:application-inference-profile/000000000000";
-        let specs = vec![spec("BedrockAgent", arn, None)];
+    fn validated_modes_from_specs_keeps_agent_with_bedrock_foundation_model() {
+        let bedrock_model = "bedrock:anthropic.claude-sonnet-4-5-20250929-v1:0";
+        let specs = vec![spec("BedrockAgent", bedrock_model, None)];
         let modes = validated_modes_from_specs(&specs, &test_models());
         assert_eq!(modes.len(), 1);
         assert_eq!(modes[0].name, "BedrockAgent");
-        assert_eq!(modes[0].model, arn);
+        assert_eq!(modes[0].model, bedrock_model);
     }
 
     #[test]

--- a/packages/aether-cli/src/acp/session_manager.rs
+++ b/packages/aether-cli/src/acp/session_manager.rs
@@ -382,11 +382,10 @@ fn validate_prompt_support(model_value: &str, content: &[ContentBlock]) -> Resul
 mod tests {
     use super::*;
     use agent_client_protocol::schema::{InitializeRequest, ProtocolVersion};
-    use llm::catalog::BedrockModel;
 
     const SONNET: &str = "anthropic:claude-sonnet-4-5";
     const DEEPSEEK: &str = "deepseek:deepseek-chat";
-    const BEDROCK_PROFILE_ARN: &str =
+    const BEDROCK_ARN_AS_MODEL_REJECTED: &str =
         "bedrock:arn:aws:bedrock:us-west-2:000000000000:application-inference-profile/000000000000";
 
     fn mock_oauth_store() -> Arc<dyn OAuthCredentialStorage> {
@@ -450,11 +449,10 @@ mod tests {
     }
 
     #[test]
-    fn parse_available_model_accepts_bedrock_inference_profile_arn() {
+    fn parse_available_model_rejects_bedrock_inference_profile_arn() {
         let available: Vec<LlmModel> = Vec::new();
-        let parsed = parse_available_model(BEDROCK_PROFILE_ARN, &available)
-            .expect("Bedrock inference-profile ARN should be accepted");
-        assert!(matches!(parsed, LlmModel::Bedrock(BedrockModel::Profile(_))));
+        let error = parse_available_model(BEDROCK_ARN_AS_MODEL_REJECTED, &available).unwrap_err();
+        assert_eq!(error, acp::Error::invalid_params());
     }
 
     #[test]

--- a/packages/aether-cli/src/provider_connection_args.rs
+++ b/packages/aether-cli/src/provider_connection_args.rs
@@ -5,7 +5,10 @@ use llm::{ProviderAuthMode, ProviderConnectionOverride, ProviderConnectionOverri
 
 #[derive(Clone, Debug, Default, clap::Args)]
 pub struct ProviderConnectionArgs {
-    #[arg(long = "provider", value_name = "PROVIDER.url=URL|PROVIDER.auth=default|none")]
+    #[arg(
+        long = "provider",
+        value_name = "PROVIDER.url=URL|PROVIDER.auth=default|none|bedrock.inference-profile-arn=ARN"
+    )]
     pub providers: Vec<ProviderArg>,
 }
 
@@ -32,7 +35,8 @@ impl FromStr for ProviderArg {
         let (key, setting) = split_key_value(value)?;
         let (provider, field) = key
             .split_once('.')
-            .ok_or_else(|| "provider override must be PROVIDER.url=URL or PROVIDER.auth=default|none".to_string())?;
+            .ok_or_else(|| "provider override must be PROVIDER.url=URL, PROVIDER.auth=default|none, or bedrock.inference-profile-arn=ARN".to_string())?;
+
         validate_provider(provider)?;
         if setting.trim().is_empty() {
             return Err("provider value cannot be empty".to_string());
@@ -44,7 +48,13 @@ impl FromStr for ProviderArg {
                 ProviderConnectionOverride::url(setting)
             }
             "auth" => ProviderConnectionOverride::auth(parse_auth_mode(setting)?),
-            _ => return Err("provider override field must be url or auth".to_string()),
+            "inference-profile-arn" => {
+                if provider != "bedrock" {
+                    return Err("inference-profile-arn is only supported for the bedrock provider".to_string());
+                }
+                ProviderConnectionOverride::inference_profile_arn(setting)
+            }
+            _ => return Err("provider override field must be url, auth, or inference-profile-arn".to_string()),
         };
 
         Ok(Self { provider: provider.to_string(), connection })
@@ -104,13 +114,39 @@ mod tests {
     #[test]
     fn combines_repeated_provider_overrides() {
         let args = ProviderConnectionArgs {
-            providers: vec!["bedrock.url=http://127.0.0.1:8787".parse().unwrap(), "bedrock.auth=none".parse().unwrap()],
+            providers: vec![
+                "bedrock.url=http://127.0.0.1:8787".parse().unwrap(),
+                "bedrock.auth=none".parse().unwrap(),
+                "bedrock.inference-profile-arn=arn:aws:bedrock:us-west-2:000000000000:application-inference-profile/000000000000"
+                    .parse()
+                    .unwrap(),
+            ],
         };
 
         let config = args.into_overrides().config_for("bedrock");
 
         assert_eq!(config.base_url.as_deref(), Some("http://127.0.0.1:8787"));
         assert_eq!(config.auth_mode, ProviderAuthMode::None);
+        assert_eq!(
+            config.inference_profile_arn.as_deref(),
+            Some("arn:aws:bedrock:us-west-2:000000000000:application-inference-profile/000000000000")
+        );
+    }
+
+    #[test]
+    fn parses_bedrock_inference_profile_arn() {
+        let arg: ProviderArg =
+            "bedrock.inference-profile-arn=arn:aws:bedrock:us-west-2:000000000000:inference-profile/us.anthropic.claude-sonnet-4-5-20250929-v1:0"
+                .parse()
+                .unwrap();
+
+        assert_eq!(arg.provider, "bedrock");
+        assert_eq!(
+            arg.connection.inference_profile_arn.as_deref(),
+            Some(
+                "arn:aws:bedrock:us-west-2:000000000000:inference-profile/us.anthropic.claude-sonnet-4-5-20250929-v1:0"
+            )
+        );
     }
 
     #[test]
@@ -122,5 +158,6 @@ mod tests {
         assert!("bedrock.url=file:///tmp/proxy".parse::<ProviderArg>().is_err());
         assert!("bedrock.auth=disabled".parse::<ProviderArg>().is_err());
         assert!("bedrock.region=us-west-2".parse::<ProviderArg>().is_err());
+        assert!("openai.inference-profile-arn=arn:aws:bedrock:us-west-2:000000000000:application-inference-profile/000000000000".parse::<ProviderArg>().is_err());
     }
 }

--- a/packages/aether-sdk/README.md
+++ b/packages/aether-sdk/README.md
@@ -60,19 +60,19 @@ yourself in a `finally` block.
 
 `AetherSessionOptions` lets you pick the initial agent or model:
 
-| Option            | Notes                                                                |
-| ----------------- | -------------------------------------------------------------------- |
-| `agent`           | Mode name from `.aether/settings.json` (e.g. `planner`).             |
-| `model`           | Direct model id (e.g. `anthropic:claude-sonnet-4-5`).                |
-| `reasoningEffort` | `"low"`, `"medium"`, `"high"`, `"xhigh"`.                            |
-| `settings`        | Inline Aether settings object using the `.aether/settings.json` shape. |
-| `settingsFile`    | Path to an alternate settings JSON file.                              |
-| `cwd`             | Working directory for the spawned `aether acp` process.              |
-| `binaryPath`      | Override the bundled `@aether-agent/cli` binary (absolute path or name on `PATH`). |
-| `tools`           | Closure-backed TypeScript tool groups keyed by Aether tool prefix.   |
-| `externalMcpServers` | External stdio/http/sse MCP servers keyed by Aether tool prefix.   |
-| `providers`       | Provider connection overrides, keyed by provider (for example `{ bedrock: { url: "http://127.0.0.1:8787", auth: "none" } }`). |
-| `abortSignal`     | Cancel the active session and tear the subprocess down.              |
+| Option               | Notes                                                                                                                         |
+| -------------------- | ----------------------------------------------------------------------------------------------------------------------------- |
+| `agent`              | Mode name from `.aether/settings.json` (e.g. `planner`).                                                                      |
+| `model`              | Direct model id (e.g. `anthropic:claude-sonnet-4-5`).                                                                         |
+| `reasoningEffort`    | `"low"`, `"medium"`, `"high"`, `"xhigh"`.                                                                                     |
+| `settings`           | Inline Aether settings object using the `.aether/settings.json` shape.                                                        |
+| `settingsFile`       | Path to an alternate settings JSON file.                                                                                      |
+| `cwd`                | Working directory for the spawned `aether acp` process.                                                                       |
+| `binaryPath`         | Override the bundled `@aether-agent/cli` binary (absolute path or name on `PATH`).                                            |
+| `tools`              | Closure-backed TypeScript tool groups keyed by Aether tool prefix.                                                            |
+| `externalMcpServers` | External stdio/http/sse MCP servers keyed by Aether tool prefix.                                                              |
+| `providers`          | Provider connection overrides, keyed by provider (for example `{ bedrock: { url: "http://127.0.0.1:8787", auth: "none" } }`). |
+| `abortSignal`        | Cancel the active session and tear the subprocess down.                                                                       |
 
 `agent` and `model` are mutually exclusive. `settings` and `settingsFile` are
 mutually exclusive. These are forwarded to the spawned `aether acp` process as
@@ -87,6 +87,21 @@ signs auth:
 await AetherSession.start({
   model: "bedrock:anthropic.claude-sonnet-4-5-20250929-v1:0",
   providers: { bedrock: { url: "http://127.0.0.1:8787", auth: "none" } },
+});
+```
+
+For Bedrock inference profiles, keep `model` as the Bedrock foundation model ID
+and pass the profile ARN as the Bedrock provider request target:
+
+```ts
+await AetherSession.start({
+  model: "bedrock:anthropic.claude-sonnet-4-5-20250929-v1:0",
+  providers: {
+    bedrock: {
+      inferenceProfileArn:
+        "arn:aws:bedrock:us-west-2:000000000000:application-inference-profile/000000000000",
+    },
+  },
 });
 ```
 
@@ -130,7 +145,9 @@ const submit = createSubmitTool();
     },
   });
 
-  for await (const _message of session.prompt("Call custom__submit_answer with the final answer.")) {
+  for await (const _message of session.prompt(
+    "Call custom__submit_answer with the final answer.",
+  )) {
     void _message;
   }
 }
@@ -203,7 +220,9 @@ await AetherSession.start({ onPermissionRequest: autoApprovePermissions });
 // Custom policy.
 await AetherSession.start({
   onPermissionRequest: async (request) => {
-    return { outcome: { outcome: "selected", optionId: request.options[0].optionId } };
+    return {
+      outcome: { outcome: "selected", optionId: request.options[0].optionId },
+    };
   },
 });
 ```

--- a/packages/aether-sdk/src/session.ts
+++ b/packages/aether-sdk/src/session.ts
@@ -150,6 +150,11 @@ export class AetherSession {
         args.push("--provider", `${provider}.url=${connection.url}`);
       if (connection.auth)
         args.push("--provider", `${provider}.auth=${connection.auth}`);
+      if (connection.inferenceProfileArn)
+        args.push(
+          "--provider",
+          `${provider}.inference-profile-arn=${connection.inferenceProfileArn}`,
+        );
     }
     if (logDir) args.push("--log-dir", logDir);
 

--- a/packages/aether-sdk/test/session.integration.test.ts
+++ b/packages/aether-sdk/test/session.integration.test.ts
@@ -44,12 +44,20 @@ describe("AetherSession with a fake ACP agent", () => {
     ).rejects.toMatchObject({ code: "invalid_options" });
   });
 
-  it("forwards provider URL and auth overrides to the CLI", async () => {
+  it("forwards provider URL, auth, and inference profile overrides to the CLI", async () => {
     const dir = await mkdtemp(path.join(tmpdir(), "aether-sdk-"));
     const logFile = path.join(dir, "fake-aether.log");
+    const arn =
+      "arn:aws:bedrock:us-west-2:123456789012:application-inference-profile/planner-profile";
     const session = await AetherSession.start({
       binaryPath: FAKE_AETHER,
-      providers: { bedrock: { url: "http://127.0.0.1:8787", auth: "none" } },
+      providers: {
+        bedrock: {
+          url: "http://127.0.0.1:8787",
+          auth: "none",
+          inferenceProfileArn: arn,
+        },
+      },
       env: { PATH: process.env.PATH, FAKE_AETHER_LOG_FILE: logFile },
     });
 
@@ -61,6 +69,7 @@ describe("AetherSession with a fake ACP agent", () => {
       expect(argv.args).toContain("--provider");
       expect(argv.args).toContain("bedrock.url=http://127.0.0.1:8787");
       expect(argv.args).toContain("bedrock.auth=none");
+      expect(argv.args).toContain(`bedrock.inference-profile-arn=${arn}`);
     } finally {
       await session.close();
       await rm(dir, { recursive: true, force: true });
@@ -76,8 +85,13 @@ describe("AetherSession with a fake ACP agent", () => {
           {
             name: "planner",
             description: "Planner agent",
-            model:
-              "bedrock:arn:aws:bedrock:us-west-2:123456789012:application-inference-profile/planner-profile",
+            model: "bedrock:anthropic.claude-sonnet-4-5-20250929-v1:0",
+            providers: {
+              bedrock: {
+                inferenceProfileArn:
+                  "arn:aws:bedrock:us-west-2:123456789012:application-inference-profile/planner-profile",
+              },
+            },
             contextWindow: 200000,
             userInvocable: true,
             prompts: [{ type: "text", text: "Plan carefully." }],

--- a/packages/llm-codegen/src/lib.rs
+++ b/packages/llm-codegen/src/lib.rs
@@ -51,6 +51,10 @@ struct CostData {
     input: f64,
     #[serde(default)]
     output: f64,
+    #[serde(default)]
+    cache_read: Option<f64>,
+    #[serde(default)]
+    cache_write: Option<f64>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -60,6 +64,12 @@ struct LimitData {
     #[serde(default)]
     #[allow(dead_code)]
     output: u32,
+}
+
+impl CostData {
+    fn has_prompt_caching(&self) -> bool {
+        self.cache_read.is_some() || self.cache_write.is_some()
+    }
 }
 
 /// Provider configuration for codegen (catalog providers with known model lists)
@@ -86,9 +96,11 @@ struct ProviderConfig {
     oauth_provider_id: Option<&'static str>,
     /// Default reasoning levels for models that support reasoning (empty = use standard 3)
     default_reasoning_levels: &'static [&'static str],
-    /// Emit a hybrid `{Enum}Model` that wraps `{Enum}FoundationModel` (catalog) plus
-    /// a `Profile(String)` variant. Used for Bedrock to accept arbitrary inference
-    /// profile IDs and ARNs at runtime.
+    /// When true, the inner catalog enum is named `{Enum}FoundationModel` and
+    /// `LlmModel::{Enum}` carries a hand-written `{Enum}Model` wrapper (defined
+    /// outside of codegen) that adds a `Profile(String)` fall-through plus any
+    /// provider-specific parsing policy. Used for Bedrock to accept arbitrary
+    /// inference profile IDs at runtime while keeping ARNs out of model identity.
     is_hybrid_dynamic: bool,
 }
 
@@ -204,6 +216,7 @@ struct ModelInfo {
     context_window: u32,
     reasoning_levels: Vec<String>,
     input_modalities: Vec<String>,
+    supports_prompt_caching: bool,
 }
 
 type ProviderModels = BTreeMap<&'static str, Vec<ModelInfo>>;
@@ -284,6 +297,7 @@ fn collect_models_from(cfg: &ProviderConfig, models: &HashMap<String, ModelData>
                 context_window,
                 reasoning_levels,
                 input_modalities,
+                supports_prompt_caching: m.cost.as_ref().is_some_and(CostData::has_prompt_caching),
             }
         })
         .collect()
@@ -352,16 +366,6 @@ fn emit_provider_enums(out: &mut String, provider_models: &ProviderModels) {
         }
         pushln(out, "}");
         blank(out);
-
-        if cfg.is_hybrid_dynamic {
-            let outer = cfg.outer_enum_name();
-            pushln(out, "#[derive(Debug, Clone, PartialEq, Eq, Hash)]");
-            pushln(out, format!("pub enum {outer} {{"));
-            pushln(out, format!("    Foundation({inner}),"));
-            pushln(out, "    Profile(String),");
-            pushln(out, "}");
-            blank(out);
-        }
     }
 }
 
@@ -419,6 +423,14 @@ fn emit_provider_impls(out: &mut String, provider_models: &ProviderModels) {
         pushln(out, "    }");
         blank(out);
 
+        // supports_prompt_caching — derived from models.dev cache pricing fields
+        pushln(out, "    pub fn supports_prompt_caching(self) -> bool {");
+        pushln(out, "        match self {");
+        emit_grouped_arms(out, models, |m| m.supports_prompt_caching.to_string(), std::string::ToString::to_string);
+        pushln(out, "        }");
+        pushln(out, "    }");
+        blank(out);
+
         for modality in ["image", "audio"] {
             pushln(out, format!("    pub fn supports_{modality}(self) -> bool {{"));
             pushln(out, "        match self {");
@@ -445,80 +457,7 @@ fn emit_provider_impls(out: &mut String, provider_models: &ProviderModels) {
         blank(out);
 
         emit_from_str_impl(out, &enum_name, cfg.parser_name, models);
-
-        if cfg.is_hybrid_dynamic {
-            emit_hybrid_wrapper_impl(out, &cfg.outer_enum_name(), cfg.enum_name);
-            emit_hybrid_wrapper_from_str(out, &cfg.outer_enum_name(), &enum_name);
-        }
     }
-}
-
-fn emit_hybrid_wrapper_impl(out: &mut String, outer_name: &str, display_prefix: &str) {
-    pushln(out, format!("impl {outer_name} {{"));
-
-    pushln(out, "    pub fn model_id(&self) -> Cow<'static, str> {");
-    pushln(out, "        match self {");
-    pushln(out, "            Self::Foundation(m) => Cow::Borrowed(m.model_id()),");
-    pushln(out, "            Self::Profile(s) => Cow::Owned(s.clone()),");
-    pushln(out, "        }");
-    pushln(out, "    }");
-    blank(out);
-
-    pushln(out, "    pub fn display_name(&self) -> Cow<'static, str> {");
-    pushln(out, "        match self {");
-    pushln(out, "            Self::Foundation(m) => Cow::Borrowed(m.display_name()),");
-    pushln(out, format!("            Self::Profile(s) => Cow::Owned(format!(\"{display_prefix} {{s}}\")),"));
-    pushln(out, "        }");
-    pushln(out, "    }");
-    blank(out);
-
-    pushln(out, "    pub fn context_window(&self) -> Option<u32> {");
-    pushln(out, "        match self {");
-    pushln(out, "            Self::Foundation(m) => Some(m.context_window()),");
-    pushln(out, "            Self::Profile(_) => None,");
-    pushln(out, "        }");
-    pushln(out, "    }");
-    blank(out);
-
-    pushln(out, "    pub fn reasoning_levels(&self) -> &'static [ReasoningEffort] {");
-    pushln(out, "        match self {");
-    pushln(out, "            Self::Foundation(m) => m.reasoning_levels(),");
-    pushln(out, "            Self::Profile(_) => &[],");
-    pushln(out, "        }");
-    pushln(out, "    }");
-    blank(out);
-
-    pushln(out, "    pub fn supports_reasoning(&self) -> bool {");
-    pushln(out, "        !self.reasoning_levels().is_empty()");
-    pushln(out, "    }");
-    blank(out);
-
-    for modality in ["image", "audio"] {
-        pushln(out, format!("    pub fn supports_{modality}(&self) -> bool {{"));
-        pushln(out, "        match self {");
-        pushln(out, format!("            Self::Foundation(m) => m.supports_{modality}(),"));
-        pushln(out, "            Self::Profile(_) => false,");
-        pushln(out, "        }");
-        pushln(out, "    }");
-        blank(out);
-    }
-
-    pushln(out, "}");
-    blank(out);
-}
-
-fn emit_hybrid_wrapper_from_str(out: &mut String, outer_name: &str, inner_name: &str) {
-    pushln(out, format!("impl std::str::FromStr for {outer_name} {{"));
-    pushln(out, "    type Err = String;");
-    blank(out);
-    pushln(out, "    fn from_str(s: &str) -> Result<Self, Self::Err> {");
-    pushln(out, format!("        match s.parse::<{inner_name}>() {{"));
-    pushln(out, "            Ok(m) => Ok(Self::Foundation(m)),");
-    pushln(out, "            Err(_) => Ok(Self::Profile(s.to_string())),");
-    pushln(out, "        }");
-    pushln(out, "    }");
-    pushln(out, "}");
-    blank(out);
 }
 
 fn emit_from_str_impl(out: &mut String, enum_name: &str, parser_name: &str, models: &[ModelInfo]) {
@@ -627,6 +566,7 @@ fn emit_llm_model_impl(out: &mut String) {
     emit_llm_oauth_provider_id(out);
     emit_llm_reasoning_levels(out);
     emit_llm_supports_reasoning(out);
+    emit_llm_supports_prompt_caching(out);
     for modality in ["image", "audio"] {
         emit_llm_supports_modality(out, modality);
     }
@@ -794,6 +734,19 @@ fn emit_llm_supports_reasoning(out: &mut String) {
     pushln(out, "    /// Whether this model supports reasoning/extended thinking");
     pushln(out, "    pub fn supports_reasoning(&self) -> bool {");
     pushln(out, "        !self.reasoning_levels().is_empty()");
+    pushln(out, "    }");
+    blank(out);
+}
+
+fn emit_llm_supports_prompt_caching(out: &mut String) {
+    pushln(out, "    /// Whether this model supports provider-side prompt caching");
+    pushln(out, "    pub fn supports_prompt_caching(&self) -> bool {");
+    pushln(out, "        match self {");
+    for cfg in PROVIDERS {
+        pushln(out, format!("            Self::{}(m) => m.supports_prompt_caching(),", cfg.enum_name));
+    }
+    pushln(out, format!("            {} => false,", dynamic_pattern_with_binding("_")));
+    pushln(out, "        }");
     pushln(out, "    }");
     blank(out);
 }
@@ -1103,25 +1056,19 @@ mod tests {
 
         assert!(source.contains("pub enum BedrockFoundationModel {"));
         assert!(source.contains("AnthropicFooV10"));
-        assert!(source.contains("pub enum BedrockModel {"));
-        assert!(source.contains("Foundation(BedrockFoundationModel)"));
-        assert!(source.contains("Profile(String)"));
         assert!(source.contains("impl std::str::FromStr for BedrockFoundationModel"));
         assert!(source.contains("\"anthropic.foo-v1:0\" => Ok(Self::AnthropicFooV10),"));
         assert!(source.contains("Unknown bedrock model"));
 
-        assert!(source.contains("impl std::str::FromStr for BedrockModel"));
-        assert!(source.contains("Err(_) => Ok(Self::Profile(s.to_string())),"));
-        assert!(source.contains("Self::Profile(s) => Cow::Owned(s.clone()),"));
-        assert!(source.contains("Self::Profile(_) => None,"));
-        assert!(source.contains("Self::Profile(_) => &[],"));
-        assert!(source.contains("Self::Profile(_) => false,"));
-        assert!(source.contains("Self::Profile(s) => Cow::Owned(format!(\"Bedrock {s}\"))"));
+        // Wrapper enum is hand-written in catalog::bedrock — codegen must NOT emit it.
+        assert!(!source.contains("pub enum BedrockModel {"));
+        assert!(!source.contains("impl std::str::FromStr for BedrockModel"));
+        assert!(!source.contains("fn is_bedrock_inference_profile_arn"));
 
+        // LlmModel still delegates to the (hand-written) wrapper.
         assert!(source.contains(
             "BedrockFoundationModel::ALL.iter().copied().map(BedrockModel::Foundation).map(LlmModel::Bedrock)"
         ));
-
         assert!(source.contains("Self::Bedrock(m) => m.model_id(),"));
         assert!(source.contains("Self::Bedrock(m) => m.display_name(),"));
         assert!(source.contains("Self::Bedrock(m) => m.context_window(),"));
@@ -1342,6 +1289,41 @@ mod tests {
     fn codex_subscription_context_window_leaves_unknown_models_unchanged() {
         assert_eq!(codex_subscription_context_window("gpt-5.3-codex-spark", 128_000), 128_000);
         assert_eq!(codex_subscription_context_window("some-future-model", 400_000), 400_000);
+    }
+
+    #[test]
+    fn generate_derives_prompt_caching_from_cost_fields() {
+        let mut data = minimal_models_dev_json();
+        let root = data.as_object_mut().expect("root object");
+        let bedrock = root.get_mut("amazon-bedrock").and_then(Value::as_object_mut).expect("bedrock provider");
+
+        bedrock.insert(
+            "models".to_string(),
+            json!({
+                "anthropic.cached-v1:0": {
+                    "id": "anthropic.cached-v1:0",
+                    "name": "Cached",
+                    "tool_call": true,
+                    "limit": {"context": 200_000, "output": 0},
+                    "cost": {"input": 3.0, "output": 15.0, "cache_read": 0.3, "cache_write": 3.75}
+                },
+                "anthropic.uncached-v1:0": {
+                    "id": "anthropic.uncached-v1:0",
+                    "name": "Uncached",
+                    "tool_call": true,
+                    "limit": {"context": 200_000, "output": 0},
+                    "cost": {"input": 3.0, "output": 15.0}
+                }
+            }),
+        );
+
+        let source = generate_from_value(&data);
+        let bedrock_impl = generated_impl_block(&source, "BedrockFoundationModel");
+
+        assert!(bedrock_impl.contains("pub fn supports_prompt_caching(self) -> bool {"));
+        assert!(bedrock_impl.contains("Self::AnthropicCachedV10 => true,"));
+        assert!(bedrock_impl.contains("Self::AnthropicUncachedV10 => false,"));
+        assert!(source.contains("Self::Bedrock(m) => m.supports_prompt_caching(),"));
     }
 
     fn generate_from_value(data: &Value) -> String {

--- a/packages/llm/examples/bedrock_inference_profile.rs
+++ b/packages/llm/examples/bedrock_inference_profile.rs
@@ -16,17 +16,21 @@ async fn main() -> ExitCode {
 
     let mut args = env::args().skip(1);
     let Some(model) = args.next() else {
-        eprintln!("usage: bedrock_inference_profile <arn-or-profile-id> [prompt]");
+        eprintln!("usage: bedrock_inference_profile <model-id> <inference-profile-arn> [prompt]");
+        return ExitCode::from(2);
+    };
+    let Some(arn) = args.next() else {
+        eprintln!("usage: bedrock_inference_profile <model-id> <inference-profile-arn> [prompt]");
         return ExitCode::from(2);
     };
     let prompt = args.next().unwrap_or_else(|| "Say hello in one sentence.".to_string());
 
-    let provider = BedrockProvider::new().await.with_model(&model);
+    let provider = BedrockProvider::new().await.with_model(&model).with_inference_profile_arn(&arn);
     println!("→ {}", provider.display_name());
 
     match provider.context_window() {
         Some(n) => println!("  context window: {n} (resolved from catalog)"),
-        None => println!("  context window: unknown (Profile pass-through)"),
+        None => println!("  context window: unknown (model not in catalog)"),
     }
     println!("  prompt: {prompt}\n");
 

--- a/packages/llm/src/catalog/bedrock.rs
+++ b/packages/llm/src/catalog/bedrock.rs
@@ -1,0 +1,143 @@
+use std::borrow::Cow;
+use std::str::FromStr;
+
+use crate::ReasoningEffort;
+use crate::catalog::BedrockFoundationModel;
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub enum BedrockModel {
+    Foundation(BedrockFoundationModel),
+    Profile(String),
+}
+
+impl BedrockModel {
+    pub fn model_id(&self) -> Cow<'static, str> {
+        match self {
+            Self::Foundation(m) => Cow::Borrowed(m.model_id()),
+            Self::Profile(s) => Cow::Owned(s.clone()),
+        }
+    }
+
+    pub fn display_name(&self) -> Cow<'static, str> {
+        match self {
+            Self::Foundation(m) => Cow::Borrowed(m.display_name()),
+            Self::Profile(s) => Cow::Owned(format!("Bedrock {s}")),
+        }
+    }
+
+    pub fn context_window(&self) -> Option<u32> {
+        match self {
+            Self::Foundation(m) => Some(m.context_window()),
+            Self::Profile(_) => None,
+        }
+    }
+
+    pub fn reasoning_levels(&self) -> &'static [ReasoningEffort] {
+        match self {
+            Self::Foundation(m) => m.reasoning_levels(),
+            Self::Profile(_) => &[],
+        }
+    }
+
+    pub fn supports_reasoning(&self) -> bool {
+        !self.reasoning_levels().is_empty()
+    }
+
+    pub fn supports_prompt_caching(&self) -> bool {
+        match self {
+            Self::Foundation(m) => m.supports_prompt_caching(),
+            Self::Profile(_) => false,
+        }
+    }
+
+    pub fn supports_image(&self) -> bool {
+        match self {
+            Self::Foundation(m) => m.supports_image(),
+            Self::Profile(_) => false,
+        }
+    }
+
+    pub fn supports_audio(&self) -> bool {
+        match self {
+            Self::Foundation(m) => m.supports_audio(),
+            Self::Profile(_) => false,
+        }
+    }
+}
+
+impl FromStr for BedrockModel {
+    type Err = String;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s.parse::<BedrockFoundationModel>() {
+            Ok(m) => Ok(Self::Foundation(m)),
+            Err(_) if is_bedrock_inference_profile_arn(s) => Err(
+                "Bedrock inference profile ARNs must be configured as providers.bedrock.inferenceProfileArn; keep model as bedrock:<model-id>".to_string(),
+            ),
+            Err(_) => Ok(Self::Profile(s.to_string())),
+        }
+    }
+}
+
+fn is_bedrock_inference_profile_arn(s: &str) -> bool {
+    let Some(rest) = s.strip_prefix("arn:") else {
+        return false;
+    };
+    let parts: Vec<&str> = rest.split(':').collect();
+    matches!(
+        parts.as_slice(),
+        [partition, "bedrock", _, _, resource, ..]
+            if partition.starts_with("aws")
+                && (resource.starts_with("inference-profile/")
+                    || resource.starts_with("application-inference-profile/"))
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn foundation_model_parses() {
+        let model: BedrockModel = "anthropic.claude-sonnet-4-5-20250929-v1:0".parse().unwrap();
+        assert!(matches!(model, BedrockModel::Foundation(_)));
+    }
+
+    #[test]
+    fn unknown_profile_id_falls_through_to_profile_variant() {
+        let model: BedrockModel = "us.anthropic.claude-future-model-v99:0".parse().unwrap();
+        assert!(matches!(model, BedrockModel::Profile(_)));
+        assert_eq!(model.context_window(), None);
+    }
+
+    #[test]
+    fn inference_profile_arn_is_rejected() {
+        let error =
+            "arn:aws:bedrock:us-west-2:000000000000:inference-profile/us.anthropic.claude-sonnet-4-5-20250929-v1:0"
+                .parse::<BedrockModel>()
+                .unwrap_err();
+        assert!(error.contains("providers.bedrock.inferenceProfileArn"));
+    }
+
+    #[test]
+    fn application_inference_profile_arn_is_rejected() {
+        let error = "arn:aws:bedrock:us-west-2:000000000000:application-inference-profile/000000000000"
+            .parse::<BedrockModel>()
+            .unwrap_err();
+        assert!(error.contains("providers.bedrock.inferenceProfileArn"));
+    }
+
+    #[test]
+    fn gov_cloud_arn_is_rejected() {
+        let error = "arn:aws-us-gov:bedrock:us-gov-west-1:000000000000:application-inference-profile/000000000000"
+            .parse::<BedrockModel>()
+            .unwrap_err();
+        assert!(error.contains("providers.bedrock.inferenceProfileArn"));
+    }
+
+    #[test]
+    fn non_bedrock_arn_falls_through_to_profile() {
+        let model: BedrockModel = "arn:aws:s3:us-west-2:000000000000:bucket/foo".parse().unwrap();
+        assert!(matches!(model, BedrockModel::Profile(_)));
+    }
+}

--- a/packages/llm/src/catalog/mod.rs
+++ b/packages/llm/src/catalog/mod.rs
@@ -2,6 +2,10 @@
 
 use crate::providers::local::discovery::discover_local_models;
 
+mod bedrock;
+
+pub use bedrock::BedrockModel;
+
 include!(concat!(env!("OUT_DIR"), "/generated.rs"));
 
 /// Returns models whose provider env var is set
@@ -54,6 +58,25 @@ mod tests {
     fn openai_gpt55_keeps_api_context_window() {
         let model: LlmModel = "openai:gpt-5.5".parse().unwrap();
         assert_eq!(model.context_window(), Some(1_050_000));
+    }
+
+    #[test]
+    fn bedrock_foundation_model_parses() {
+        let model: LlmModel = "bedrock:anthropic.claude-sonnet-4-5-20250929-v1:0".parse().unwrap();
+
+        assert_eq!(model.to_string(), "bedrock:anthropic.claude-sonnet-4-5-20250929-v1:0");
+        assert_eq!(model.context_window(), Some(200_000));
+    }
+
+    #[test]
+    fn bedrock_prompt_caching_support_comes_from_catalog() {
+        let claude: LlmModel = "bedrock:anthropic.claude-sonnet-4-5-20250929-v1:0".parse().unwrap();
+        let nova: LlmModel = "bedrock:amazon.nova-lite-v1:0".parse().unwrap();
+        let profile: LlmModel = "bedrock:us.anthropic.claude-future-model-v99:0".parse().unwrap();
+
+        assert!(claude.supports_prompt_caching());
+        assert!(nova.supports_prompt_caching());
+        assert!(!profile.supports_prompt_caching());
     }
 
     #[test]

--- a/packages/llm/src/parser.rs
+++ b/packages/llm/src/parser.rs
@@ -132,11 +132,24 @@ impl ModelProviderParser {
             return Err(LlmError::Other("No models provided".to_string()));
         }
 
+        let bedrock_has_inference_profile_arn =
+            self.provider_connections.config_for("bedrock").inference_profile_arn.is_some();
+        let mut seen_bedrock = false;
         let mut providers = Vec::new();
         let mut first_identity: Option<LlmModel> = None;
 
         for pair in provider_model_pairs {
             let (provider_name, model) = pair.split_once(':').unwrap_or((pair, ""));
+
+            if provider_name == "bedrock" && bedrock_has_inference_profile_arn {
+                if seen_bedrock {
+                    return Err(LlmError::Other(
+                        "providers.bedrock.inferenceProfileArn cannot be used with multiple bedrock models in one alloy spec"
+                            .to_string(),
+                    ));
+                }
+                seen_bedrock = true;
+            }
 
             let factory = self
                 .factories
@@ -252,29 +265,30 @@ mod tests {
 
     #[cfg(feature = "bedrock")]
     #[tokio::test]
-    async fn test_parse_bedrock_inference_profile_arn() {
-        // ARNs (including those with extra `:` separators) must round-trip through the parser
-        // without being misinterpreted as `provider:model` splits — the parser splits on the
-        // first `:` only, so everything after `bedrock:` becomes the model string.
+    async fn test_parse_rejects_bedrock_inference_profile_arn() {
         let parser = ModelProviderParser::default();
-        let arn = "arn:aws:bedrock:us-west-2:000000000000:inference-profile/us.anthropic.claude-opus-4-7";
-        let spec = format!("bedrock:{arn}");
-        let (provider, model) = parser.parse(&spec).await.expect("Bedrock ARN should parse");
+        let spec = "bedrock:arn:aws:bedrock:us-west-2:000000000000:inference-profile/us.anthropic.claude-opus-4-7";
 
-        assert_eq!(model.to_string(), spec);
-        assert_eq!(provider.display_name(), format!("Bedrock ({arn})"));
+        let error = match parser.parse(spec).await {
+            Ok(_) => panic!("Bedrock ARN should be rejected"),
+            Err(error) => error.to_string(),
+        };
+
+        assert!(error.contains("providers.bedrock.inferenceProfileArn"), "{error}");
     }
 
     #[cfg(feature = "bedrock")]
     #[tokio::test]
-    async fn test_parse_bedrock_application_inference_profile_arn() {
+    async fn test_parse_rejects_bedrock_application_inference_profile_arn() {
         let parser = ModelProviderParser::default();
-        let arn = "arn:aws:bedrock:us-west-2:000000000000:application-inference-profile/000000000000";
-        let spec = format!("bedrock:{arn}");
+        let spec = "bedrock:arn:aws:bedrock:us-west-2:000000000000:application-inference-profile/000000000000";
 
-        let (_, model) = parser.parse(&spec).await.expect("Application inference profile ARN should parse");
-        assert_eq!(model.to_string(), spec);
-        assert_eq!(model.context_window(), None);
+        let error = match parser.parse(spec).await {
+            Ok(_) => panic!("Bedrock ARN should be rejected"),
+            Err(error) => error.to_string(),
+        };
+
+        assert!(error.contains("providers.bedrock.inferenceProfileArn"), "{error}");
     }
 
     #[tokio::test]

--- a/packages/llm/src/provider_connection.rs
+++ b/packages/llm/src/provider_connection.rs
@@ -12,6 +12,7 @@ pub enum ProviderAuthMode {
 pub struct ProviderConnectionConfig {
     pub base_url: Option<String>,
     pub auth_mode: ProviderAuthMode,
+    pub inference_profile_arn: Option<String>,
 }
 
 #[derive(Clone, Debug, Default, PartialEq, Eq, serde::Deserialize, serde::Serialize, schemars::JsonSchema)]
@@ -21,6 +22,8 @@ pub struct ProviderConnectionOverride {
     pub base_url: Option<String>,
     #[serde(default, rename = "auth", skip_serializing_if = "Option::is_none")]
     pub auth_mode: Option<ProviderAuthMode>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub inference_profile_arn: Option<String>,
 }
 
 #[derive(Clone, Debug, Default, PartialEq, Eq, serde::Deserialize, serde::Serialize, schemars::JsonSchema)]
@@ -31,17 +34,25 @@ pub struct ProviderConnectionOverrides {
 
 impl ProviderConnectionConfig {
     pub fn from_override(value: ProviderConnectionOverride) -> Self {
-        Self { base_url: value.base_url, auth_mode: value.auth_mode.unwrap_or_default() }
+        Self {
+            base_url: value.base_url,
+            auth_mode: value.auth_mode.unwrap_or_default(),
+            inference_profile_arn: value.inference_profile_arn,
+        }
     }
 }
 
 impl ProviderConnectionOverride {
     pub fn url(url: impl Into<String>) -> Self {
-        Self { base_url: Some(url.into()), auth_mode: None }
+        Self { base_url: Some(url.into()), ..Self::default() }
     }
 
     pub fn auth(auth_mode: ProviderAuthMode) -> Self {
-        Self { base_url: None, auth_mode: Some(auth_mode) }
+        Self { auth_mode: Some(auth_mode), ..Self::default() }
+    }
+
+    pub fn inference_profile_arn(arn: impl Into<String>) -> Self {
+        Self { inference_profile_arn: Some(arn.into()), ..Self::default() }
     }
 
     pub fn merge(&mut self, override_value: Self) {
@@ -50,6 +61,9 @@ impl ProviderConnectionOverride {
         }
         if override_value.auth_mode.is_some() {
             self.auth_mode = override_value.auth_mode;
+        }
+        if override_value.inference_profile_arn.is_some() {
+            self.inference_profile_arn = override_value.inference_profile_arn;
         }
     }
 }
@@ -78,5 +92,50 @@ impl ProviderConnectionOverrides {
 
     pub fn into_inner(self) -> BTreeMap<String, ProviderConnectionOverride> {
         self.providers
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn deserializes_bedrock_inference_profile_arn() {
+        let overrides: ProviderConnectionOverrides = serde_json::from_str(
+            r#"{"bedrock":{"inferenceProfileArn":"arn:aws:bedrock:us-west-2:000000000000:application-inference-profile/000000000000"}}"#,
+        )
+        .unwrap();
+
+        let config = overrides.config_for("bedrock");
+
+        assert_eq!(
+            config.inference_profile_arn.as_deref(),
+            Some("arn:aws:bedrock:us-west-2:000000000000:application-inference-profile/000000000000")
+        );
+    }
+
+    #[test]
+    fn merge_replaces_inference_profile_arn() {
+        let mut first = ProviderConnectionOverride::inference_profile_arn("arn:first");
+
+        first.merge(ProviderConnectionOverride::inference_profile_arn("arn:second"));
+
+        assert_eq!(first.inference_profile_arn.as_deref(), Some("arn:second"));
+    }
+
+    #[test]
+    fn provider_overrides_merge_inference_profile_arn() {
+        let mut first = ProviderConnectionOverrides::new(BTreeMap::from([(
+            "bedrock".to_string(),
+            ProviderConnectionOverride::inference_profile_arn("arn:first"),
+        )]));
+        let second = ProviderConnectionOverrides::new(BTreeMap::from([(
+            "bedrock".to_string(),
+            ProviderConnectionOverride::inference_profile_arn("arn:second"),
+        )]));
+
+        first.merge(second);
+
+        assert_eq!(first.config_for("bedrock").inference_profile_arn.as_deref(), Some("arn:second"));
     }
 }

--- a/packages/llm/src/providers/anthropic/provider.rs
+++ b/packages/llm/src/providers/anthropic/provider.rs
@@ -302,7 +302,7 @@ mod tests {
     fn build_headers_skips_api_key_when_auth_is_none() {
         let provider = AnthropicProvider::new(None)
             .unwrap()
-            .with_connection(ProviderConnectionConfig { base_url: None, auth_mode: ProviderAuthMode::None });
+            .with_connection(ProviderConnectionConfig { auth_mode: ProviderAuthMode::None, ..Default::default() });
         let headers = provider.build_headers().expect("headers");
         assert!(headers.get("x-api-key").is_none());
         assert_eq!(headers.get("anthropic-version").and_then(|value| value.to_str().ok()), Some("2023-06-01"));

--- a/packages/llm/src/providers/bedrock/mappers.rs
+++ b/packages/llm/src/providers/bedrock/mappers.rs
@@ -1,7 +1,7 @@
 use aws_sdk_bedrockruntime::types::{
-    ContentBlock as BedrockContentBlock, ConversationRole, ImageBlock, ImageFormat, ImageSource, Message,
-    SystemContentBlock, Tool, ToolConfiguration, ToolInputSchema, ToolResultBlock, ToolResultContentBlock,
-    ToolResultStatus, ToolSpecification, ToolUseBlock,
+    CachePointBlock, CachePointType, ContentBlock as BedrockContentBlock, ConversationRole, ImageBlock, ImageFormat,
+    ImageSource, Message, SystemContentBlock, Tool, ToolConfiguration, ToolInputSchema, ToolResultBlock,
+    ToolResultContentBlock, ToolResultStatus, ToolSpecification, ToolUseBlock,
 };
 use aws_smithy_types::{Blob, Document, Number};
 use base64::Engine;
@@ -15,7 +15,10 @@ fn bedrock_err(e: impl Display) -> LlmError {
     LlmError::Other(e.to_string())
 }
 
-pub fn map_messages(messages: &[ChatMessage]) -> Result<(Vec<SystemContentBlock>, Vec<Message>)> {
+pub fn map_messages(
+    messages: &[ChatMessage],
+    cache_point: Option<&CachePointBlock>,
+) -> Result<(Vec<SystemContentBlock>, Vec<Message>)> {
     let mut system_blocks = Vec::new();
     let mut bedrock_messages = Vec::new();
     let mut pending_tool_results = Vec::new();
@@ -54,12 +57,25 @@ pub fn map_messages(messages: &[ChatMessage]) -> Result<(Vec<SystemContentBlock>
     }
 
     flush_tool_results(&mut pending_tool_results, &mut bedrock_messages)?;
+    if let Some(cache_point) = cache_point {
+        if !system_blocks.is_empty() {
+            system_blocks.push(SystemContentBlock::CachePoint(cache_point.clone()));
+        }
+        if let Some(last) = bedrock_messages.pop() {
+            let mut builder = Message::builder().role(last.role().clone());
+            for block in last.content() {
+                builder = builder.content(block.clone());
+            }
+            builder = builder.content(BedrockContentBlock::CachePoint(cache_point.clone()));
+            bedrock_messages.push(builder.build().map_err(bedrock_err)?);
+        }
+    }
 
     Ok((system_blocks, bedrock_messages))
 }
 
-pub fn map_tools(tools: &[ToolDefinition]) -> Result<ToolConfiguration> {
-    let bedrock_tools: Vec<Tool> = tools
+pub fn map_tools(tools: &[ToolDefinition], cache_point: Option<&CachePointBlock>) -> Result<ToolConfiguration> {
+    let mut bedrock_tools: Vec<Tool> = tools
         .iter()
         .map(|tool| {
             let schema_value: serde_json::Value = serde_json::from_str(&tool.parameters)
@@ -74,7 +90,17 @@ pub fn map_tools(tools: &[ToolDefinition]) -> Result<ToolConfiguration> {
         })
         .collect::<Result<_>>()?;
 
+    if let Some(cache_point) = cache_point
+        && !bedrock_tools.is_empty()
+    {
+        bedrock_tools.push(Tool::CachePoint(cache_point.clone()));
+    }
+
     ToolConfiguration::builder().set_tools(Some(bedrock_tools)).build().map_err(bedrock_err)
+}
+
+pub fn default_cache_point() -> Result<CachePointBlock> {
+    CachePointBlock::builder().r#type(CachePointType::Default).build().map_err(bedrock_err)
 }
 
 fn build_user_message(content: &str) -> Result<Message> {
@@ -212,12 +238,46 @@ mod tests {
     use crate::tools::{ToolCallError, ToolCallRequest, ToolCallResult};
     use crate::types::IsoString;
 
+    fn user_message(text: &str) -> ChatMessage {
+        ChatMessage::User { content: vec![ContentBlock::text(text)], timestamp: IsoString::now() }
+    }
+
+    fn assistant_message(content: &str, tool_calls: Vec<ToolCallRequest>) -> ChatMessage {
+        ChatMessage::Assistant {
+            content: content.to_string(),
+            reasoning: AssistantReasoning::default(),
+            timestamp: IsoString::now(),
+            tool_calls,
+        }
+    }
+
+    fn tool_call(id: &str, name: &str, arguments: &str) -> ToolCallRequest {
+        ToolCallRequest { id: id.to_string(), name: name.to_string(), arguments: arguments.to_string() }
+    }
+
+    fn tool_result_ok(id: &str, name: &str, arguments: &str, result: &str) -> ChatMessage {
+        ChatMessage::ToolCallResult(Ok(ToolCallResult {
+            id: id.to_string(),
+            name: name.to_string(),
+            arguments: arguments.to_string(),
+            result: result.to_string(),
+        }))
+    }
+
+    fn tool_result_err(id: &str, name: &str, error: &str) -> ChatMessage {
+        ChatMessage::ToolCallResult(Err(ToolCallError {
+            id: id.to_string(),
+            name: name.to_string(),
+            arguments: None,
+            error: error.to_string(),
+        }))
+    }
+
     #[test]
     fn test_map_simple_user_message() {
-        let messages =
-            vec![ChatMessage::User { content: vec![ContentBlock::text("Hello")], timestamp: IsoString::now() }];
+        let messages = vec![user_message("Hello")];
 
-        let (system, mapped) = map_messages(&messages).unwrap();
+        let (system, mapped) = map_messages(&messages, None).unwrap();
         assert!(system.is_empty());
         assert_eq!(mapped.len(), 1);
         assert_eq!(mapped[0].role(), &ConversationRole::User);
@@ -235,7 +295,7 @@ mod tests {
             timestamp: IsoString::now(),
         }];
 
-        let (_system, mapped) = map_messages(&messages).unwrap();
+        let (_system, mapped) = map_messages(&messages, None).unwrap();
         assert_eq!(mapped[0].content().len(), 2);
         assert!(mapped[0].content()[0].is_text());
         assert!(mapped[0].content()[1].is_image());
@@ -251,17 +311,17 @@ mod tests {
             timestamp: IsoString::now(),
         }];
 
-        assert!(matches!(map_messages(&messages), Err(LlmError::UnsupportedContent(_))));
+        assert!(matches!(map_messages(&messages, None), Err(LlmError::UnsupportedContent(_))));
     }
 
     #[test]
     fn test_map_system_message() {
         let messages = vec![
             ChatMessage::System { content: "You are helpful".to_string(), timestamp: IsoString::now() },
-            ChatMessage::User { content: vec![ContentBlock::text("Hello")], timestamp: IsoString::now() },
+            user_message("Hello"),
         ];
 
-        let (system, mapped) = map_messages(&messages).unwrap();
+        let (system, mapped) = map_messages(&messages, None).unwrap();
         assert_eq!(system.len(), 1);
         assert!(system[0].is_text());
         assert_eq!(mapped.len(), 1);
@@ -269,18 +329,10 @@ mod tests {
 
     #[test]
     fn test_map_assistant_with_tool_calls() {
-        let messages = vec![ChatMessage::Assistant {
-            content: "I'll help".to_string(),
-            reasoning: AssistantReasoning::default(),
-            timestamp: IsoString::now(),
-            tool_calls: vec![ToolCallRequest {
-                id: "call_1".to_string(),
-                name: "search".to_string(),
-                arguments: r#"{"query": "test"}"#.to_string(),
-            }],
-        }];
+        let messages =
+            vec![assistant_message("I'll help", vec![tool_call("call_1", "search", r#"{"query": "test"}"#)])];
 
-        let (_system, mapped) = map_messages(&messages).unwrap();
+        let (_system, mapped) = map_messages(&messages, None).unwrap();
         assert_eq!(mapped.len(), 1);
         assert_eq!(mapped[0].role(), &ConversationRole::Assistant);
 
@@ -292,18 +344,9 @@ mod tests {
 
     #[test]
     fn test_map_assistant_tool_calls_without_text() {
-        let messages = vec![ChatMessage::Assistant {
-            content: String::new(),
-            reasoning: AssistantReasoning::default(),
-            timestamp: IsoString::now(),
-            tool_calls: vec![ToolCallRequest {
-                id: "call_1".to_string(),
-                name: "search".to_string(),
-                arguments: r#"{"query": "test"}"#.to_string(),
-            }],
-        }];
+        let messages = vec![assistant_message("", vec![tool_call("call_1", "search", r#"{"query": "test"}"#)])];
 
-        let (_system, mapped) = map_messages(&messages).unwrap();
+        let (_system, mapped) = map_messages(&messages, None).unwrap();
         let content = mapped[0].content();
         // Empty text should not be included
         assert_eq!(content.len(), 1);
@@ -312,14 +355,9 @@ mod tests {
 
     #[test]
     fn test_map_tool_result_success() {
-        let messages = vec![ChatMessage::ToolCallResult(Ok(ToolCallResult {
-            id: "call_1".to_string(),
-            name: "search".to_string(),
-            arguments: "{}".to_string(),
-            result: "found it".to_string(),
-        }))];
+        let messages = vec![tool_result_ok("call_1", "search", "{}", "found it")];
 
-        let (_system, mapped) = map_messages(&messages).unwrap();
+        let (_system, mapped) = map_messages(&messages, None).unwrap();
         assert_eq!(mapped.len(), 1);
         assert_eq!(mapped[0].role(), &ConversationRole::User);
 
@@ -330,14 +368,9 @@ mod tests {
 
     #[test]
     fn test_map_tool_result_error() {
-        let messages = vec![ChatMessage::ToolCallResult(Err(ToolCallError {
-            id: "call_1".to_string(),
-            name: "search".to_string(),
-            arguments: None,
-            error: "not found".to_string(),
-        }))];
+        let messages = vec![tool_result_err("call_1", "search", "not found")];
 
-        let (_system, mapped) = map_messages(&messages).unwrap();
+        let (_system, mapped) = map_messages(&messages, None).unwrap();
         assert_eq!(mapped.len(), 1);
 
         let content = mapped[0].content();
@@ -348,38 +381,18 @@ mod tests {
     #[test]
     fn test_map_consecutive_tool_results_into_single_user_message() {
         let messages = vec![
-            ChatMessage::Assistant {
-                content: String::new(),
-                reasoning: AssistantReasoning::default(),
-                timestamp: IsoString::now(),
-                tool_calls: vec![
-                    ToolCallRequest {
-                        id: "call_1".to_string(),
-                        name: "find".to_string(),
-                        arguments: r#"{"pattern":"**/*.ts"}"#.to_string(),
-                    },
-                    ToolCallRequest {
-                        id: "call_2".to_string(),
-                        name: "find".to_string(),
-                        arguments: r#"{"pattern":"**/package.json"}"#.to_string(),
-                    },
+            assistant_message(
+                "",
+                vec![
+                    tool_call("call_1", "find", r#"{"pattern":"**/*.ts"}"#),
+                    tool_call("call_2", "find", r#"{"pattern":"**/package.json"}"#),
                 ],
-            },
-            ChatMessage::ToolCallResult(Ok(ToolCallResult {
-                id: "call_1".to_string(),
-                name: "find".to_string(),
-                arguments: r#"{"pattern":"**/*.ts"}"#.to_string(),
-                result: "17 files".to_string(),
-            })),
-            ChatMessage::ToolCallResult(Ok(ToolCallResult {
-                id: "call_2".to_string(),
-                name: "find".to_string(),
-                arguments: r#"{"pattern":"**/package.json"}"#.to_string(),
-                result: "2 files".to_string(),
-            })),
+            ),
+            tool_result_ok("call_1", "find", r#"{"pattern":"**/*.ts"}"#, "17 files"),
+            tool_result_ok("call_2", "find", r#"{"pattern":"**/package.json"}"#, "2 files"),
         ];
 
-        let (_system, mapped) = map_messages(&messages).unwrap();
+        let (_system, mapped) = map_messages(&messages, None).unwrap();
         assert_eq!(mapped.len(), 2);
         assert_eq!(mapped[0].role(), &ConversationRole::Assistant);
         assert_eq!(mapped[1].role(), &ConversationRole::User);
@@ -395,7 +408,7 @@ mod tests {
     fn test_map_error_message() {
         let messages = vec![ChatMessage::Error { message: "something broke".to_string(), timestamp: IsoString::now() }];
 
-        let (_system, mapped) = map_messages(&messages).unwrap();
+        let (_system, mapped) = map_messages(&messages, None).unwrap();
         assert_eq!(mapped.len(), 1);
         assert_eq!(mapped[0].role(), &ConversationRole::User);
         match &mapped[0].content()[0] {
@@ -412,7 +425,7 @@ mod tests {
             messages_compacted: 10,
         }];
 
-        let (_system, mapped) = map_messages(&messages).unwrap();
+        let (_system, mapped) = map_messages(&messages, None).unwrap();
         assert_eq!(mapped.len(), 1);
         match &mapped[0].content()[0] {
             BedrockContentBlock::Text(text) => {
@@ -432,7 +445,7 @@ mod tests {
             server: None,
         }];
 
-        let config = map_tools(&tools).unwrap();
+        let config = map_tools(&tools, None).unwrap();
         assert_eq!(config.tools().len(), 1);
         match &config.tools()[0] {
             Tool::ToolSpec(spec) => {
@@ -444,6 +457,100 @@ mod tests {
     }
 
     #[test]
+    fn system_cache_point_is_added_when_cache_point_provided() {
+        let messages = vec![
+            ChatMessage::System { content: "You are helpful".to_string(), timestamp: IsoString::now() },
+            user_message("Hello"),
+        ];
+        let cache_point = default_cache_point().unwrap();
+
+        let (system, _mapped) = map_messages(&messages, Some(&cache_point)).unwrap();
+
+        assert_eq!(system.len(), 2);
+        assert!(system[0].is_text());
+        assert!(system[1].is_cache_point());
+    }
+
+    #[test]
+    fn system_cache_point_is_not_added_without_system_content() {
+        let messages = vec![user_message("Hello")];
+        let cache_point = default_cache_point().unwrap();
+
+        let (system, _mapped) = map_messages(&messages, Some(&cache_point)).unwrap();
+
+        assert!(system.is_empty());
+    }
+
+    #[test]
+    fn message_cache_point_is_added_to_last_user_message() {
+        let messages = vec![user_message("Hello")];
+        let cache_point = default_cache_point().unwrap();
+
+        let (_system, mapped) = map_messages(&messages, Some(&cache_point)).unwrap();
+
+        assert_eq!(mapped.len(), 1);
+        let content = mapped[0].content();
+        assert_eq!(content.len(), 2);
+        assert!(content[0].is_text());
+        assert!(content[1].is_cache_point());
+    }
+
+    #[test]
+    fn message_cache_point_is_added_only_to_last_message_in_multi_turn_history() {
+        let messages = vec![user_message("turn 1"), assistant_message("ack", vec![]), user_message("turn 2")];
+        let cache_point = default_cache_point().unwrap();
+
+        let (_system, mapped) = map_messages(&messages, Some(&cache_point)).unwrap();
+
+        assert!(mapped[0].content().iter().all(|b| !b.is_cache_point()));
+        assert!(mapped[1].content().iter().all(|b| !b.is_cache_point()));
+        assert!(mapped[2].content().last().unwrap().is_cache_point());
+    }
+
+    #[test]
+    fn message_cache_point_is_added_to_tool_result_message() {
+        let messages = vec![
+            user_message("search please"),
+            assistant_message("", vec![tool_call("call_1", "search", "{}")]),
+            tool_result_ok("call_1", "search", "{}", "found"),
+        ];
+        let cache_point = default_cache_point().unwrap();
+        let (_system, mapped) = map_messages(&messages, Some(&cache_point)).unwrap();
+
+        let last = mapped.last().unwrap();
+        assert_eq!(last.role(), &ConversationRole::User);
+        assert!(last.content().last().unwrap().is_cache_point());
+    }
+
+    #[test]
+    fn message_cache_points_not_added_when_cache_point_is_none() {
+        let messages = vec![user_message("turn 1"), assistant_message("ack", vec![]), user_message("turn 2")];
+
+        let (_system, mapped) = map_messages(&messages, None).unwrap();
+
+        for msg in &mapped {
+            assert!(msg.content().iter().all(|b| !b.is_cache_point()));
+        }
+    }
+
+    #[test]
+    fn tool_cache_point_is_added_when_cache_point_provided() {
+        let tools = vec![ToolDefinition {
+            name: "search".to_string(),
+            description: "Search for information".to_string(),
+            parameters: r#"{"type": "object", "properties": {"query": {"type": "string"}}}"#.to_string(),
+            server: None,
+        }];
+        let cache_point = default_cache_point().unwrap();
+
+        let config = map_tools(&tools, Some(&cache_point)).unwrap();
+
+        assert_eq!(config.tools().len(), 2);
+        assert!(config.tools()[0].is_tool_spec());
+        assert!(config.tools()[1].is_cache_point());
+    }
+
+    #[test]
     fn test_map_tools_invalid_json() {
         let tools = vec![ToolDefinition {
             name: "broken".to_string(),
@@ -452,7 +559,7 @@ mod tests {
             server: None,
         }];
 
-        let result = map_tools(&tools);
+        let result = map_tools(&tools, None);
         assert!(result.is_err());
         match result.unwrap_err() {
             LlmError::ToolParameterParsing { tool_name, .. } => {

--- a/packages/llm/src/providers/bedrock/provider.rs
+++ b/packages/llm/src/providers/bedrock/provider.rs
@@ -1,4 +1,4 @@
-use super::mappers::{map_messages, map_tools};
+use super::mappers::{default_cache_point, map_messages, map_tools};
 use super::streaming::process_bedrock_stream;
 use crate::provider::{LlmResponseStream, ProviderFactory, StreamingModelProvider, get_context_window};
 use crate::{Context, LlmError, ProviderAuthMode, ProviderConnectionConfig, Result};
@@ -29,6 +29,7 @@ pub struct AwsCredentials {
 pub struct BedrockProvider {
     client: Client,
     model: String,
+    inference_profile_arn: Option<String>,
     max_tokens: i32,
     temperature: Option<f32>,
 }
@@ -52,14 +53,26 @@ impl BedrockProvider {
             Client::new(&config)
         };
 
-        Self { client, model: DEFAULT_MODEL.to_string(), max_tokens: DEFAULT_MAX_TOKENS, temperature: None }
+        Self {
+            client,
+            model: DEFAULT_MODEL.to_string(),
+            inference_profile_arn: connection.inference_profile_arn,
+            max_tokens: DEFAULT_MAX_TOKENS,
+            temperature: None,
+        }
     }
 
     /// Create a provider from explicit configuration without async credential discovery.
     pub fn from_config(credentials: Option<AwsCredentials>, region: Option<&str>) -> Self {
         let client = build_client(credentials, region);
 
-        Self { client, model: DEFAULT_MODEL.to_string(), max_tokens: DEFAULT_MAX_TOKENS, temperature: None }
+        Self {
+            client,
+            model: DEFAULT_MODEL.to_string(),
+            inference_profile_arn: None,
+            max_tokens: DEFAULT_MAX_TOKENS,
+            temperature: None,
+        }
     }
 
     pub fn with_model(mut self, model: &str) -> Self {
@@ -77,11 +90,22 @@ impl BedrockProvider {
         self
     }
 
+    pub fn with_inference_profile_arn(mut self, arn: impl Into<String>) -> Self {
+        self.inference_profile_arn = Some(arn.into());
+        self
+    }
+
+    fn request_model_id(&self) -> &str {
+        self.inference_profile_arn.as_deref().unwrap_or(&self.model)
+    }
+
     async fn send_converse_stream(
         &self,
         context: &Context,
     ) -> Result<EventReceiver<ConverseStreamOutput, ConverseStreamOutputError>> {
-        let (system_blocks, messages) = map_messages(context.messages())?;
+        let cache_point =
+            self.model().is_some_and(|m| m.supports_prompt_caching()).then(default_cache_point).transpose()?;
+        let (system_blocks, messages) = map_messages(context.messages(), cache_point.as_ref())?;
         let mut inference_config = InferenceConfiguration::builder().max_tokens(self.max_tokens);
 
         if let Some(temp) = self.temperature {
@@ -93,7 +117,7 @@ impl BedrockProvider {
         let mut request = self
             .client
             .converse_stream()
-            .model_id(&self.model)
+            .model_id(self.request_model_id())
             .set_messages(Some(messages))
             .inference_config(inference_config);
 
@@ -102,11 +126,15 @@ impl BedrockProvider {
         }
 
         if !context.tools().is_empty() {
-            let tool_config = map_tools(context.tools())?;
+            let tool_config = map_tools(context.tools(), cache_point.as_ref())?;
             request = request.tool_config(tool_config);
         }
 
-        info!(model = %self.model, "Sending Bedrock converse_stream request");
+        if let Some(arn) = self.inference_profile_arn.as_deref() {
+            info!(model = %self.model, inference_profile_arn = %arn, "Sending Bedrock converse_stream request");
+        } else {
+            info!(model = %self.model, "Sending Bedrock converse_stream request");
+        }
 
         let response = request.send().await.map_err(|e| {
             error!(model = %self.model, error = ?e, "Bedrock API error");
@@ -242,6 +270,14 @@ mod tests {
     use tokio::net::TcpListener;
     use tokio::sync::{Mutex, oneshot};
 
+    fn inference_profile_arn(model: &str) -> String {
+        format!("arn:aws:bedrock:us-west-2:000000000000:inference-profile/{model}")
+    }
+
+    fn application_inference_profile_arn() -> &'static str {
+        "arn:aws:bedrock:us-west-2:000000000000:application-inference-profile/000000000000"
+    }
+
     fn test_provider() -> BedrockProvider {
         BedrockProvider::from_config(None, None)
     }
@@ -283,6 +319,7 @@ mod tests {
         let provider = BedrockProvider::new_with_connection(ProviderConnectionConfig {
             base_url: Some(endpoint.url.clone()),
             auth_mode: ProviderAuthMode::None,
+            ..Default::default()
         })
         .await;
 
@@ -363,22 +400,52 @@ mod tests {
         assert_eq!(provider.display_name(), format!("Bedrock ({id})"));
     }
 
-    #[test]
-    fn inference_profile_arn_is_passed_through_as_profile() {
-        let arn = "arn:aws:bedrock:us-west-2:000000000000:inference-profile/us.anthropic.claude-opus-4-7";
-        let provider = test_provider().with_model(arn);
-        assert_eq!(provider.context_window(), None);
-        assert_eq!(provider.model, arn);
-        assert_eq!(provider.model().unwrap().to_string(), format!("bedrock:{arn}"));
+    #[tokio::test]
+    async fn separate_inference_profile_arn_is_used_as_request_model_id() {
+        let endpoint = FakeBedrockEndpoint::start().await;
+        let provider = BedrockProvider::new_with_connection(ProviderConnectionConfig {
+            base_url: Some(endpoint.url.clone()),
+            auth_mode: ProviderAuthMode::None,
+            inference_profile_arn: Some(application_inference_profile_arn().to_string()),
+        })
+        .await
+        .with_model("anthropic.claude-sonnet-4-5-20250929-v1:0");
+        let context = Context::new(
+            vec![ChatMessage::User { content: vec![ContentBlock::text("hello")], timestamp: IsoString::now() }],
+            vec![],
+        );
+
+        let result = provider.send_converse_stream(&context).await;
+        let request = endpoint.request.await.expect("fake Bedrock endpoint received no request");
+
+        assert!(result.is_err());
+        assert!(
+            request.path.contains("arn%3Aaws%3Abedrock%3Aus-west-2%3A000000000000%3Aapplication-inference-profile"),
+            "{}",
+            request.path
+        );
+        assert_eq!(provider.context_window(), Some(200_000));
+        assert_eq!(provider.model().unwrap().to_string(), "bedrock:anthropic.claude-sonnet-4-5-20250929-v1:0");
     }
 
     #[test]
-    fn application_inference_profile_arn_is_passed_through_as_profile() {
-        let arn = "arn:aws:bedrock:us-west-2:000000000000:application-inference-profile/000000000000";
-        let provider = test_provider().with_model(arn);
-        assert_eq!(provider.context_window(), None);
-        assert_eq!(provider.model, arn);
-        assert_eq!(provider.display_name(), format!("Bedrock ({arn})"));
+    fn with_inference_profile_arn_keeps_canonical_model_identity() {
+        let arn = inference_profile_arn("us.anthropic.claude-sonnet-4-5-20250929-v1:0");
+        let provider =
+            test_provider().with_model("anthropic.claude-sonnet-4-5-20250929-v1:0").with_inference_profile_arn(&arn);
+
+        assert_eq!(provider.request_model_id(), arn);
+        assert_eq!(provider.context_window(), Some(200_000));
+        assert_eq!(provider.model().unwrap().to_string(), "bedrock:anthropic.claude-sonnet-4-5-20250929-v1:0");
+    }
+
+    #[test]
+    fn prompt_caching_support_comes_from_canonical_model() {
+        let cached = test_provider().with_model("anthropic.claude-sonnet-4-5-20250929-v1:0");
+        assert!(cached.model().unwrap().supports_prompt_caching());
+
+        let unknown_profile = test_provider().with_model("us.anthropic.claude-future-model-v99:0");
+        assert!(!unknown_profile.model().unwrap().supports_prompt_caching());
     }
 
     struct FakeBedrockEndpoint {

--- a/packages/llm/src/providers/gemini/provider.rs
+++ b/packages/llm/src/providers/gemini/provider.rs
@@ -128,14 +128,14 @@ mod tests {
     #[test]
     fn get_api_key_returns_empty_when_auth_is_none() {
         let provider = GeminiProvider::new(Some("real-key".to_string()))
-            .with_connection(ProviderConnectionConfig { base_url: None, auth_mode: ProviderAuthMode::None });
+            .with_connection(ProviderConnectionConfig { auth_mode: ProviderAuthMode::None, ..Default::default() });
         assert_eq!(provider.get_api_key().unwrap(), "");
     }
 
     #[test]
     fn build_openai_client_strips_authorization_when_auth_is_none() {
         let provider = GeminiProvider::new(Some("real-key".to_string()))
-            .with_connection(ProviderConnectionConfig { base_url: None, auth_mode: ProviderAuthMode::None });
+            .with_connection(ProviderConnectionConfig { auth_mode: ProviderAuthMode::None, ..Default::default() });
         let api_key = provider.get_api_key().unwrap();
         let client = provider.build_openai_client(&api_key);
         assert!(!client.config().headers().contains_key(AUTHORIZATION));

--- a/website/src/content/docs/aether/configuration/agent-settings.mdx
+++ b/website/src/content/docs/aether/configuration/agent-settings.mdx
@@ -50,12 +50,13 @@ The onboarding wizard creates `.aether/<AGENT>.md` for the first scaffolded agen
 
 `AetherSettings` is camelCase JSON and rejects unknown fields.
 
-| Field     | Type              | Description                                                                     |
-| --------- | ----------------- | ------------------------------------------------------------------------------- |
-| `agent`   | `string \| null`  | Optional default user-invocable agent name                                      |
-| `prompts` | `PromptSource[]`  | Top-level prompt sources inherited by agents whose own `prompts` array is empty |
-| `mcps`    | `McpSourceSpec[]` | Top-level MCP sources inherited by agents whose own `mcps` array is empty       |
-| `agents`  | `AgentConfig[]`   | Authored agent definitions                                                      |
+| Field       | Type              | Description                                                                     |
+| ----------- | ----------------- | ------------------------------------------------------------------------------- |
+| `agent`     | `string \| null`  | Optional default user-invocable agent name                                      |
+| `prompts`   | `PromptSource[]`  | Top-level prompt sources inherited by agents whose own `prompts` array is empty |
+| `mcps`      | `McpSourceSpec[]` | Top-level MCP sources inherited by agents whose own `mcps` array is empty       |
+| `agents`    | `AgentConfig[]`   | Authored agent definitions                                                      |
+| `providers` | `object`          | Optional provider-specific connection/request overrides keyed by provider       |
 
 Regenerate the reference schema from source with:
 
@@ -78,8 +79,31 @@ cargo run -p aether-project --bin aether-settings-schema > /tmp/aether-settings.
 | `prompts`         | `PromptSource[]`                                 | `[]`     | Agent-specific prompt sources. A non-empty array replaces the top-level prompt list. |
 | `mcps`            | `McpSourceSpec[]`                                | `[]`     | Agent-specific MCP sources. A non-empty array replaces the top-level MCP list.       |
 | `tools`           | `{ allow?: string[], deny?: string[] }`          | `{}`     | Tool filter applied after MCP tools are discovered.                                  |
+| `providers`       | `object`                                         | `{}`     | Agent-specific provider overrides merged with top-level `providers`.                 |
 
 Every authored agent must have at least one invocation surface: `userInvocable: true`, `agentInvocable: true`, or both.
+
+Provider overrides can be set globally or per agent. For Bedrock inference profiles, keep `model` as the foundation model ID and put the profile ARN in `providers.bedrock.inferenceProfileArn`:
+
+```json title=".aether/settings.json"
+{
+  "providers": {
+    "bedrock": {
+      "inferenceProfileArn": "arn:aws:bedrock:us-west-2:000000000000:application-inference-profile/000000000000"
+    }
+  },
+  "agents": [
+    {
+      "name": "BedrockBuild",
+      "description": "Uses a Bedrock application inference profile",
+      "model": "bedrock:anthropic.claude-sonnet-4-5-20250929-v1:0",
+      "userInvocable": true
+    }
+  ]
+}
+```
+
+Per-agent `providers` values override matching top-level provider values for that agent.
 
 ## Sub-agent example
 

--- a/website/src/content/docs/aether/configuration/llm-providers.mdx
+++ b/website/src/content/docs/aether/configuration/llm-providers.mdx
@@ -120,6 +120,30 @@ Aether has built-in OpenAI-compatible provider configs for:
 | **Credentials**  | AWS credential chain (environment, config file, IAM role, etc.) |
 | **Model syntax** | `bedrock:<model-id>`                                            |
 
+Use the Bedrock foundation model or system profile model ID as the Aether model identity. Aether uses this value for context windows, multimodal/reasoning capability checks, and Bedrock prompt caching decisions.
+
+If you route traffic through an inference profile, configure the profile ARN as a provider override instead of putting the ARN in `model`:
+
+```json title=".aether/settings.json"
+{
+  "agents": [
+    {
+      "name": "BedrockProfile",
+      "description": "Routes Bedrock requests through an application inference profile",
+      "model": "bedrock:anthropic.claude-sonnet-4-5-20250929-v1:0",
+      "providers": {
+        "bedrock": {
+          "inferenceProfileArn": "arn:aws:bedrock:us-west-2:000000000000:application-inference-profile/000000000000"
+        }
+      },
+      "userInvocable": true
+    }
+  ]
+}
+```
+
+Do not use `bedrock:arn:aws:bedrock:...` as the model. The ARN only identifies the request target; it does not tell Aether which model capabilities or context window to use.
+
 ### Ollama
 
 |                   |                     |

--- a/website/src/content/docs/aether/running/headless.mdx
+++ b/website/src/content/docs/aether/running/headless.mdx
@@ -43,23 +43,31 @@ aether headless --model anthropic:claude-sonnet-4-5-20250929 \
   "Summarize the architecture"
 ```
 
+Use `--provider` for provider-specific request routing and connection overrides. For Bedrock inference profiles, keep `--model` as the Bedrock model ID and pass the ARN separately:
+
+```bash
+aether headless --model bedrock:anthropic.claude-sonnet-4-5-20250929-v1:0 \
+  --provider bedrock.inference-profile-arn=arn:aws:bedrock:us-west-2:000000000000:application-inference-profile/000000000000 \
+  "Summarize the architecture"
+```
+
 ## Flags
 
-| Flag                | Type                     | Description                                                        |
-| ------------------- | ------------------------ | ------------------------------------------------------------------ |
-| `[PROMPT]...`       | positional               | Prompt text. Reads stdin if omitted and stdin is not a TTY.        |
-| `-a, --agent`       | `string`                 | Named agent from settings. Defaults to first user-invocable agent. |
-| `-m, --model`       | `string`                 | Ad-hoc model spec. Mutually exclusive with `--agent`.              |
-| `-C, --cwd`         | `path`                   | Working directory. Defaults to `.`.                                |
-| `--settings-json`   | `string`                 | Inline settings JSON.                                              |
-| `--settings-file`   | `path`                   | Settings JSON file.                                                |
-| `--mcp-config`      | `path`                   | Additional MCP config file. Repeatable.                            |
-| `--mcp-config-json` | `string`                 | Additional inline MCP config JSON. Repeatable.                     |
-| `--system-prompt`   | `string`                 | Additional system prompt text.                                     |
-| `--output`          | `text \| pretty \| json` | Output format. Defaults to `text`.                                 |
-| `-v, --verbose`     | flag                     | Verbose diagnostic logging to stderr.                              |
-| `--events`          | comma-separated list     | Event kinds to emit. Omit to emit all.                             |
-| `--sandbox-image`   | `string`                 | Run inside a Docker sandbox using the given image.                 |
+| Flag                | Type                     | Description                                                                                       |
+| ------------------- | ------------------------ | ------------------------------------------------------------------------------------------------- |
+| `[PROMPT]...`       | positional               | Prompt text. Reads stdin if omitted and stdin is not a TTY.                                       |
+| `-a, --agent`       | `string`                 | Named agent from settings. Defaults to first user-invocable agent.                                |
+| `-m, --model`       | `string`                 | Ad-hoc model spec. Mutually exclusive with `--agent`.                                             |
+| `-C, --cwd`         | `path`                   | Working directory. Defaults to `.`.                                                               |
+| `--settings-json`   | `string`                 | Inline settings JSON.                                                                             |
+| `--settings-file`   | `path`                   | Settings JSON file.                                                                               |
+| `--mcp-config`      | `path`                   | Additional MCP config file. Repeatable.                                                           |
+| `--mcp-config-json` | `string`                 | Additional inline MCP config JSON. Repeatable.                                                    |
+| `--system-prompt`   | `string`                 | Additional system prompt text.                                                                    |
+| `--output`          | `text \| pretty \| json` | Output format. Defaults to `text`.                                                                |
+| `-v, --verbose`     | flag                     | Verbose diagnostic logging to stderr.                                                             |
+| `--events`          | comma-separated list     | Event kinds to emit. Omit to emit all.                                                            |
+| `--provider`        | `provider.field=value`   | Provider override. Supports `PROVIDER.url`, `PROVIDER.auth`, and `bedrock.inference-profile-arn`. |
 
 `--sandbox-image` is a global CLI flag, so it can appear before the subcommand or in the subcommand options shown by help.
 


### PR DESCRIPTION
This PR enables prompt caching for Bedrock models that support it. 

Aether now requires passing a opaque Bedrock application inference profile arn and the _actual_ Bedrock model being used separately. This makes it much easier for Aether to determine which model is in use and then determine if it supports prompt caching or not (Bedrock only supports prompt caching for a small handful of models, mostly Anthropic models). 