### PR TITLE
fix(aether-cli): Detect stdio file descriptors and use unix streams o…

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -88,8 +88,10 @@ jobs:
         run: pnpm fmt-check
       - name: Typecheck
         run: pnpm sdk:typecheck
-      - name: Build
+      - name: Build SDK
         run: pnpm sdk:build
+      - name: Build aether CLI
+        run: cargo build -p aether-agent-cli
       - name: Test
         run: pnpm sdk:test
 

--- a/justfile
+++ b/justfile
@@ -50,6 +50,11 @@ doc-check *PKGS:
 sdk-install:
     pnpm install --frozen-lockfile
 
+# Build the cli debug binary, then run SDK tests (incl. the real-binary stdio e2e test).
+sdk-test:
+    cargo build -p aether-agent-cli
+    pnpm sdk:test
+
 # End-to-end probe: build aether + SDK, then run one prompt through the real binary.
 # Forwards extra args to the script (e.g. `just sdk-e2e -- --model anthropic:claude-sonnet-4-5`).
 sdk-e2e *ARGS:

--- a/packages/aether-cli/src/acp/mod.rs
+++ b/packages/aether-cli/src/acp/mod.rs
@@ -32,9 +32,15 @@ use tracing::info;
 use tracing_appender::rolling::daily;
 use tracing_subscriber::EnvFilter;
 
-use aether_auth::OAuthCredentialStorage;
+use aether_auth::{FakeOAuthCredentialStore, OAuthCredentialStorage, OsKeyringStore};
 use session_factory::InitialSessionSelection;
 use session_store::SessionStore;
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq, clap::ValueEnum)]
+pub enum OAuthCredentialStoreKind {
+    Keyring,
+    Memory,
+}
 
 #[derive(clap::Args, Debug)]
 pub struct AcpArgs {
@@ -60,6 +66,10 @@ pub struct AcpArgs {
 
     #[command(flatten)]
     pub settings_source: SettingsSourceArgs,
+
+    /// OAuth credential backend to use. Use `memory` for tests to avoid OS keychain access.
+    #[clap(long, value_enum, default_value_t = OAuthCredentialStoreKind::Keyring)]
+    pub credential_store: OAuthCredentialStoreKind,
 }
 
 /// Outcome of running the ACP server successfully.
@@ -90,8 +100,7 @@ pub async fn run_acp(args: AcpArgs) -> Result<AcpRunOutcome, AcpRunError> {
     };
     let session_store =
         SessionStore::new().map_or_else(|e| panic!("Failed to initialize session store: {e}"), Arc::new);
-    let oauth_credential_store: Arc<dyn OAuthCredentialStorage> =
-        Arc::new(aether_auth::OsKeyringStore::with_platform_store());
+    let oauth_credential_store = oauth_credential_store(args.credential_store);
     let provider_connections = args.provider_connection.into_overrides();
     let state = Arc::new(AcpState::new(AcpStateConfig {
         session_store,
@@ -107,6 +116,13 @@ pub async fn run_acp(args: AcpArgs) -> Result<AcpRunOutcome, AcpRunError> {
     match connect_result {
         Ok(()) => Ok(AcpRunOutcome::CleanDisconnect),
         Err(err) => Err(AcpRunError::Protocol(err)),
+    }
+}
+
+fn oauth_credential_store(kind: OAuthCredentialStoreKind) -> Arc<dyn OAuthCredentialStorage> {
+    match kind {
+        OAuthCredentialStoreKind::Keyring => Arc::new(OsKeyringStore::with_platform_store()),
+        OAuthCredentialStoreKind::Memory => Arc::new(FakeOAuthCredentialStore::new()),
     }
 }
 
@@ -150,6 +166,13 @@ mod tests {
         let err = TestCli::try_parse_from(["test", "--reasoning-effort", "high"])
             .expect_err("reasoning effort should require model");
         assert_eq!(err.kind(), clap::error::ErrorKind::MissingRequiredArgument);
+    }
+
+    #[test]
+    fn oauth_credential_store_memory_flag_is_allowed() {
+        let cli = TestCli::try_parse_from(["test", "--credential-store", "memory"])
+            .expect("memory credential store can be selected for tests");
+        assert_eq!(cli.args.credential_store, OAuthCredentialStoreKind::Memory);
     }
 
     #[test]

--- a/packages/aether-cli/src/acp/stdio.rs
+++ b/packages/aether-cli/src/acp/stdio.rs
@@ -2,17 +2,25 @@
 //!
 //! `agent_client_protocol::Stdio` (from acp crate) drives stdin/stdout via
 //! `blocking::Unblock` (blocking syscalls on a thread-pool worker) and treats
-//! every io error as fatal. That's a provlem when the parent process spawns
+//! every io error as fatal. That's a problem when the parent process spawns
 //! this binary with non-blocking pipe fds: a `read`/`write` on the child side
 //! can return `EAGAIN`, which the upstream transport surfaces as a fatal io error
 //! and tears the session down.
 //!
-//! `tokio::net::unix::pipe` polls the fds via epoll instead, so `EAGAIN` isn't
-//! a fatal error.
+//! We poll the fds via epoll instead, so `EAGAIN` isn't fatal. Which tokio type
+//! backs that depends on the fd: when spawned with `stdio: 'pipe'`, Node/libuv
+//! backs stdin/stdout with `AF_UNIX` socketpairs (not FIFOs), so we route sockets
+//! through `tokio::net::UnixStream` and real FIFOs through
+//! `tokio::net::unix::pipe`.
 
 use agent_client_protocol::{ByteStreams, ConnectTo, Error, Role};
+use futures::{AsyncRead, AsyncWrite};
+use std::fs::File;
 use std::io;
-use std::os::fd::AsFd;
+use std::os::fd::{AsFd, BorrowedFd, OwnedFd};
+use std::os::unix::fs::FileTypeExt;
+use std::os::unix::net::UnixStream as StdUnixStream;
+use tokio::net::UnixStream;
 use tokio::net::unix::pipe::{Receiver, Sender};
 use tokio_util::compat::{TokioAsyncReadCompatExt, TokioAsyncWriteCompatExt};
 
@@ -26,19 +34,10 @@ impl Stdio {
 
 impl<T: Role> ConnectTo<T> for Stdio {
     async fn connect_to(self, client: impl ConnectTo<T::Counterpart>) -> Result<(), Error> {
-        let stdin = io::stdin()
-            .as_fd()
-            .try_clone_to_owned()
-            .and_then(Receiver::from_owned_fd)
-            .map_err(Error::into_internal_error)?;
-
-        let stdout = io::stdout()
-            .as_fd()
-            .try_clone_to_owned()
-            .and_then(Sender::from_owned_fd)
-            .map_err(Error::into_internal_error)?;
-
-        let streams = ByteStreams::new(stdout.compat_write(), stdin.compat());
+        let streams = ByteStreams::new(
+            stdout(io::stdout().as_fd()).map_err(Error::into_internal_error)?,
+            stdin(io::stdin().as_fd()).map_err(Error::into_internal_error)?,
+        );
         ConnectTo::<T>::connect_to(streams, client).await
     }
 }
@@ -47,4 +46,36 @@ impl Default for Stdio {
     fn default() -> Self {
         Self::new()
     }
+}
+
+type BoxRead = Box<dyn AsyncRead + Unpin + Send>;
+type BoxWrite = Box<dyn AsyncWrite + Unpin + Send>;
+
+fn stdin(fd: BorrowedFd) -> io::Result<BoxRead> {
+    let owned = fd.try_clone_to_owned()?;
+    if is_socket(&owned)? {
+        Ok(Box::new(unix_stream(owned)?.compat()))
+    } else {
+        Ok(Box::new(Receiver::from_owned_fd(owned)?.compat()))
+    }
+}
+
+fn stdout(fd: BorrowedFd) -> io::Result<BoxWrite> {
+    let owned = fd.try_clone_to_owned()?;
+    if is_socket(&owned)? {
+        Ok(Box::new(unix_stream(owned)?.compat_write()))
+    } else {
+        Ok(Box::new(Sender::from_owned_fd(owned)?.compat_write()))
+    }
+}
+
+fn unix_stream(owned: OwnedFd) -> io::Result<UnixStream> {
+    let std = StdUnixStream::from(owned);
+    std.set_nonblocking(true)?;
+    UnixStream::from_std(std)
+}
+
+fn is_socket(fd: &OwnedFd) -> io::Result<bool> {
+    let probe = File::from(fd.try_clone()?);
+    Ok(probe.metadata()?.file_type().is_socket())
 }

--- a/packages/aether-cli/tests/acp_stdio.rs
+++ b/packages/aether-cli/tests/acp_stdio.rs
@@ -1,0 +1,71 @@
+use agent_client_protocol::JsonRpcMessage;
+use agent_client_protocol::jsonrpcmsg::{Id, Params, Request};
+use agent_client_protocol::schema::{InitializeRequest, ProtocolVersion};
+use std::error::Error;
+use std::io::{BufRead, BufReader, Error as IoError, Write};
+use std::os::fd::OwnedFd;
+use std::os::unix::net::UnixStream;
+use std::process::{Command, Stdio};
+
+type TestResult<T = ()> = std::result::Result<T, Box<dyn Error>>;
+
+#[test]
+fn socket_backed_stdio_serves_acp() -> TestResult {
+    let log_dir = tempfile::tempdir()?;
+    let (mut child_stdout_reader, child_stdout) = UnixStream::pair()?;
+    let (mut child_stdin_writer, child_stdin) = UnixStream::pair()?;
+    let mut child = acp_command(log_dir.path())
+        .stdin(Stdio::from(OwnedFd::from(child_stdin)))
+        .stdout(Stdio::from(OwnedFd::from(child_stdout)))
+        .spawn()?;
+
+    child_stdin_writer.write_all(initialize_line()?.as_bytes())?;
+    child_stdin_writer.flush()?;
+
+    let mut response = String::new();
+    BufReader::new(&mut child_stdout_reader).read_line(&mut response)?;
+    assert_initialize_response(&response)?;
+    let _ = child.kill();
+    let _ = child.wait();
+    Ok(())
+}
+
+#[test]
+fn pipe_backed_stdio_serves_acp() -> TestResult {
+    let log_dir = tempfile::tempdir()?;
+    let mut child = acp_command(log_dir.path()).stdin(Stdio::piped()).stdout(Stdio::piped()).spawn()?;
+
+    let mut stdin = child.stdin.take().ok_or_else(|| IoError::other("child stdin"))?;
+    let stdout = child.stdout.take().ok_or_else(|| IoError::other("child stdout"))?;
+
+    stdin.write_all(initialize_line()?.as_bytes())?;
+    stdin.flush()?;
+
+    let mut response = String::new();
+    BufReader::new(stdout).read_line(&mut response)?;
+    assert_initialize_response(&response)?;
+
+    let _ = child.kill();
+    let _ = child.wait();
+    Ok(())
+}
+
+fn acp_command(log_dir: &std::path::Path) -> Command {
+    let mut command = Command::new(env!("CARGO_BIN_EXE_aether"));
+    command.arg("acp").arg("--log-dir").arg(log_dir).stderr(Stdio::null());
+    command
+}
+
+fn initialize_line() -> TestResult<String> {
+    let message = InitializeRequest::new(ProtocolVersion::LATEST).to_untyped_message()?;
+    let params = serde_json::from_value::<Params>(message.params)?;
+    let request = Request::new_v2(message.method, Some(params), Some(Id::Number(1)));
+    Ok(format!("{}\n", serde_json::to_string(&request)?))
+}
+
+fn assert_initialize_response(line: &str) -> TestResult {
+    let response: serde_json::Value = serde_json::from_str(line)?;
+    assert_eq!(response["id"], serde_json::json!(1), "response should echo the request id: {response}");
+    assert!(response.get("result").is_some(), "initialize should return a result: {response}");
+    Ok(())
+}

--- a/packages/aether-cli/tests/acp_stdio.rs
+++ b/packages/aether-cli/tests/acp_stdio.rs
@@ -52,7 +52,7 @@ fn pipe_backed_stdio_serves_acp() -> TestResult {
 
 fn acp_command(log_dir: &std::path::Path) -> Command {
     let mut command = Command::new(env!("CARGO_BIN_EXE_aether"));
-    command.arg("acp").arg("--log-dir").arg(log_dir).stderr(Stdio::null());
+    command.arg("acp").arg("--log-dir").arg(log_dir).arg("--credential-store").arg("memory").stderr(Stdio::null());
     command
 }
 

--- a/packages/aether-sdk/package.json
+++ b/packages/aether-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aether-agent/sdk",
-  "version": "0.2.6",
+  "version": "0.2.7",
   "description": "TypeScript SDK for the Aether agent CLI",
   "repository": {
     "type": "git",

--- a/packages/aether-sdk/src/session.ts
+++ b/packages/aether-sdk/src/session.ts
@@ -39,6 +39,7 @@ export interface CommonAetherSessionOptions {
   cwd?: string;
   binaryPath?: string;
   env?: Record<string, string | undefined>;
+  oauthCredentialStore?: "platform" | "memory";
   logDir?: string;
   tools?: AetherToolGroups;
   externalMcpServers?: Record<string, ExternalMcpServerConfig>;
@@ -98,6 +99,7 @@ export class AetherSession {
       logDir,
       cwd = process.cwd(),
       env,
+      oauthCredentialStore,
       onPermissionRequest = autoApprovePermissions,
       onElicitation,
     } = options;
@@ -157,6 +159,8 @@ export class AetherSession {
         );
     }
     if (logDir) args.push("--log-dir", logDir);
+    if (oauthCredentialStore)
+      args.push("--credential-store", oauthCredentialStore);
 
     const spawned = spawnAetherProcess({
       command: resolved.command,

--- a/packages/aether-sdk/test/realBinary.e2e.test.ts
+++ b/packages/aether-sdk/test/realBinary.e2e.test.ts
@@ -37,6 +37,7 @@ describe("E2E tests", () => {
             },
           ],
         },
+        oauthCredentialStore: "memory",
         env: {
           ...process.env,
           ANTHROPIC_API_KEY: "sk-ant-e2e-dummy",

--- a/packages/aether-sdk/test/realBinary.e2e.test.ts
+++ b/packages/aether-sdk/test/realBinary.e2e.test.ts
@@ -1,0 +1,51 @@
+import { existsSync } from "node:fs";
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+import { AetherSession } from "../src/index.js";
+
+const binaryPath =
+  process.env.AETHER_BIN ??
+  fileURLToPath(new URL("../../../target/debug/aether", import.meta.url));
+
+describe("E2E tests", () => {
+  it("initializes a stdio session", async () => {
+    expect(
+      existsSync(binaryPath),
+      `aether binary not found at ${binaryPath}. Build it first via just command.`,
+    ).toBe(true);
+
+    const cwd = await mkdtemp(path.join(tmpdir(), "aether-e2e-"));
+    try {
+      const session = await AetherSession.start({
+        binaryPath,
+        cwd,
+        logDir: cwd,
+        settings: {
+          agent: "Dummy",
+          agents: [
+            {
+              name: "Dummy",
+              description: "Dummy agent for SDK real-binary startup tests",
+              model: "anthropic:claude-sonnet-4-6",
+              userInvocable: true,
+              prompts: [
+                { type: "text", text: "You are a dummy SDK test agent." },
+              ],
+            },
+          ],
+        },
+        env: {
+          ...process.env,
+          ANTHROPIC_API_KEY: "sk-ant-e2e-dummy",
+        },
+      });
+      expect(session.sessionId).toBeTruthy();
+      await session.close();
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
+  }, 30_000);
+});

--- a/packages/aether-sdk/test/session.integration.test.ts
+++ b/packages/aether-sdk/test/session.integration.test.ts
@@ -58,6 +58,7 @@ describe("AetherSession with a fake ACP agent", () => {
           inferenceProfileArn: arn,
         },
       },
+      oauthCredentialStore: "memory",
       env: { PATH: process.env.PATH, FAKE_AETHER_LOG_FILE: logFile },
     });
 
@@ -70,6 +71,8 @@ describe("AetherSession with a fake ACP agent", () => {
       expect(argv.args).toContain("bedrock.url=http://127.0.0.1:8787");
       expect(argv.args).toContain("bedrock.auth=none");
       expect(argv.args).toContain(`bedrock.inference-profile-arn=${arn}`);
+      expect(argv.args).toContain("--credential-store");
+      expect(argv.args).toContain("memory");
     } finally {
       await session.close();
       await rm(dir, { recursive: true, force: true });


### PR DESCRIPTION
This PR fixes `aether acp` stdio handling when the CLI is spawned using Unix socket pairs instead of FIFO pipes. 

Previously the code assumed FIFO pipes via `tokio::net::unix::pipe`, which caused the  TypeScript SDK to fail to start a session as it uses Node’s `child_process.spawn(..., stdio: "pipe")`. Node/libuv backs stdio pipes with Unix socketpairs on Linux so trying to use `tokio::net::unix::pipe` there would cause the session to fail to start. 

Now we check the file descriptor type and  conditionally use `tokio::net::UnixStream` or `tokio::net::unix::pipe`