### PR TITLE
feat(aether-cli): Prompt history search

### DIFF
--- a/packages/acp-utils/src/client/event.rs
+++ b/packages/acp-utils/src/client/event.rs
@@ -6,7 +6,7 @@ use agent_client_protocol::schema::{SessionConfigOption, SessionId, SessionInfo}
 
 use crate::notifications::{
     AuthMethodsUpdatedParams, ContextClearedParams, ContextUsageParams, ElicitationParams, ElicitationResponse,
-    McpNotification, SubAgentProgressParams,
+    McpNotification, PromptSearchResponse, SubAgentProgressParams,
 };
 
 /// Events forwarded from the ACP connection to the main event loop.
@@ -25,5 +25,7 @@ pub enum AcpEvent {
     SessionsListed { sessions: Vec<SessionInfo> },
     SessionLoaded { session_id: SessionId, config_options: Vec<SessionConfigOption> },
     NewSessionCreated { session_id: SessionId, config_options: Vec<SessionConfigOption> },
+    PromptSearchResults(PromptSearchResponse),
+    PromptSearchFailed { query: String, error: String },
     ConnectionClosed,
 }

--- a/packages/acp-utils/src/client/prompt_handle.rs
+++ b/packages/acp-utils/src/client/prompt_handle.rs
@@ -3,6 +3,7 @@ use std::path::{Path, PathBuf};
 use tokio::sync::mpsc;
 
 use super::error::AcpClientError;
+use crate::notifications::PromptSearchParams;
 
 /// Commands sent from the main thread to the ACP client task.
 #[derive(Debug)]
@@ -15,6 +16,7 @@ pub enum PromptCommand {
     ListSessions,
     LoadSession { session_id: SessionId, cwd: PathBuf },
     NewSession { cwd: std::path::PathBuf },
+    SearchPrompts(PromptSearchParams),
 }
 
 /// Send-safe handle for issuing prompt commands to the ACP client task.
@@ -86,6 +88,10 @@ impl AcpPromptHandle {
 
     pub fn new_session(&self, cwd: &Path) -> Result<(), AcpClientError> {
         self.send(PromptCommand::NewSession { cwd: cwd.to_path_buf() })
+    }
+
+    pub fn search_prompts(&self, params: PromptSearchParams) -> Result<(), AcpClientError> {
+        self.send(PromptCommand::SearchPrompts(params))
     }
 
     fn send(&self, cmd: PromptCommand) -> Result<(), AcpClientError> {

--- a/packages/acp-utils/src/client/session.rs
+++ b/packages/acp-utils/src/client/session.rs
@@ -328,6 +328,17 @@ async fn handle_side_command(
                 }
             }
         }
+        PromptCommand::SearchPrompts(params) => {
+            let query = params.query.clone();
+            match cx.send_request(params).block_task().await {
+                Ok(resp) => {
+                    let _ = event_tx.send(AcpEvent::PromptSearchResults(resp));
+                }
+                Err(e) => {
+                    let _ = event_tx.send(AcpEvent::PromptSearchFailed { query, error: format!("{e}") });
+                }
+            }
+        }
     }
 }
 

--- a/packages/acp-utils/src/notifications.rs
+++ b/packages/acp-utils/src/notifications.rs
@@ -1,5 +1,7 @@
 //! Typed wire-format types for Aether's custom ACP extension requests and
 //! notifications.
+use std::path::PathBuf;
+
 use agent_client_protocol::schema::AuthMethod;
 use agent_client_protocol::{JsonRpcNotification, JsonRpcRequest, JsonRpcResponse};
 pub use mcp_utils::display_meta::{ToolDisplayMeta, ToolResultMeta};
@@ -7,6 +9,9 @@ pub use rmcp::model::CreateElicitationRequestParams;
 use serde::{Deserialize, Serialize};
 
 pub use mcp_utils::status::{McpServerAuthCapability, McpServerStatus, McpServerStatusEntry};
+
+pub const AETHER_META_NAMESPACE: &str = "contextbridge/aether";
+pub const PROMPT_SEARCH_CAPABILITY_KEY: &str = "promptSearch";
 
 /// Parameters for `_aether/context_usage` notifications.
 ///
@@ -66,6 +71,64 @@ pub struct ElicitationParams {
 }
 
 pub use rmcp::model::ElicitationAction;
+
+/// Parameters for the `_aether/prompt_search` request.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, JsonRpcRequest)]
+#[request(method = "_aether/prompt_search", response = PromptSearchResponse)]
+#[serde(rename_all = "camelCase")]
+pub struct PromptSearchParams {
+    pub query: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub limit: Option<usize>,
+}
+
+/// Response for the `_aether/prompt_search` request.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, JsonRpcResponse)]
+#[serde(rename_all = "camelCase")]
+pub struct PromptSearchResponse {
+    pub query: String,
+    pub results: Vec<PromptSearchResult>,
+    pub truncated: bool,
+}
+
+/// A single prompt-history search hit.
+///
+/// `match_start` and `match_end` are UTF-8 byte offsets into `prompt` and are
+/// guaranteed to fall on char boundaries.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct PromptSearchResult {
+    pub session_id: String,
+    pub cwd: PathBuf,
+    pub session_created_at: String,
+    pub prompt: String,
+    pub match_start: usize,
+    pub match_end: usize,
+}
+
+/// Metadata advertised on `PromptCapabilities::_meta` when the agent supports
+/// `_aether/prompt_search`.
+pub mod prompt_search_capability {
+    use super::{AETHER_META_NAMESPACE, PROMPT_SEARCH_CAPABILITY_KEY};
+    use agent_client_protocol::schema::Meta;
+    use serde_json::{Value, json};
+
+    #[must_use]
+    pub fn to_meta() -> Meta {
+        let mut meta = Meta::new();
+        meta.insert(AETHER_META_NAMESPACE.to_string(), json!({ PROMPT_SEARCH_CAPABILITY_KEY: true }));
+        meta
+    }
+
+    #[must_use]
+    pub fn is_advertised(meta: Option<&Meta>) -> bool {
+        meta.and_then(|m| m.get(AETHER_META_NAMESPACE))
+            .and_then(Value::as_object)
+            .and_then(|aether| aether.get(PROMPT_SEARCH_CAPABILITY_KEY))
+            .and_then(Value::as_bool)
+            .unwrap_or(false)
+    }
+}
 
 /// Response returned from the client for an elicitation request.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, JsonRpcResponse)]
@@ -160,6 +223,15 @@ mod tests {
             McpRequest::Authenticate { session_id: String::new(), server_name: String::new() }.method()
                 == "_aether/mcp_request"
         );
+        assert_eq!(PromptSearchParams { query: String::new(), limit: None }.method(), "_aether/prompt_search");
+    }
+
+    #[test]
+    fn prompt_search_capability_meta_roundtrip() {
+        let meta = prompt_search_capability::to_meta();
+        assert!(prompt_search_capability::is_advertised(Some(&meta)));
+        assert!(!prompt_search_capability::is_advertised(None));
+        assert!(!prompt_search_capability::is_advertised(Some(&agent_client_protocol::schema::Meta::new())));
     }
 
     #[test]

--- a/packages/aether-cli/src/acp/handlers.rs
+++ b/packages/aether-cli/src/acp/handlers.rs
@@ -1,5 +1,5 @@
 use super::session_manager::SessionManager;
-use acp_utils::notifications::McpRequest;
+use acp_utils::notifications::{McpRequest, PromptSearchParams};
 use agent_client_protocol::schema::{
     AuthenticateRequest, CancelNotification, InitializeRequest, ListSessionsRequest, LoadSessionRequest,
     NewSessionRequest, PromptRequest, SetSessionConfigOptionRequest,
@@ -10,6 +10,7 @@ use agent_client_protocol::{
 use std::future::Future;
 use std::sync::Arc;
 
+#[allow(clippy::too_many_lines)]
 pub(crate) fn acp_agent_builder(
     manager: Arc<SessionManager>,
 ) -> Builder<Agent, impl HandleDispatchFrom<Client>, NullRun> {
@@ -84,6 +85,16 @@ pub(crate) fn acp_agent_builder(
                 async move |req: SetSessionConfigOptionRequest, responder, cx| {
                     let mgr = mgr.clone();
                     spawn_task(&cx, responder, async move { mgr.set_session_config_option(req).await })
+                }
+            },
+            acp::on_receive_request!(),
+        )
+        .on_receive_request(
+            {
+                let mgr = manager.clone();
+                async move |req: PromptSearchParams, responder, cx| {
+                    let mgr = mgr.clone();
+                    spawn_task(&cx, responder, async move { mgr.search_prompts(&req) })
                 }
             },
             acp::on_receive_request!(),

--- a/packages/aether-cli/src/acp/mod.rs
+++ b/packages/aether-cli/src/acp/mod.rs
@@ -2,6 +2,7 @@ pub(crate) mod config_setting;
 pub(crate) mod handlers;
 pub(crate) mod mappers;
 pub(crate) mod model_config;
+pub(crate) mod prompt_history_index;
 pub(crate) mod relay;
 pub(crate) mod session;
 pub(crate) mod session_manager;

--- a/packages/aether-cli/src/acp/prompt_history_index.rs
+++ b/packages/aether-cli/src/acp/prompt_history_index.rs
@@ -1,0 +1,211 @@
+use super::session_store::SessionMeta;
+use acp_utils::notifications::{PromptSearchParams, PromptSearchResponse, PromptSearchResult};
+use serde::{Deserialize, Serialize};
+use std::collections::VecDeque;
+use std::fs::{self, File, OpenOptions};
+use std::io::{self, BufRead, BufReader, Write};
+use std::path::{Path, PathBuf};
+use std::sync::{Mutex, MutexGuard, PoisonError};
+use tracing::warn;
+
+const PROMPT_HISTORY_MAX_ENTRIES: usize = 100;
+const PROMPT_SEARCH_DEFAULT_LIMIT: usize = 20;
+const PROMPT_SEARCH_MAX_LIMIT: usize = 50;
+
+pub(super) struct PromptHistoryIndex {
+    path: PathBuf,
+    state: Mutex<State>,
+}
+
+impl PromptHistoryIndex {
+    pub(super) fn new(path: PathBuf) -> Self {
+        Self { path, state: Mutex::new(State::Unloaded) }
+    }
+
+    pub(super) fn append_prompt(&self, meta: &SessionMeta, prompt: String) -> io::Result<()> {
+        let entry = PromptHistoryEntry::new(meta, prompt);
+        let mut state = self.lock_state();
+        let entries = self.ensure_loaded(&mut state)?;
+
+        entries.push_back(entry);
+        if entries.len() > PROMPT_HISTORY_MAX_ENTRIES {
+            entries.pop_front();
+            self.rewrite_file(entries.iter())
+        } else {
+            self.append_to_file(entries.back().expect("just pushed"))
+        }
+    }
+
+    pub(super) fn search(&self, params: &PromptSearchParams) -> io::Result<PromptSearchResponse> {
+        let query = params.query.trim();
+        let limit = prompt_search_limit(params.limit);
+        let mut state = self.lock_state();
+        let entries = self.ensure_loaded(&mut state)?;
+
+        let response = PromptSearchResponse { query: query.to_string(), results: Vec::new(), truncated: false };
+        if query.is_empty() {
+            return Ok(response);
+        }
+
+        let mut results: Vec<_> =
+            entries.iter().rev().filter_map(|entry| entry.search_result(query)).take(limit + 1).collect();
+        let truncated = results.len() > limit;
+        if truncated {
+            results.truncate(limit);
+        }
+        Ok(PromptSearchResponse { results, truncated, ..response })
+    }
+
+    pub(super) fn is_index_path(&self, path: &Path) -> bool {
+        path == self.path
+    }
+
+    fn lock_state(&self) -> MutexGuard<'_, State> {
+        self.state.lock().unwrap_or_else(PoisonError::into_inner)
+    }
+
+    fn ensure_loaded<'a>(&self, state: &'a mut State) -> io::Result<&'a mut VecDeque<PromptHistoryEntry>> {
+        if let State::Unloaded = state {
+            let (entries, needs_rewrite) = self.load_history()?;
+            *state = State::Loaded(entries);
+            if needs_rewrite {
+                let State::Loaded(entries) = state else { unreachable!() };
+                self.rewrite_file(entries.iter())?;
+            }
+        }
+        let State::Loaded(entries) = state else { unreachable!() };
+        Ok(entries)
+    }
+
+    fn load_history(&self) -> io::Result<(VecDeque<PromptHistoryEntry>, bool)> {
+        let file = match File::open(&self.path) {
+            Ok(file) => file,
+            Err(e) if e.kind() == io::ErrorKind::NotFound => return Ok((VecDeque::new(), false)),
+            Err(e) => return Err(e),
+        };
+
+        let parsed: Vec<_> = BufReader::new(file)
+            .lines()
+            .map_while(Result::ok)
+            .filter_map(|line| parse_prompt_history_line(&line))
+            .collect();
+
+        let needs_rewrite = parsed.len() > PROMPT_HISTORY_MAX_ENTRIES;
+        let skip = parsed.len().saturating_sub(PROMPT_HISTORY_MAX_ENTRIES);
+        Ok((parsed.into_iter().skip(skip).collect(), needs_rewrite))
+    }
+
+    fn append_to_file(&self, entry: &PromptHistoryEntry) -> io::Result<()> {
+        if let Some(parent) = self.path.parent() {
+            fs::create_dir_all(parent)?;
+        }
+        let mut file = OpenOptions::new().create(true).append(true).open(&self.path)?;
+        let line = serde_json::to_string(entry)
+            .map_err(|e| io::Error::other(format!("Failed to serialize prompt history entry: {e}")))?;
+        writeln!(file, "{line}")
+    }
+
+    fn rewrite_file<'a>(&self, entries: impl IntoIterator<Item = &'a PromptHistoryEntry>) -> io::Result<()> {
+        if let Some(parent) = self.path.parent() {
+            fs::create_dir_all(parent)?;
+        }
+        let tmp_path = self.path.with_extension("jsonl.tmp");
+        {
+            let mut file = File::create(&tmp_path)?;
+            for entry in entries {
+                let line = serde_json::to_string(entry)
+                    .map_err(|e| io::Error::other(format!("Failed to serialize prompt history entry: {e}")))?;
+                writeln!(file, "{line}")?;
+            }
+        }
+        fs::rename(tmp_path, &self.path)
+    }
+}
+
+enum State {
+    Unloaded,
+    Loaded(VecDeque<PromptHistoryEntry>),
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct PromptHistoryEntry {
+    session_id: String,
+    cwd: PathBuf,
+    session_created_at: String,
+    prompt: String,
+}
+
+impl PromptHistoryEntry {
+    fn new(meta: &SessionMeta, prompt: String) -> Self {
+        Self {
+            session_id: meta.session_id.clone(),
+            cwd: meta.cwd.clone(),
+            session_created_at: meta.created_at.clone(),
+            prompt,
+        }
+    }
+
+    fn search_result(&self, query: &str) -> Option<PromptSearchResult> {
+        let (match_start, match_end) = find_prompt_match(&self.prompt, query)?;
+        Some(PromptSearchResult {
+            session_id: self.session_id.clone(),
+            cwd: self.cwd.clone(),
+            session_created_at: self.session_created_at.clone(),
+            prompt: self.prompt.clone(),
+            match_start,
+            match_end,
+        })
+    }
+}
+
+fn prompt_search_limit(requested: Option<usize>) -> usize {
+    requested.unwrap_or(PROMPT_SEARCH_DEFAULT_LIMIT).clamp(1, PROMPT_SEARCH_MAX_LIMIT)
+}
+
+fn parse_prompt_history_line(line: &str) -> Option<PromptHistoryEntry> {
+    if line.trim().is_empty() {
+        return None;
+    }
+    match serde_json::from_str(line) {
+        Ok(entry) => Some(entry),
+        Err(e) => {
+            warn!("Skipping malformed prompt history line: {e}");
+            None
+        }
+    }
+}
+
+fn find_prompt_match(prompt: &str, query: &str) -> Option<(usize, usize)> {
+    // Smart case: a query with any uppercase char triggers an exact-substring
+    // match; otherwise the comparison is case-insensitive.
+    if query.chars().any(char::is_uppercase) {
+        prompt.find(query).map(|start| (start, start + query.len()))
+    } else {
+        find_case_insensitive(prompt, query)
+    }
+}
+
+/// Case-insensitive substring search that returns byte offsets into the
+/// **original** `prompt`. Lowercasing can change byte length (e.g. 'İ' → "i̇"),
+/// so we walk the original and lowercased strings in parallel to translate
+/// the match position back.
+fn find_case_insensitive(prompt: &str, query: &str) -> Option<(usize, usize)> {
+    let lower_query = query.to_lowercase();
+    let lower_prompt = prompt.to_lowercase();
+    let lower_match = lower_prompt.find(&lower_query)?;
+    let lower_match_end = lower_match + lower_query.len();
+
+    let mut lower_offset = 0usize;
+    let mut orig_start: Option<usize> = None;
+    for (orig_idx, ch) in prompt.char_indices() {
+        if lower_offset == lower_match && orig_start.is_none() {
+            orig_start = Some(orig_idx);
+        }
+        if lower_offset >= lower_match_end {
+            return orig_start.map(|s| (s, orig_idx));
+        }
+        lower_offset += ch.to_lowercase().map(char::len_utf8).sum::<usize>();
+    }
+    orig_start.map(|s| (s, prompt.len()))
+}

--- a/packages/aether-cli/src/acp/session_manager.rs
+++ b/packages/aether-cli/src/acp/session_manager.rs
@@ -1,4 +1,6 @@
-use acp_utils::notifications::{AuthMethodsUpdatedParams, McpRequest};
+use acp_utils::notifications::{
+    AuthMethodsUpdatedParams, McpRequest, PromptSearchParams, PromptSearchResponse, prompt_search_capability,
+};
 use acp_utils::server::AcpServerError;
 use aether_auth::OAuthCredentialStorage;
 use agent_client_protocol::schema::{
@@ -410,6 +412,24 @@ mod tests {
         assert!(json.contains("\"loadSession\":true"));
     }
 
+    #[tokio::test]
+    async fn initialize_advertises_prompt_search_capability() {
+        let session_store =
+            SessionStore::new().map_or_else(|e| panic!("Failed to initialize session store: {e}"), Arc::new);
+        let manager = SessionManager::new(SessionManagerConfig {
+            registry: Arc::new(SessionRegistry::new()),
+            session_store,
+            oauth_credential_store: mock_oauth_store(),
+            initial_selection: InitialSessionSelection::default(),
+            settings_source: SettingsSourceArgs::default(),
+            provider_connections: ProviderConnectionOverrides::default(),
+        });
+
+        let response =
+            manager.initialize(InitializeRequest::new(ProtocolVersion::LATEST)).await.expect("initialize succeeds");
+
+        assert!(prompt_search_capability::is_advertised(response.agent_capabilities.prompt_capabilities.meta.as_ref()));
+    }
     #[test]
     fn prompt_capabilities_reflect_available_modalities() {
         let image_only = prompt_capabilities_for_models(&["anthropic:claude-sonnet-4-5".parse().unwrap()]);
@@ -474,6 +494,9 @@ impl SessionManager {
         info!("Received initialize request: {:?}", args);
         let auth_methods = build_auth_methods(self.oauth_credential_store.as_ref());
         let available = get_local_models().await;
+        let prompt_capabilities =
+            prompt_capabilities_for_models(&available).meta(Some(prompt_search_capability::to_meta()));
+
         Ok(InitializeResponse::new(ProtocolVersion::V1)
             .agent_info(Implementation::new("Aether", "0.1.0"))
             .agent_capabilities(
@@ -481,9 +504,16 @@ impl SessionManager {
                     .load_session(true)
                     .mcp_capabilities(McpCapabilities::new().http(true).sse(true))
                     .session_capabilities(acp::SessionCapabilities::new().list(acp::SessionListCapabilities::new()))
-                    .prompt_capabilities(prompt_capabilities_for_models(&available)),
+                    .prompt_capabilities(prompt_capabilities),
             )
             .auth_methods(auth_methods))
+    }
+
+    pub fn search_prompts(&self, params: &PromptSearchParams) -> Result<PromptSearchResponse, acp::Error> {
+        self.session_store.search_prompts(params).map_err(|e| {
+            error!("Prompt search failed: {e}");
+            acp::Error::internal_error()
+        })
     }
 
     pub async fn authenticate(

--- a/packages/aether-cli/src/acp/session_store.rs
+++ b/packages/aether-cli/src/acp/session_store.rs
@@ -1,3 +1,5 @@
+use super::prompt_history_index::PromptHistoryIndex;
+use acp_utils::notifications::{PromptSearchParams, PromptSearchResponse};
 use aether_core::context::ext::{SessionEvent, UserEvent};
 use aether_core::events::AgentMessage;
 use serde::{Deserialize, Serialize};
@@ -5,6 +7,8 @@ use std::fs::{self, File, OpenOptions};
 use std::io::{self, BufRead, BufReader, Write};
 use std::path::PathBuf;
 use tracing::warn;
+
+const PROMPT_HISTORY_FILE: &str = "prompt-history.jsonl";
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 #[serde(rename_all = "camelCase")]
@@ -25,17 +29,19 @@ pub struct SessionSummary {
 
 pub struct SessionStore {
     dir: PathBuf,
+    prompt_history: PromptHistoryIndex,
 }
 
 impl SessionStore {
     pub fn new() -> io::Result<Self> {
         let home =
             dirs::home_dir().ok_or_else(|| io::Error::new(io::ErrorKind::NotFound, "Home directory not found"))?;
-        Ok(Self { dir: home.join(".aether/sessions") })
+        Ok(Self::from_path(home.join(".aether/sessions")))
     }
 
     pub(crate) fn from_path(dir: PathBuf) -> Self {
-        Self { dir }
+        let prompt_history = PromptHistoryIndex::new(dir.join(PROMPT_HISTORY_FILE));
+        Self { dir, prompt_history }
     }
 
     pub fn append_meta(&self, session_id: &str, meta: &SessionMeta) -> io::Result<()> {
@@ -46,7 +52,13 @@ impl SessionStore {
         if is_streaming_event(event) {
             return Ok(());
         }
-        self.append_line(session_id, event)
+        self.append_line(session_id, event)?;
+        if let Some(prompt) = user_prompt_text_from_event(event)
+            && let Some(meta) = self.session_meta(session_id)
+        {
+            self.prompt_history.append_prompt(&meta, prompt)?;
+        }
+        Ok(())
     }
 
     pub fn load(&self, session_id: &str) -> Option<(SessionMeta, Vec<SessionEvent>)> {
@@ -82,41 +94,64 @@ impl SessionStore {
     }
 
     pub fn list(&self) -> Vec<SessionSummary> {
+        self.read_metas_sorted()
+            .into_iter()
+            .map(|meta| {
+                let title = self.title_for_session(&meta.session_id);
+                SessionSummary { meta, title }
+            })
+            .collect()
+    }
+
+    pub fn search_prompts(&self, params: &PromptSearchParams) -> io::Result<PromptSearchResponse> {
+        self.prompt_history.search(params)
+    }
+
+    fn session_meta(&self, session_id: &str) -> Option<SessionMeta> {
+        let file = File::open(self.session_path(session_id)).ok()?;
+        let mut reader = BufReader::new(file);
+        let mut first_line = String::new();
+        reader.read_line(&mut first_line).ok()?;
+        serde_json::from_str(first_line.trim()).ok()
+    }
+
+    fn read_metas_sorted(&self) -> Vec<SessionMeta> {
         let Ok(entries) = fs::read_dir(&self.dir) else {
             return Vec::new();
         };
 
-        let mut sessions: Vec<SessionSummary> = entries
+        let mut metas: Vec<SessionMeta> = entries
             .filter_map(|entry| {
-                let entry = entry.ok()?;
-                let path = entry.path();
-                if path.extension().and_then(|e| e.to_str()) != Some("jsonl") {
+                let path = entry.ok()?.path();
+                if path.extension().and_then(|e| e.to_str()) != Some("jsonl")
+                    || self.prompt_history.is_index_path(&path)
+                {
                     return None;
                 }
-                let file = File::open(&path).ok()?;
-                let mut reader = BufReader::new(file);
-
                 let mut first_line = String::new();
-                reader.read_line(&mut first_line).ok()?;
-                let meta = serde_json::from_str::<SessionMeta>(first_line.trim()).ok()?;
-
-                let mut second_line = String::new();
-                let title = reader
-                    .read_line(&mut second_line)
-                    .ok()
-                    .and_then(|n| (n > 0).then_some(()))
-                    .and_then(|()| serde_json::from_str::<SessionEvent>(second_line.trim()).ok())
-                    .and_then(|event| match event {
-                        SessionEvent::User(UserEvent::Message { content }) => Some(extract_title(&content)),
-                        _ => None,
-                    });
-
-                Some(SessionSummary { meta, title })
+                BufReader::new(File::open(&path).ok()?).read_line(&mut first_line).ok()?;
+                serde_json::from_str::<SessionMeta>(first_line.trim()).ok()
             })
             .collect();
 
-        sessions.sort_by(|a, b| b.meta.created_at.cmp(&a.meta.created_at));
-        sessions
+        metas.sort_by(|a, b| b.created_at.cmp(&a.created_at));
+        metas
+    }
+
+    fn title_for_session(&self, session_id: &str) -> Option<String> {
+        let file = File::open(self.session_path(session_id)).ok()?;
+        let mut reader = BufReader::new(file);
+        let mut first = String::new();
+        reader.read_line(&mut first).ok()?;
+        let mut second = String::new();
+        let read = reader.read_line(&mut second).ok()?;
+        if read == 0 {
+            return None;
+        }
+        match serde_json::from_str::<SessionEvent>(second.trim()).ok()? {
+            SessionEvent::User(UserEvent::Message { content }) => Some(extract_title(&content)),
+            _ => None,
+        }
     }
 
     fn append_line<T: Serialize>(&self, session_id: &str, value: &T) -> io::Result<()> {
@@ -144,6 +179,16 @@ fn extract_title(content: &[llm::ContentBlock]) -> String {
         format!("{}…", &first_line[..end])
     } else {
         first_line.to_string()
+    }
+}
+
+fn user_prompt_text_from_event(event: &SessionEvent) -> Option<String> {
+    match event {
+        SessionEvent::User(UserEvent::Message { content }) => {
+            let joined = llm::ContentBlock::join_text(content);
+            if joined.is_empty() { None } else { Some(joined) }
+        }
+        _ => None,
     }
 }
 
@@ -189,14 +234,12 @@ mod tests {
         })
     }
 
-    /// Create a temp dir and store; returns both so the dir lives long enough.
     fn temp_store() -> (tempfile::TempDir, SessionStore) {
         let dir = tempfile::tempdir().unwrap();
         let store = SessionStore::from_path(dir.path().to_path_buf());
         (dir, store)
     }
 
-    /// Append default meta + an optional user message, return listed title.
     fn listed_title(content: Option<&str>) -> Option<String> {
         let (_dir, store) = temp_store();
         store.append_meta("s1", &default_meta()).unwrap();
@@ -329,6 +372,77 @@ mod tests {
     }
 
     #[test]
+    fn list_ignores_prompt_history_file() {
+        let (dir, store) = temp_store();
+        store.append_meta("s1", &default_meta()).unwrap();
+        store.append_event("s1", &user_msg("hello world")).unwrap();
+
+        let listed = store.list();
+        assert_eq!(listed.len(), 1);
+        assert_eq!(listed[0].meta.session_id, "s1");
+        assert!(dir.path().join(PROMPT_HISTORY_FILE).exists());
+    }
+
+    #[test]
+    fn prompt_history_searches_recent_user_prompts() {
+        let (_dir, store) = temp_store();
+        store.append_meta("s1", &default_meta()).unwrap();
+        store.append_event("s1", &user_msg("hello world")).unwrap();
+        store.append_event("s1", &agent_text("msg", "hello from agent", true)).unwrap();
+
+        let response = store.search_prompts(&PromptSearchParams { query: "hello".to_string(), limit: None }).unwrap();
+        assert_eq!(response.results.len(), 1);
+        assert_eq!(response.results[0].prompt, "hello world");
+        assert_eq!(
+            &response.results[0].prompt[response.results[0].match_start..response.results[0].match_end],
+            "hello"
+        );
+    }
+
+    #[test]
+    fn prompt_history_keeps_only_last_entries() {
+        let (_dir, store) = temp_store();
+        store.append_meta("s1", &default_meta()).unwrap();
+        for i in 0..105 {
+            store.append_event("s1", &user_msg(&format!("prompt {i}"))).unwrap();
+        }
+
+        let old = store.search_prompts(&PromptSearchParams { query: "prompt 0".to_string(), limit: None }).unwrap();
+        assert!(old.results.is_empty());
+
+        let newest =
+            store.search_prompts(&PromptSearchParams { query: "prompt 104".to_string(), limit: None }).unwrap();
+        assert_eq!(newest.results.len(), 1);
+    }
+
+    #[test]
+    fn prompt_history_matching_is_literal_smart_case_and_unicode_safe() {
+        let (_dir, store) = temp_store();
+        store.append_meta("s1", &default_meta()).unwrap();
+        store.append_event("s1", &user_msg("hello world")).unwrap();
+        store.append_event("s1", &user_msg("HELLO world")).unwrap();
+        store.append_event("s1", &user_msg("hello.world")).unwrap();
+        store.append_event("s1", &user_msg("café hello")).unwrap();
+
+        let literal =
+            store.search_prompts(&PromptSearchParams { query: "hello.world".to_string(), limit: None }).unwrap();
+        assert_eq!(literal.results.len(), 1);
+        assert_eq!(literal.results[0].prompt, "hello.world");
+
+        let lower = store.search_prompts(&PromptSearchParams { query: "hello".to_string(), limit: None }).unwrap();
+        assert!(lower.results.iter().any(|hit| hit.prompt == "hello world"));
+        assert!(lower.results.iter().any(|hit| hit.prompt == "HELLO world"));
+
+        let upper = store.search_prompts(&PromptSearchParams { query: "Hello".to_string(), limit: None }).unwrap();
+        assert!(upper.results.is_empty());
+
+        let unicode = store.search_prompts(&PromptSearchParams { query: "fé".to_string(), limit: None }).unwrap();
+        assert_eq!(unicode.results.len(), 1);
+        let hit = &unicode.results[0];
+        assert_eq!(&hit.prompt[hit.match_start..hit.match_end], "fé");
+    }
+
+    #[test]
     fn list_title_extraction() {
         let cases: &[(&str, Option<&str>)] =
             &[("Fix the login bug", Some("Fix the login bug")), ("First line\nSecond\nThird", Some("First line"))];
@@ -345,7 +459,7 @@ mod tests {
     #[test]
     fn list_truncates_long_title() {
         let title = listed_title(Some(&"a".repeat(120))).unwrap();
-        assert!(title.len() <= 84); // 80 chars + "…" (3 bytes)
+        assert!(title.len() <= 84);
         assert!(title.ends_with('…'));
     }
 

--- a/packages/aether-cli/src/acp/testing.rs
+++ b/packages/aether-cli/src/acp/testing.rs
@@ -4,14 +4,17 @@ use super::session::Session;
 use super::session_manager::{InitialSessionSelection, SessionManager, SessionManagerConfig};
 use super::session_registry::SessionRegistry;
 use super::session_store::SessionStore;
+use crate::acp::session_store::SessionMeta;
 use crate::settings_args::SettingsSourceArgs;
 use acp_utils::testing::{TestPeer, duplex_pair};
 use aether_auth::OAuthCredentialStorage;
+use aether_core::context::ext::{SessionEvent, UserEvent};
 use aether_core::core::AgentHandle;
 use aether_core::events::{AgentMessage, UserMessage};
 use agent_client_protocol::schema::SessionId;
 use agent_client_protocol::{Agent, Client, ConnectionTo};
 use llm::ProviderConnectionOverrides;
+use std::path::PathBuf;
 use std::sync::Arc;
 use tempfile::TempDir;
 use tokio::sync::{mpsc, oneshot};
@@ -107,5 +110,44 @@ impl AcpTestHarness {
         let relay =
             spawn_relay(session, self.agent_cx.clone(), id.clone(), self.session_store.clone(), mock_oauth_store());
         self.registry.insert(id.0.to_string(), relay, model.to_string(), None, None, vec![]).await;
+    }
+
+    pub fn append_stored_session(&self, session_id: &str, created_at: &str) {
+        let meta = SessionMeta {
+            session_id: session_id.to_string(),
+            cwd: PathBuf::from("/tmp"),
+            model: "test-model".to_string(),
+            selected_mode: None,
+            created_at: created_at.to_string(),
+        };
+
+        self.session_store.append_meta(session_id, &meta).expect("stored session meta appends");
+    }
+
+    pub fn append_stored_prompt(&self, session_id: &str, prompt: &str) {
+        self.append_stored_event(
+            session_id,
+            &SessionEvent::User(UserEvent::Message { content: vec![llm::ContentBlock::text(prompt)] }),
+        );
+    }
+
+    pub fn append_stored_user_blocks(&self, session_id: &str, blocks: Vec<llm::ContentBlock>) {
+        self.append_stored_event(session_id, &SessionEvent::User(UserEvent::Message { content: blocks }));
+    }
+
+    pub fn append_stored_agent_text(&self, session_id: &str, text: &str) {
+        self.append_stored_event(
+            session_id,
+            &SessionEvent::Agent(AgentMessage::Text {
+                message_id: "msg".to_string(),
+                chunk: text.to_string(),
+                is_complete: true,
+                model_name: "test".to_string(),
+            }),
+        );
+    }
+
+    fn append_stored_event(&self, session_id: &str, event: &SessionEvent) {
+        self.session_store.append_event(session_id, event).expect("stored session event appends");
     }
 }

--- a/packages/aether-cli/tests/acp_prompt_search.rs
+++ b/packages/aether-cli/tests/acp_prompt_search.rs
@@ -1,0 +1,133 @@
+use acp_utils::notifications::{PromptSearchParams, PromptSearchResponse};
+use aether_cli::acp::testing::AcpTestHarness;
+use std::future::Future;
+use tokio::task::LocalSet;
+
+#[tokio::test(flavor = "current_thread")]
+async fn prompt_search_request_finds_user_prompt_history() {
+    with_harness(|harness| async move {
+        harness.append_stored_session("s1", "2026-05-01T00:00:00Z");
+        harness.append_stored_prompt("s1", "hello world");
+
+        let response = search(&harness, "hello").await;
+
+        assert_eq!(response.results.len(), 1);
+        let hit = &response.results[0];
+        assert_eq!(hit.prompt, "hello world");
+        assert_eq!(&hit.prompt[hit.match_start..hit.match_end], "hello");
+        assert_eq!(hit.session_id, "s1");
+        assert!(!response.truncated);
+    })
+    .await;
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn prompt_search_request_searches_user_text_only() {
+    with_harness(|harness| async move {
+        harness.append_stored_session("agent", "2026-05-01T00:00:00Z");
+        harness.append_stored_agent_text("agent", "hello from agent");
+        harness.append_stored_session("media", "2026-05-02T00:00:00Z");
+        harness.append_stored_user_blocks(
+            "media",
+            vec![llm::ContentBlock::Image { data: "aW1n".to_string(), mime_type: "image/png".to_string() }],
+        );
+        harness.append_stored_session("multi", "2026-05-03T00:00:00Z");
+        harness.append_stored_user_blocks(
+            "multi",
+            vec![llm::ContentBlock::text("first block"), llm::ContentBlock::text("second block")],
+        );
+
+        assert!(search(&harness, "agent").await.results.is_empty());
+        assert!(search(&harness, "aW1n").await.results.is_empty());
+
+        let multi = search(&harness, "second").await;
+        assert_eq!(multi.results.len(), 1);
+        assert_eq!(multi.results[0].prompt, "first block\nsecond block");
+    })
+    .await;
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn prompt_search_request_uses_literal_smart_case_unicode_matching() {
+    with_harness(|harness| async move {
+        harness.append_stored_session("lower", "2026-05-01T00:00:00Z");
+        harness.append_stored_prompt("lower", "hello world");
+        harness.append_stored_session("upper", "2026-05-02T00:00:00Z");
+        harness.append_stored_prompt("upper", "HELLO world");
+        harness.append_stored_session("literal", "2026-05-03T00:00:00Z");
+        harness.append_stored_prompt("literal", "hello.world");
+        harness.append_stored_session("unicode", "2026-05-04T00:00:00Z");
+        harness.append_stored_prompt("unicode", "café hello");
+
+        let literal = search(&harness, "hello.world").await;
+        assert_eq!(literal.results.len(), 1);
+        assert_eq!(literal.results[0].prompt, "hello.world");
+
+        let lower = search(&harness, "hello").await;
+        assert!(lower.results.iter().any(|hit| hit.prompt == "hello world"));
+        assert!(lower.results.iter().any(|hit| hit.prompt == "HELLO world"));
+
+        let upper = search(&harness, "Hello").await;
+        assert!(upper.results.is_empty());
+
+        let unicode = search(&harness, "fé").await;
+        assert_eq!(unicode.results.len(), 1);
+        let hit = &unicode.results[0];
+        assert_eq!(&hit.prompt[hit.match_start..hit.match_end], "fé");
+    })
+    .await;
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn prompt_search_request_limits_results_and_prompt_history() {
+    with_harness(|harness| async move {
+        harness.append_stored_session("s1", "2026-06-01T00:00:00Z");
+        for i in 0..105 {
+            harness.append_stored_prompt("s1", &format!("match #{i}"));
+        }
+
+        let matches = search(&harness, "match").await;
+        assert_eq!(matches.results.len(), 20);
+        assert!(matches.truncated);
+        assert!(matches.results.iter().any(|hit| hit.prompt == "match #104"));
+
+        let old = search(&harness, "match #0").await;
+        assert!(old.results.is_empty(), "oldest prompt outside the history window should be ignored");
+    })
+    .await;
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn prompt_search_request_with_empty_query_returns_no_results() {
+    with_harness(|harness| async move {
+        harness.append_stored_session("s1", "2026-05-01T00:00:00Z");
+        harness.append_stored_prompt("s1", "cached alpha");
+
+        let response = search(&harness, "").await;
+        assert!(response.results.is_empty());
+        assert!(!response.truncated);
+    })
+    .await;
+}
+
+async fn with_harness<F, Fut>(body: F)
+where
+    F: FnOnce(AcpTestHarness) -> Fut,
+    Fut: Future<Output = ()>,
+{
+    LocalSet::new()
+        .run_until(async move {
+            let harness = AcpTestHarness::start().await;
+            body(harness).await;
+        })
+        .await;
+}
+
+async fn search(harness: &AcpTestHarness, query: &str) -> PromptSearchResponse {
+    harness
+        .client_cx
+        .send_request(PromptSearchParams { query: query.to_string(), limit: None })
+        .block_task()
+        .await
+        .expect("prompt search succeeds")
+}

--- a/packages/wisp/src/components/app/mod.rs
+++ b/packages/wisp/src/components/app/mod.rs
@@ -22,7 +22,9 @@ use crate::workspace_status::WorkspaceStatus;
 use acp_utils::client::{AcpEvent, AcpPromptHandle};
 use acp_utils::config_meta::SelectOptionMeta;
 use acp_utils::config_option_id::ConfigOptionId;
-use acp_utils::notifications::{CreateElicitationRequestParams, ElicitationAction, ElicitationResponse};
+use acp_utils::notifications::{
+    CreateElicitationRequestParams, ElicitationAction, ElicitationResponse, prompt_search_capability,
+};
 use agent_client_protocol::Responder;
 use agent_client_protocol::schema::{self as acp, SessionId};
 use attachments::build_attachment_blocks;
@@ -94,12 +96,13 @@ impl App {
         let keybindings = Keybindings::default();
         let wisp_settings = settings::load_or_create_settings();
         let content_padding = settings::resolve_content_padding(&wisp_settings);
+        let prompt_search_enabled = prompt_search_capability::is_advertised(prompt_capabilities.meta.as_ref());
         Self {
             agent_name,
             context_usage: None,
             exit_requested: false,
             ctrl_c_pressed_at: None,
-            conversation_screen: ConversationScreen::new(keybindings.clone(), content_padding),
+            conversation_screen: ConversationScreen::new(keybindings.clone(), content_padding, prompt_search_enabled),
             prompt_capabilities,
             config_options,
             server_statuses: Vec::new(),
@@ -196,6 +199,12 @@ impl App {
                 self.session_loading_buffer.clear();
                 self.exit_requested = true;
             }
+            AcpEvent::PromptSearchResults(response) => {
+                self.conversation_screen.on_prompt_search_results(response);
+            }
+            AcpEvent::PromptSearchFailed { query, error } => {
+                self.conversation_screen.on_prompt_search_failed(&query, error);
+            }
         }
         EventOutcome::Render
     }
@@ -288,6 +297,11 @@ impl App {
                     if let Err(e) = self.prompt_handle.load_session(&session_id, &cwd) {
                         self.session_loading_buffer.remove(&session_id);
                         tracing::warn!("Failed to load session: {e}");
+                    }
+                }
+                ConversationScreenMessage::SearchPrompts(params) => {
+                    if let Err(e) = self.prompt_handle.search_prompts(params) {
+                        tracing::warn!("Failed to send prompt search: {e}");
                     }
                 }
             }

--- a/packages/wisp/src/components/conversation_screen.rs
+++ b/packages/wisp/src/components/conversation_screen.rs
@@ -10,7 +10,7 @@ use crate::components::session_picker::{SessionEntry, SessionPicker, SessionPick
 use crate::components::tool_call_statuses::ToolCallStatuses;
 use crate::keybindings::Keybindings;
 use acp_utils::CreateElicitationRequestParams;
-use acp_utils::notifications::ElicitationResponse;
+use acp_utils::notifications::{ElicitationResponse, PromptSearchParams, PromptSearchResponse};
 use agent_client_protocol::Responder;
 use agent_client_protocol::schema::{self as acp, SessionId};
 use std::collections::HashSet;
@@ -25,6 +25,7 @@ pub enum ConversationScreenMessage {
     OpenSettings,
     OpenSessionPicker,
     LoadSession { session_id: SessionId, cwd: PathBuf },
+    SearchPrompts(PromptSearchParams),
 }
 
 pub(crate) enum Modal {
@@ -46,11 +47,11 @@ pub struct ConversationScreen {
 }
 
 impl ConversationScreen {
-    pub fn new(keybindings: Keybindings, content_padding: usize) -> Self {
+    pub fn new(keybindings: Keybindings, content_padding: usize, prompt_search_enabled: bool) -> Self {
         Self {
             conversation: ConversationBuffer::new(),
             tool_call_statuses: ToolCallStatuses::new(),
-            prompt_composer: PromptComposer::new(keybindings),
+            prompt_composer: PromptComposer::new(keybindings, prompt_search_enabled),
             plan_tracker: PlanTracker::default(),
             progress_indicator: ProgressIndicator::default(),
             waiting_for_response: false,
@@ -279,9 +280,20 @@ impl ConversationScreen {
                     self.waiting_for_response = true;
                     out.push(ConversationScreenMessage::SendPrompt { user_input, attachments });
                 }
+                PromptComposerMessage::SearchPrompts(params) => {
+                    out.push(ConversationScreenMessage::SearchPrompts(params));
+                }
             }
         }
         Some(out)
+    }
+
+    pub fn on_prompt_search_results(&mut self, response: PromptSearchResponse) {
+        self.prompt_composer.on_prompt_search_results(response);
+    }
+
+    pub fn on_prompt_search_failed(&mut self, query: &str, error: String) {
+        self.prompt_composer.on_prompt_search_failed(query, error);
     }
 }
 

--- a/packages/wisp/src/components/input_prompt.rs
+++ b/packages/wisp/src/components/input_prompt.rs
@@ -1,3 +1,4 @@
+use std::ops::Range;
 use tui::{Line, ViewContext, soft_wrap_text_position};
 
 pub fn prompt_content_width(terminal_width: usize) -> usize {
@@ -11,6 +12,7 @@ pub fn prompt_text_start_col(_terminal_width: usize) -> usize {
 pub struct InputPrompt<'a> {
     pub input: &'a str,
     pub cursor_index: usize,
+    pub highlight_range: Option<Range<usize>>,
 }
 
 pub struct InputPromptLayout {
@@ -24,14 +26,14 @@ pub struct InputPromptLayout {
 impl InputPrompt<'_> {
     pub fn layout(&self, context: &ViewContext) -> InputPromptLayout {
         let width = usize::from(context.size.width);
-        let styled_input = style_input(self.input, context);
+        let cursor_index = clamp_to_char_boundary(self.input, self.cursor_index);
+        let styled_input = style_input(self.input, context, self.highlight_range.as_ref());
 
         let content_width = prompt_content_width(width);
         let content_width_u16 = u16::try_from(content_width).unwrap_or(u16::MAX);
         let wrapped_chunks = styled_input.soft_wrap(content_width_u16);
 
-        let (cursor_content_row, cursor_content_col) =
-            soft_wrap_text_position(self.input, self.cursor_index, content_width);
+        let (cursor_content_row, cursor_content_col) = soft_wrap_text_position(self.input, cursor_index, content_width);
 
         let content_rows = wrapped_chunks.len().max(cursor_content_row + 1);
 
@@ -67,34 +69,70 @@ impl InputPrompt<'_> {
     }
 }
 
-fn style_input(input: &str, context: &ViewContext) -> Line {
-    if !input.contains('@') {
-        return Line::styled(input, context.theme.text_primary());
+fn clamp_to_char_boundary(input: &str, index: usize) -> usize {
+    let mut index = index.min(input.len());
+    while index > 0 && !input.is_char_boundary(index) {
+        index -= 1;
     }
-    style_mentions(input, context)
+    index
 }
 
-fn style_mentions(input: &str, context: &ViewContext) -> Line {
-    let mut styled = Line::default();
-    let mut last_pos = 0;
+fn style_input(input: &str, context: &ViewContext, highlight: Option<&Range<usize>>) -> Line {
+    let highlight = highlight
+        .filter(|r| r.start < r.end && r.end <= input.len())
+        .filter(|r| input.is_char_boundary(r.start) && input.is_char_boundary(r.end));
 
+    if highlight.is_none() && !input.contains('@') {
+        return Line::styled(input, context.theme.text_primary());
+    }
+
+    let mentions = mention_ranges(input);
+    let base = context.theme.text_primary();
+    let info = context.theme.info();
+    let warning = context.theme.warning();
+
+    let color_at = |byte: usize| -> tui::Color {
+        if let Some(r) = &highlight
+            && r.contains(&byte)
+        {
+            return warning;
+        }
+        if mentions.iter().any(|m| m.contains(&byte)) {
+            return info;
+        }
+        base
+    };
+
+    let mut line = Line::default();
+    let mut run_start = 0;
+    let mut current = color_at(0);
+    for (i, _) in input.char_indices().skip(1) {
+        let c = color_at(i);
+        if c != current {
+            line.push_styled(&input[run_start..i], current);
+            run_start = i;
+            current = c;
+        }
+    }
+    line.push_styled(&input[run_start..], current);
+    line
+}
+
+fn mention_ranges(input: &str) -> Vec<Range<usize>> {
+    if !input.contains('@') {
+        return Vec::new();
+    }
+    let mut out = Vec::new();
+    let mut last_end = 0;
     for (at_pos, _) in input.match_indices('@') {
-        if at_pos < last_pos {
+        if at_pos < last_end {
             continue;
         }
-
-        styled.push_styled(&input[last_pos..at_pos], context.theme.text_primary());
-
-        let mention_end = input[at_pos..].find(char::is_whitespace).map_or(input.len(), |i| at_pos + i);
-        styled.push_styled(&input[at_pos..mention_end], context.theme.info());
-        last_pos = mention_end;
+        let end = input[at_pos..].find(char::is_whitespace).map_or(input.len(), |i| at_pos + i);
+        out.push(at_pos..end);
+        last_end = end;
     }
-
-    if last_pos < input.len() {
-        styled.push_styled(&input[last_pos..], context.theme.text_primary());
-    }
-
-    styled
+    out
 }
 
 #[cfg(test)]
@@ -103,7 +141,7 @@ mod tests {
 
     #[test]
     fn renders_three_lines() {
-        let prompt = InputPrompt { input: "", cursor_index: 0 };
+        let prompt = InputPrompt { input: "", cursor_index: 0, highlight_range: None };
         let ctx = ViewContext::new((80, 24));
         let lines = prompt.render(&ctx);
         assert_eq!(lines.len(), 3);
@@ -111,7 +149,7 @@ mod tests {
 
     #[test]
     fn top_rule_is_horizontal_line() {
-        let prompt = InputPrompt { input: "", cursor_index: 0 };
+        let prompt = InputPrompt { input: "", cursor_index: 0, highlight_range: None };
         let ctx = ViewContext::new((80, 24));
         let lines = prompt.render(&ctx);
         assert!(lines[0].plain_text().chars().all(|c| c == '─'));
@@ -120,7 +158,7 @@ mod tests {
 
     #[test]
     fn bottom_rule_is_horizontal_line() {
-        let prompt = InputPrompt { input: "", cursor_index: 0 };
+        let prompt = InputPrompt { input: "", cursor_index: 0, highlight_range: None };
         let ctx = ViewContext::new((80, 24));
         let lines = prompt.render(&ctx);
         assert!(lines[2].plain_text().chars().all(|c| c == '─'));
@@ -128,7 +166,7 @@ mod tests {
 
     #[test]
     fn middle_line_contains_prompt() {
-        let prompt = InputPrompt { input: "", cursor_index: 0 };
+        let prompt = InputPrompt { input: "", cursor_index: 0, highlight_range: None };
         let ctx = ViewContext::new((80, 24));
         let lines = prompt.render(&ctx);
         assert!(lines[1].plain_text().starts_with("> "));
@@ -136,7 +174,7 @@ mod tests {
 
     #[test]
     fn renders_input_text() {
-        let prompt = InputPrompt { input: "hello", cursor_index: 5 };
+        let prompt = InputPrompt { input: "hello", cursor_index: 5, highlight_range: None };
         let ctx = ViewContext::new((80, 24));
         let lines = prompt.render(&ctx);
         assert!(lines[1].plain_text().contains("hello"));
@@ -144,7 +182,7 @@ mod tests {
 
     #[test]
     fn renders_consistently() {
-        let prompt = InputPrompt { input: "test", cursor_index: 4 };
+        let prompt = InputPrompt { input: "test", cursor_index: 4, highlight_range: None };
         let ctx = ViewContext::new((80, 24));
         let a = prompt.render(&ctx);
         let b = prompt.render(&ctx);
@@ -153,7 +191,7 @@ mod tests {
 
     #[test]
     fn adapts_to_terminal_width() {
-        let prompt = InputPrompt { input: "", cursor_index: 0 };
+        let prompt = InputPrompt { input: "", cursor_index: 0, highlight_range: None };
         let narrow = ViewContext::new((40, 24));
         let wide = ViewContext::new((120, 24));
         let narrow_lines = prompt.render(&narrow);
@@ -167,7 +205,11 @@ mod tests {
 
     #[test]
     fn wraps_long_input() {
-        let prompt = InputPrompt { input: "this is a very long input that should wrap", cursor_index: 41 };
+        let prompt = InputPrompt {
+            input: "this is a very long input that should wrap",
+            cursor_index: 41,
+            highlight_range: None,
+        };
         let ctx = ViewContext::new((20, 24));
         let lines = prompt.render(&ctx);
         assert!(lines.len() > 3);
@@ -175,7 +217,7 @@ mod tests {
 
     #[test]
     fn hard_newline_renders_continuation_row() {
-        let prompt = InputPrompt { input: "one\ntwo", cursor_index: "one\ntwo".len() };
+        let prompt = InputPrompt { input: "one\ntwo", cursor_index: "one\ntwo".len(), highlight_range: None };
         let ctx = ViewContext::new((80, 24));
         let layout = prompt.layout(&ctx);
         let line_text = layout.lines.iter().map(Line::plain_text).collect::<Vec<_>>();
@@ -185,7 +227,7 @@ mod tests {
 
     #[test]
     fn cursor_after_hard_newline_starts_continuation_row() {
-        let prompt = InputPrompt { input: "one\ntwo", cursor_index: 4 };
+        let prompt = InputPrompt { input: "one\ntwo", cursor_index: 4, highlight_range: None };
         let ctx = ViewContext::new((80, 24));
         let layout = prompt.layout(&ctx);
         assert_eq!((layout.cursor_row, layout.cursor_col), (2, 2));
@@ -193,7 +235,7 @@ mod tests {
 
     #[test]
     fn cursor_after_wrapped_space_uses_rendered_row() {
-        let prompt = InputPrompt { input: "hello world", cursor_index: "hello ".len() };
+        let prompt = InputPrompt { input: "hello world", cursor_index: "hello ".len(), highlight_range: None };
         let ctx = ViewContext::new((9, 24));
         let layout = prompt.layout(&ctx);
         let line_text = layout.lines.iter().map(Line::plain_text).collect::<Vec<_>>();
@@ -204,7 +246,7 @@ mod tests {
 
     #[test]
     fn mention_and_plain_text_both_render() {
-        let prompt = InputPrompt { input: "@main.rs explain this", cursor_index: 20 };
+        let prompt = InputPrompt { input: "@main.rs explain this", cursor_index: 20, highlight_range: None };
         let ctx = ViewContext::new((80, 24));
         let lines = prompt.render(&ctx);
         assert!(lines[1].plain_text().contains("@main.rs"));
@@ -213,7 +255,7 @@ mod tests {
 
     #[test]
     fn hard_newline_terminates_mention_styling() {
-        let prompt = InputPrompt { input: "@main.rs\nhello", cursor_index: 14 };
+        let prompt = InputPrompt { input: "@main.rs\nhello", cursor_index: 14, highlight_range: None };
         let ctx = ViewContext::new((80, 24));
         let layout = prompt.layout(&ctx);
 

--- a/packages/wisp/src/components/mod.rs
+++ b/packages/wisp/src/components/mod.rs
@@ -19,6 +19,7 @@ pub(crate) mod plan_tracker;
 pub mod plan_view;
 pub mod progress_indicator;
 pub(crate) mod prompt_composer;
+pub(crate) mod prompt_search_picker;
 pub mod provider_login;
 pub(crate) mod reasoning_bar;
 pub(crate) mod review_comments;

--- a/packages/wisp/src/components/prompt_composer.rs
+++ b/packages/wisp/src/components/prompt_composer.rs
@@ -3,8 +3,10 @@ use crate::components::command_picker::{CommandEntry, CommandPicker, CommandPick
 use crate::components::dropped_files::parse_dropped_file_paths;
 use crate::components::file_picker::{FilePicker, FilePickerMessage};
 use crate::components::input_prompt::{InputPrompt, prompt_content_width};
+use crate::components::prompt_search_picker::{PromptSearchPicker, PromptSearchPickerMessage, cursor_at_match_end};
 use crate::components::text_input::{SelectedFileMention, TextInput, TextInputMessage, is_newline_modifier};
 use crate::keybindings::Keybindings;
+use acp_utils::notifications::{PromptSearchParams, PromptSearchResponse};
 use std::collections::HashSet;
 use std::path::PathBuf;
 use tui::{Component, Cursor, Event, Frame, KeyCode, Line, PickerMessage, ViewContext};
@@ -17,31 +19,128 @@ pub enum PromptComposerMessage {
     OpenSettings,
     OpenSessionPicker,
     NewSession,
+    SearchPrompts(PromptSearchParams),
 }
 
 pub struct PromptComposer {
     text_input: TextInput,
     available_commands: Vec<CommandEntry>,
-    file_picker: Option<FilePicker>,
-    command_picker: Option<CommandPicker>,
+    active_overlay: Option<Overlay>,
     pending_media: Vec<PromptAttachment>,
+    prompt_search_enabled: bool,
+    keybindings: Keybindings,
+}
+
+enum Overlay {
+    File(FilePicker),
+    Command(CommandPicker),
+    PromptSearch { picker: PromptSearchPicker, draft: String },
 }
 
 impl Default for PromptComposer {
     fn default() -> Self {
-        Self::new(Keybindings::default())
+        Self::new(Keybindings::default(), true)
     }
 }
 
 impl PromptComposer {
-    pub fn new(keybindings: Keybindings) -> Self {
+    pub fn new(keybindings: Keybindings, prompt_search_enabled: bool) -> Self {
         Self {
-            text_input: TextInput::new(keybindings),
+            text_input: TextInput::new(keybindings.clone()),
             available_commands: Vec::new(),
-            file_picker: None,
-            command_picker: None,
+            active_overlay: None,
             pending_media: Vec::new(),
+            prompt_search_enabled,
+            keybindings,
         }
+    }
+
+    pub fn on_prompt_search_results(&mut self, response: PromptSearchResponse) {
+        let Some(Overlay::PromptSearch { picker, .. }) = self.active_overlay.as_mut() else {
+            return;
+        };
+        if picker.on_results(response) {
+            self.apply_selected_search_result_to_input();
+        }
+    }
+
+    pub fn on_prompt_search_failed(&mut self, query: &str, error: String) {
+        let Some(Overlay::PromptSearch { picker, .. }) = self.active_overlay.as_mut() else {
+            return;
+        };
+        let _ = picker.on_failed(query, error);
+    }
+
+    fn apply_selected_search_result_to_input(&mut self) {
+        let Some(Overlay::PromptSearch { picker, .. }) = self.active_overlay.as_ref() else {
+            return;
+        };
+        if let Some(result) = picker.selected_result() {
+            let cursor = cursor_at_match_end(&result.prompt, result.match_end);
+            self.text_input.set_input(result.prompt.clone());
+            self.text_input.set_cursor_pos(cursor);
+        }
+    }
+
+    fn issue_search_request(&mut self, query: String) -> Option<PromptComposerMessage> {
+        if query.trim().is_empty() {
+            self.restore_draft_in_input();
+            return None;
+        }
+        Some(PromptComposerMessage::SearchPrompts(PromptSearchParams { query, limit: None }))
+    }
+
+    fn restore_draft_in_input(&mut self) {
+        let Some(Overlay::PromptSearch { draft, .. }) = &self.active_overlay else {
+            return;
+        };
+        self.text_input.set_input(draft.clone());
+    }
+
+    fn open_prompt_search(&mut self) {
+        let draft = self.text_input.buffer().to_string();
+        self.active_overlay = Some(Overlay::PromptSearch { picker: PromptSearchPicker::new(), draft });
+    }
+
+    fn close_prompt_search(&mut self, confirmed: bool) {
+        let Some(Overlay::PromptSearch { draft, .. }) = self.active_overlay.take() else {
+            return;
+        };
+        if confirmed {
+            self.text_input.set_cursor_pos(self.text_input.buffer().len());
+        } else {
+            self.text_input.set_input(draft);
+        }
+    }
+
+    /// Highlight range derived from the picker's currently-selected match.
+    /// Overlays onto the input at render time so `TextInput` never has to
+    /// know about search state.
+    fn current_search_highlight(&self) -> Option<std::ops::Range<usize>> {
+        match &self.active_overlay {
+            Some(Overlay::PromptSearch { picker, .. }) => picker.selected_result().map(|r| r.match_start..r.match_end),
+            _ => None,
+        }
+    }
+
+    fn handle_prompt_search_outcome(
+        &mut self,
+        outcome: Option<Vec<PromptSearchPickerMessage>>,
+    ) -> Vec<PromptComposerMessage> {
+        let mut messages = Vec::new();
+        for message in outcome.unwrap_or_default() {
+            match message {
+                PromptSearchPickerMessage::Cancel => self.close_prompt_search(false),
+                PromptSearchPickerMessage::Confirm => self.close_prompt_search(true),
+                PromptSearchPickerMessage::QueryChanged(query) => {
+                    if let Some(message) = self.issue_search_request(query) {
+                        messages.push(message);
+                    }
+                }
+                PromptSearchPickerMessage::SelectionChanged => self.apply_selected_search_result_to_input(),
+            }
+        }
+        messages
     }
 
     pub fn set_available_commands(&mut self, commands: Vec<CommandEntry>) {
@@ -50,7 +149,7 @@ impl PromptComposer {
 
     #[cfg(test)]
     pub fn has_active_picker(&self) -> bool {
-        self.file_picker.is_some() || self.command_picker.is_some()
+        self.active_overlay.is_some()
     }
 
     #[cfg(test)]
@@ -65,7 +164,10 @@ impl PromptComposer {
 
     #[cfg(test)]
     pub(crate) fn cursor_index(&self) -> usize {
-        let picker_query_len = self.file_picker.as_ref().map(|picker| picker.query().len());
+        let picker_query_len = match &self.active_overlay {
+            Some(Overlay::File(picker)) => Some(picker.query().len()),
+            _ => None,
+        };
         self.text_input.cursor_index(picker_query_len)
     }
 
@@ -76,7 +178,7 @@ impl PromptComposer {
 
     #[cfg(test)]
     pub(crate) fn open_command_picker_with_entries(&mut self, commands: Vec<CommandEntry>) {
-        self.command_picker = Some(CommandPicker::new(commands));
+        self.active_overlay = Some(Overlay::Command(CommandPicker::new(commands)));
     }
 
     #[cfg(test)]
@@ -85,8 +187,8 @@ impl PromptComposer {
     }
 
     pub fn close_all(&mut self) {
-        self.file_picker = None;
-        self.command_picker = None;
+        self.close_prompt_search(false);
+        self.active_overlay = None;
     }
 
     pub fn clear_content(&mut self) {
@@ -96,10 +198,14 @@ impl PromptComposer {
     }
 
     pub fn cursor(&self, context: &ViewContext) -> Cursor {
-        let picker_query_len = self.file_picker.as_ref().map(|picker| picker.query().len());
+        let picker_query_len = match &self.active_overlay {
+            Some(Overlay::File(picker)) => Some(picker.query().len()),
+            _ => None,
+        };
         let layout = InputPrompt {
             input: self.text_input.buffer(),
             cursor_index: self.text_input.cursor_index(picker_query_len),
+            highlight_range: self.current_search_highlight(),
         }
         .layout(context);
 
@@ -108,12 +214,12 @@ impl PromptComposer {
 
     #[cfg(test)]
     pub(crate) fn has_file_picker(&self) -> bool {
-        self.file_picker.is_some()
+        matches!(self.active_overlay, Some(Overlay::File(_)))
     }
 
     #[cfg(test)]
     pub(crate) fn has_command_picker(&self) -> bool {
-        self.command_picker.is_some()
+        matches!(self.active_overlay, Some(Overlay::Command(_)))
     }
 
     fn handle_picker_outcome<T>(&mut self, outcome: Option<Vec<PickerMessage<T>>>) -> (bool, Option<T>) {
@@ -145,10 +251,10 @@ impl PromptComposer {
     fn handle_file_picker_outcome(&mut self, outcome: Option<Vec<FilePickerMessage>>) -> Vec<PromptComposerMessage> {
         let (close, confirmed) = self.handle_picker_outcome(outcome);
         if let Some(file_match) = confirmed {
-            self.file_picker = None;
+            self.active_overlay = None;
             self.text_input.apply_file_selection(file_match.path, file_match.display_name);
         } else if close {
-            self.file_picker = None;
+            self.active_overlay = None;
         }
         vec![]
     }
@@ -159,10 +265,10 @@ impl PromptComposer {
     ) -> Vec<PromptComposerMessage> {
         let (close, confirmed) = self.handle_picker_outcome(outcome);
         if let Some(cmd) = confirmed {
-            self.command_picker = None;
+            self.active_overlay = None;
             return self.apply_command(&cmd);
         } else if close {
-            self.command_picker = None;
+            self.active_overlay = None;
         }
         vec![]
     }
@@ -177,11 +283,11 @@ impl PromptComposer {
             Some(TextInputMessage::OpenCommandPicker) => {
                 let mut commands = builtin_commands();
                 commands.extend(self.available_commands.clone());
-                self.command_picker = Some(CommandPicker::new(commands));
+                self.active_overlay = Some(Overlay::Command(CommandPicker::new(commands)));
                 Some(vec![])
             }
             Some(TextInputMessage::OpenFilePicker) => {
-                self.file_picker = Some(FilePicker::new());
+                self.active_overlay = Some(Overlay::File(FilePicker::new()));
                 Some(vec![])
             }
             None => Some(vec![]),
@@ -260,6 +366,10 @@ impl Component for PromptComposer {
     async fn on_event(&mut self, event: &Event) -> Option<Vec<Self::Message>> {
         match event {
             Event::Paste(text) => {
+                if let Some(Overlay::PromptSearch { picker, .. }) = self.active_overlay.as_mut() {
+                    let outcome = picker.on_event(event).await;
+                    return Some(self.handle_prompt_search_outcome(outcome));
+                }
                 self.close_all();
                 let added = parse_dropped_file_paths(text).is_some_and(|paths| self.add_dropped_media(paths));
                 if !added {
@@ -268,32 +378,51 @@ impl Component for PromptComposer {
                 Some(vec![])
             }
             Event::Key(key_event) => {
+                if self.prompt_search_enabled
+                    && self.keybindings.open_prompt_search.matches(*key_event)
+                    && self.active_overlay.is_none()
+                {
+                    self.open_prompt_search();
+                    return Some(vec![]);
+                }
+
                 if key_event.code == KeyCode::Enter && is_newline_modifier(key_event.modifiers) {
                     self.close_all();
                     let outcome = self.text_input.on_event(event).await;
                     return self.handle_text_input_outcome(outcome);
                 }
 
-                if let Some(ref mut picker) = self.file_picker {
-                    let outcome = picker.on_event(event).await;
-                    if outcome.is_some() {
-                        return Some(self.handle_file_picker_outcome(outcome));
-                    }
+                if let Some(active_overlay) = self.active_overlay.as_mut() {
+                    match active_overlay {
+                        Overlay::PromptSearch { picker, .. } => {
+                            let outcome = picker.on_event(event).await;
+                            return Some(self.handle_prompt_search_outcome(outcome));
+                        }
+                        Overlay::File(picker) => {
+                            let outcome = picker.on_event(event).await;
+                            if outcome.is_some() {
+                                return Some(self.handle_file_picker_outcome(outcome));
+                            }
 
-                    if matches!(
-                        key_event.code,
-                        KeyCode::Left | KeyCode::Right | KeyCode::Home | KeyCode::End | KeyCode::Up | KeyCode::Down
-                    ) {
-                        return Some(vec![]);
+                            if matches!(
+                                key_event.code,
+                                KeyCode::Left
+                                    | KeyCode::Right
+                                    | KeyCode::Home
+                                    | KeyCode::End
+                                    | KeyCode::Up
+                                    | KeyCode::Down
+                            ) {
+                                return Some(vec![]);
+                            }
+                        }
+                        Overlay::Command(picker) => {
+                            let outcome = picker.on_event(event).await;
+                            return Some(self.handle_command_picker_outcome(outcome));
+                        }
                     }
                 }
 
-                if let Some(ref mut picker) = self.command_picker {
-                    let outcome = picker.on_event(event).await;
-                    return Some(self.handle_command_picker_outcome(outcome));
-                }
-
-                // Backspace on empty prompt removes the last dropped media attachment
                 if key_event.code == KeyCode::Backspace
                     && self.text_input.buffer().is_empty()
                     && !self.pending_media.is_empty()
@@ -313,10 +442,15 @@ impl Component for PromptComposer {
         let content_width = prompt_content_width(usize::from(context.size.width));
         self.text_input.set_content_width(content_width);
 
-        let picker_query_len = self.file_picker.as_ref().map(|picker| picker.query().len());
+        let picker_query_len = match &self.active_overlay {
+            Some(Overlay::File(picker)) => Some(picker.query().len()),
+            _ => None,
+        };
+        let highlight_range = self.current_search_highlight();
         let mut lines = InputPrompt {
             input: self.text_input.buffer(),
             cursor_index: self.text_input.cursor_index(picker_query_len),
+            highlight_range,
         }
         .layout(context)
         .lines;
@@ -333,12 +467,12 @@ impl Component for PromptComposer {
             lines.push(line);
         }
 
-        if let Some(ref mut picker) = self.file_picker {
-            lines.extend(picker.render(context).into_lines());
-        }
-
-        if let Some(ref mut picker) = self.command_picker {
-            lines.extend(picker.render(context).into_lines());
+        if let Some(active_overlay) = &mut self.active_overlay {
+            match active_overlay {
+                Overlay::File(picker) => lines.extend(picker.render(context).into_lines()),
+                Overlay::Command(picker) => lines.extend(picker.render(context).into_lines()),
+                Overlay::PromptSearch { picker, .. } => lines.extend(picker.render(context).into_lines()),
+            }
         }
 
         Frame::new(lines).with_cursor(self.cursor(context))

--- a/packages/wisp/src/components/prompt_search_picker.rs
+++ b/packages/wisp/src/components/prompt_search_picker.rs
@@ -1,0 +1,365 @@
+use acp_utils::notifications::{PromptSearchResponse, PromptSearchResult};
+use std::ops::Range;
+use std::path::{Path, PathBuf};
+use tui::{
+    Combobox, Component, Event, Frame, KeyCode, KeyModifiers, Line, Searchable, Style, Theme, ViewContext,
+    display_width_text,
+};
+use unicode_width::UnicodeWidthChar;
+
+/// Newtype wrapper to `impl Searchable` (foreign trait) for the foreign
+/// `PromptSearchResult` type. The `Combobox` filtering path never runs — items
+/// are pre-matched server-side and pushed via `Combobox::from_matches` — but
+/// the trait bound is required for the rest of `Combobox`'s API.
+#[derive(Clone)]
+struct PromptResultItem(PromptSearchResult);
+
+impl Searchable for PromptResultItem {
+    fn search_text(&self) -> String {
+        self.0.prompt.clone()
+    }
+}
+
+/// Land the cursor at the end of the matched substring so the user can
+/// immediately edit at the hit site instead of at end-of-prompt. Clamps to a
+/// valid char boundary.
+pub fn cursor_at_match_end(prompt: &str, match_end: usize) -> usize {
+    let mut idx = match_end.min(prompt.len());
+    while idx > 0 && !prompt.is_char_boundary(idx) {
+        idx -= 1;
+    }
+    idx
+}
+
+pub enum PromptSearchPickerMessage {
+    Cancel,
+    Confirm,
+    QueryChanged(String),
+    SelectionChanged,
+}
+
+/// A lightweight agent-backed prompt-history search picker.
+///
+/// Owns the in-progress query and a `Combobox` of results pushed in from the
+/// backend via [`PromptSearchPicker::on_results`]. JSON-RPC correlates each
+/// response with its request, so the picker only checks `query` equality when
+/// deciding whether a response is stale.
+pub struct PromptSearchPicker {
+    query: String,
+    combobox: Combobox<PromptResultItem>,
+    loading: bool,
+    error: Option<String>,
+}
+
+impl Default for PromptSearchPicker {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl PromptSearchPicker {
+    pub fn new() -> Self {
+        Self { query: String::new(), combobox: Combobox::from_matches(Vec::new()), loading: false, error: None }
+    }
+
+    pub fn selected_result(&self) -> Option<&PromptSearchResult> {
+        self.combobox.selected().map(|item| &item.0)
+    }
+
+    /// Apply a response from the backend. Stale responses (different `query`)
+    /// are ignored.
+    pub fn on_results(&mut self, response: PromptSearchResponse) -> bool {
+        if response.query != self.query {
+            return false;
+        }
+        self.combobox = Combobox::from_matches(response.results.into_iter().map(PromptResultItem).collect());
+        self.loading = false;
+        self.error = None;
+        true
+    }
+
+    /// Apply a failure from the backend. Stale failures are ignored.
+    pub fn on_failed(&mut self, query: &str, error: String) -> bool {
+        if self.query != query {
+            return false;
+        }
+        self.combobox = Combobox::from_matches(Vec::new());
+        self.loading = false;
+        self.error = Some(error);
+        true
+    }
+
+    fn refresh_query_state(&mut self) {
+        self.error = None;
+        if self.query.trim().is_empty() {
+            self.combobox = Combobox::from_matches(Vec::new());
+            self.loading = false;
+        } else {
+            self.loading = true;
+        }
+    }
+}
+
+impl Component for PromptSearchPicker {
+    type Message = PromptSearchPickerMessage;
+
+    async fn on_event(&mut self, event: &Event) -> Option<Vec<Self::Message>> {
+        match event {
+            Event::Paste(text) => {
+                let sanitized: String = text.chars().filter(|c| !c.is_control()).collect();
+                if sanitized.is_empty() {
+                    return Some(vec![]);
+                }
+                self.query.push_str(&sanitized);
+                self.refresh_query_state();
+                Some(vec![PromptSearchPickerMessage::QueryChanged(self.query.clone())])
+            }
+            Event::Key(key_event) => match key_event.code {
+                KeyCode::Esc => Some(vec![PromptSearchPickerMessage::Cancel]),
+                KeyCode::Enter => Some(vec![if self.selected_result().is_some() {
+                    PromptSearchPickerMessage::Confirm
+                } else {
+                    PromptSearchPickerMessage::Cancel
+                }]),
+                KeyCode::Down => {
+                    self.combobox.move_down();
+                    Some(vec![PromptSearchPickerMessage::SelectionChanged])
+                }
+                KeyCode::Up => {
+                    self.combobox.move_up();
+                    Some(vec![PromptSearchPickerMessage::SelectionChanged])
+                }
+                KeyCode::Backspace => {
+                    if self.query.pop().is_some() {
+                        self.refresh_query_state();
+                        Some(vec![PromptSearchPickerMessage::QueryChanged(self.query.clone())])
+                    } else {
+                        Some(vec![])
+                    }
+                }
+                KeyCode::Char(c) if !key_event.modifiers.intersects(KeyModifiers::CONTROL | KeyModifiers::ALT) => {
+                    self.query.push(c);
+                    self.refresh_query_state();
+                    Some(vec![PromptSearchPickerMessage::QueryChanged(self.query.clone())])
+                }
+                _ => Some(vec![]),
+            },
+            _ => None,
+        }
+    }
+
+    fn render(&mut self, context: &ViewContext) -> Frame {
+        let mut lines = Vec::new();
+        let muted = context.theme.muted();
+        let info = context.theme.info();
+
+        let header = format!("history search: {}", self.query);
+        let mut header_line = Line::default();
+        header_line.push_styled(header, info);
+        lines.push(header_line);
+
+        if let Some(err) = &self.error {
+            lines.push(Line::styled(format!("  error: {err}"), muted));
+            return Frame::new(lines);
+        }
+
+        if self.query.trim().is_empty() {
+            lines.push(Line::styled("  type to search prompt history".to_string(), muted));
+            return Frame::new(lines);
+        }
+
+        if self.loading && self.combobox.is_empty() {
+            lines.push(Line::styled("  searching…".to_string(), muted));
+            return Frame::new(lines);
+        }
+
+        if self.combobox.is_empty() {
+            lines.push(Line::styled("  no matching prompts".to_string(), muted));
+            return Frame::new(lines);
+        }
+
+        let item_lines =
+            self.combobox.render_items(context, |item, is_selected, ctx| render_picker_row(&item.0, is_selected, ctx));
+        lines.extend(item_lines);
+        Frame::new(lines)
+    }
+}
+
+/// Render one picker row: highlighted prompt on the left, muted cwd on the right.
+fn render_picker_row(item: &PromptSearchResult, is_selected: bool, ctx: &ViewContext) -> Line {
+    let max_width = usize::from(ctx.size.width).max(1);
+    let theme = &ctx.theme;
+    let styles = RowStyles::for_row(theme, is_selected);
+
+    let cwd_display = abbreviate_cwd(&item.cwd, MAX_CWD_WIDTH);
+    let cwd_width = display_width_text(&cwd_display);
+    let (prompt_budget, show_cwd) = layout_widths(max_width, cwd_width);
+
+    let mut line = Line::default();
+    let prompt_width = push_prompt_with_highlight(
+        &mut line,
+        &item.prompt,
+        item.match_start..item.match_end,
+        prompt_budget,
+        styles.base,
+        styles.highlight,
+    );
+
+    if show_cwd {
+        let pad = max_width.saturating_sub(prompt_width + cwd_width);
+        if pad > 0 {
+            line.push_with_style(" ".repeat(pad), styles.base);
+        }
+        line.push_with_style(cwd_display, styles.muted);
+    }
+
+    if is_selected { line.with_fill(theme.highlight_bg()) } else { line }
+}
+
+const MAX_CWD_WIDTH: usize = 32;
+const CWD_GAP: usize = 2;
+const MIN_PROMPT_WIDTH: usize = 16;
+const ELLIPSIS: &str = "...";
+const ELLIPSIS_WIDTH: usize = 3;
+
+struct RowStyles {
+    base: Style,
+    highlight: Style,
+    muted: Style,
+}
+
+impl RowStyles {
+    fn for_row(theme: &Theme, is_selected: bool) -> Self {
+        if is_selected {
+            Self {
+                base: theme.selected_row_style(),
+                highlight: theme.selected_row_style_with_fg(theme.warning()),
+                muted: theme.selected_row_style_with_fg(theme.muted()),
+            }
+        } else {
+            Self {
+                base: Style::fg(theme.text_primary()),
+                highlight: Style::fg(theme.warning()),
+                muted: Style::fg(theme.muted()),
+            }
+        }
+    }
+}
+
+fn layout_widths(max_width: usize, cwd_width: usize) -> (usize, bool) {
+    if cwd_width > 0 && max_width >= cwd_width + CWD_GAP + MIN_PROMPT_WIDTH {
+        (max_width - cwd_width - CWD_GAP, true)
+    } else {
+        (max_width, false)
+    }
+}
+
+/// Whitespace-collapses `prompt`, truncates to fit `max_width` display columns
+/// (appending an ellipsis if it overflows), and pushes styled spans onto `line`
+/// — coloring chars whose byte offset falls within `highlight` with
+/// `highlight_style`, the rest with `base_style`.
+///
+/// Returns the display width actually pushed.
+fn push_prompt_with_highlight(
+    line: &mut Line,
+    prompt: &str,
+    highlight: Range<usize>,
+    max_width: usize,
+    base_style: Style,
+    highlight_style: Style,
+) -> usize {
+    if max_width == 0 {
+        return 0;
+    }
+    let use_ellipsis = max_width >= ELLIPSIS_WIDTH;
+    let budget = if use_ellipsis { max_width - ELLIPSIS_WIDTH } else { max_width };
+
+    let mut visible: Vec<(char, bool)> = Vec::new();
+    let mut visible_width = 0usize; // width of chars currently in `visible`
+    let mut budget_width = 0usize; // width up to `fit_end`
+    let mut fit_end = 0usize; // number of chars in `visible` that fit within `budget`
+    let mut last_was_ws = false;
+    let mut overflowed = false;
+
+    for (i, ch) in prompt.char_indices() {
+        let in_hl = i >= highlight.start && i < highlight.end;
+        let out_ch = if ch.is_whitespace() {
+            if last_was_ws {
+                continue;
+            }
+            last_was_ws = true;
+            ' '
+        } else {
+            last_was_ws = false;
+            ch
+        };
+
+        let cw = UnicodeWidthChar::width(out_ch).unwrap_or(0);
+        if visible_width + cw > max_width {
+            overflowed = true;
+            break;
+        }
+        visible_width += cw;
+        visible.push((out_ch, in_hl));
+        if visible_width <= budget {
+            fit_end = visible.len();
+            budget_width = visible_width;
+        }
+    }
+
+    let (kept, kept_width) = if overflowed && use_ellipsis {
+        visible.truncate(fit_end);
+        (&visible[..], budget_width)
+    } else {
+        (&visible[..], visible_width)
+    };
+
+    let mut i = 0;
+    while i < kept.len() {
+        let in_hl = kept[i].1;
+        let mut j = i + 1;
+        while j < kept.len() && kept[j].1 == in_hl {
+            j += 1;
+        }
+        let run: String = kept[i..j].iter().map(|(c, _)| *c).collect();
+        line.push_with_style(run, if in_hl { highlight_style } else { base_style });
+        i = j;
+    }
+
+    if overflowed && use_ellipsis {
+        line.push_with_style(ELLIPSIS, base_style);
+        kept_width + ELLIPSIS_WIDTH
+    } else {
+        kept_width
+    }
+}
+
+/// Render `cwd` as a home-relative path, falling back to a basename when the
+/// home-relative form exceeds `max_width`.
+fn abbreviate_cwd(cwd: &Path, max_width: usize) -> String {
+    let full = home_relative_path(cwd);
+    if display_width_text(&full) <= max_width {
+        return full;
+    }
+    cwd.file_name()
+        .map(|name| name.to_string_lossy().into_owned())
+        .filter(|name| display_width_text(name) <= max_width)
+        .unwrap_or(full)
+}
+
+fn home_relative_path(path: &Path) -> String {
+    let Some(home) = home_dir() else {
+        return path.display().to_string();
+    };
+    if path == home {
+        return "~".to_string();
+    }
+    path.strip_prefix(&home)
+        .ok()
+        .filter(|relative| !relative.as_os_str().is_empty())
+        .map_or_else(|| path.display().to_string(), |relative| format!("~/{}", relative.display()))
+}
+
+fn home_dir() -> Option<PathBuf> {
+    std::env::var_os("HOME").or_else(|| std::env::var_os("USERPROFILE")).map(PathBuf::from)
+}

--- a/packages/wisp/src/components/text_input.rs
+++ b/packages/wisp/src/components/text_input.rs
@@ -133,7 +133,6 @@ impl TextInput {
         self.field.set_value(s);
     }
 
-    #[cfg(test)]
     pub fn set_cursor_pos(&mut self, pos: usize) {
         self.field.set_cursor_pos(pos);
     }

--- a/packages/wisp/src/keybindings.rs
+++ b/packages/wisp/src/keybindings.rs
@@ -35,6 +35,7 @@ pub struct Keybindings {
     pub open_command_picker: KeyBinding,
     pub open_file_picker: KeyBinding,
     pub toggle_git_diff: KeyBinding,
+    pub open_prompt_search: KeyBinding,
 }
 
 impl Default for Keybindings {
@@ -48,6 +49,7 @@ impl Default for Keybindings {
             open_command_picker: KeyBinding::new(KeyCode::Char('/'), KeyModifiers::NONE),
             open_file_picker: KeyBinding::new(KeyCode::Char('@'), KeyModifiers::NONE),
             toggle_git_diff: KeyBinding::new(KeyCode::Char('g'), KeyModifiers::CONTROL),
+            open_prompt_search: KeyBinding::new(KeyCode::Char('r'), KeyModifiers::CONTROL),
         }
     }
 }
@@ -106,5 +108,7 @@ mod tests {
         assert_eq!(kb.open_file_picker.code, KeyCode::Char('@'));
         assert_eq!(kb.toggle_git_diff.code, KeyCode::Char('g'));
         assert_eq!(kb.toggle_git_diff.modifiers, KeyModifiers::CONTROL);
+        assert_eq!(kb.open_prompt_search.code, KeyCode::Char('r'));
+        assert_eq!(kb.open_prompt_search.modifiers, KeyModifiers::CONTROL);
     }
 }

--- a/packages/wisp/tests/app_tests.rs
+++ b/packages/wisp/tests/app_tests.rs
@@ -9,6 +9,7 @@ mod app_tests {
     mod mode_cycling_tests;
     mod notifications_tests;
     mod progress_indicator_tests;
+    mod prompt_search_tests;
     mod session_tests;
     mod settings_menu_tests;
     mod small_terminal_tests;

--- a/packages/wisp/tests/app_tests/common.rs
+++ b/packages/wisp/tests/app_tests/common.rs
@@ -78,10 +78,44 @@ impl Renderer {
         auth_methods: Vec<acp::AuthMethod>,
         size: (u16, u16),
     ) -> Self {
+        Self::new_with_prompt_capabilities_and_auth_methods(
+            terminal,
+            agent_name,
+            config_options,
+            acp::PromptCapabilities::new(),
+            auth_methods,
+            size,
+        )
+    }
+
+    pub(super) fn new_with_prompt_capabilities(
+        terminal: TestTerminal,
+        agent_name: String,
+        prompt_capabilities: acp::PromptCapabilities,
+        size: (u16, u16),
+    ) -> Self {
+        Self::new_with_prompt_capabilities_and_auth_methods(
+            terminal,
+            agent_name,
+            &[],
+            prompt_capabilities,
+            vec![],
+            size,
+        )
+    }
+
+    fn new_with_prompt_capabilities_and_auth_methods(
+        terminal: TestTerminal,
+        agent_name: String,
+        config_options: &[acp::SessionConfigOption],
+        prompt_capabilities: acp::PromptCapabilities,
+        auth_methods: Vec<acp::AuthMethod>,
+        size: (u16, u16),
+    ) -> Self {
         let app = App::new(AppInfo {
             session_id: acp::SessionId::new("test"),
             agent_name,
-            prompt_capabilities: acp::PromptCapabilities::new(),
+            prompt_capabilities,
             config_options: config_options.to_vec(),
             auth_methods,
             working_dir: std::path::PathBuf::from("."),
@@ -205,6 +239,23 @@ impl Renderer {
         responder: Responder<ElicitationResponse>,
     ) -> Result<(), Box<dyn std::error::Error>> {
         self.handle_acp_event(AcpEvent::ElicitationRequest { params, responder })?;
+        Ok(())
+    }
+
+    pub(super) fn on_prompt_search_results(
+        &mut self,
+        response: acp_utils::notifications::PromptSearchResponse,
+    ) -> Result<(), Box<dyn std::error::Error>> {
+        self.handle_acp_event(AcpEvent::PromptSearchResults(response))?;
+        Ok(())
+    }
+
+    pub(super) fn on_prompt_search_failed(
+        &mut self,
+        query: &str,
+        error: impl Into<String>,
+    ) -> Result<(), Box<dyn std::error::Error>> {
+        self.handle_acp_event(AcpEvent::PromptSearchFailed { query: query.to_string(), error: error.into() })?;
         Ok(())
     }
 

--- a/packages/wisp/tests/app_tests/prompt_search_tests.rs
+++ b/packages/wisp/tests/app_tests/prompt_search_tests.rs
@@ -1,0 +1,333 @@
+use super::common::*;
+use acp_utils::notifications::{PromptSearchResponse, PromptSearchResult, prompt_search_capability};
+use agent_client_protocol::schema as acp;
+use std::path::PathBuf;
+use tui::testing::{TestTerminal, assert_buffer_eq};
+use tui::{KeyCode, KeyModifiers};
+
+#[tokio::test]
+async fn prompt_search_prefills_selected_history_result() {
+    let terminal = TestTerminal::new(80, 24);
+    let mut renderer = Renderer::new_with_prompt_capabilities(
+        terminal,
+        TEST_AGENT.to_string(),
+        prompt_search_capabilities(),
+        (80, 24),
+    );
+    renderer.initial_render().unwrap();
+
+    send_key(&mut renderer, KeyCode::Char('r'), KeyModifiers::CONTROL).await;
+    type_string(&mut renderer, "hello").await;
+    renderer.on_prompt_search_results(response("hello", vec![result("hello world", 0, 5)])).unwrap();
+
+    let rule = "─".repeat(80);
+    let mut expected = vec![rule.clone(), "> hello world".to_string(), rule, "history search: hello".to_string()];
+    expected.push(format!("  hello world{}/tmp/repo", " ".repeat(58)));
+    expected.push(expected_status_line(80, TEST_AGENT));
+    assert_buffer_eq(renderer.writer(), &expected);
+    let (cursor_col, cursor_row) = renderer.writer().cursor_position();
+    assert_eq!((cursor_col, cursor_row), (7, 1));
+}
+
+#[tokio::test]
+async fn prompt_search_restore_draft_on_escape() {
+    let terminal = TestTerminal::new(80, 24);
+    let mut renderer = Renderer::new_with_prompt_capabilities(
+        terminal,
+        TEST_AGENT.to_string(),
+        prompt_search_capabilities(),
+        (80, 24),
+    );
+    renderer.initial_render().unwrap();
+
+    type_string(&mut renderer, "draft").await;
+    send_key(&mut renderer, KeyCode::Char('r'), KeyModifiers::CONTROL).await;
+    type_string(&mut renderer, "hello").await;
+    renderer.on_prompt_search_results(response("hello", vec![result("hello world", 0, 5)])).unwrap();
+    press_esc(&mut renderer).await;
+
+    assert_buffer_eq(renderer.writer(), &expected_prompt(80, "draft", TEST_AGENT));
+}
+
+#[tokio::test]
+async fn prompt_search_shows_backend_errors() {
+    let terminal = TestTerminal::new(80, 24);
+    let mut renderer = Renderer::new_with_prompt_capabilities(
+        terminal,
+        TEST_AGENT.to_string(),
+        prompt_search_capabilities(),
+        (80, 24),
+    );
+    renderer.initial_render().unwrap();
+
+    send_key(&mut renderer, KeyCode::Char('r'), KeyModifiers::CONTROL).await;
+    type_string(&mut renderer, "hello").await;
+    renderer.on_prompt_search_failed("hello", "boom").unwrap();
+
+    assert_buffer_contains(renderer.writer(), "history search: hello");
+    assert_buffer_contains(renderer.writer(), "error: boom");
+}
+
+#[tokio::test]
+async fn ctrl_r_opens_prompt_search_when_capability_is_enabled() {
+    let terminal = TestTerminal::new(80, 24);
+    let mut renderer = Renderer::new_with_prompt_capabilities(
+        terminal,
+        TEST_AGENT.to_string(),
+        prompt_search_capabilities(),
+        (80, 24),
+    );
+    renderer.initial_render().unwrap();
+
+    send_key(&mut renderer, KeyCode::Char('r'), KeyModifiers::CONTROL).await;
+    type_string(&mut renderer, "h").await;
+
+    assert_buffer_contains(renderer.writer(), "history search: h");
+    assert_buffer_contains(renderer.writer(), "searching…");
+}
+
+#[tokio::test]
+async fn ctrl_r_is_noop_when_prompt_search_capability_is_missing() {
+    let terminal = TestTerminal::new(80, 24);
+    let mut renderer = Renderer::new(terminal, TEST_AGENT.to_string(), &[], (80, 24));
+    renderer.initial_render().unwrap();
+
+    send_key(&mut renderer, KeyCode::Char('r'), KeyModifiers::CONTROL).await;
+    assert_buffer_eq(renderer.writer(), &expected_prompt(80, "", TEST_AGENT));
+}
+
+#[tokio::test]
+async fn prompt_search_enter_confirms_selected_result() {
+    let terminal = TestTerminal::new(80, 24);
+    let mut renderer = Renderer::new_with_prompt_capabilities(
+        terminal,
+        TEST_AGENT.to_string(),
+        prompt_search_capabilities(),
+        (80, 24),
+    );
+    renderer.initial_render().unwrap();
+
+    send_key(&mut renderer, KeyCode::Char('r'), KeyModifiers::CONTROL).await;
+    type_string(&mut renderer, "hello").await;
+    renderer.on_prompt_search_results(response("hello", vec![result("hello world", 0, 5)])).unwrap();
+    press_enter(&mut renderer).await;
+
+    assert_buffer_eq(renderer.writer(), &expected_prompt(80, "hello world", TEST_AGENT));
+    let (cursor_col, cursor_row) = renderer.writer().cursor_position();
+    assert_eq!((cursor_col, cursor_row), (13, 1));
+}
+
+#[tokio::test]
+async fn stale_prompt_search_response_does_not_overwrite_current_selection() {
+    let terminal = TestTerminal::new(80, 24);
+    let mut renderer = Renderer::new_with_prompt_capabilities(
+        terminal,
+        TEST_AGENT.to_string(),
+        prompt_search_capabilities(),
+        (80, 24),
+    );
+    renderer.initial_render().unwrap();
+
+    send_key(&mut renderer, KeyCode::Char('r'), KeyModifiers::CONTROL).await;
+    type_string(&mut renderer, "he").await;
+    renderer.on_prompt_search_results(response("he", vec![result("hello world", 0, 2)])).unwrap();
+    renderer.on_prompt_search_results(response("h", vec![result("OTHER", 0, 1)])).unwrap();
+
+    assert_buffer_contains(renderer.writer(), "> hello world");
+    assert_buffer_not_contains(renderer.writer(), "> OTHER");
+}
+
+#[tokio::test]
+async fn prompt_search_empty_query_renders_instruction() {
+    let terminal = TestTerminal::new(80, 24);
+    let mut renderer = Renderer::new_with_prompt_capabilities(
+        terminal,
+        TEST_AGENT.to_string(),
+        prompt_search_capabilities(),
+        (80, 24),
+    );
+    renderer.initial_render().unwrap();
+
+    send_key(&mut renderer, KeyCode::Char('r'), KeyModifiers::CONTROL).await;
+
+    let rule = "─".repeat(80);
+    let expected = vec![
+        rule.clone(),
+        ">".to_string(),
+        rule,
+        "history search:".to_string(),
+        "  type to search prompt history".to_string(),
+        expected_status_line(80, TEST_AGENT),
+    ];
+    assert_buffer_eq(renderer.writer(), &expected);
+}
+
+#[tokio::test]
+async fn prompt_search_empty_results_render_no_matches() {
+    let terminal = TestTerminal::new(80, 24);
+    let mut renderer = Renderer::new_with_prompt_capabilities(
+        terminal,
+        TEST_AGENT.to_string(),
+        prompt_search_capabilities(),
+        (80, 24),
+    );
+    renderer.initial_render().unwrap();
+
+    type_string(&mut renderer, "draft").await;
+    send_key(&mut renderer, KeyCode::Char('r'), KeyModifiers::CONTROL).await;
+    type_string(&mut renderer, "zzz").await;
+    renderer.on_prompt_search_results(response("zzz", vec![])).unwrap();
+
+    let rule = "─".repeat(80);
+    let expected = vec![
+        rule.clone(),
+        "> draft".to_string(),
+        rule,
+        "history search: zzz".to_string(),
+        "  no matching prompts".to_string(),
+        expected_status_line(80, TEST_AGENT),
+    ];
+    assert_buffer_eq(renderer.writer(), &expected);
+}
+
+#[tokio::test]
+async fn prompt_search_enter_without_selection_restores_draft() {
+    let terminal = TestTerminal::new(80, 24);
+    let mut renderer = Renderer::new_with_prompt_capabilities(
+        terminal,
+        TEST_AGENT.to_string(),
+        prompt_search_capabilities(),
+        (80, 24),
+    );
+    renderer.initial_render().unwrap();
+
+    type_string(&mut renderer, "draft").await;
+    send_key(&mut renderer, KeyCode::Char('r'), KeyModifiers::CONTROL).await;
+    type_string(&mut renderer, "zzz").await;
+    renderer.on_prompt_search_results(response("zzz", vec![])).unwrap();
+    press_enter(&mut renderer).await;
+
+    assert_buffer_eq(renderer.writer(), &expected_prompt(80, "draft", TEST_AGENT));
+}
+
+#[tokio::test]
+async fn prompt_search_paste_sanitizes_query() {
+    let terminal = TestTerminal::new(80, 24);
+    let mut renderer = Renderer::new_with_prompt_capabilities(
+        terminal,
+        TEST_AGENT.to_string(),
+        prompt_search_capabilities(),
+        (80, 24),
+    );
+    renderer.initial_render().unwrap();
+
+    send_key(&mut renderer, KeyCode::Char('r'), KeyModifiers::CONTROL).await;
+    renderer.on_paste("hello\nworld").await.unwrap();
+
+    assert_buffer_contains(renderer.writer(), "history search: helloworld");
+    assert_buffer_contains(renderer.writer(), "searching…");
+}
+
+#[tokio::test]
+async fn prompt_search_backspace_to_empty_restores_draft_but_keeps_picker_open() {
+    let terminal = TestTerminal::new(80, 24);
+    let mut renderer = Renderer::new_with_prompt_capabilities(
+        terminal,
+        TEST_AGENT.to_string(),
+        prompt_search_capabilities(),
+        (80, 24),
+    );
+    renderer.initial_render().unwrap();
+
+    type_string(&mut renderer, "draft").await;
+    send_key(&mut renderer, KeyCode::Char('r'), KeyModifiers::CONTROL).await;
+    type_string(&mut renderer, "h").await;
+    renderer.on_prompt_search_results(response("h", vec![result("hello", 0, 1)])).unwrap();
+    press_backspace(&mut renderer).await;
+
+    let rule = "─".repeat(80);
+    let expected = vec![
+        rule.clone(),
+        "> draft".to_string(),
+        rule,
+        "history search:".to_string(),
+        "  type to search prompt history".to_string(),
+        expected_status_line(80, TEST_AGENT),
+    ];
+    assert_buffer_eq(renderer.writer(), &expected);
+}
+
+#[tokio::test]
+async fn prompt_search_up_and_down_change_selected_prompt() {
+    let terminal = TestTerminal::new(80, 24);
+    let mut renderer = Renderer::new_with_prompt_capabilities(
+        terminal,
+        TEST_AGENT.to_string(),
+        prompt_search_capabilities(),
+        (80, 24),
+    );
+    renderer.initial_render().unwrap();
+
+    send_key(&mut renderer, KeyCode::Char('r'), KeyModifiers::CONTROL).await;
+    type_string(&mut renderer, "h").await;
+    renderer.on_prompt_search_results(response("h", vec![result("hello", 0, 1), result("hey", 0, 1)])).unwrap();
+    assert_buffer_contains(renderer.writer(), "> hello");
+
+    press_down(&mut renderer).await;
+    assert_buffer_contains(renderer.writer(), "> hey");
+
+    send_key(&mut renderer, KeyCode::Up, KeyModifiers::empty()).await;
+    assert_buffer_contains(renderer.writer(), "> hello");
+}
+
+#[tokio::test]
+async fn prompt_search_rows_truncate_prompt_and_show_cwd_basename() {
+    let terminal = TestTerminal::new(40, 24);
+    let mut renderer = Renderer::new_with_prompt_capabilities(
+        terminal,
+        TEST_AGENT.to_string(),
+        prompt_search_capabilities(),
+        (40, 24),
+    );
+    renderer.initial_render().unwrap();
+
+    send_key(&mut renderer, KeyCode::Char('r'), KeyModifiers::CONTROL).await;
+    type_string(&mut renderer, "quick").await;
+    renderer
+        .on_prompt_search_results(response(
+            "quick",
+            vec![result_with_cwd(
+                "the quick brown fox jumps over the lazy dog",
+                4,
+                9,
+                PathBuf::from("/some/deeply/nested/project/repo-name"),
+            )],
+        ))
+        .unwrap();
+
+    assert_buffer_contains(renderer.writer(), "...");
+    assert_buffer_contains(renderer.writer(), "repo-name");
+}
+
+fn prompt_search_capabilities() -> acp::PromptCapabilities {
+    acp::PromptCapabilities::new().meta(Some(prompt_search_capability::to_meta()))
+}
+
+fn result(prompt: &str, start: usize, end: usize) -> PromptSearchResult {
+    result_with_cwd(prompt, start, end, PathBuf::from("/tmp/repo"))
+}
+
+fn result_with_cwd(prompt: &str, start: usize, end: usize, cwd: PathBuf) -> PromptSearchResult {
+    PromptSearchResult {
+        session_id: "s1".to_string(),
+        cwd,
+        session_created_at: "2026-05-17T00:00:00Z".to_string(),
+        prompt: prompt.to_string(),
+        match_start: start,
+        match_end: end,
+    }
+}
+
+fn response(query: &str, results: Vec<PromptSearchResult>) -> PromptSearchResponse {
+    PromptSearchResponse { query: query.to_string(), results, truncated: false }
+}


### PR DESCRIPTION
This PR adds a new feature that lets users search across their prompt history via a `cmd+r` keyboard shortcut. It is implemented as an ACP extension. Prompt history begins populating after users upgrade. 

Closes https://github.com/contextbridge/aether/issues/48