### PR TITLE
fix(wisp): Show cwd and git branch to avoid confusing users with multiple terminal tabs open

### DIFF
--- a/packages/wisp/examples/wisp_gallery.rs
+++ b/packages/wisp/examples/wisp_gallery.rs
@@ -16,6 +16,7 @@ use wisp::components::text_input::TextInput;
 use wisp::components::thought_message::ThoughtMessage;
 use wisp::components::tool_call_status_view::{ToolCallStatus, ToolCallStatusView};
 use wisp::keybindings::Keybindings;
+use wisp::workspace_status::WorkspaceStatus;
 
 enum WispStory {
     TextInput(TextInput),
@@ -173,7 +174,9 @@ impl Component for StatusLineStory {
     }
 
     fn render(&mut self, ctx: &ViewContext) -> Frame {
+        let workspace_status = WorkspaceStatus::new("~/code/foo", Some("main".to_string()));
         let status = StatusLine {
+            workspace_status: &workspace_status,
             agent_name: "aether",
             config_options: &[],
             context_usage: Some(ContextUsageDisplay::new(144_000, 200_000)),

--- a/packages/wisp/src/components/app/mod.rs
+++ b/packages/wisp/src/components/app/mod.rs
@@ -18,6 +18,7 @@ use crate::components::status_line::ContextUsageDisplay;
 use crate::keybindings::Keybindings;
 use crate::settings;
 use crate::settings::overlay::{SettingsMessage, SettingsOverlay};
+use crate::workspace_status::WorkspaceStatus;
 use acp_utils::client::{AcpEvent, AcpPromptHandle};
 use acp_utils::config_meta::SelectOptionMeta;
 use acp_utils::config_option_id::ConfigOptionId;
@@ -44,6 +45,17 @@ pub enum EventOutcome {
     DontRender,
 }
 
+pub struct AppInfo {
+    pub session_id: SessionId,
+    pub agent_name: String,
+    pub prompt_capabilities: acp::PromptCapabilities,
+    pub config_options: Vec<acp::SessionConfigOption>,
+    pub auth_methods: Vec<acp::AuthMethod>,
+    pub working_dir: PathBuf,
+    pub workspace_status: WorkspaceStatus,
+    pub prompt_handle: AcpPromptHandle,
+}
+
 #[doc = include_str!("../../docs/app.md")]
 pub struct App {
     agent_name: String,
@@ -63,19 +75,22 @@ pub struct App {
     session_loading_buffer: SessionLoadingBuffer,
     prompt_handle: AcpPromptHandle,
     working_dir: PathBuf,
+    workspace_status: WorkspaceStatus,
     content_padding: usize,
 }
 
 impl App {
-    pub fn new(
-        session_id: SessionId,
-        agent_name: String,
-        prompt_capabilities: acp::PromptCapabilities,
-        config_options: &[acp::SessionConfigOption],
-        auth_methods: Vec<acp::AuthMethod>,
-        working_dir: PathBuf,
-        prompt_handle: AcpPromptHandle,
-    ) -> Self {
+    pub fn new(info: AppInfo) -> Self {
+        let AppInfo {
+            session_id,
+            agent_name,
+            prompt_capabilities,
+            config_options,
+            auth_methods,
+            working_dir,
+            workspace_status,
+            prompt_handle,
+        } = info;
         let keybindings = Keybindings::default();
         let wisp_settings = settings::load_or_create_settings();
         let content_padding = settings::resolve_content_padding(&wisp_settings);
@@ -86,7 +101,7 @@ impl App {
             ctrl_c_pressed_at: None,
             conversation_screen: ConversationScreen::new(keybindings.clone(), content_padding),
             prompt_capabilities,
-            config_options: config_options.to_vec(),
+            config_options,
             server_statuses: Vec::new(),
             auth_methods,
             settings_overlay: None,
@@ -97,6 +112,7 @@ impl App {
             session_loading_buffer: SessionLoadingBuffer::new(),
             prompt_handle,
             working_dir,
+            workspace_status,
             content_padding,
         }
     }
@@ -616,68 +632,32 @@ pub(crate) mod test_helpers {
     use acp_utils::client::PromptCommand;
     use tokio::sync::mpsc;
 
+    pub fn test_workspace_status() -> WorkspaceStatus {
+        WorkspaceStatus::new("~/code/foo", Some("main".to_string()))
+    }
+
     pub fn make_app() -> App {
-        App::new(
-            SessionId::new("test"),
-            "test-agent".to_string(),
-            acp::PromptCapabilities::new(),
-            &[],
-            vec![],
-            PathBuf::from("."),
-            AcpPromptHandle::noop(),
-        )
+        make_app_with_options("test", acp::PromptCapabilities::new(), &[], vec![], AcpPromptHandle::noop())
     }
 
     pub fn make_app_with_config(config_options: &[acp::SessionConfigOption]) -> App {
-        App::new(
-            SessionId::new("test"),
-            "test-agent".to_string(),
-            acp::PromptCapabilities::new(),
-            config_options,
-            vec![],
-            PathBuf::from("."),
-            AcpPromptHandle::noop(),
-        )
+        make_app_with_options("test", acp::PromptCapabilities::new(), config_options, vec![], AcpPromptHandle::noop())
     }
 
     pub fn make_app_with_auth(auth_methods: Vec<acp::AuthMethod>) -> App {
-        App::new(
-            SessionId::new("test"),
-            "test-agent".to_string(),
-            acp::PromptCapabilities::new(),
-            &[],
-            auth_methods,
-            PathBuf::from("."),
-            AcpPromptHandle::noop(),
-        )
+        make_app_with_options("test", acp::PromptCapabilities::new(), &[], auth_methods, AcpPromptHandle::noop())
     }
 
     pub fn make_app_with_config_recording(
         config_options: &[acp::SessionConfigOption],
     ) -> (App, mpsc::UnboundedReceiver<PromptCommand>) {
         let (handle, rx) = AcpPromptHandle::recording();
-        let app = App::new(
-            SessionId::new("test"),
-            "test-agent".to_string(),
-            acp::PromptCapabilities::new(),
-            config_options,
-            vec![],
-            PathBuf::from("."),
-            handle,
-        );
+        let app = make_app_with_options("test", acp::PromptCapabilities::new(), config_options, vec![], handle);
         (app, rx)
     }
 
     pub fn make_app_with_session_id(session_id: &str) -> App {
-        App::new(
-            SessionId::new(session_id),
-            "test-agent".to_string(),
-            acp::PromptCapabilities::new(),
-            &[],
-            vec![],
-            PathBuf::from("."),
-            AcpPromptHandle::noop(),
-        )
+        make_app_with_options(session_id, acp::PromptCapabilities::new(), &[], vec![], AcpPromptHandle::noop())
     }
 
     pub fn make_app_with_config_and_capabilities_recording(
@@ -685,16 +665,27 @@ pub(crate) mod test_helpers {
         prompt_capabilities: acp::PromptCapabilities,
     ) -> (App, mpsc::UnboundedReceiver<PromptCommand>) {
         let (handle, rx) = AcpPromptHandle::recording();
-        let app = App::new(
-            SessionId::new("test"),
-            "test-agent".to_string(),
-            prompt_capabilities,
-            config_options,
-            vec![],
-            PathBuf::from("."),
-            handle,
-        );
+        let app = make_app_with_options("test", prompt_capabilities, config_options, vec![], handle);
         (app, rx)
+    }
+
+    fn make_app_with_options(
+        session_id: &str,
+        prompt_capabilities: acp::PromptCapabilities,
+        config_options: &[acp::SessionConfigOption],
+        auth_methods: Vec<acp::AuthMethod>,
+        prompt_handle: AcpPromptHandle,
+    ) -> App {
+        App::new(AppInfo {
+            session_id: SessionId::new(session_id),
+            agent_name: "test-agent".to_string(),
+            prompt_capabilities,
+            config_options: config_options.to_vec(),
+            auth_methods,
+            working_dir: PathBuf::from("."),
+            workspace_status: test_workspace_status(),
+            prompt_handle,
+        })
     }
 }
 
@@ -1568,7 +1559,9 @@ mod tests {
             "m1",
             vec![acp::SessionConfigSelectOption::new("m1", "M1")],
         )];
+        let workspace_status = test_workspace_status();
         let status = StatusLine {
+            workspace_status: &workspace_status,
             agent_name: "test-agent",
             config_options: &options,
             context_usage: None,

--- a/packages/wisp/src/components/app/view.rs
+++ b/packages/wisp/src/components/app/view.rs
@@ -19,6 +19,7 @@ pub fn build_frame(app: &mut App, context: &ViewContext) -> Frame {
 
 fn make_status_line(app: &App) -> StatusLine<'_> {
     StatusLine {
+        workspace_status: &app.workspace_status,
         agent_name: &app.agent_name,
         config_options: &app.config_options,
         context_usage: app.context_usage,

--- a/packages/wisp/src/components/reasoning_bar.rs
+++ b/packages/wisp/src/components/reasoning_bar.rs
@@ -6,15 +6,16 @@ fn filled_slots(effort: Option<ReasoningEffort>, total: usize) -> usize {
     effort.map_or(0, |e| e.ordinal() + 1).min(total)
 }
 
-/// Renders a compact labeled reasoning effort bar with a dynamic slot count.
+/// Renders a compact reasoning effort bar labeled with the current effort.
 ///
 /// Visual mapping (e.g. `total_levels = 3`):
-/// - `None` => `reasoning [···]` (all empty)
-/// - `Low` => `reasoning [■··]` (1 filled)
-/// - `Medium` => `reasoning [■■·]` (2 filled)
-/// - `High` => `reasoning [■■■]` (3 filled)
+/// - `None` => `none [···]` (all empty)
+/// - `Low` => `low [■··]` (1 filled)
+/// - `Medium` => `medium [■■·]` (2 filled)
+/// - `High` => `high [■■■]` (3 filled)
 pub(crate) fn reasoning_bar(effort: Option<ReasoningEffort>, total_levels: usize) -> String {
-    format!("reasoning {}", slot_bar(filled_slots(effort, total_levels), total_levels))
+    let label = effort.map_or("none", ReasoningEffort::as_str);
+    format!("{label} {}", slot_bar(filled_slots(effort, total_levels), total_levels))
 }
 
 /// Returns the appropriate theme color for the given reasoning effort.
@@ -40,36 +41,35 @@ mod tests {
 
     #[test]
     fn bar_none_3_slots() {
-        assert_eq!(reasoning_bar(None, 3), "reasoning [···]");
+        assert_eq!(reasoning_bar(None, 3), "none [···]");
     }
 
     #[test]
     fn bar_low_3_slots() {
-        assert_eq!(reasoning_bar(Some(ReasoningEffort::Low), 3), "reasoning [■··]");
+        assert_eq!(reasoning_bar(Some(ReasoningEffort::Low), 3), "low [■··]");
     }
 
     #[test]
     fn bar_medium_3_slots() {
-        assert_eq!(reasoning_bar(Some(ReasoningEffort::Medium), 3), "reasoning [■■·]");
+        assert_eq!(reasoning_bar(Some(ReasoningEffort::Medium), 3), "medium [■■·]");
     }
 
     #[test]
     fn bar_high_3_slots() {
-        assert_eq!(reasoning_bar(Some(ReasoningEffort::High), 3), "reasoning [■■■]");
+        assert_eq!(reasoning_bar(Some(ReasoningEffort::High), 3), "high [■■■]");
     }
 
     #[test]
     fn bar_4_slots() {
-        assert_eq!(reasoning_bar(None, 4), "reasoning [····]");
-        assert_eq!(reasoning_bar(Some(ReasoningEffort::Low), 4), "reasoning [■···]");
-        assert_eq!(reasoning_bar(Some(ReasoningEffort::High), 4), "reasoning [■■■·]");
-        assert_eq!(reasoning_bar(Some(ReasoningEffort::Xhigh), 4), "reasoning [■■■■]");
+        assert_eq!(reasoning_bar(None, 4), "none [····]");
+        assert_eq!(reasoning_bar(Some(ReasoningEffort::Low), 4), "low [■···]");
+        assert_eq!(reasoning_bar(Some(ReasoningEffort::High), 4), "high [■■■·]");
+        assert_eq!(reasoning_bar(Some(ReasoningEffort::Xhigh), 4), "xhigh [■■■■]");
     }
 
     #[test]
     fn bar_xhigh_clamped_to_3_slots() {
-        // Xhigh ordinal=3, clamped to total_levels=3
-        assert_eq!(reasoning_bar(Some(ReasoningEffort::Xhigh), 3), "reasoning [■■■]");
+        assert_eq!(reasoning_bar(Some(ReasoningEffort::Xhigh), 3), "xhigh [■■■]");
     }
 
     #[test]

--- a/packages/wisp/src/components/status_line.rs
+++ b/packages/wisp/src/components/status_line.rs
@@ -243,10 +243,8 @@ mod tests {
         let context = ViewContext::new((120, 40));
         let frame = status.render(&context);
         let text = frame.lines()[0].plain_text();
-        assert!(
-            text.contains("reasoning"),
-            "reasoning bar should be visible when reasoning_effort option exists, got: {text}"
-        );
+        assert!(text.contains("medium"), "reasoning bar should use current reasoning effort as its label, got: {text}");
+        assert!(!text.contains("reasoning"), "reasoning bar should not use a generic reasoning label, got: {text}");
     }
 
     #[test]

--- a/packages/wisp/src/components/status_line.rs
+++ b/packages/wisp/src/components/status_line.rs
@@ -1,16 +1,18 @@
 use crate::components::context_bar::{context_bar, context_color};
 use crate::components::reasoning_bar::{reasoning_bar, reasoning_color};
+use crate::workspace_status::WorkspaceStatus;
 use acp_utils::config_option_id::ConfigOptionId;
 use agent_client_protocol::schema::{
     self as acp, SessionConfigKind, SessionConfigOption, SessionConfigOptionCategory, SessionConfigSelectOptions,
 };
-use tui::{Color, Frame, Line, ViewContext, display_width_text};
+use tui::{Color, FitOptions, Frame, Line, ViewContext, display_width_text};
 use utils::ReasoningEffort;
 
 pub use crate::components::context_bar::ContextUsageDisplay;
 
 #[doc = include_str!("../docs/status_line.md")]
 pub struct StatusLine<'a> {
+    pub workspace_status: &'a WorkspaceStatus,
     pub agent_name: &'a str,
     pub config_options: &'a [SessionConfigOption],
     pub context_usage: Option<ContextUsageDisplay>,
@@ -23,67 +25,84 @@ pub struct StatusLine<'a> {
 impl StatusLine<'_> {
     #[allow(clippy::similar_names)]
     pub fn render(&self, context: &ViewContext) -> Frame {
-        let mode_display = extract_mode_display(self.config_options);
-        let model_display = extract_model_display(self.config_options);
-        let reasoning_effort = extract_reasoning_effort(self.config_options);
-
-        let mut left_line = Line::default();
-        let sep = context.theme.text_secondary();
-
-        left_line.push_text(" ".repeat(self.content_padding));
-
-        if self.exit_confirmation_active {
-            left_line.push_styled("Ctrl-C again to exit", context.theme.warning());
-        } else {
-            left_line.push_styled(self.agent_name, context.theme.info());
-
-            if let Some(ref mode) = mode_display {
-                left_line.push_styled(" · ", sep);
-                left_line.push_styled(mode.as_str(), context.theme.secondary());
-            }
-
-            if let Some(ref model) = model_display {
-                left_line.push_styled(" · ", sep);
-                left_line.push_styled(model.as_str(), context.theme.success());
-            }
-        }
-
-        let mut right_parts: Vec<(String, Color)> = Vec::new();
-
-        let reasoning_levels = extract_reasoning_levels(self.config_options);
-        if model_display.is_some() && !reasoning_levels.is_empty() {
-            right_parts.push((
-                reasoning_bar(reasoning_effort, reasoning_levels.len()),
-                reasoning_color(reasoning_effort, reasoning_levels.len(), &context.theme),
-            ));
-        }
-
-        if let Some(usage) = self.context_usage {
-            if !right_parts.is_empty() {
-                right_parts.push((" · ".to_string(), sep));
-            }
-            right_parts.push((context_bar(usage), context_color(usage, &context.theme)));
-        }
-
-        if !self.waiting_for_response && self.unhealthy_server_count > 0 {
-            let count = self.unhealthy_server_count;
-            let msg = if count == 1 { "1 server needs auth".to_string() } else { format!("{count} servers unhealthy") };
-            if !right_parts.is_empty() {
-                right_parts.push((" · ".to_string(), sep));
-            }
-            right_parts.push((msg, context.theme.warning()));
-        }
-
+        let mut line = render_left(self.workspace_status, context, self.content_padding);
+        let right_parts = render_right(self, context);
         let width = context.size.width as usize;
         let right_len: usize = right_parts.iter().map(|(s, _)| display_width_text(s)).sum();
-        let left_len = left_line.display_width();
+        let left_len = line.display_width();
 
         let padding = width.saturating_sub(left_len + right_len);
-        left_line.push_text(" ".repeat(padding));
+        line.push_text(" ".repeat(padding));
         for (text, color) in right_parts {
-            left_line.push_styled(text, color);
+            line.push_styled(text, color);
         }
-        Frame::new(vec![left_line])
+
+        Frame::new(vec![line]).fit(context.size.width, FitOptions::truncate())
+    }
+}
+
+fn render_left(status: &WorkspaceStatus, context: &ViewContext, content_padding: usize) -> Line {
+    let mut line = Line::default();
+    line.push_text(" ".repeat(content_padding));
+    line.push_styled(status.display_dir.as_str(), context.theme.secondary());
+    if let Some(ref git_ref) = status.git_ref {
+        line.push_styled(" · ", context.theme.text_secondary());
+        line.push_styled(git_ref.as_str(), context.theme.success());
+    }
+    line
+}
+
+fn render_right(status: &StatusLine<'_>, context: &ViewContext) -> Vec<(String, Color)> {
+    let sep = context.theme.text_secondary();
+    let mode_text = extract_mode_display(status.config_options);
+    let model_summary = extract_model_display(status.config_options);
+    let reasoning_effort = extract_reasoning_effort(status.config_options);
+
+    let mut parts = Vec::new();
+
+    if status.exit_confirmation_active {
+        parts.push(("Ctrl-C again to exit".to_string(), context.theme.warning()));
+    } else {
+        parts.push((status.agent_name.to_string(), context.theme.info()));
+
+        if let Some(ref mode) = mode_text {
+            push_separator(&mut parts, sep);
+            parts.push((mode.clone(), context.theme.secondary()));
+        }
+
+        if let Some(ref model) = model_summary {
+            push_separator(&mut parts, sep);
+            parts.push((model.clone(), context.theme.success()));
+        }
+    }
+
+    let reasoning_levels = extract_reasoning_levels(status.config_options);
+    if model_summary.is_some() && !reasoning_levels.is_empty() {
+        push_separator(&mut parts, sep);
+        parts.push((
+            reasoning_bar(reasoning_effort, reasoning_levels.len()),
+            reasoning_color(reasoning_effort, reasoning_levels.len(), &context.theme),
+        ));
+    }
+
+    if let Some(usage) = status.context_usage {
+        push_separator(&mut parts, sep);
+        parts.push((context_bar(usage), context_color(usage, &context.theme)));
+    }
+
+    if !status.waiting_for_response && status.unhealthy_server_count > 0 {
+        let count = status.unhealthy_server_count;
+        let msg = if count == 1 { "1 server needs auth".to_string() } else { format!("{count} servers unhealthy") };
+        push_separator(&mut parts, sep);
+        parts.push((msg, context.theme.warning()));
+    }
+
+    parts
+}
+
+fn push_separator(parts: &mut Vec<(String, Color)>, color: Color) {
+    if !parts.is_empty() {
+        parts.push((" · ".to_string(), color));
     }
 }
 
@@ -182,6 +201,11 @@ pub(crate) fn extract_reasoning_effort(config_options: &[SessionConfigOption]) -
 mod tests {
     use super::*;
     use crate::settings::DEFAULT_CONTENT_PADDING;
+    use crate::workspace_status::WorkspaceStatus;
+
+    fn test_workspace_status() -> WorkspaceStatus {
+        WorkspaceStatus::new("~/code/aether-2", Some("main".to_string()))
+    }
 
     fn model_option() -> SessionConfigOption {
         acp::SessionConfigOption::select(
@@ -208,7 +232,9 @@ mod tests {
     #[test]
     fn reasoning_bar_hidden_without_reasoning_option() {
         let options = vec![model_option()];
+        let workspace_status = test_workspace_status();
         let status = StatusLine {
+            workspace_status: &workspace_status,
             agent_name: "test-agent",
             config_options: &options,
             context_usage: None,
@@ -230,7 +256,9 @@ mod tests {
     #[test]
     fn reasoning_bar_shown_with_reasoning_option() {
         let options = vec![model_option(), reasoning_option()];
+        let workspace_status = test_workspace_status();
         let status = StatusLine {
+            workspace_status: &workspace_status,
             agent_name: "test-agent",
             config_options: &options,
             context_usage: None,

--- a/packages/wisp/src/docs/runtime_state.md
+++ b/packages/wisp/src/docs/runtime_state.md
@@ -13,6 +13,7 @@ Holds everything needed to start the TUI after the ACP handshake completes.
 - **`event_rx`** — channel receiver for streamed [`AcpEvent`](acp_utils::client::AcpEvent)s.
 - **`prompt_handle`** — handle for sending user prompts back to the agent.
 - **`working_dir`** — the working directory passed to the agent session.
+- **`workspace_status`** — pre-resolved display metadata for the status line's workspace segment.
 
 # See also
 

--- a/packages/wisp/src/docs/status_line.md
+++ b/packages/wisp/src/docs/status_line.md
@@ -1,13 +1,15 @@
-The bottom status bar showing agent state at a glance.
+The bottom status bar showing workspace and agent state at a glance.
 
-Renders a single line with left-aligned identity info and right-aligned indicators:
+Renders a single line with current workspace context on the left and session indicators on the right:
 
 **Left side:**
+- Current working directory, shortened relative to the user's home directory when possible
+- Current git branch or detached HEAD short SHA when the working directory is in a git repo/worktree
+
+**Right side:**
 - Agent name
 - Current mode/profile (if configured)
 - Active model name
-
-**Right side:**
 - Reasoning effort bar (visual level indicator)
 - Context window usage bar (shows current context usage against the model limit)
 - Unhealthy MCP server count (when not waiting for a response)

--- a/packages/wisp/src/lib.rs
+++ b/packages/wisp/src/lib.rs
@@ -11,9 +11,10 @@ mod session_loading_buffer;
 pub mod settings;
 #[cfg(test)]
 pub(crate) mod test_helpers;
+pub mod workspace_status;
 
 use acp_utils::client::AcpEvent;
-use components::app::{App, EventOutcome};
+use components::app::{App, AppInfo, EventOutcome};
 use error::AppError;
 use runtime_state::RuntimeState;
 use std::fs::create_dir_all;
@@ -51,17 +52,19 @@ pub async fn run_with_state(state: RuntimeState) -> Result<(), AppError> {
         event_rx,
         prompt_handle,
         working_dir,
+        workspace_status,
     } = state;
 
-    let app = App::new(
+    let app = App::new(AppInfo {
         session_id,
         agent_name,
         prompt_capabilities,
-        &config_options,
+        config_options,
         auth_methods,
         working_dir,
+        workspace_status,
         prompt_handle,
-    );
+    });
 
     run_app(app, theme, event_rx).await
 }

--- a/packages/wisp/src/runtime_state.rs
+++ b/packages/wisp/src/runtime_state.rs
@@ -1,6 +1,7 @@
 use crate::cli::Cli;
 use crate::error::AppError;
 use crate::settings::load_or_create_settings;
+use crate::workspace_status::WorkspaceStatus;
 use acp_utils::client::{AcpEvent, AcpPromptHandle, spawn_acp_session};
 use agent_client_protocol::schema::{
     AuthMethod, Implementation, InitializeRequest, NewSessionRequest, PromptCapabilities, ProtocolVersion,
@@ -21,11 +22,13 @@ pub struct RuntimeState {
     pub event_rx: mpsc::UnboundedReceiver<AcpEvent>,
     pub prompt_handle: AcpPromptHandle,
     pub working_dir: std::path::PathBuf,
+    pub workspace_status: WorkspaceStatus,
 }
 
 impl RuntimeState {
     pub async fn new(agent_command: &str) -> Result<Self, AppError> {
         let cwd = current_dir().unwrap_or_else(|_| std::path::PathBuf::from("."));
+        let workspace_status = WorkspaceStatus::resolve(&cwd).await;
         let new_session_request = NewSessionRequest::new(cwd.clone());
         let init_request = InitializeRequest::new(ProtocolVersion::LATEST)
             .client_info(Implementation::new("wisp", env!("CARGO_PKG_VERSION")));
@@ -45,6 +48,7 @@ impl RuntimeState {
             event_rx: session.event_rx,
             prompt_handle: session.prompt_handle,
             working_dir: cwd,
+            workspace_status,
         })
     }
 

--- a/packages/wisp/src/settings/overlay.rs
+++ b/packages/wisp/src/settings/overlay.rs
@@ -154,13 +154,16 @@ impl SettingsOverlay {
         matches!(self.active_pane, SettingsPane::Picker(_))
     }
 
-    fn footer_text(&self) -> &'static str {
+    fn footer_text(&self) -> String {
         match &self.active_pane {
-            SettingsPane::ModelSelector(_) => "[Space/Enter] Toggle  [Tab] Reasoning  [Esc] Done",
-            SettingsPane::Picker(_) => "[Enter] Confirm  [Esc] Back",
-            SettingsPane::ServerStatus(_) => "[Enter] Authenticate OAuth servers  [Esc] Back",
-            SettingsPane::ProviderLogin(_) => "[Enter] Authenticate  [Esc] Back",
-            SettingsPane::Menu => "[Enter] Select  [Esc] Close",
+            SettingsPane::ModelSelector(selector) => {
+                let effort = utils::ReasoningEffort::config_str(selector.reasoning_effort());
+                format!("[Space/Enter] Toggle  [Tab] Effort: {effort}  [Esc] Done")
+            }
+            SettingsPane::Picker(_) => "[Enter] Confirm  [Esc] Back".to_string(),
+            SettingsPane::ServerStatus(_) => "[Enter] Authenticate OAuth servers  [Esc] Back".to_string(),
+            SettingsPane::ProviderLogin(_) => "[Enter] Authenticate  [Esc] Back".to_string(),
+            SettingsPane::Menu => "[Enter] Select  [Esc] Close".to_string(),
         }
     }
 }
@@ -603,9 +606,10 @@ mod tests {
             SettingsOverlay::new(menu, vec![], vec![]).with_reasoning_effort_from_options(&reasoning_options);
 
         send_keys(&mut overlay, &[KeyCode::Enter]).await;
-        assert_footer_contains(&mut overlay, "Toggle");
+        assert_footer_contains(&mut overlay, "Effort: medium");
 
         send_keys(&mut overlay, &[KeyCode::Tab]).await;
+        assert_footer_contains(&mut overlay, "Effort: high");
         let messages = overlay.on_event(&Event::Key(key(KeyCode::Esc))).await.unwrap();
 
         let reasoning_msg = messages.iter().find(

--- a/packages/wisp/src/workspace_status.rs
+++ b/packages/wisp/src/workspace_status.rs
@@ -1,0 +1,101 @@
+use std::path::{Path, PathBuf};
+
+use tokio::process::Command;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct WorkspaceStatus {
+    pub display_dir: String,
+    pub git_ref: Option<String>,
+}
+
+impl WorkspaceStatus {
+    pub fn new(display_dir: impl Into<String>, git_ref: Option<String>) -> Self {
+        Self { display_dir: display_dir.into(), git_ref }
+    }
+
+    pub fn label(&self) -> String {
+        self.git_ref
+            .as_ref()
+            .map_or_else(|| self.display_dir.clone(), |git_ref| format!("{} · {git_ref}", self.display_dir))
+    }
+
+    pub async fn resolve(cwd: &Path) -> Self {
+        let display_dir = home_relative_path(cwd);
+        let git_ref = resolve_git_ref(cwd).await;
+        Self::new(display_dir, git_ref)
+    }
+}
+
+async fn resolve_git_ref(cwd: &Path) -> Option<String> {
+    if let Some(branch) = git_stdout(cwd, &["branch", "--show-current"]).await {
+        return Some(branch);
+    }
+    git_stdout(cwd, &["rev-parse", "--short", "HEAD"]).await
+}
+
+async fn git_stdout(cwd: &Path, args: &[&str]) -> Option<String> {
+    let output = Command::new("git").args(args).current_dir(cwd).output().await.ok()?;
+
+    if !output.status.success() {
+        return None;
+    }
+
+    let text = String::from_utf8_lossy(&output.stdout).trim().to_string();
+    if text.is_empty() { None } else { Some(text) }
+}
+
+fn home_relative_path(path: &Path) -> String {
+    home_dir().map_or_else(|| path.display().to_string(), |home| home_relative_path_with_home(path, &home))
+}
+
+fn home_dir() -> Option<PathBuf> {
+    std::env::var_os("HOME").or_else(|| std::env::var_os("USERPROFILE")).map(PathBuf::from)
+}
+
+fn home_relative_path_with_home(path: &Path, home: &Path) -> String {
+    if path == home {
+        return "~".to_string();
+    }
+
+    path.strip_prefix(home)
+        .ok()
+        .filter(|relative| !relative.as_os_str().is_empty())
+        .map_or_else(|| path.display().to_string(), |relative| format!("~/{}", relative.display()))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn label_combines_dir_and_ref() {
+        let status = WorkspaceStatus::new("~/code/aether-2", Some("main".to_string()));
+        assert_eq!(status.label(), "~/code/aether-2 · main");
+    }
+
+    #[test]
+    fn label_omits_ref_when_absent() {
+        let status = WorkspaceStatus::new("~/scratch", None);
+        assert_eq!(status.label(), "~/scratch");
+    }
+
+    #[test]
+    fn home_relative_path_rewrites_home_child() {
+        let path = Path::new("/Users/josh/code/aether-2");
+        let home = Path::new("/Users/josh");
+        assert_eq!(home_relative_path_with_home(path, home), "~/code/aether-2");
+    }
+
+    #[test]
+    fn home_relative_path_handles_home_itself() {
+        let home = Path::new("/Users/josh");
+        assert_eq!(home_relative_path_with_home(home, home), "~");
+    }
+
+    #[test]
+    fn home_relative_path_leaves_external_path_absolute() {
+        let path = Path::new("/opt/work/aether-2");
+        let home = Path::new("/Users/josh");
+        assert_eq!(home_relative_path_with_home(path, home), "/opt/work/aether-2");
+    }
+}

--- a/packages/wisp/tests/app_tests/common.rs
+++ b/packages/wisp/tests/app_tests/common.rs
@@ -5,16 +5,43 @@ use std::path::PathBuf;
 use tui::Renderer as FrameRenderer;
 use tui::RendererCommand;
 use tui::Theme;
+use tui::display_width_text;
 use tui::testing::TestTerminal;
 use tui::{Component, Event, KeyCode, KeyEvent, KeyEventKind, KeyEventState, KeyModifiers};
-use wisp::components::app::{App, EventOutcome};
+use wisp::components::app::{App, AppInfo, EventOutcome};
 use wisp::settings::DEFAULT_CONTENT_PADDING;
+use wisp::workspace_status::WorkspaceStatus;
 
 pub(super) const TEST_AGENT: &str = "test-agent";
 pub(super) const TEST_WIDTH: u16 = 200;
+pub(super) const TEST_WORKSPACE_DIR: &str = "~/code/foo";
+pub(super) const TEST_GIT_REF: &str = "main";
+
+pub(super) fn test_workspace_status() -> WorkspaceStatus {
+    WorkspaceStatus::new(TEST_WORKSPACE_DIR, Some(TEST_GIT_REF.to_string()))
+}
 
 pub(super) fn p(s: &str) -> String {
     format!("{}{s}", " ".repeat(DEFAULT_CONTENT_PADDING))
+}
+
+pub(super) fn expected_status_line(width: u16, agent_name: &str) -> String {
+    let left = format!("{}{} · {}", " ".repeat(DEFAULT_CONTENT_PADDING), TEST_WORKSPACE_DIR, TEST_GIT_REF);
+    let padding = usize::from(width).saturating_sub(display_width_text(&left) + display_width_text(agent_name));
+    let line = format!("{left}{}{agent_name}", " ".repeat(padding));
+    truncate_to_display_width(&line, usize::from(width))
+}
+
+fn truncate_to_display_width(text: &str, width: usize) -> String {
+    let mut truncated = String::new();
+    for ch in text.chars() {
+        let next = format!("{truncated}{ch}");
+        if display_width_text(&next) > width {
+            break;
+        }
+        truncated = next;
+    }
+    truncated
 }
 /// Expected progress-indicator line for the first inactive→active transition.
 pub(super) const PROGRESS_LINE: &str =
@@ -48,15 +75,16 @@ impl Renderer {
         auth_methods: Vec<acp::AuthMethod>,
         size: (u16, u16),
     ) -> Self {
-        let app = App::new(
-            acp::SessionId::new("test"),
+        let app = App::new(AppInfo {
+            session_id: acp::SessionId::new("test"),
             agent_name,
-            acp::PromptCapabilities::new(),
-            config_options,
+            prompt_capabilities: acp::PromptCapabilities::new(),
+            config_options: config_options.to_vec(),
             auth_methods,
-            std::path::PathBuf::from("."),
-            AcpPromptHandle::noop(),
-        );
+            working_dir: std::path::PathBuf::from("."),
+            workspace_status: test_workspace_status(),
+            prompt_handle: AcpPromptHandle::noop(),
+        });
         let frame_renderer = FrameRenderer::new(terminal, Theme::default(), size);
         Self { app, frame_renderer }
     }
@@ -222,7 +250,7 @@ pub(super) fn expected_prompt(width: u16, input: &str, agent_name: &str) -> Vec<
     let top = "─".repeat(w);
     let middle = format!("> {input}").trim_end().to_string();
     let bottom = "─".repeat(w);
-    let status = p(agent_name);
+    let status = expected_status_line(width, agent_name);
     vec![top, middle, bottom, status]
 }
 

--- a/packages/wisp/tests/app_tests/input_prompt_tests.rs
+++ b/packages/wisp/tests/app_tests/input_prompt_tests.rs
@@ -172,7 +172,13 @@ async fn test_cursor_position_after_whitespace_wrap() {
     type_string(&mut renderer, "abc def ghi").await;
 
     let rule = "─".repeat(width as usize);
-    let expected = vec![rule.clone(), "> abc def".to_string(), "  ghi".to_string(), rule.clone(), p(TEST_AGENT)];
+    let expected = vec![
+        rule.clone(),
+        "> abc def".to_string(),
+        "  ghi".to_string(),
+        rule.clone(),
+        expected_status_line(width, TEST_AGENT),
+    ];
     assert_buffer_eq(renderer.writer(), &expected);
 
     let (cursor_col, cursor_row) = renderer.writer().cursor_position();
@@ -181,7 +187,13 @@ async fn test_cursor_position_after_whitespace_wrap() {
 
     type_string(&mut renderer, "j").await;
 
-    let expected_after = vec![rule.clone(), "> abc def".to_string(), "  ghij".to_string(), rule, p(TEST_AGENT)];
+    let expected_after = vec![
+        rule.clone(),
+        "> abc def".to_string(),
+        "  ghij".to_string(),
+        rule,
+        expected_status_line(width, TEST_AGENT),
+    ];
     assert_buffer_eq(renderer.writer(), &expected_after);
 
     let (cursor_col_after, cursor_row_after) = renderer.writer().cursor_position();
@@ -219,7 +231,13 @@ async fn test_shift_enter_creates_hard_line_break() {
     type_string(&mut renderer, "line two").await;
 
     let rule = "─".repeat(80);
-    let expected = vec![rule.clone(), "> line one".to_string(), "  line two".to_string(), rule, p(TEST_AGENT)];
+    let expected = vec![
+        rule.clone(),
+        "> line one".to_string(),
+        "  line two".to_string(),
+        rule,
+        expected_status_line(80, TEST_AGENT),
+    ];
     assert_buffer_eq(renderer.writer(), &expected);
 
     let (cursor_col, cursor_row) = renderer.writer().cursor_position();

--- a/packages/wisp/tests/app_tests/status_line_tests.rs
+++ b/packages/wisp/tests/app_tests/status_line_tests.rs
@@ -6,6 +6,21 @@ use tui::testing::TestTerminal;
 use super::common::*;
 
 #[tokio::test]
+async fn test_status_line_shows_workspace_on_left() {
+    let terminal = TestTerminal::new(TEST_WIDTH, 24);
+    let mut renderer = Renderer::new(terminal, TEST_AGENT.to_string(), &[], (TEST_WIDTH, 24));
+
+    renderer.initial_render().unwrap();
+
+    let lines = renderer.writer().get_lines();
+    let status_line = lines
+        .iter()
+        .find(|line| line.contains(TEST_WORKSPACE_DIR) && line.contains(TEST_GIT_REF) && line.contains(TEST_AGENT))
+        .unwrap_or_else(|| panic!("Status line should show workspace and agent.\nBuffer:\n{}", lines.join("\n")));
+    assert!(status_line.find(TEST_WORKSPACE_DIR).unwrap() < status_line.find(TEST_AGENT).unwrap());
+}
+
+#[tokio::test]
 async fn test_status_line_shows_agent_name() {
     let terminal = TestTerminal::new(80, 24);
     let mut renderer = Renderer::new(terminal, "claude-code".to_string(), &[], (80, 24));

--- a/packages/wisp/tests/component_tests/model_selector.rs
+++ b/packages/wisp/tests/component_tests/model_selector.rs
@@ -310,7 +310,8 @@ fn render_shows_bar_on_focused_reasoning_row() {
         .find(|(i, _)| term.get_style_at(*i, 0).bg == Some(ctx.theme.highlight_bg()))
         .map(|(_, l)| l)
         .expect("should have focused line");
-    assert!(focused_line.contains("reasoning [■■·]"), "expected reasoning bar, got: {focused_line}");
+    assert!(focused_line.contains("medium [■■·]"), "expected reasoning bar with effort label, got: {focused_line}");
+    assert!(!focused_line.contains("reasoning"), "expected no generic reasoning label, got: {focused_line}");
 }
 
 #[tokio::test]

--- a/packages/wisp/tests/component_tests/settings_overlay.rs
+++ b/packages/wisp/tests/component_tests/settings_overlay.rs
@@ -216,7 +216,8 @@ async fn render_model_selector_hides_top_level_rows() {
     assert!(!text.contains("Provider: OpenRouter"), "rendered:\n{text}");
     assert!(!text.contains("Model: GPT-4o"), "rendered:\n{text}");
     assert!(text.contains("Toggle"), "rendered:\n{text}");
-    assert!(text.contains("Reasoning"), "rendered:\n{text}");
+    assert!(text.contains("Effort: none"), "rendered:\n{text}");
+    assert!(!text.contains("[Tab] Reasoning"), "rendered:\n{text}");
     assert!(text.contains("[Esc] Done"), "rendered:\n{text}");
 }
 
@@ -353,6 +354,8 @@ async fn footer_shows_toggle_when_model_selector_open() {
     let output = term.get_lines();
     let footer = &output[21];
     assert!(footer.contains("Toggle"), "footer: {footer}");
+    assert!(footer.contains("Effort: none"), "footer: {footer}");
+    assert!(!footer.contains("[Tab] Reasoning"), "footer: {footer}");
     assert!(footer.contains("[Esc] Done"), "footer: {footer}");
 }
 
@@ -410,6 +413,7 @@ async fn multi_select_entry_opens_model_selector() {
 
     let footer = render_footer(&mut overlay);
     assert!(footer.contains("Toggle"), "expected model selector, got: {footer}");
+    assert!(footer.contains("Effort: none"), "expected effort label, got: {footer}");
 }
 
 #[tokio::test]

--- a/packages/wisp/tests/component_tests/status_line.rs
+++ b/packages/wisp/tests/component_tests/status_line.rs
@@ -4,6 +4,7 @@ use tui::ViewContext;
 use tui::testing::render_lines;
 use wisp::components::status_line::{ContextUsageDisplay, StatusLine};
 use wisp::settings::DEFAULT_CONTENT_PADDING;
+use wisp::workspace_status::WorkspaceStatus;
 
 fn mode_option(value: impl Into<String>, name: impl Into<String>) -> SessionConfigOption {
     let value = value.into();
@@ -41,11 +42,20 @@ struct StatusBuilder<'a> {
     waiting: bool,
     unhealthy: usize,
     width: u16,
+    workspace_status: WorkspaceStatus,
 }
 
 impl<'a> StatusBuilder<'a> {
     fn new(name: &'a str) -> Self {
-        Self { name, options: vec![], ctx_usage: None, waiting: false, unhealthy: 0, width: 80 }
+        Self {
+            name,
+            options: vec![],
+            ctx_usage: None,
+            waiting: false,
+            unhealthy: 0,
+            width: 80,
+            workspace_status: WorkspaceStatus::new("~/code/aether-2", Some("main".to_string())),
+        }
     }
 
     fn model(mut self, m: &str) -> Self {
@@ -76,9 +86,14 @@ impl<'a> StatusBuilder<'a> {
         self.width = w;
         self
     }
+    fn workspace(mut self, dir: &str, git_ref: Option<&str>) -> Self {
+        self.workspace_status = WorkspaceStatus::new(dir, git_ref.map(str::to_string));
+        self
+    }
 
     fn render(&self) -> (String, tui::testing::TestTerminal) {
         let status = StatusLine {
+            workspace_status: &self.workspace_status,
             agent_name: self.name,
             config_options: &self.options,
             context_usage: self.ctx_usage,
@@ -100,10 +115,88 @@ impl<'a> StatusBuilder<'a> {
 }
 
 #[test]
-fn renders_agent_name_and_indentation() {
+fn renders_workspace_on_left_and_existing_status_on_right() {
+    let line = StatusBuilder::new("Aether")
+        .mode("planner", "Planner")
+        .model("Codex: GPT-5.5")
+        .reasoning("medium")
+        .ctx_usage(164_000, 272_000)
+        .width(140)
+        .line();
+
+    let workspace_at = line.find("~/code/aether-2 · main").unwrap();
+    let agent_at = line.find("Aether").unwrap();
+    assert!(workspace_at < agent_at);
+    assert!(line.contains("Planner"));
+    assert!(line.contains("Codex: GPT-5.5"));
+    assert!(line.contains("medium [■■·]"));
+    assert!(line.contains("ctx"));
+}
+
+#[test]
+fn renders_workspace_without_git_ref() {
+    let line = StatusBuilder::new("aether").workspace("~/scratch", None).line();
+    assert!(line.contains("~/scratch"));
+    assert!(!line.contains("main"));
+}
+
+#[test]
+fn renders_workspace_with_expected_colors() {
+    let ctx = ViewContext::new((80, 24));
+    let (_, term) = StatusBuilder::new("wisp").render();
+
+    assert_eq!(term.style_of_text(0, "~/code/aether-2").unwrap().fg, Some(ctx.theme.secondary()));
+    assert_eq!(term.style_of_text(0, " · ").unwrap().fg, Some(ctx.theme.text_secondary()));
+    assert_eq!(term.style_of_text(0, "main").unwrap().fg, Some(ctx.theme.success()));
+}
+
+#[test]
+fn keeps_status_area_to_one_line_when_narrow() {
+    let workspace_status = WorkspaceStatus::new(
+        "~/very/long/path/that/would/wrap/without/truncation",
+        Some("feature/very-long-branch".to_string()),
+    );
+    let options = vec![model_option("model", "very-long-model-name")];
+    let status = StatusLine {
+        workspace_status: &workspace_status,
+        agent_name: "agent-name",
+        config_options: &options,
+        context_usage: Some(ContextUsageDisplay::new(100_000, 200_000)),
+        waiting_for_response: false,
+        unhealthy_server_count: 0,
+        content_padding: DEFAULT_CONTENT_PADDING,
+        exit_confirmation_active: false,
+    };
+    let ctx = ViewContext::new((24, 24));
+
+    assert_eq!(status.render(&ctx).lines().len(), 1);
+}
+
+#[test]
+fn exit_confirmation_keeps_workspace_and_moves_warning_right() {
+    let workspace_status = WorkspaceStatus::new("~/code/aether-2", Some("main".to_string()));
+    let status = StatusLine {
+        workspace_status: &workspace_status,
+        agent_name: "agent-name",
+        config_options: &[],
+        context_usage: None,
+        waiting_for_response: false,
+        unhealthy_server_count: 0,
+        content_padding: DEFAULT_CONTENT_PADDING,
+        exit_confirmation_active: true,
+    };
+    let ctx = ViewContext::new((100, 24));
+    let text = status.render(&ctx).lines()[0].plain_text();
+
+    assert!(text.contains("~/code/aether-2 · main"));
+    assert!(text.contains("Ctrl-C again to exit"));
+    assert!(!text.contains("agent-name"));
+}
+
+#[test]
+fn renders_agent_name() {
     let line = StatusBuilder::new("test-agent").line();
-    let padding = " ".repeat(DEFAULT_CONTENT_PADDING);
-    assert!(line.contains(&format!("{padding}test-agent")));
+    assert!(line.contains("test-agent"));
 }
 
 #[test]
@@ -115,7 +208,7 @@ fn renders_model_display() {
 
 #[test]
 fn renders_without_model_when_none() {
-    let line = StatusBuilder::new("aether-acp").line();
+    let line = StatusBuilder::new("aether-acp").workspace("~/code/aether-2", None).line();
     assert!(line.contains("aether-acp"));
     assert!(!line.contains("·"), "no separator when no model");
 }

--- a/packages/wisp/tests/component_tests/status_line.rs
+++ b/packages/wisp/tests/component_tests/status_line.rs
@@ -190,12 +190,13 @@ fn renders_elements_with_correct_colors() {
 fn renders_reasoning_bar() {
     // Medium effort
     let line = StatusBuilder::new("wisp").model("gpt-4o").reasoning("medium").line();
-    assert!(line.contains("reasoning [■■·]"));
-    assert!(line.find("gpt-4o").unwrap() < line.find("reasoning").unwrap());
+    assert!(line.contains("medium [■■·]"));
+    assert!(line.find("gpt-4o").unwrap() < line.find("medium").unwrap());
+    assert!(!line.contains("reasoning"));
 
     // None effort shows empty bar
     let line = StatusBuilder::new("wisp").model("gpt-4o").reasoning("none").line();
-    assert!(line.contains("reasoning [···]"));
+    assert!(line.contains("none [···]"));
 
     // No model = no reasoning bar even with reasoning set
     let line = StatusBuilder::new("wisp").reasoning("high").line();


### PR DESCRIPTION
- Fixes #67 
- Replaces `reasoning:` label with actual name of reasoning level, e.g. `medium, high, xhigh`. 