### PR TITLE
fix(acp): Spawn parent acp process via tokio to avoid spinning cpu

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -293,6 +293,7 @@ version = "0.2.9"
 dependencies = [
  "aether-tui",
  "crossterm",
+ "futures",
  "nucleo",
  "pulldown-cmark",
  "serde_json",

--- a/packages/acp-utils/Cargo.toml
+++ b/packages/acp-utils/Cargo.toml
@@ -27,12 +27,12 @@ workspace = true
 default = ["client", "server"]
 client = ["dep:thiserror"]
 server = ["dep:thiserror"]
-testing = ["client", "dep:tokio-util"]
+testing = ["client"]
 
 [dependencies]
 agent-client-protocol = { workspace = true }
 futures = { workspace = true }
-tokio-util = { workspace = true, features = ["compat"], optional = true }
+tokio-util = { workspace = true, features = ["compat"] }
 rmcp = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }

--- a/packages/acp-utils/src/client/error.rs
+++ b/packages/acp-utils/src/client/error.rs
@@ -1,8 +1,7 @@
 /// Errors returned by ACP client-side operations.
 #[derive(Debug, thiserror::Error)]
 pub enum AcpClientError {
-    /// The agent command string could not be parsed / the subprocess could
-    /// not be spawned.
+    /// The agent command string could not be parsed.
     #[error("invalid agent command: {0}")]
     InvalidAgentCommand(#[source] agent_client_protocol::Error),
 

--- a/packages/acp-utils/src/client/mod.rs
+++ b/packages/acp-utils/src/client/mod.rs
@@ -2,8 +2,10 @@ mod error;
 mod event;
 mod prompt_handle;
 mod session;
+mod tokio_agent;
 
 pub use error::AcpClientError;
 pub use event::AcpEvent;
 pub use prompt_handle::{AcpPromptHandle, PromptCommand};
 pub use session::{AcpSession, spawn_acp_session};
+pub use tokio_agent::TokioAcpAgent;

--- a/packages/acp-utils/src/client/session.rs
+++ b/packages/acp-utils/src/client/session.rs
@@ -1,6 +1,7 @@
 use super::error::AcpClientError;
 use super::event::AcpEvent;
 use super::prompt_handle::{AcpPromptHandle, PromptCommand};
+use super::tokio_agent::TokioAcpAgent;
 use crate::notifications::{
     AuthMethodsUpdatedParams, ContextClearedParams, ContextUsageParams, ElicitationParams, McpNotification, McpRequest,
     SubAgentProgressParams,
@@ -12,7 +13,7 @@ use agent_client_protocol::schema::{
     RequestPermissionRequest, RequestPermissionResponse, SelectedPermissionOutcome, SessionConfigOption, SessionId,
     SessionNotification, SessionUpdate, SetSessionConfigOptionRequest, TextContent,
 };
-use agent_client_protocol::{self as acp, AcpAgent, Client, ConnectionTo};
+use agent_client_protocol::{self as acp, Client, ConnectionTo};
 use std::str::FromStr;
 use tokio::sync::mpsc;
 use tracing::info;
@@ -40,7 +41,7 @@ pub async fn spawn_acp_session(
     init_request: InitializeRequest,
     new_session_request: NewSessionRequest,
 ) -> Result<AcpSession, AcpClientError> {
-    let agent = AcpAgent::from_str(agent_command).map_err(AcpClientError::InvalidAgentCommand)?;
+    let agent = TokioAcpAgent::from_str(agent_command).map_err(AcpClientError::InvalidAgentCommand)?;
     let (event_tx, event_rx) = mpsc::unbounded_channel::<AcpEvent>();
     let (cmd_tx, cmd_rx) = mpsc::unbounded_channel::<PromptCommand>();
     let (init_tx, mut init_rx) = mpsc::unbounded_channel::<InitializeResult>();
@@ -69,7 +70,7 @@ pub async fn spawn_acp_session(
 
 #[allow(clippy::too_many_lines)]
 async fn run_client_connection(
-    agent: AcpAgent,
+    agent: TokioAcpAgent,
     event_tx: mpsc::UnboundedSender<AcpEvent>,
     cmd_rx: mpsc::UnboundedReceiver<PromptCommand>,
     init_tx: mpsc::UnboundedSender<InitializeResult>,

--- a/packages/acp-utils/src/client/tokio_agent.rs
+++ b/packages/acp-utils/src/client/tokio_agent.rs
@@ -7,11 +7,11 @@
 use agent_client_protocol::schema::{McpServer, McpServerStdio};
 use agent_client_protocol::util::internal_error;
 use agent_client_protocol::{AcpAgent, ByteStreams, ConnectTo, Error, Role, util};
-use std::pin::pin;
 use std::process::Stdio;
 use std::str::FromStr;
 use tokio::io::{AsyncBufReadExt, BufReader};
 use tokio::process::Command;
+use tokio::sync::oneshot;
 use tokio_util::compat::{TokioAsyncReadCompatExt, TokioAsyncWriteCompatExt};
 
 pub struct TokioAcpAgent {
@@ -63,37 +63,33 @@ async fn connect_stdio<T: Role>(server: McpServerStdio, client: impl ConnectTo<T
         (stdin, stdout, stderr, child)
     };
 
-    let bytes = ByteStreams::new(stdin.compat_write(), stdout.compat());
-    let mut wait = pin!(child.wait());
-    let mut protocol = pin!(ConnectTo::<T>::connect_to(bytes, client));
-    let mut stderr_lines = BufReader::new(stderr).lines();
-    let mut stderr_buf = String::new();
-    let mut stderr_open = true;
-
-    loop {
-        tokio::select! {
-            result = &mut protocol => return result,
-            status = &mut wait => {
-                while let Ok(Some(line)) = stderr_lines.next_line().await {
-                    stderr_buf.push_str(&line);
-                    stderr_buf.push('\n');
-                }
-
-                return match status {
-                    Ok(s) if s.success() => Ok(()),
-                    Ok(s) => Err(util::internal_error(format!("agent process exited ({s}): {stderr_buf}"))),
-                    Err(e) => Err(Error::into_internal_error(e)),
-                };
+    let (stderr_tx, stderr_rx) = oneshot::channel::<String>();
+    tokio::spawn(async move {
+        let mut lines = BufReader::new(stderr).lines();
+        let mut buf = String::new();
+        while let Ok(Some(line)) = lines.next_line().await {
+            if !buf.is_empty() {
+                buf.push('\n');
             }
-
-            line = stderr_lines.next_line(), if stderr_open => match line {
-                Ok(Some(line)) => {
-                    stderr_buf.push_str(&line);
-                    stderr_buf.push('\n');
-                }
-
-                Ok(None) | Err(_) => stderr_open = false,
-            }
+            buf.push_str(&line);
         }
+        let _ = stderr_tx.send(buf);
+    });
+
+    let child_fut = async move {
+        match child.wait().await {
+            Ok(s) if s.success() => Ok(()),
+            Ok(s) => {
+                let stderr = stderr_rx.await.unwrap_or_default();
+                Err(util::internal_error(format!("agent process exited ({s}): {stderr}")))
+            }
+            Err(e) => Err(Error::into_internal_error(e)),
+        }
+    };
+
+    let bytes = ByteStreams::new(stdin.compat_write(), stdout.compat());
+    tokio::select! {
+        result = ConnectTo::<T>::connect_to(bytes, client) => result,
+        result = child_fut => result,
     }
 }

--- a/packages/acp-utils/src/client/tokio_agent.rs
+++ b/packages/acp-utils/src/client/tokio_agent.rs
@@ -1,0 +1,99 @@
+//! Tokio-native parent-side ACP transport.
+//!
+//! `agent_client_protocol::AcpAgent` spawns the child via smol's
+//! `async_process::Command`, which wraps stdio in `blocking::Unblock`. Inside a
+//! tokio runtime that causes a busy loop. This avoids the issue by spawning stdio agents with `tokio::process::Command`
+//!
+use agent_client_protocol::schema::{McpServer, McpServerStdio};
+use agent_client_protocol::util::internal_error;
+use agent_client_protocol::{AcpAgent, ByteStreams, ConnectTo, Error, Role, util};
+use std::pin::pin;
+use std::process::Stdio;
+use std::str::FromStr;
+use tokio::io::{AsyncBufReadExt, BufReader};
+use tokio::process::Command;
+use tokio_util::compat::{TokioAsyncReadCompatExt, TokioAsyncWriteCompatExt};
+
+pub struct TokioAcpAgent {
+    stdio: McpServerStdio,
+}
+
+impl TokioAcpAgent {
+    pub fn stdio(&self) -> &McpServerStdio {
+        &self.stdio
+    }
+}
+
+impl<T: Role> ConnectTo<T> for TokioAcpAgent {
+    async fn connect_to(self, client: impl ConnectTo<T::Counterpart>) -> Result<(), Error> {
+        connect_stdio::<T>(self.stdio, client).await
+    }
+}
+
+impl FromStr for TokioAcpAgent {
+    type Err = Error;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match AcpAgent::from_str(s)?.into_server() {
+            McpServer::Stdio(stdio) => Ok(Self { stdio }),
+            _ => Err(util::internal_error("unsupported ACP agent transport")),
+        }
+    }
+}
+
+async fn connect_stdio<T: Role>(server: McpServerStdio, client: impl ConnectTo<T::Counterpart>) -> Result<(), Error> {
+    let (stdin, stdout, stderr, mut child) = {
+        let mut cmd = Command::new(&server.command);
+        cmd.args(&server.args);
+        for env_var in &server.env {
+            cmd.env(&env_var.name, &env_var.value);
+        }
+
+        let mut child = cmd
+            .stdin(Stdio::piped())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped())
+            .kill_on_drop(true)
+            .spawn()
+            .map_err(Error::into_internal_error)?;
+
+        let stdin = child.stdin.take().ok_or_else(|| internal_error("missing child stdin"))?;
+        let stdout = child.stdout.take().ok_or_else(|| internal_error("missing child stdout"))?;
+        let stderr = child.stderr.take().ok_or_else(|| internal_error("missing child stderr"))?;
+        (stdin, stdout, stderr, child)
+    };
+
+    let bytes = ByteStreams::new(stdin.compat_write(), stdout.compat());
+    let mut wait = pin!(child.wait());
+    let mut protocol = pin!(ConnectTo::<T>::connect_to(bytes, client));
+    let mut stderr_lines = BufReader::new(stderr).lines();
+    let mut stderr_buf = String::new();
+    let mut stderr_open = true;
+
+    loop {
+        tokio::select! {
+            result = &mut protocol => return result,
+            status = &mut wait => {
+                while let Ok(Some(line)) = stderr_lines.next_line().await {
+                    stderr_buf.push_str(&line);
+                    stderr_buf.push('\n');
+                }
+
+                return match status {
+                    Ok(s) if s.success() => Ok(()),
+                    Ok(s) => Err(util::internal_error(format!("agent process exited ({s}): {stderr_buf}"))),
+                    Err(e) => Err(Error::into_internal_error(e)),
+                };
+            }
+
+            line = stderr_lines.next_line(), if stderr_open => match line {
+                Ok(Some(line)) => {
+                    stderr_buf.push_str(&line);
+                    stderr_buf.push('\n');
+                }
+
+                Ok(None) | Err(_) => stderr_open = false,
+            }
+        }
+    }
+}

--- a/packages/acp-utils/tests/tokio_agent.rs
+++ b/packages/acp-utils/tests/tokio_agent.rs
@@ -1,0 +1,72 @@
+use acp_utils::client::TokioAcpAgent;
+use agent_client_protocol::{Client, ConnectTo};
+use std::path::Path;
+use std::str::FromStr;
+use tokio::task::LocalSet;
+
+#[test]
+fn parses_shell_command() {
+    let agent = TokioAcpAgent::from_str("aether acp --foo bar").expect("parses");
+    let server = agent.stdio();
+    assert_eq!(server.command.as_path(), Path::new("aether"));
+    assert_eq!(server.args.as_slice(), &["acp", "--foo", "bar"]);
+}
+
+#[test]
+fn parses_quoted_shell_command() {
+    let agent = TokioAcpAgent::from_str(r#"python "my agent.py" --name "Test Agent""#).expect("parses");
+    let server = agent.stdio();
+    assert_eq!(server.command.as_path(), Path::new("python"));
+    assert_eq!(server.args.as_slice(), &["my agent.py", "--name", "Test Agent"]);
+}
+
+#[test]
+fn parses_leading_environment_variables() {
+    let agent = TokioAcpAgent::from_str("RUST_LOG=debug aether acp").expect("parses");
+    let server = agent.stdio();
+    assert_eq!(server.command.as_path(), Path::new("aether"));
+    assert_eq!(server.args.as_slice(), &["acp"]);
+    assert_eq!(server.env[0].name, "RUST_LOG");
+    assert_eq!(server.env[0].value, "debug");
+}
+
+#[test]
+fn parses_json_stdio_agent_config() {
+    let agent = TokioAcpAgent::from_str(
+        r#"{"type":"stdio","name":"test-agent","command":"/usr/bin/python","args":["agent.py","--verbose"],"env":[{"name":"RUST_LOG","value":"debug"}]}"#,
+    )
+    .expect("parses");
+
+    let server = agent.stdio();
+    assert_eq!(server.command.as_path(), Path::new("/usr/bin/python"));
+    assert_eq!(server.args.as_slice(), &["agent.py", "--verbose"]);
+    assert_eq!(server.env[0].name, "RUST_LOG");
+    assert_eq!(server.env[0].value, "debug");
+}
+
+#[test]
+fn rejects_empty_command() {
+    assert!(TokioAcpAgent::from_str("").is_err());
+    assert!(TokioAcpAgent::from_str("   ").is_err());
+}
+
+#[test]
+fn rejects_non_stdio_transport_at_parse_time() {
+    let json = r#"{"type":"http","name":"remote","url":"https://example.com/agent","headers":[]}"#;
+    assert!(TokioAcpAgent::from_str(json).is_err());
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn agent_exited_message_includes_stderr_and_status() {
+    LocalSet::new()
+        .run_until(async {
+            let agent = TokioAcpAgent::from_str("/bin/ls /nonexistent-aether-test-path-12345").expect("parses");
+            let result = ConnectTo::<Client>::connect_to(agent, Client.builder()).await;
+
+            let err = result.expect_err("child exited with non-zero status");
+            let msg = format!("{err}");
+            assert!(msg.contains("exited"), "expected exit info in error: {msg}");
+            assert!(msg.contains("No such file"), "expected stderr in error: {msg}");
+        })
+        .await;
+}

--- a/packages/tui/Cargo.toml
+++ b/packages/tui/Cargo.toml
@@ -37,6 +37,7 @@ testing = []
 
 [dependencies]
 crossterm = { workspace = true }
+futures = { workspace = true }
 syntect = { workspace = true, optional = true }
 two-face = { workspace = true, optional = true }
 pulldown-cmark = { workspace = true, optional = true }

--- a/packages/tui/src/runtime/mod.rs
+++ b/packages/tui/src/runtime/mod.rs
@@ -1,7 +1,7 @@
-use crossterm::event::{Event as CrosstermEvent, poll, read};
-use std::time::Duration;
+use crossterm::event::{Event as CrosstermEvent, EventStream};
+use futures::StreamExt;
 use tokio::sync::mpsc;
-use tokio::task::{JoinHandle, spawn_blocking};
+use tokio::task::JoinHandle;
 use tokio_util::sync::CancellationToken;
 
 pub mod terminal;
@@ -12,7 +12,7 @@ pub use terminal_runtime::{TerminalConfig, TerminalRuntime};
 pub(crate) struct EventTaskHandle {
     rx: mpsc::UnboundedReceiver<CrosstermEvent>,
     cancel: CancellationToken,
-    join: JoinHandle<()>,
+    join: Option<JoinHandle<()>>,
 }
 
 impl EventTaskHandle {
@@ -20,13 +20,17 @@ impl EventTaskHandle {
         &mut self.rx
     }
 
-    pub(crate) fn cancel(&self) {
+    pub(crate) async fn stop(mut self) {
         self.cancel.cancel();
+        if let Some(join) = self.join.take() {
+            let _ = join.await;
+        }
     }
+}
 
-    pub(crate) async fn stop(self) {
+impl Drop for EventTaskHandle {
+    fn drop(&mut self) {
         self.cancel.cancel();
-        let _ = self.join.await;
     }
 }
 
@@ -34,22 +38,25 @@ pub(crate) fn spawn_terminal_event_task() -> EventTaskHandle {
     let (tx, rx) = mpsc::unbounded_channel();
     let cancel = CancellationToken::new();
     let task_cancel = cancel.clone();
-    let join = spawn_blocking(move || {
+    let mut stream = EventStream::new();
+    let join = tokio::spawn(async move {
         loop {
-            if task_cancel.is_cancelled() || tx.is_closed() {
-                break;
-            }
-
-            match poll(Duration::from_millis(10)).and_then(|ready| ready.then(read).transpose()) {
-                Ok(Some(event)) => {
-                    if tx.send(event).is_err() {
+            tokio::select! {
+                () = task_cancel.cancelled() => break,
+                event = stream.next() => match event {
+                    Some(Ok(event)) => {
+                        if tx.send(event).is_err() {
+                            break;
+                        }
+                    }
+                    Some(Err(err)) => tracing::warn!(%err, "Terminal event error"),
+                    None => {
+                        tracing::warn!("Terminal event stream ended");
                         break;
                     }
-                }
-                Ok(None) => {}
-                Err(e) => eprintln!("Terminal event error: {e}"),
+                },
             }
         }
     });
-    EventTaskHandle { rx, cancel, join }
+    EventTaskHandle { rx, cancel, join: Some(join) }
 }

--- a/packages/tui/src/runtime/terminal_runtime.rs
+++ b/packages/tui/src/runtime/terminal_runtime.rs
@@ -79,9 +79,7 @@ impl<T: Write> TerminalRuntime<T> {
 
 impl<T: Write> Drop for TerminalRuntime<T> {
     fn drop(&mut self) {
-        if let Some(ref handle) = self.event_task {
-            handle.cancel();
-        }
+        drop(self.event_task.take());
         let _ = self.renderer.cleanup();
     }
 }


### PR DESCRIPTION
This PR follows up from https://github.com/contextbridge/aether/pull/87 , which only modified one side of the ACP transport to use tokio. After that PR, the parent side of the transport was still using the acp crate's `AcpAgent` which recently changed to use blocking stdio pipes. 

That combination led to a performance regression that would spike CPUs pretty hard. This PR fixes that by changing the other side of the transport to also use tokio. In addition, it switches the TUI event loop to use `crossterm`'s event stream instead of polling every 10ms