### PR TITLE
feat(aether-cli): Support encrypted file store for oauth for users th…

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9,6 +9,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
+name = "aead"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d122413f284cf2d62fb1b7db97e02edb8cda96d769b16e443a4f6195e35662b0"
+dependencies = [
+ "crypto-common 0.1.7",
+ "generic-array",
+]
+
+[[package]]
 name = "aes"
 version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -109,9 +119,11 @@ dependencies = [
 name = "aether-auth"
 version = "0.1.4"
 dependencies = [
+ "age",
  "apple-native-keyring-store",
  "async-trait",
  "dbus-secret-service-keyring-store",
+ "dirs",
  "futures",
  "keyring-core",
  "oauth2",
@@ -119,6 +131,7 @@ dependencies = [
  "rmcp",
  "serde",
  "serde_json",
+ "tempfile",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -161,7 +174,7 @@ dependencies = [
  "aws-sdk-bedrockruntime",
  "aws-smithy-types",
  "axum",
- "base64",
+ "base64 0.22.1",
  "chrono",
  "eventsource-stream",
  "futures",
@@ -344,7 +357,7 @@ dependencies = [
  "aether-tui",
  "aether-utils",
  "agent-client-protocol",
- "base64",
+ "base64 0.22.1",
  "chrono",
  "clap",
  "ignore",
@@ -362,6 +375,49 @@ dependencies = [
 ]
 
 [[package]]
+name = "age"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a07d86e4272c093c88caf7864a2d09af52a5159180848ca4832a3cdbd7d014d5"
+dependencies = [
+ "age-core",
+ "base64 0.21.7",
+ "bech32",
+ "chacha20poly1305",
+ "cookie-factory",
+ "hmac 0.12.1",
+ "i18n-embed",
+ "i18n-embed-fl",
+ "lazy_static",
+ "nom 7.1.3",
+ "pin-project",
+ "rand 0.8.6",
+ "rust-embed",
+ "scrypt",
+ "sha2 0.10.9",
+ "subtle",
+ "x25519-dalek",
+ "zeroize",
+]
+
+[[package]]
+name = "age-core"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e2bf6a89c984ca9d850913ece2da39e1d200563b0a94b002b253beee4c5acf99"
+dependencies = [
+ "base64 0.21.7",
+ "chacha20poly1305",
+ "cookie-factory",
+ "hkdf",
+ "io_tee",
+ "nom 7.1.3",
+ "rand 0.8.6",
+ "secrecy",
+ "sha2 0.10.9",
+]
+
+[[package]]
 name = "agent-client-protocol"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -375,7 +431,7 @@ dependencies = [
  "futures-concurrency",
  "jsonrpcmsg",
  "rmcp",
- "rustc-hash",
+ "rustc-hash 2.1.2",
  "schemars 1.2.1",
  "serde",
  "serde_json",
@@ -554,7 +610,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "278af84d3d19995d440ea7b401a4b121c780c8d37f5eb6e883d987c17b523aa4"
 dependencies = [
  "async-openai-macros",
- "base64",
+ "base64 0.22.1",
  "bytes",
  "derive_builder",
  "eventsource-stream",
@@ -1163,6 +1219,12 @@ dependencies = [
 
 [[package]]
 name = "base64"
+version = "0.21.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d297deb1925b89f2ccc13d7635fa0714f12c87adce1c75356b39ca9b7178567"
+
+[[package]]
+name = "base64"
 version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
@@ -1176,6 +1238,21 @@ dependencies = [
  "outref",
  "vsimd",
 ]
+
+[[package]]
+name = "basic-toml"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba62675e8242a4c4e806d12f11d136e626e6c8361d6b829310732241652a178a"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "bech32"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d86b93f97252c47b41663388e6d155714a9d0c398b99f1005cbc5f978b29f445"
 
 [[package]]
 name = "bincode"
@@ -1335,6 +1412,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
+name = "chacha20"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3613f74bd2eac03dad61bd53dbe620703d4371614fe0bc3b9f04dd36fe4e818"
+dependencies = [
+ "cfg-if",
+ "cipher",
+ "cpufeatures 0.2.17",
+]
+
+[[package]]
+name = "chacha20poly1305"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10cd79432192d1c0f4e1a0fef9527696cc039165d729fb41b3f4f4f354c2dc35"
+dependencies = [
+ "aead",
+ "chacha20",
+ "cipher",
+ "poly1305",
+ "zeroize",
+]
+
+[[package]]
 name = "chrono"
 version = "0.4.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1356,6 +1457,7 @@ checksum = "773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad"
 dependencies = [
  "crypto-common 0.1.7",
  "inout",
+ "zeroize",
 ]
 
 [[package]]
@@ -1451,6 +1553,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "633458d4ef8c78b72454de2d54fd6ab2e60f9e02be22f3c6104cdc8a4e0fceb9"
 dependencies = [
  "unicode-segmentation",
+]
+
+[[package]]
+name = "cookie-factory"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9885fa71e26b8ab7855e2ec7cae6e9b380edff76cd052e07c683a0319d51b3a2"
+dependencies = [
+ "futures",
 ]
 
 [[package]]
@@ -1624,6 +1735,32 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7d5515a3834141de9eafb9717ad39eea8247b5674e6066c404e8c4b365d2a29e"
 dependencies = [
  "cmov",
+]
+
+[[package]]
+name = "curve25519-dalek"
+version = "4.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97fb8b7c4503de7d6ae7b42ab72a5a59857b4c937ec27a3d4539dba95b5ab2be"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.2.17",
+ "curve25519-dalek-derive",
+ "fiat-crypto",
+ "rustc_version",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "curve25519-dalek-derive"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f46882e17999c6cc590af592290432be3bce0428cb0d5f8b6715e4dc7b383eb3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -2013,6 +2150,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
 
 [[package]]
+name = "fiat-crypto"
+version = "0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "28dea519a9695b9977216879a3ebfddf92f1c08c05d984f8996aecd6ecdc811d"
+
+[[package]]
+name = "find-crate"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59a98bbaacea1c0eb6a0876280051b892eb73594fd90cf3b20e9c817029c57d2"
+dependencies = [
+ "toml",
+]
+
+[[package]]
 name = "find-msvc-tools"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2038,6 +2190,50 @@ checksum = "843fba2746e448b37e26a819579957415c8cef339bf08564fe8b7ddbd959573c"
 dependencies = [
  "crc32fast",
  "miniz_oxide",
+]
+
+[[package]]
+name = "fluent"
+version = "0.16.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb74634707bebd0ce645a981148e8fb8c7bccd4c33c652aeffd28bf2f96d555a"
+dependencies = [
+ "fluent-bundle",
+ "unic-langid",
+]
+
+[[package]]
+name = "fluent-bundle"
+version = "0.15.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7fe0a21ee80050c678013f82edf4b705fe2f26f1f9877593d13198612503f493"
+dependencies = [
+ "fluent-langneg",
+ "fluent-syntax",
+ "intl-memoizer",
+ "intl_pluralrules",
+ "rustc-hash 1.1.0",
+ "self_cell 0.10.3",
+ "smallvec",
+ "unic-langid",
+]
+
+[[package]]
+name = "fluent-langneg"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7eebbe59450baee8282d71676f3bfed5689aeab00b27545e83e5f14b1195e8b0"
+dependencies = [
+ "unic-langid",
+]
+
+[[package]]
+name = "fluent-syntax"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a530c4694a6a8d528794ee9bbd8ba0122e779629ac908d15ad5a7ae7763a33d"
+dependencies = [
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -2662,7 +2858,7 @@ version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "96547c2556ec9d12fb1578c4eaf448b04993e7fb79cbaad930a656880a6bdfa0"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "bytes",
  "futures-channel",
  "futures-util",
@@ -2677,6 +2873,72 @@ dependencies = [
  "tokio",
  "tower-service",
  "tracing",
+]
+
+[[package]]
+name = "i18n-config"
+version = "0.4.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3e06b90c8a0d252e203c94344b21e35a30f3a3a85dc7db5af8f8df9f3e0c63ef"
+dependencies = [
+ "basic-toml",
+ "log",
+ "serde",
+ "serde_derive",
+ "thiserror 1.0.69",
+ "unic-langid",
+]
+
+[[package]]
+name = "i18n-embed"
+version = "0.15.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "669ffc2c93f97e6ddf06ddbe999fcd6782e3342978bb85f7d3c087c7978404c4"
+dependencies = [
+ "arc-swap",
+ "fluent",
+ "fluent-langneg",
+ "fluent-syntax",
+ "i18n-embed-impl",
+ "intl-memoizer",
+ "log",
+ "parking_lot",
+ "rust-embed",
+ "thiserror 1.0.69",
+ "unic-langid",
+ "walkdir",
+]
+
+[[package]]
+name = "i18n-embed-fl"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04b2969d0b3fc6143776c535184c19722032b43e6a642d710fa3f88faec53c2d"
+dependencies = [
+ "find-crate",
+ "fluent",
+ "fluent-syntax",
+ "i18n-config",
+ "i18n-embed",
+ "proc-macro-error2",
+ "proc-macro2",
+ "quote",
+ "strsim",
+ "syn",
+ "unic-langid",
+]
+
+[[package]]
+name = "i18n-embed-impl"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0f2cc0e0523d1fe6fc2c6f66e5038624ea8091b3e7748b5e8e0c84b1698db6c2"
+dependencies = [
+ "find-crate",
+ "i18n-config",
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -2886,6 +3148,31 @@ dependencies = [
  "block-padding",
  "generic-array",
 ]
+
+[[package]]
+name = "intl-memoizer"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "310da2e345f5eb861e7a07ee182262e94975051db9e4223e909ba90f392f163f"
+dependencies = [
+ "type-map",
+ "unic-langid",
+]
+
+[[package]]
+name = "intl_pluralrules"
+version = "7.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "078ea7b7c29a2b4df841a7f6ac8775ff6074020c6776d48491ce2268e068f972"
+dependencies = [
+ "unic-langid",
+]
+
+[[package]]
+name = "io_tee"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b3f7cef34251886990511df1c61443aa928499d598a9473929ab5a90a527304"
 
 [[package]]
 name = "ipnet"
@@ -3395,7 +3682,7 @@ version = "5.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "51e219e79014df21a225b1860a479e2dcd7cbd9130f4defd4bd0e191ea31d67d"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "chrono",
  "getrandom 0.2.17",
  "http 1.4.1",
@@ -3420,6 +3707,12 @@ name = "once_cell_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
+
+[[package]]
+name = "opaque-debug"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
 
 [[package]]
 name = "openssl-probe"
@@ -3473,6 +3766,16 @@ name = "pastey"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2ee67f1008b1ba2321834326597b8e186293b049a023cdef258527550b9935b4"
+
+[[package]]
+name = "pbkdf2"
+version = "0.12.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8ed6a7761f76e3b9f92dfb0a60a6a6477c61024b775147ff0973a02653abaf2"
+dependencies = [
+ "digest 0.10.7",
+ "hmac 0.12.1",
+]
 
 [[package]]
 name = "percent-encoding"
@@ -3588,7 +3891,7 @@ version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "092791278e026273c1b65bbdcfbba3a300f2994c896bd01ab01da613c29c46f1"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "indexmap 2.14.0",
  "quick-xml",
  "serde",
@@ -3607,6 +3910,17 @@ dependencies = [
  "pin-project-lite",
  "rustix",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "poly1305"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8159bd90725d2df49889a078b54f4f79e87f1f8a8444194cdca81d38f5393abf"
+dependencies = [
+ "cpufeatures 0.2.17",
+ "opaque-debug",
+ "universal-hash",
 ]
 
 [[package]]
@@ -3646,6 +3960,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
 dependencies = [
  "proc-macro2",
+ "syn",
+]
+
+[[package]]
+name = "proc-macro-error-attr2"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96de42df36bb9bba5542fe9f1a054b8cc87e172759a1868aa05c1f3acc89dfc5"
+dependencies = [
+ "proc-macro2",
+ "quote",
+]
+
+[[package]]
+name = "proc-macro-error2"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11ec05c52be0a07b08061f7dd003e7d7092e0472bc731b4af7bb1ef876109802"
+dependencies = [
+ "proc-macro-error-attr2",
+ "proc-macro2",
+ "quote",
  "syn",
 ]
 
@@ -3711,7 +4047,7 @@ dependencies = [
  "pin-project-lite",
  "quinn-proto",
  "quinn-udp",
- "rustc-hash",
+ "rustc-hash 2.1.2",
  "rustls 0.23.40",
  "socket2 0.6.4",
  "thiserror 2.0.18",
@@ -3732,7 +4068,7 @@ dependencies = [
  "lru-slab",
  "rand 0.9.4",
  "ring",
- "rustc-hash",
+ "rustc-hash 2.1.2",
  "rustls 0.23.40",
  "rustls-pki-types",
  "slab",
@@ -3937,7 +4273,7 @@ version = "0.12.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "bytes",
  "futures-core",
  "http 1.4.1",
@@ -3975,7 +4311,7 @@ version = "0.13.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "219c5811de6525e5416c7d5d53bb656d3afdbc6c5af816e0802bcfa42dbdc1c3"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "bytes",
  "futures-core",
  "futures-util",
@@ -4033,7 +4369,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0810a9f717d9828f475fe1f629f4c305c8464b7f496c3a854b58d29e65f4058e"
 dependencies = [
  "async-trait",
- "base64",
+ "base64 0.22.1",
  "chrono",
  "futures",
  "http 1.4.1",
@@ -4067,6 +4403,46 @@ dependencies = [
  "serde_json",
  "syn",
 ]
+
+[[package]]
+name = "rust-embed"
+version = "8.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04113cb9355a377d83f06ef1f0a45b8ab8cd7d8b1288160717d66df5c7988d27"
+dependencies = [
+ "rust-embed-impl",
+ "rust-embed-utils",
+ "walkdir",
+]
+
+[[package]]
+name = "rust-embed-impl"
+version = "8.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da0902e4c7c8e997159ab384e6d0fc91c221375f6894346ae107f47dd0f3ccaa"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "rust-embed-utils",
+ "syn",
+ "walkdir",
+]
+
+[[package]]
+name = "rust-embed-utils"
+version = "8.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5bcdef0be6fe7f6fa333b1073c949729274b05f123a0ad7efcb8efd878e5c3b1"
+dependencies = [
+ "sha2 0.10.9",
+ "walkdir",
+]
+
+[[package]]
+name = "rustc-hash"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
 
 [[package]]
 name = "rustc-hash"
@@ -4207,6 +4583,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
 
 [[package]]
+name = "salsa20"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97a22f5af31f73a954c10289c93e8a50cc23d971e80ee446f1f6f7137a088213"
+dependencies = [
+ "cipher",
+]
+
+[[package]]
 name = "same-file"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4269,6 +4654,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
+name = "scrypt"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0516a385866c09368f0b5bcd1caff3366aace790fcd46e2bb032697bb172fd1f"
+dependencies = [
+ "pbkdf2",
+ "salsa20",
+ "sha2 0.10.9",
+]
+
+[[package]]
 name = "sct"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4325,10 +4721,25 @@ dependencies = [
  "phf",
  "phf_codegen",
  "precomputed-hash",
- "rustc-hash",
+ "rustc-hash 2.1.2",
  "servo_arc",
  "smallvec",
 ]
+
+[[package]]
+name = "self_cell"
+version = "0.10.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e14e4d63b804dc0c7ec4a1e52bcb63f02c7ac94476755aa579edac21e01f915d"
+dependencies = [
+ "self_cell 1.2.2",
+]
+
+[[package]]
+name = "self_cell"
+version = "1.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b12e76d157a900eb52e81bc6e9f3069344290341720e9178cde2407113ac8d89"
 
 [[package]]
 name = "semver"
@@ -4430,7 +4841,7 @@ version = "3.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e72c1c2cb7b223fafb600a619537a871c2818583d619401b785e7c0b746ccde2"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "bs58",
  "chrono",
  "hex",
@@ -4888,6 +5299,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8323304221c2a851516f22236c5722a72eaa19749016521d6dff0824447d96d"
 dependencies = [
  "displaydoc",
+ "serde_core",
  "zerovec",
 ]
 
@@ -4977,6 +5389,15 @@ dependencies = [
  "futures-sink",
  "pin-project-lite",
  "tokio",
+]
+
+[[package]]
+name = "toml"
+version = "0.5.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f4f7f0dd8d50a853a531c426359045b1998f04219d88799810762cd4ad314234"
+dependencies = [
+ "serde",
 ]
 
 [[package]]
@@ -5132,10 +5553,38 @@ dependencies = [
 ]
 
 [[package]]
+name = "type-map"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb30dbbd9036155e74adad6812e9898d03ec374946234fbcebd5dfc7b9187b90"
+dependencies = [
+ "rustc-hash 2.1.2",
+]
+
+[[package]]
 name = "typenum"
 version = "1.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6f5e870be6c3b371b77fe0ee0bafb859fa4964b4404c27de1d380043c4dda20"
+
+[[package]]
+name = "unic-langid"
+version = "0.9.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a28ba52c9b05311f4f6e62d5d9d46f094bd6e84cb8df7b3ef952748d752a7d05"
+dependencies = [
+ "unic-langid-impl",
+]
+
+[[package]]
+name = "unic-langid-impl"
+version = "0.9.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dce1bf08044d4b7a94028c93786f8566047edc11110595914de93362559bc658"
+dependencies = [
+ "serde",
+ "tinystr",
+]
 
 [[package]]
 name = "unicase"
@@ -5166,6 +5615,16 @@ name = "unicode-xid"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
+
+[[package]]
+name = "universal-hash"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc1de2c688dc15305988b563c3854064043356019f97a4b46276fe734c4f07ea"
+dependencies = [
+ "crypto-common 0.1.7",
+ "subtle",
+]
 
 [[package]]
 name = "untrusted"
@@ -5851,6 +6310,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
 
 [[package]]
+name = "x25519-dalek"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7e468321c81fb07fa7f4c636c3972b9100f0346e5b6a9f2bd0603a52f7ed277"
+dependencies = [
+ "curve25519-dalek",
+ "rand_core 0.6.4",
+ "serde",
+ "zeroize",
+]
+
+[[package]]
 name = "xml5ever"
 version = "0.38.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5976,6 +6447,7 @@ version = "0.11.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "90f911cbc359ab6af17377d242225f4d75119aec87ea711a880987b18cd7b239"
 dependencies = [
+ "serde",
  "yoke",
  "zerofrom",
  "zerovec-derive",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -91,6 +91,9 @@ serde_yml = "0.0.12"
 htmd = "0.5"
 dom_smoothie = "0.17"
 
+# Encryption
+age = "0.11.3"
+
 # Error handling
 thiserror = "2.0"
 

--- a/packages/aether-auth/Cargo.toml
+++ b/packages/aether-auth/Cargo.toml
@@ -24,7 +24,9 @@ keyring = [
 mcp = ["dep:rmcp", "dep:url"]
 
 [dependencies]
+age = { workspace = true }
 async-trait = { workspace = true }
+dirs = { workspace = true }
 futures = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
@@ -49,3 +51,6 @@ windows-native-keyring-store = { workspace = true, optional = true }
 
 [target.'cfg(any(target_os = "linux", target_os = "freebsd"))'.dependencies]
 dbus-secret-service-keyring-store = { workspace = true, optional = true }
+
+[dev-dependencies]
+tempfile = { workspace = true }

--- a/packages/aether-auth/src/encrypted_file.rs
+++ b/packages/aether-auth/src/encrypted_file.rs
@@ -1,0 +1,282 @@
+use crate::credential::{OAuthCredential, OAuthCredentialStorage};
+use crate::error::OAuthError;
+use age::scrypt::Identity;
+use age::secrecy::SecretString;
+use age::{Decryptor, Encryptor};
+use async_trait::async_trait;
+use dirs::home_dir;
+use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
+use std::env::var;
+use std::io::{Read, Write};
+use std::iter::once;
+use std::path::{Path, PathBuf};
+use std::sync::Mutex;
+
+const DEFAULT_PASSWORD_ENV: &str = "AETHER_CREDENTIALS_PASSWORD";
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct CredentialStore {
+    credentials: HashMap<String, OAuthCredential>,
+}
+
+pub struct EncryptedFileOAuthCredentialStorage {
+    path: PathBuf,
+    passphrase: String,
+    write_guard: Mutex<()>,
+}
+
+impl EncryptedFileOAuthCredentialStorage {
+    pub fn new(path: PathBuf, passphrase: String) -> Self {
+        Self { path, passphrase, write_guard: Mutex::new(()) }
+    }
+
+    pub fn from_settings(path: Option<PathBuf>, password_env: Option<&str>) -> Result<Self, OAuthError> {
+        let path = path.map_or_else(default_path, Ok)?;
+        let env_var = password_env.unwrap_or(DEFAULT_PASSWORD_ENV);
+        let passphrase = var(env_var).ok().filter(|pass| !pass.is_empty()).ok_or_else(|| {
+            OAuthError::CredentialStore(format!(
+                "Encrypted file credential store requires a passphrase. \
+                     Set the {env_var} environment variable or configure a custom `passwordEnv` in settings."
+            ))
+        })?;
+
+        Ok(Self::new(path, passphrase))
+    }
+
+    fn encrypt(plaintext: &[u8], passphrase: &str) -> Result<Vec<u8>, OAuthError> {
+        let fail = |e| OAuthError::CredentialStore(format!("Encryption failed: {e}"));
+
+        let mut ciphertext = Vec::new();
+        let mut writer = Encryptor::with_user_passphrase(SecretString::from(passphrase))
+            .wrap_output(&mut ciphertext)
+            .map_err(fail)?;
+        writer.write_all(plaintext).map_err(fail)?;
+        writer.finish().map_err(fail)?;
+
+        Ok(ciphertext)
+    }
+
+    fn decrypt(ciphertext: &[u8], passphrase: &str) -> Result<Vec<u8>, OAuthError> {
+        let decryptor = Decryptor::new(ciphertext)
+            .map_err(|e| OAuthError::CredentialStore(format!("Invalid encrypted file: {e}")))?;
+
+        let mut reader =
+            decryptor.decrypt(once(&Identity::new(SecretString::from(passphrase)) as &dyn age::Identity)).map_err(
+                |e| OAuthError::CredentialStore(format!("Decryption failed — wrong passphrase or corrupted file: {e}")),
+            )?;
+
+        let mut plaintext = Vec::new();
+        reader
+            .read_to_end(&mut plaintext)
+            .map_err(|e| OAuthError::CredentialStore(format!("Decryption failed: {e}")))?;
+
+        Ok(plaintext)
+    }
+
+    fn load(&self) -> Result<CredentialStore, OAuthError> {
+        if !self.path.exists() {
+            return Ok(CredentialStore { credentials: HashMap::new() });
+        }
+
+        let bytes = std::fs::read(&self.path)?;
+        if bytes.is_empty() {
+            return Ok(CredentialStore { credentials: HashMap::new() });
+        }
+
+        let plaintext = Self::decrypt(&bytes, &self.passphrase)?;
+        serde_json::from_slice(&plaintext)
+            .map_err(|e| OAuthError::CredentialStore(format!("Invalid credential data: {e}")))
+    }
+
+    fn update(&self, mutate: impl FnOnce(&mut CredentialStore)) -> Result<(), OAuthError> {
+        let _guard = self
+            .write_guard
+            .lock()
+            .map_err(|_| OAuthError::CredentialStore("Failed to acquire write lock on credential store".to_string()))?;
+
+        let mut store = self.load()?;
+        mutate(&mut store);
+
+        let plaintext = serde_json::to_vec(&store)
+            .map_err(|e| OAuthError::CredentialStore(format!("Failed to serialize credentials: {e}")))?;
+
+        let ciphertext = Self::encrypt(&plaintext, &self.passphrase)?;
+        write_atomic(&self.path, &ciphertext)
+    }
+}
+
+fn default_path() -> Result<PathBuf, OAuthError> {
+    home_dir().map(|home| home.join(".aether").join("credentials.enc")).ok_or_else(|| {
+        OAuthError::CredentialStore(
+            "Could not determine the home directory for the encrypted credential file".to_string(),
+        )
+    })
+}
+
+fn write_atomic(path: &Path, data: &[u8]) -> Result<(), OAuthError> {
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent)?;
+    }
+
+    let temp_path = path.with_extension("tmp");
+
+    {
+        let mut file = std::fs::File::create(&temp_path)?;
+        file.write_all(data)?;
+        file.sync_all()?;
+    }
+
+    std::fs::rename(&temp_path, path)?;
+
+    Ok(())
+}
+
+#[async_trait]
+impl OAuthCredentialStorage for EncryptedFileOAuthCredentialStorage {
+    async fn load_credential(&self, key: &str) -> Result<Option<OAuthCredential>, OAuthError> {
+        let store = self.load()?;
+        Ok(store.credentials.get(key).cloned())
+    }
+
+    async fn save_credential(&self, key: &str, credential: OAuthCredential) -> Result<(), OAuthError> {
+        self.update(|store| {
+            store.credentials.insert(key.to_string(), credential);
+        })
+    }
+
+    async fn delete_credential(&self, key: &str) -> Result<(), OAuthError> {
+        self.update(|store| {
+            store.credentials.remove(key);
+        })
+    }
+
+    fn has_credential(&self, key: &str) -> bool {
+        self.load().is_ok_and(|store| store.credentials.contains_key(key))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn save_then_load_round_trips() {
+        let store = temp_store("correct-passphrase");
+        let cred = test_credential();
+
+        store.save_credential("server-1", cred.clone()).await.unwrap();
+        let loaded = store.load_credential("server-1").await.unwrap().unwrap();
+
+        assert_eq!(loaded.client_id, "client_1");
+        assert_eq!(loaded.access_token, "tok_abc");
+        assert_eq!(loaded.refresh_token.as_deref(), Some("ref_xyz"));
+        assert_eq!(loaded.granted_scopes, vec!["scope1"]);
+    }
+
+    #[tokio::test]
+    async fn load_returns_none_for_missing_key() {
+        let store = temp_store("pass");
+        assert!(store.load_credential("nonexistent").await.unwrap().is_none());
+    }
+
+    #[tokio::test]
+    async fn delete_removes_credential() {
+        let store = temp_store("pass");
+        store.save_credential("server-1", test_credential()).await.unwrap();
+        assert!(store.has_credential("server-1"));
+
+        store.delete_credential("server-1").await.unwrap();
+        assert!(!store.has_credential("server-1"));
+    }
+
+    #[tokio::test]
+    async fn wrong_passphrase_fails_to_load() {
+        let store = temp_store("correct-pass");
+        store.save_credential("server-1", test_credential()).await.unwrap();
+
+        let wrong_store = EncryptedFileOAuthCredentialStorage::new(store.path.clone(), "wrong-pass".to_string());
+
+        let err = wrong_store.load_credential("server-1").await.unwrap_err();
+        let msg = err.to_string();
+        assert!(msg.contains("Decryption failed"), "Expected decryption error, got: {msg}");
+    }
+
+    #[tokio::test]
+    async fn multiple_credentials_are_isolated() {
+        let store = temp_store("pass");
+
+        let cred_a = OAuthCredential {
+            client_id: "a".to_string(),
+            access_token: "token_a".to_string(),
+            refresh_token: None,
+            expires_at: None,
+            granted_scopes: vec![],
+        };
+        let cred_b = OAuthCredential {
+            client_id: "b".to_string(),
+            access_token: "token_b".to_string(),
+            refresh_token: None,
+            expires_at: None,
+            granted_scopes: vec![],
+        };
+
+        store.save_credential("server-a", cred_a).await.unwrap();
+        store.save_credential("server-b", cred_b).await.unwrap();
+
+        let loaded_a = store.load_credential("server-a").await.unwrap().unwrap();
+        let loaded_b = store.load_credential("server-b").await.unwrap().unwrap();
+
+        assert_eq!(loaded_a.access_token, "token_a");
+        assert_eq!(loaded_b.access_token, "token_b");
+    }
+
+    #[tokio::test]
+    async fn save_overwrites_existing_credential() {
+        let store = temp_store("pass");
+        let cred_v1 = OAuthCredential {
+            client_id: "c".to_string(),
+            access_token: "v1".to_string(),
+            refresh_token: None,
+            expires_at: None,
+            granted_scopes: vec![],
+        };
+        let cred_v2 = OAuthCredential {
+            client_id: "c".to_string(),
+            access_token: "v2".to_string(),
+            refresh_token: None,
+            expires_at: None,
+            granted_scopes: vec![],
+        };
+
+        store.save_credential("server", cred_v1).await.unwrap();
+        store.save_credential("server", cred_v2).await.unwrap();
+
+        let loaded = store.load_credential("server").await.unwrap().unwrap();
+        assert_eq!(loaded.access_token, "v2");
+    }
+
+    #[test]
+    fn encrypt_decrypt_round_trips() {
+        let plaintext = b"hello, world!";
+        let ciphertext = EncryptedFileOAuthCredentialStorage::encrypt(plaintext, "passphrase").unwrap();
+        let decrypted = EncryptedFileOAuthCredentialStorage::decrypt(&ciphertext, "passphrase").unwrap();
+        assert_eq!(decrypted, plaintext);
+    }
+
+    fn test_credential() -> OAuthCredential {
+        OAuthCredential {
+            client_id: "client_1".to_string(),
+            access_token: "tok_abc".to_string(),
+            refresh_token: Some("ref_xyz".to_string()),
+            expires_at: Some(9_999_999_999_999),
+            granted_scopes: vec!["scope1".to_string()],
+        }
+    }
+
+    fn temp_store(passphrase: &str) -> EncryptedFileOAuthCredentialStorage {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.keep().join("creds.enc");
+        EncryptedFileOAuthCredentialStorage::new(path, passphrase.to_string())
+    }
+}

--- a/packages/aether-auth/src/lib.rs
+++ b/packages/aether-auth/src/lib.rs
@@ -2,12 +2,14 @@
 
 mod browser;
 mod credential;
+pub mod encrypted_file;
 pub mod error;
 mod fake;
 mod handler;
 
 pub use browser::{BrowserOAuthHandler, accept_oauth_callback, open_browser, wait_for_callback};
 pub use credential::{OAuthCredential, OAuthCredentialStorage, oauth_http_client};
+pub use encrypted_file::EncryptedFileOAuthCredentialStorage;
 pub use error::OAuthError;
 pub use fake::FakeOAuthCredentialStore;
 pub use handler::{OAuthCallback, OAuthHandler};

--- a/packages/aether-auth/src/oauth.md
+++ b/packages/aether-auth/src/oauth.md
@@ -6,6 +6,7 @@ OAuth 2.0 authentication primitives for the Aether agent framework.
 - [`BrowserOAuthHandler`] -- Default implementation that opens the system browser and listens on a dynamic local port.
 - [`OAuthCredentialStorage`] -- Trait for persisting OAuth credentials keyed by provider ID, MCP server ID, or another credential key.
 - [`OsKeyringStore`] -- OS-keychain-backed [`OAuthCredentialStorage`] (macOS Keychain, Windows Credential Manager, Linux/FreeBSD Secret Service). Available under the `keyring` feature.
+- [`EncryptedFileOAuthCredentialStorage`] -- File-backed [`OAuthCredentialStorage`] that encrypts the file with [`age`](https://docs.rs/age). The passphrase is read from an environment variable.
 - [`FakeOAuthCredentialStore`] -- In-memory storage for tests.
 
 Behind the `mcp` feature:

--- a/packages/aether-cli/src/acp/mod.rs
+++ b/packages/aether-cli/src/acp/mod.rs
@@ -25,6 +25,7 @@ use crate::provider_connection_args::ProviderConnectionArgs;
 use crate::settings_args::SettingsSourceArgs;
 use agent_client_protocol as acp;
 use llm::ReasoningEffort;
+use std::env::current_dir;
 use std::sync::Arc;
 use std::{fs::create_dir_all, path::PathBuf};
 use thiserror::Error;
@@ -32,15 +33,10 @@ use tracing::info;
 use tracing_appender::rolling::daily;
 use tracing_subscriber::EnvFilter;
 
-use aether_auth::{FakeOAuthCredentialStore, OAuthCredentialStorage, OsKeyringStore};
+use crate::credentials::build_oauth_credential_store;
+use aether_auth::OAuthError;
 use session_factory::InitialSessionSelection;
 use session_store::SessionStore;
-
-#[derive(Clone, Copy, Debug, Eq, PartialEq, clap::ValueEnum)]
-pub enum OAuthCredentialStoreKind {
-    Keyring,
-    Memory,
-}
 
 #[derive(clap::Args, Debug)]
 pub struct AcpArgs {
@@ -66,10 +62,6 @@ pub struct AcpArgs {
 
     #[command(flatten)]
     pub settings_source: SettingsSourceArgs,
-
-    /// OAuth credential backend to use. Use `memory` for tests to avoid OS keychain access.
-    #[clap(long, value_enum, default_value_t = OAuthCredentialStoreKind::Keyring)]
-    pub credential_store: OAuthCredentialStoreKind,
 }
 
 /// Outcome of running the ACP server successfully.
@@ -84,6 +76,9 @@ pub enum AcpRunOutcome {
 pub enum AcpRunError {
     #[error("ACP protocol error: {0}")]
     Protocol(#[from] acp::Error),
+
+    #[error("Failed to initialize OAuth credential store: {0}")]
+    CredentialStore(#[from] OAuthError),
 }
 
 pub async fn run_acp(args: AcpArgs) -> Result<AcpRunOutcome, AcpRunError> {
@@ -100,7 +95,8 @@ pub async fn run_acp(args: AcpArgs) -> Result<AcpRunOutcome, AcpRunError> {
     };
     let session_store =
         SessionStore::new().map_or_else(|e| panic!("Failed to initialize session store: {e}"), Arc::new);
-    let oauth_credential_store = oauth_credential_store(args.credential_store);
+    let cwd = current_dir().unwrap_or_else(|_| PathBuf::from("."));
+    let oauth_credential_store = build_oauth_credential_store(&args.settings_source, &cwd)?;
     let provider_connections = args.provider_connection.into_overrides();
     let state = Arc::new(AcpState::new(AcpStateConfig {
         session_store,
@@ -116,13 +112,6 @@ pub async fn run_acp(args: AcpArgs) -> Result<AcpRunOutcome, AcpRunError> {
     match connect_result {
         Ok(()) => Ok(AcpRunOutcome::CleanDisconnect),
         Err(err) => Err(AcpRunError::Protocol(err)),
-    }
-}
-
-fn oauth_credential_store(kind: OAuthCredentialStoreKind) -> Arc<dyn OAuthCredentialStorage> {
-    match kind {
-        OAuthCredentialStoreKind::Keyring => Arc::new(OsKeyringStore::with_platform_store()),
-        OAuthCredentialStoreKind::Memory => Arc::new(FakeOAuthCredentialStore::new()),
     }
 }
 
@@ -166,13 +155,6 @@ mod tests {
         let err = TestCli::try_parse_from(["test", "--reasoning-effort", "high"])
             .expect_err("reasoning effort should require model");
         assert_eq!(err.kind(), clap::error::ErrorKind::MissingRequiredArgument);
-    }
-
-    #[test]
-    fn oauth_credential_store_memory_flag_is_allowed() {
-        let cli = TestCli::try_parse_from(["test", "--credential-store", "memory"])
-            .expect("memory credential store can be selected for tests");
-        assert_eq!(cli.args.credential_store, OAuthCredentialStoreKind::Memory);
     }
 
     #[test]

--- a/packages/aether-cli/src/credentials.rs
+++ b/packages/aether-cli/src/credentials.rs
@@ -1,0 +1,65 @@
+use crate::settings_args::SettingsSourceArgs;
+use aether_auth::{
+    EncryptedFileOAuthCredentialStorage, FakeOAuthCredentialStore, OAuthCredentialStorage, OAuthError, OsKeyringStore,
+};
+use aether_project::{AetherSettings, CredentialsStoreConfig};
+use std::path::Path;
+use std::sync::Arc;
+
+pub fn build_oauth_credential_store(
+    settings_source: &SettingsSourceArgs,
+    cwd: &Path,
+) -> Result<Arc<dyn OAuthCredentialStorage>, OAuthError> {
+    let result = match settings_source.source(cwd) {
+        Some(source) => AetherSettings::load(cwd, [source]),
+        None => AetherSettings::load_default(cwd),
+    };
+
+    let settings_source = match result {
+        Ok(settings) => Ok(settings.credentials_store),
+        Err(e) => Err(OAuthError::CredentialStore(format!("Failed to load settings for credential store config: {e}"))),
+    }?;
+
+    match settings_source {
+        Some(CredentialsStoreConfig::Memory) => Ok(Arc::new(FakeOAuthCredentialStore::new())),
+        Some(CredentialsStoreConfig::EncryptedFile { path, password_env }) => {
+            Ok(Arc::new(EncryptedFileOAuthCredentialStorage::from_settings(path, password_env.as_deref())?))
+        }
+        Some(CredentialsStoreConfig::Keyring) | None => Ok(Arc::new(OsKeyringStore::with_platform_store())),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn json_source(json: &str) -> SettingsSourceArgs {
+        SettingsSourceArgs { settings_json: Some(json.to_string()), settings_file: None }
+    }
+
+    #[test]
+    fn memory_store_selected_from_settings() {
+        let source = json_source(
+            r#"{
+                "credentialsStore": { "type": "memory" },
+                "agents": [{"name":"a","description":"a","model":"anthropic:claude-sonnet-4-5","userInvocable":true}]
+            }"#,
+        );
+
+        let store = build_oauth_credential_store(&source, Path::new(".")).unwrap();
+        assert!(!store.has_credential("anything"));
+    }
+
+    #[test]
+    fn encrypted_file_from_settings_propagates_missing_passphrase_error() {
+        let source = json_source(
+            r#"{
+                "credentialsStore": { "type": "encryptedFile", "passwordEnv": "AETHER_DEFINITELY_UNSET_VAR_98765" },
+                "agents": [{"name":"a","description":"a","model":"anthropic:claude-sonnet-4-5","userInvocable":true}]
+            }"#,
+        );
+
+        let result = build_oauth_credential_store(&source, Path::new("."));
+        assert!(result.is_err(), "missing passphrase should surface as a clean error");
+    }
+}

--- a/packages/aether-cli/src/error.rs
+++ b/packages/aether-cli/src/error.rs
@@ -1,3 +1,4 @@
+use aether_auth::OAuthError;
 use std::io;
 use thiserror::Error;
 
@@ -15,4 +16,6 @@ pub enum CliError {
     IoError(#[from] io::Error),
     #[error("Agent error: {0}")]
     AgentError(String),
+    #[error("Credential store error: {0}")]
+    CredentialStore(#[from] OAuthError),
 }

--- a/packages/aether-cli/src/headless/mod.rs
+++ b/packages/aether-cli/src/headless/mod.rs
@@ -9,10 +9,13 @@ use std::io::{IsTerminal, Read as _, stdin};
 use std::path::PathBuf;
 use std::process::ExitCode;
 
+use crate::credentials::build_oauth_credential_store;
 use crate::mcp_config_args::McpConfigArgs;
 use crate::provider_connection_args::ProviderConnectionArgs;
 use crate::resolve::resolve_agent_spec;
 use crate::settings_args::SettingsSourceArgs;
+use aether_auth::OAuthCredentialStorage;
+use std::sync::Arc;
 
 #[derive(Clone)]
 pub enum OutputFormat {
@@ -72,6 +75,7 @@ pub struct RunConfig {
     pub output: OutputFormat,
     pub verbose: bool,
     pub events: Vec<CliEventKind>,
+    pub oauth_credential_store: Arc<dyn OAuthCredentialStorage>,
 }
 
 pub async fn run_headless(args: HeadlessArgs) -> Result<ExitCode, CliError> {
@@ -88,6 +92,7 @@ pub async fn run_headless(args: HeadlessArgs) -> Result<ExitCode, CliError> {
     };
 
     let mcp_config_sources = args.mcp_config.sources(&cwd);
+    let oauth_credential_store = build_oauth_credential_store(&args.settings_source, &cwd)?;
 
     let config = RunConfig {
         prompt,
@@ -98,6 +103,7 @@ pub async fn run_headless(args: HeadlessArgs) -> Result<ExitCode, CliError> {
         output,
         verbose: args.verbose,
         events: args.events,
+        oauth_credential_store,
     };
 
     run::run(config).await

--- a/packages/aether-cli/src/headless/run.rs
+++ b/packages/aether-cli/src/headless/run.rs
@@ -13,6 +13,7 @@ pub async fn run(config: RunConfig) -> Result<ExitCode, CliError> {
 
     let agent = RuntimeBuilder::from_spec(config.cwd.clone(), config.spec)
         .mcp_sources(config.mcp_config_sources)
+        .oauth_credential_store(config.oauth_credential_store)
         .build(config.system_prompt.as_deref().map(Prompt::text), None)
         .await?;
 

--- a/packages/aether-cli/src/lib.rs
+++ b/packages/aether-cli/src/lib.rs
@@ -1,6 +1,7 @@
 #![doc = include_str!("../README.md")]
 
 pub mod acp;
+pub mod credentials;
 pub mod error;
 pub mod headless;
 pub mod init;

--- a/packages/aether-cli/src/runtime.rs
+++ b/packages/aether-cli/src/runtime.rs
@@ -176,7 +176,8 @@ impl RuntimeBuilder {
     }
 
     async fn spawn_mcp(self) -> Result<(AgentSpec, McpSpawnResult), CliError> {
-        let mut builder = mcp(&self.cwd).with_builtin_servers(self.cwd.clone(), &self.cwd);
+        let mut builder =
+            mcp(&self.cwd).with_builtin_servers(self.cwd.clone(), &self.cwd, self.oauth_credential_store.clone());
 
         if !self.extra_mcp_servers.is_empty() {
             builder = builder.with_servers(self.extra_mcp_servers);

--- a/packages/aether-cli/tests/acp_stdio.rs
+++ b/packages/aether-cli/tests/acp_stdio.rs
@@ -52,7 +52,13 @@ fn pipe_backed_stdio_serves_acp() -> TestResult {
 
 fn acp_command(log_dir: &std::path::Path) -> Command {
     let mut command = Command::new(env!("CARGO_BIN_EXE_aether"));
-    command.arg("acp").arg("--log-dir").arg(log_dir).arg("--credential-store").arg("memory").stderr(Stdio::null());
+    command
+        .arg("acp")
+        .arg("--log-dir")
+        .arg(log_dir)
+        .arg("--settings-json")
+        .arg(r#"{"credentialsStore":{"type":"memory"},"agents":[]}"#)
+        .stderr(Stdio::null());
     command
 }
 

--- a/packages/aether-project/src/aether_settings.rs
+++ b/packages/aether-project/src/aether_settings.rs
@@ -4,8 +4,34 @@ use crate::agent_config::AgentConfig;
 use crate::error::SettingsError;
 use crate::{McpSourceSpec, PromptSource};
 use llm::ProviderConnectionOverrides;
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
 use std::fs::read_to_string;
 use std::path::{Path, PathBuf};
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+#[serde(tag = "type", rename_all = "camelCase")]
+pub enum CredentialsStoreConfig {
+    /// Holds credentials in the OS keyring
+    Keyring,
+
+    /// Holds credentials in-memory and only for the lifetime of the
+    /// process. Intended for tests and ephemeral runs that must not touch the OS
+    /// keychain.
+    Memory,
+
+    /// Holds credentials in an encrypted file
+    EncryptedFile {
+        /// File path for the encrypted credential blob. Defaults to
+        /// `.aether/credentials.enc` in the Aether home directory when unset.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        path: Option<PathBuf>,
+        /// Environment variable name to read the passphrase from. Uses
+        /// `AETHER_CREDENTIALS_PASSWORD` when unset.
+        #[serde(default, skip_serializing_if = "Option::is_none", rename = "passwordEnv")]
+        password_env: Option<String>,
+    },
+}
 
 const PROJECT_SETTINGS_PATH: &str = ".aether/settings.json";
 const USER_SETTINGS_FILENAME: &str = "settings.json";
@@ -46,6 +72,10 @@ pub struct AetherSettings {
     /// applied to every agent unless overridden per-agent.
     #[serde(default, skip_serializing_if = "ProviderConnectionOverrides::is_empty")]
     pub providers: ProviderConnectionOverrides,
+    /// Credential storage backend for OAuth tokens. Defaults to the OS keyring
+    /// when unset.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub credentials_store: Option<CredentialsStoreConfig>,
     /// The agents defined for this project. At least one agent is required.
     #[schemars(length(min = 1))]
     pub agents: Vec<AgentConfig>,
@@ -98,6 +128,10 @@ impl AetherSettings {
             self.mcps = next.mcps;
         }
         self.providers.merge(next.providers);
+
+        if next.credentials_store.is_some() {
+            self.credentials_store = next.credentials_store;
+        }
 
         for next_agent in next.agents {
             if let Some(existing) = self.agents.iter_mut().find(|agent| agent.name.trim() == next_agent.name.trim()) {
@@ -912,5 +946,53 @@ mod tests {
             prompts: vec![PromptSource::file("PROMPT.md")],
             ..AgentConfig::default()
         }
+    }
+
+    #[test]
+    fn parses_credentials_store_keyring() {
+        let config = AetherSettings::try_from(
+            r#"{
+                "credentialsStore": { "type": "keyring" },
+                "agents": [{"name":"alpha","description":"Alpha","model":"anthropic:claude-sonnet-4-5","userInvocable":true}]
+            }"#,
+        )
+        .unwrap();
+
+        assert_eq!(config.credentials_store, Some(CredentialsStoreConfig::Keyring));
+    }
+
+    #[test]
+    fn parses_credentials_store_memory() {
+        let config = AetherSettings::try_from(
+            r#"{
+                "credentialsStore": { "type": "memory" },
+                "agents": [{"name":"alpha","description":"Alpha","model":"anthropic:claude-sonnet-4-5","userInvocable":true}]
+            }"#,
+        )
+        .unwrap();
+
+        assert_eq!(config.credentials_store, Some(CredentialsStoreConfig::Memory));
+    }
+
+    #[test]
+    fn parses_credentials_store_encrypted_file_with_options() {
+        let config = AetherSettings::try_from(
+            r#"{
+                "credentialsStore": {
+                    "type": "encryptedFile",
+                    "path": "/custom/creds.enc",
+                    "passwordEnv": "MY_SECRET"
+                },
+                "agents": [{"name":"alpha","description":"Alpha","model":"anthropic:claude-sonnet-4-5","userInvocable":true}]
+            }"#,
+        )
+        .unwrap();
+
+        assert!(matches!(
+            &config.credentials_store,
+            Some(CredentialsStoreConfig::EncryptedFile { path, password_env })
+            if path == &Some(PathBuf::from("/custom/creds.enc"))
+                && password_env == &Some("MY_SECRET".to_string())
+        ));
     }
 }

--- a/packages/aether-project/src/docs/aether_settings.md
+++ b/packages/aether-project/src/docs/aether_settings.md
@@ -40,3 +40,22 @@ A fuller setup with shared prompts, an MCP source, and a provider override:
   ]
 }
 ```
+
+An encrypted file credential store using a passphrase from the environment:
+
+```json
+{
+  "credentialsStore": {
+    "type": "encryptedFile",
+    "passwordEnv": "PASSWORD_ENV_VAR_NAME"
+  },
+  "agents": [
+    {
+      "name": "Build",
+      "description": "Builds features and fixes bugs",
+      "model": "anthropic:claude-sonnet-4-5-20250929",
+      "userInvocable": true
+    }
+  ]
+}
+```

--- a/packages/aether-project/src/lib.rs
+++ b/packages/aether-project/src/lib.rs
@@ -10,8 +10,8 @@ pub mod prompt_file;
 
 pub use aether_core::core::{PromptSource, PromptSourceError};
 pub use aether_settings::{
-    AetherSettings, AetherSettingsSource, SettingsFileSource, project_settings_exist, project_settings_path,
-    user_settings_exist, user_settings_path,
+    AetherSettings, AetherSettingsSource, CredentialsStoreConfig, SettingsFileSource, project_settings_exist,
+    project_settings_path, user_settings_exist, user_settings_path,
 };
 pub use agent_catalog::AgentCatalog;
 pub use agent_config::AgentConfig;

--- a/packages/aether-sdk/src/session.ts
+++ b/packages/aether-sdk/src/session.ts
@@ -39,7 +39,6 @@ export interface CommonAetherSessionOptions {
   cwd?: string;
   binaryPath?: string;
   env?: Record<string, string | undefined>;
-  oauthCredentialStore?: "platform" | "memory";
   logDir?: string;
   tools?: AetherToolGroups;
   externalMcpServers?: Record<string, ExternalMcpServerConfig>;
@@ -99,7 +98,6 @@ export class AetherSession {
       logDir,
       cwd = process.cwd(),
       env,
-      oauthCredentialStore,
       onPermissionRequest = autoApprovePermissions,
       onElicitation,
     } = options;
@@ -159,8 +157,6 @@ export class AetherSession {
         );
     }
     if (logDir) args.push("--log-dir", logDir);
-    if (oauthCredentialStore)
-      args.push("--credential-store", oauthCredentialStore);
 
     const spawned = spawnAetherProcess({
       command: resolved.command,

--- a/packages/aether-sdk/test/realBinary.e2e.test.ts
+++ b/packages/aether-sdk/test/realBinary.e2e.test.ts
@@ -25,6 +25,7 @@ describe("E2E tests", () => {
         logDir: cwd,
         settings: {
           agent: "Dummy",
+          credentialsStore: { type: "memory" },
           agents: [
             {
               name: "Dummy",
@@ -37,7 +38,6 @@ describe("E2E tests", () => {
             },
           ],
         },
-        oauthCredentialStore: "memory",
         env: {
           ...process.env,
           ANTHROPIC_API_KEY: "sk-ant-e2e-dummy",

--- a/packages/aether-sdk/test/session.integration.test.ts
+++ b/packages/aether-sdk/test/session.integration.test.ts
@@ -58,7 +58,7 @@ describe("AetherSession with a fake ACP agent", () => {
           inferenceProfileArn: arn,
         },
       },
-      oauthCredentialStore: "memory",
+      settings: { credentialsStore: { type: "memory" }, agents: [] },
       env: { PATH: process.env.PATH, FAKE_AETHER_LOG_FILE: logFile },
     });
 
@@ -71,8 +71,10 @@ describe("AetherSession with a fake ACP agent", () => {
       expect(argv.args).toContain("bedrock.url=http://127.0.0.1:8787");
       expect(argv.args).toContain("bedrock.auth=none");
       expect(argv.args).toContain(`bedrock.inference-profile-arn=${arn}`);
-      expect(argv.args).toContain("--credential-store");
-      expect(argv.args).toContain("memory");
+      const settingsJson = argv.args[argv.args.indexOf("--settings-json") + 1];
+      expect(JSON.parse(settingsJson).credentialsStore).toEqual({
+        type: "memory",
+      });
     } finally {
       await session.close();
       await rm(dir, { recursive: true, force: true });

--- a/packages/mcp-servers/src/setup.rs
+++ b/packages/mcp-servers/src/setup.rs
@@ -1,18 +1,30 @@
 use crate::{CodingMcp, CodingMcpArgs, DefaultCodingTools, PlanMcp, SkillsMcp, SubAgentsMcp, SurveyMcp, TasksMcp};
+use aether_auth::OAuthCredentialStorage;
 use aether_core::mcp::McpBuilder;
 use futures::FutureExt;
 use mcp_utils::ServiceExt;
 use std::path::{Path, PathBuf};
+use std::sync::Arc;
 use tracing::{debug, warn};
 
 #[doc = include_str!("docs/mcp_builder_ext.md")]
 pub trait McpBuilderExt {
     /// Registers all built-in in-memory MCP server factories and workspace roots.
-    fn with_builtin_servers(self, cwd: PathBuf, roots_path: &Path) -> Self;
+    fn with_builtin_servers(
+        self,
+        cwd: PathBuf,
+        roots_path: &Path,
+        oauth_credential_store: Option<Arc<dyn OAuthCredentialStorage>>,
+    ) -> Self;
 }
 
 impl McpBuilderExt for McpBuilder {
-    fn with_builtin_servers(self, cwd: PathBuf, roots_path: &Path) -> Self {
+    fn with_builtin_servers(
+        self,
+        cwd: PathBuf,
+        roots_path: &Path,
+        oauth_credential_store: Option<Arc<dyn OAuthCredentialStorage>>,
+    ) -> Self {
         self.register_in_memory_server(
             "coding",
             Box::new(move |args, _input| {
@@ -50,9 +62,16 @@ impl McpBuilderExt for McpBuilder {
         )
         .register_in_memory_server(
             "subagents",
-            Box::new(|args, _input| {
-                async move { SubAgentsMcp::from_args(args).expect("Failed to parse SubAgentsMcp args").into_dyn() }
-                    .boxed()
+            Box::new(move |args, _input| {
+                let store = oauth_credential_store.clone();
+                async move {
+                    let mut mcp = SubAgentsMcp::from_args(args).expect("Failed to parse SubAgentsMcp args");
+                    if let Some(store) = store {
+                        mcp = mcp.with_oauth_credential_store(store);
+                    }
+                    mcp.into_dyn()
+                }
+                .boxed()
             }),
         )
         .register_in_memory_server(

--- a/packages/mcp-servers/src/subagents/server.rs
+++ b/packages/mcp-servers/src/subagents/server.rs
@@ -1,4 +1,4 @@
-use aether_auth::{OAuthCredentialStorage, OsKeyringStore};
+use aether_auth::OAuthCredentialStorage;
 use aether_core::events::AgentMessage;
 use aether_core::events::SubAgentProgressPayload;
 use aether_project::{AetherSettings, AgentCatalog};
@@ -44,7 +44,7 @@ pub struct SubAgentsMcp {
     catalog: AgentCatalog,
     tool_router: ToolRouter<Self>,
     roots: Arc<RwLock<Vec<PathBuf>>>,
-    oauth_credential_store: Arc<dyn OAuthCredentialStorage>,
+    oauth_credential_store: Option<Arc<dyn OAuthCredentialStorage>>,
 }
 
 impl SubAgentsMcp {
@@ -64,12 +64,12 @@ impl SubAgentsMcp {
             catalog,
             tool_router: Self::tool_router(),
             roots: Arc::new(RwLock::new(vec![project_root])),
-            oauth_credential_store: Arc::new(OsKeyringStore::with_platform_store()),
+            oauth_credential_store: None,
         }
     }
 
     pub fn with_oauth_credential_store(mut self, store: Arc<dyn OAuthCredentialStorage>) -> Self {
-        self.oauth_credential_store = store;
+        self.oauth_credential_store = Some(store);
         self
     }
 
@@ -171,8 +171,7 @@ impl SubAgentsMcp {
         };
 
         let roots = self.roots.read().await.clone();
-        let executor = AgentExecutor::new(self.catalog.clone(), roots)
-            .with_oauth_credential_store(Arc::clone(&self.oauth_credential_store))
+        let executor = AgentExecutor::new(self.catalog.clone(), roots, self.oauth_credential_store.clone())
             .with_progress_callback(progress_callback);
 
         let output = executor.execute_tasks(args.tasks).await;

--- a/packages/mcp-servers/src/subagents/tools/spawn_subagent/mod.rs
+++ b/packages/mcp-servers/src/subagents/tools/spawn_subagent/mod.rs
@@ -1,5 +1,5 @@
 use crate::setup::McpBuilderExt;
-use aether_auth::{OAuthCredentialStorage, OsKeyringStore};
+use aether_auth::OAuthCredentialStorage;
 use aether_core::{
     agent_spec::McpConfigSource,
     core::{AgentBuilder, AgentHandle, Prompt},
@@ -157,23 +157,17 @@ pub struct AgentExecutor {
     catalog: Arc<AgentCatalog>,
     progress_callback: Option<Arc<ProgressCallback>>,
     roots: Vec<PathBuf>,
-    oauth_credential_store: Arc<dyn OAuthCredentialStorage>,
+    oauth_credential_store: Option<Arc<dyn OAuthCredentialStorage>>,
 }
 
 impl AgentExecutor {
-    /// Create a new `AgentExecutor` with the given agent catalog and workspace roots
-    pub fn new(catalog: AgentCatalog, roots: Vec<PathBuf>) -> Self {
-        Self {
-            catalog: Arc::new(catalog),
-            progress_callback: None,
-            roots,
-            oauth_credential_store: Arc::new(OsKeyringStore::with_platform_store()),
-        }
-    }
-
-    pub fn with_oauth_credential_store(mut self, store: Arc<dyn OAuthCredentialStorage>) -> Self {
-        self.oauth_credential_store = store;
-        self
+    /// Create a new `AgentExecutor` with the given agent catalog and workspace roots.
+    pub fn new(
+        catalog: AgentCatalog,
+        roots: Vec<PathBuf>,
+        oauth_credential_store: Option<Arc<dyn OAuthCredentialStorage>>,
+    ) -> Self {
+        Self { catalog: Arc::new(catalog), progress_callback: None, roots, oauth_credential_store }
     }
 
     /// Set a callback for receiving progress updates during agent execution
@@ -198,7 +192,7 @@ impl AgentExecutor {
         let catalog = Arc::clone(&self.catalog);
         let progress_callback = self.progress_callback.clone();
         let roots = self.roots.clone();
-        let oauth_credential_store = Arc::clone(&self.oauth_credential_store);
+        let oauth_credential_store = self.oauth_credential_store.clone();
         let handles: Vec<_> = tasks
             .into_iter()
             .enumerate()
@@ -207,7 +201,7 @@ impl AgentExecutor {
                 let catalog = Arc::clone(&catalog);
                 let progress_callback = progress_callback.clone();
                 let roots = roots.clone();
-                let oauth_credential_store = Arc::clone(&oauth_credential_store);
+                let oauth_credential_store = oauth_credential_store.clone();
                 spawn(async move {
                     execute_single_agent(task_id, task, catalog, progress_callback, roots, oauth_credential_store).await
                 })
@@ -247,7 +241,7 @@ async fn execute_single_agent(
     catalog: Arc<AgentCatalog>,
     progress_callback: Option<Arc<ProgressCallback>>,
     roots: Vec<PathBuf>,
-    oauth_credential_store: Arc<dyn OAuthCredentialStorage>,
+    oauth_credential_store: Option<Arc<dyn OAuthCredentialStorage>>,
 ) -> SubAgentResult {
     let agent_name = task.agent_name.clone();
 
@@ -258,7 +252,8 @@ async fn execute_single_agent(
             return Err(format!("Agent '{}' is not agent-invocable", task.agent_name));
         }
 
-        let mut spawn_result = spawn_mcps(&spec.mcp_config_sources, roots, catalog.project_root()).await?;
+        let mut spawn_result =
+            spawn_mcps(&spec.mcp_config_sources, roots, catalog.project_root(), oauth_credential_store.clone()).await?;
         let snapshot = spawn_result
             .block_until_ready()
             .await
@@ -341,8 +336,10 @@ async fn spawn_mcps(
     effective_mcp_config_sources: &[McpConfigSource],
     roots: Vec<PathBuf>,
     project_root: &Path,
+    oauth_credential_store: Option<Arc<dyn OAuthCredentialStorage>>,
 ) -> Result<McpSpawnResult, String> {
-    let mut builder = mcp(project_root).with_builtin_servers(project_root.to_path_buf(), project_root);
+    let mut builder =
+        mcp(project_root).with_builtin_servers(project_root.to_path_buf(), project_root, oauth_credential_store);
     builder = builder.with_roots(roots);
 
     if !effective_mcp_config_sources.is_empty() {
@@ -359,9 +356,9 @@ async fn spawn_agent(
     spec: aether_core::agent_spec::AgentSpec,
     mcp_tx: mpsc::Sender<McpCommand>,
     tools: Vec<ToolDefinition>,
-    oauth_credential_store: Arc<dyn OAuthCredentialStorage>,
+    oauth_credential_store: Option<Arc<dyn OAuthCredentialStorage>>,
 ) -> Result<(mpsc::Sender<Command>, mpsc::Receiver<AgentMessage>, AgentHandle), String> {
-    AgentBuilder::from_spec(&spec, vec![], Some(oauth_credential_store))
+    AgentBuilder::from_spec(&spec, vec![], oauth_credential_store)
         .await
         .map_err(|e| format!("Failed to build agent from spec: {e}"))?
         .tools(mcp_tx, tools)


### PR DESCRIPTION
This PR adds an encrypted file store that can be optionally configured in `setitings.json` that replaces the OS keyring store that's used by default. 

This services use-cases where the user might not want to grant aether access to the login key chain and/or headless agents that do not have access to a keychain. 

Fixes https://github.com/contextbridge/aether/issues/57 