### PR TITLE
fix(aether-cli): Crashes due to eagin being fatal in transport

### DIFF
--- a/packages/aether-cli/Cargo.toml
+++ b/packages/aether-cli/Cargo.toml
@@ -43,7 +43,7 @@ aether-lspd = { path = "../aether-lspd", version = "0.1.14" }
 rmcp = { workspace = true }
 thiserror = { workspace = true }
 tokio = { workspace = true }
-tokio-util = { workspace = true }
+tokio-util = { workspace = true, features = ["compat"] }
 serde = { workspace = true }
 serde_json = { workspace = true }
 async-trait = { workspace = true }

--- a/packages/aether-cli/src/acp/mod.rs
+++ b/packages/aether-cli/src/acp/mod.rs
@@ -7,16 +7,17 @@ pub(crate) mod session;
 pub(crate) mod session_manager;
 pub(crate) mod session_registry;
 pub(crate) mod session_store;
+pub(crate) mod stdio;
 pub mod testing;
 
 pub use mappers::map_mcp_prompt_to_available_command;
 pub use session_manager::SessionManager;
 
 use crate::acp::handlers::acp_agent_builder;
+use crate::acp::stdio::Stdio;
 use crate::provider_connection_args::ProviderConnectionArgs;
 use crate::settings_args::SettingsSourceArgs;
 use agent_client_protocol as acp;
-use agent_client_protocol::Stdio;
 use llm::ReasoningEffort;
 use std::sync::Arc;
 use std::{fs::create_dir_all, path::PathBuf};

--- a/packages/aether-cli/src/acp/stdio.rs
+++ b/packages/aether-cli/src/acp/stdio.rs
@@ -1,0 +1,50 @@
+//! Piped Stdio transport for ACP.
+//!
+//! `agent_client_protocol::Stdio` (from acp crate) drives stdin/stdout via
+//! `blocking::Unblock` (blocking syscalls on a thread-pool worker) and treats
+//! every io error as fatal. That's a provlem when the parent process spawns
+//! this binary with non-blocking pipe fds: a `read`/`write` on the child side
+//! can return `EAGAIN`, which the upstream transport surfaces as a fatal io error
+//! and tears the session down.
+//!
+//! `tokio::net::unix::pipe` polls the fds via epoll instead, so `EAGAIN` isn't
+//! a fatal error.
+
+use agent_client_protocol::{ByteStreams, ConnectTo, Error, Role};
+use std::io;
+use std::os::fd::AsFd;
+use tokio::net::unix::pipe::{Receiver, Sender};
+use tokio_util::compat::{TokioAsyncReadCompatExt, TokioAsyncWriteCompatExt};
+
+pub struct Stdio;
+
+impl Stdio {
+    pub fn new() -> Self {
+        Self
+    }
+}
+
+impl<T: Role> ConnectTo<T> for Stdio {
+    async fn connect_to(self, client: impl ConnectTo<T::Counterpart>) -> Result<(), Error> {
+        let stdin = io::stdin()
+            .as_fd()
+            .try_clone_to_owned()
+            .and_then(Receiver::from_owned_fd)
+            .map_err(Error::into_internal_error)?;
+
+        let stdout = io::stdout()
+            .as_fd()
+            .try_clone_to_owned()
+            .and_then(Sender::from_owned_fd)
+            .map_err(Error::into_internal_error)?;
+
+        let streams = ByteStreams::new(stdout.compat_write(), stdin.compat());
+        ConnectTo::<T>::connect_to(streams, client).await
+    }
+}
+
+impl Default for Stdio {
+    fn default() -> Self {
+        Self::new()
+    }
+}


### PR DESCRIPTION
The ACP crate's built-in `Stdio` transport uses blocking syscalls on a thread pool worker via the [blocking](https://crates.io/crates/blocking) crate. 

It assumes the file descriptors it uses for stdio are always blocking. This assumption turned out to be invalid as our parent was spawning our acp agent using non-blocking file descriptors. This would cause the file descriptors to occasionally return  `EAGAIN`, which the acp crate would treat as a fatal error, and Aether would crash.

This PR fixes that by providing a small custom `Stdio` transport based on tokio, which uses `epoll` under the covers. 