### PR TITLE
fix(aether-cli): Default Plan edit unable to create/edit plan files

### DIFF
--- a/packages/aether-cli/src/init/build_settings.rs
+++ b/packages/aether-cli/src/init/build_settings.rs
@@ -86,7 +86,7 @@ fn build_batteries_included_preset(
     let display = provider.display_name();
     let plan = AgentConfig {
         name: "Plan".to_string(),
-        description: format!("{display} planner (read-only)"),
+        description: format!("{display} planner (read-only except plan files)"),
         model: recs.plan.model.to_string(),
         reasoning_effort: recs.plan.reasoning_effort,
         user_invocable: true,

--- a/packages/aether-cli/tests/run_init.rs
+++ b/packages/aether-cli/tests/run_init.rs
@@ -5,6 +5,7 @@ use llm::catalog::Provider;
 use llm::{LlmModel, ReasoningEffort};
 use mcp_servers::{CodingMcpArgs, PlanMcpArgs, SkillsMcpArgs, SubAgentsMcpArgs, TasksMcpArgs};
 use mcp_utils::client::McpServerConfig;
+use std::collections::BTreeMap;
 use std::path::Path;
 
 fn load(settings_path: &Path) -> AetherSettings {
@@ -72,7 +73,7 @@ fn writes_project_minimal_preset_for_codex() {
 }
 
 #[test]
-fn writes_project_batteries_preset_for_anthropic() {
+fn writes_project_batteries_preset_for_anthropic() -> Result<(), String> {
     let dir = tempfile::tempdir().unwrap();
     let outcome = apply_init(InitTarget::project(dir.path()), Provider::Anthropic, Preset::BatteriesIncluded, false)
         .expect("apply_init");
@@ -93,14 +94,20 @@ fn writes_project_batteries_preset_for_anthropic() {
     let plan = &settings.agents[0];
     assert_read_only_coding_tools(plan);
 
+    let plan_servers = inline_servers(&plan.mcps[0])?;
+    let plan_server_names: Vec<&str> = plan_servers.keys().map(String::as_str).collect();
+    assert_eq!(plan_server_names, vec!["coding", "plan", "skills", "subagents", "survey", "tasks"]);
+    assert!(!plan.tools.deny.iter().any(|tool| tool.starts_with("plan__")));
+
     let explore = &settings.agents[2];
     assert!(explore.agent_invocable);
     assert!(!explore.user_invocable);
     assert_eq!(explore.prompts[0].path(), Some(".aether/agents/codebase-explorer/AGENTS.md"));
     assert_read_only_coding_tools(explore);
-    let McpSourceSpec::Inline { servers } = &explore.mcps[0] else { panic!("explore MCPs should be inline") };
-    let server_names: Vec<&str> = servers.keys().map(String::as_str).collect();
+    let explore_servers = inline_servers(&explore.mcps[0])?;
+    let server_names: Vec<&str> = explore_servers.keys().map(String::as_str).collect();
     assert_eq!(server_names, vec!["coding"]);
+    Ok(())
 }
 
 #[test]
@@ -200,6 +207,13 @@ fn unsupported_provider_returns_error_without_writing_files() {
     assert!(matches!(err, InitError::UnsupportedProvider { provider: Provider::Gemini, .. }), "{err:?}");
     assert!(!dir.path().join("settings.json").exists(), "no settings.json should be written");
     assert!(!dir.path().join("SYSTEM.md").exists(), "no SYSTEM.md should be written");
+}
+
+fn inline_servers(spec: &McpSourceSpec) -> Result<&BTreeMap<String, McpServerConfig>, String> {
+    match spec {
+        McpSourceSpec::Inline { servers } => Ok(servers),
+        McpSourceSpec::File(_) => Err("expected inline MCPs, got a file spec".to_string()),
+    }
 }
 
 fn assert_read_only_coding_tools(agent: &aether_project::AgentConfig) {

--- a/packages/mcp-servers/Cargo.toml
+++ b/packages/mcp-servers/Cargo.toml
@@ -27,7 +27,9 @@ workspace = true
 [features]
 default = ["coding", "skills", "tasks", "subagents", "plan"]
 test-helpers = []
+file-ops = ["dep:thiserror"]
 coding = [
+    "file-ops",
     "dep:aether-project",
     "dep:aether-lspd",
     "dep:futures",
@@ -58,7 +60,7 @@ tasks = [
     "dep:tempfile",
     "dep:thiserror",
 ]
-plan = []
+plan = ["file-ops"]
 subagents = [
     "coding",
     "skills",

--- a/packages/mcp-servers/src/bin/stdio.rs
+++ b/packages/mcp-servers/src/bin/stdio.rs
@@ -1,4 +1,5 @@
 use clap::Parser;
+use mcp_servers::plan::default_plans_dir;
 use mcp_servers::{CodingMcp, CodingMcpArgs, PlanMcp, SkillsMcp, SubAgentsMcp, SurveyMcp, TasksMcp};
 use mcp_utils::ServiceExt;
 use rmcp::ServerHandler;
@@ -76,7 +77,7 @@ async fn main() -> Result<(), StdioError> {
             serve_stdio(server).await
         }
         "plan" => {
-            let server = PlanMcp::from_args(cli.args).map_err(StdioError::ServerArgs)?;
+            let server = PlanMcp::from_args(cli.args, default_plans_dir()).map_err(StdioError::ServerArgs)?;
             serve_stdio(server).await
         }
         other => Err(StdioError::UnknownServer(other.to_string())),

--- a/packages/mcp-servers/src/coding/error.rs
+++ b/packages/mcp-servers/src/coding/error.rs
@@ -5,6 +5,8 @@
 
 use thiserror::Error;
 
+pub use crate::file_ops::FileError;
+
 #[doc = include_str!("../docs/coding_error.md")]
 #[derive(Debug, Error)]
 pub enum CodingError {
@@ -39,38 +41,6 @@ pub enum CodingError {
     /// Tool not configured/available
     #[error("{0}")]
     NotConfigured(String),
-}
-
-/// Errors related to file operations (read, write, edit)
-#[derive(Debug, Error)]
-pub enum FileError {
-    /// File does not exist
-    #[error("File does not exist: {path}")]
-    NotFound { path: String },
-
-    /// Failed to read file
-    #[error("Failed to read file {path}: {reason}")]
-    ReadFailed { path: String, reason: String },
-
-    /// Failed to write file
-    #[error("Failed to write to file {path}: {reason}")]
-    WriteFailed { path: String, reason: String },
-
-    /// Failed to create parent directories
-    #[error("Failed to create directories for {path}: {reason}")]
-    CreateDirFailed { path: String, reason: String },
-
-    /// Invalid offset (must be 1-indexed)
-    #[error("Invalid offset for file {path}: offset must be 1-indexed (start from 1)")]
-    InvalidOffset { path: String },
-
-    /// String replacement failed (string not found)
-    #[error("String replacement failed for file {path}: string '{pattern}' not found")]
-    PatternNotFound { path: String, pattern: String },
-
-    /// IO error (wraps `std::io::Error`)
-    #[error("IO error: {0}")]
-    Io(#[from] std::io::Error),
 }
 
 /// Errors related to bash command execution

--- a/packages/mcp-servers/src/coding/tools/edit_file/mod.rs
+++ b/packages/mcp-servers/src/coding/tools/edit_file/mod.rs
@@ -1,9 +1,8 @@
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
-use tokio::fs::write;
+use std::path::Path;
 
-use crate::coding::error::FileError;
-use crate::coding::tools::file_io::read_text_file;
+use crate::file_ops::{FileError, edit_text_file};
 use mcp_utils::display_meta::{FileDiff, ToolDisplayMeta, ToolResultMeta, basename};
 
 #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
@@ -43,42 +42,23 @@ pub struct EditFileResponse {
 }
 
 pub async fn edit_file_contents(args: EditFileArgs) -> Result<EditFileResponse, FileError> {
-    // Read current file content
-    let current_content = read_text_file(&args.file_path).await?;
-
-    // Perform string replacement
-    let (updated_content, replacements_made) = if args.replace_all {
-        let count = current_content.matches(&args.old_string).count();
-        (current_content.replace(&args.old_string, &args.new_string), count)
-    } else if current_content.contains(&args.old_string) {
-        (current_content.replacen(&args.old_string, &args.new_string, 1), 1)
-    } else {
-        (current_content.clone(), 0)
+    let result =
+        edit_text_file(Path::new(&args.file_path), &args.old_string, &args.new_string, args.replace_all).await?;
+    let file_path = result.path.to_string_lossy().into_owned();
+    let total_lines = result.updated_content.lines().count();
+    let display_meta = ToolDisplayMeta::new("Edit file", basename(&file_path));
+    let file_diff = FileDiff {
+        path: file_path.clone(),
+        old_text: Some(result.original_content),
+        new_text: result.updated_content.clone(),
     };
-
-    // Check if any replacement actually occurred
-    if replacements_made == 0 {
-        return Err(FileError::PatternNotFound { path: args.file_path, pattern: args.old_string });
-    }
-
-    // Write back to file
-    if let Err(e) = write(&args.file_path, &updated_content).await {
-        return Err(FileError::WriteFailed { path: args.file_path, reason: e.to_string() });
-    }
-
-    // Count lines for response
-    let total_lines = updated_content.lines().count();
-
-    let display_meta = ToolDisplayMeta::new("Edit file", basename(&args.file_path));
-    let file_diff =
-        FileDiff { path: args.file_path.clone(), old_text: Some(current_content), new_text: updated_content.clone() };
 
     Ok(EditFileResponse {
         status: "success".to_string(),
-        file_path: args.file_path,
+        file_path,
         total_lines,
-        replacements_made,
-        content: updated_content,
+        replacements_made: result.replacements_made,
+        content: result.updated_content,
         meta: Some(ToolResultMeta::with_file_diff(display_meta, file_diff)),
     })
 }

--- a/packages/mcp-servers/src/coding/tools/file_io.rs
+++ b/packages/mcp-servers/src/coding/tools/file_io.rs
@@ -1,10 +1,1 @@
-use std::io::ErrorKind;
-
-use crate::coding::error::FileError;
-
-pub async fn read_text_file(path: &str) -> Result<String, FileError> {
-    tokio::fs::read_to_string(path).await.map_err(|error| match error.kind() {
-        ErrorKind::NotFound => FileError::NotFound { path: path.to_string() },
-        _ => FileError::ReadFailed { path: path.to_string(), reason: error.to_string() },
-    })
-}
+pub use crate::file_ops::read_text_file;

--- a/packages/mcp-servers/src/coding/tools/read_file/mod.rs
+++ b/packages/mcp-servers/src/coding/tools/read_file/mod.rs
@@ -1,9 +1,8 @@
+use crate::file_ops::{FileError, read_text_file};
+use mcp_utils::display_meta::{ToolDisplayMeta, ToolResultMeta, basename};
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
-
-use crate::coding::error::FileError;
-use crate::coding::tools::file_io::read_text_file;
-use mcp_utils::display_meta::{ToolDisplayMeta, ToolResultMeta, basename};
+use std::path::Path;
 
 const MAX_LINE_LENGTH: usize = 2000;
 const DEFAULT_LINE_LIMIT: usize = 2000;
@@ -42,7 +41,7 @@ pub struct ReadFileResult {
 }
 
 pub async fn read_file_contents(args: ReadFileArgs) -> Result<ReadFileResult, FileError> {
-    let content = read_text_file(&args.file_path).await?;
+    let content = read_text_file(Path::new(&args.file_path)).await?;
 
     let all_lines: Vec<&str> = content.lines().collect();
     let total_lines = all_lines.len();

--- a/packages/mcp-servers/src/coding/tools/write_file/mod.rs
+++ b/packages/mcp-servers/src/coding/tools/write_file/mod.rs
@@ -1,10 +1,8 @@
+use crate::file_ops::{FileError, write_text_file};
+use mcp_utils::display_meta::{FileDiff, ToolDisplayMeta, ToolResultMeta, basename};
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use std::path::Path;
-use tokio::fs::{create_dir_all, write};
-
-use crate::coding::error::FileError;
-use mcp_utils::display_meta::{FileDiff, ToolDisplayMeta, ToolResultMeta, basename};
 
 #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
 #[serde(rename_all = "camelCase")]
@@ -33,25 +31,15 @@ pub struct WriteFileResponse {
 
 pub async fn write_file_contents(args: WriteFileArgs) -> Result<WriteFileResponse, FileError> {
     let file_path = Path::new(&args.file_path);
-
-    if let Some(parent) = file_path.parent()
-        && let Err(e) = create_dir_all(parent).await
-    {
-        return Err(FileError::CreateDirFailed { path: args.file_path, reason: e.to_string() });
-    }
-
-    if let Err(e) = write(&args.file_path, &args.content).await {
-        return Err(FileError::WriteFailed { path: args.file_path, reason: e.to_string() });
-    }
-
-    let bytes_written = args.content.len();
-    let display_meta = ToolDisplayMeta::new("Write file", basename(&args.file_path));
-    let file_diff = FileDiff { path: args.file_path.clone(), old_text: None, new_text: args.content.clone() };
+    let result = write_text_file(file_path, &args.content).await?;
+    let file_path = result.path.to_string_lossy().into_owned();
+    let display_meta = ToolDisplayMeta::new("Write file", basename(&file_path));
+    let file_diff = FileDiff { path: file_path.clone(), old_text: None, new_text: args.content };
 
     Ok(WriteFileResponse {
-        message: format!("Successfully wrote {} bytes to {}", bytes_written, args.file_path),
-        bytes_written,
-        file_path: args.file_path,
+        message: format!("Successfully wrote {} bytes to {}", result.bytes_written, file_path),
+        bytes_written: result.bytes_written,
+        file_path,
         meta: Some(ToolResultMeta::with_file_diff(display_meta, file_diff)),
     })
 }

--- a/packages/mcp-servers/src/docs/plan_mcp.md
+++ b/packages/mcp-servers/src/docs/plan_mcp.md
@@ -1,6 +1,6 @@
 MCP server for plan review workflows.
 
-Exposes a single tool, `submit_plan`, that accepts an absolute markdown file path and returns `{ approved, feedback }`. The planner instructions themselves live in a user-customizable skill (e.g. `.aether/skills/plan/SKILL.md`) -- this server is just the review trigger.
+Exposes plan-specific file lifecycle tools: `write_plan`, `edit_plan`, and `submit_plan`. Agents address plans by a stable `planName`; the server maps that name to `<planName>-plan.md` inside the configured plans directory. The planner instructions themselves live in a user-customizable skill (e.g. `.aether/skills/plan/SKILL.md`).
 
 Reviews are collected via MCP elicitation: the client receives a form elicitation with `ui: "planReview"` metadata (plus the plan path and markdown body) and returns an approve/deny decision with optional feedback.
 
@@ -12,6 +12,8 @@ use mcp_servers::PlanMcp;
 let server = PlanMcp::new();
 ```
 
-# Tool provided
+# Tools provided
 
-- **`submit_plan`** -- Reads a markdown file and returns a structured approval decision.
+- **`write_plan`** -- Writes a markdown plan in the configured plans directory.
+- **`edit_plan`** -- Applies an exact string replacement to an existing plan.
+- **`submit_plan`** -- Reads a named plan and returns a structured approval decision.

--- a/packages/mcp-servers/src/file_ops.rs
+++ b/packages/mcp-servers/src/file_ops.rs
@@ -1,0 +1,93 @@
+use std::io::ErrorKind;
+use std::path::{Path, PathBuf};
+
+use thiserror::Error;
+use tokio::fs::{create_dir_all, write};
+
+#[derive(Debug, Error)]
+pub enum FileError {
+    #[error("File does not exist: {path}")]
+    NotFound { path: String },
+
+    #[error("Failed to read file {path}: {reason}")]
+    ReadFailed { path: String, reason: String },
+
+    #[error("Failed to write to file {path}: {reason}")]
+    WriteFailed { path: String, reason: String },
+
+    #[error("Failed to create directories for {path}: {reason}")]
+    CreateDirFailed { path: String, reason: String },
+
+    #[error("Invalid offset for file {path}: offset must be 1-indexed (start from 1)")]
+    InvalidOffset { path: String },
+
+    #[error("String replacement failed for file {path}: string '{pattern}' not found")]
+    PatternNotFound { path: String, pattern: String },
+
+    #[error("IO error: {0}")]
+    Io(#[from] std::io::Error),
+}
+
+pub struct WriteTextFileResult {
+    pub path: PathBuf,
+    pub bytes_written: usize,
+}
+
+pub struct EditTextFileResult {
+    pub path: PathBuf,
+    pub original_content: String,
+    pub updated_content: String,
+    pub replacements_made: usize,
+}
+
+pub async fn read_text_file(path: &Path) -> Result<String, FileError> {
+    tokio::fs::read_to_string(path).await.map_err(|error| match error.kind() {
+        ErrorKind::NotFound => FileError::NotFound { path: display_path(path) },
+        _ => FileError::ReadFailed { path: display_path(path), reason: error.to_string() },
+    })
+}
+
+pub async fn write_text_file(path: &Path, content: &str) -> Result<WriteTextFileResult, FileError> {
+    if let Some(parent) = path.parent()
+        && let Err(error) = create_dir_all(parent).await
+    {
+        return Err(FileError::CreateDirFailed { path: display_path(path), reason: error.to_string() });
+    }
+
+    if let Err(error) = write(path, content).await {
+        return Err(FileError::WriteFailed { path: display_path(path), reason: error.to_string() });
+    }
+
+    Ok(WriteTextFileResult { path: path.to_path_buf(), bytes_written: content.len() })
+}
+
+pub async fn edit_text_file(
+    path: &Path,
+    old_string: &str,
+    new_string: &str,
+    replace_all: bool,
+) -> Result<EditTextFileResult, FileError> {
+    let original_content = read_text_file(path).await?;
+    let (updated_content, replacements_made) = if replace_all {
+        let count = original_content.matches(old_string).count();
+        (original_content.replace(old_string, new_string), count)
+    } else if original_content.contains(old_string) {
+        (original_content.replacen(old_string, new_string, 1), 1)
+    } else {
+        (original_content.clone(), 0)
+    };
+
+    if replacements_made == 0 {
+        return Err(FileError::PatternNotFound { path: display_path(path), pattern: old_string.to_string() });
+    }
+
+    if let Err(error) = write(path, &updated_content).await {
+        return Err(FileError::WriteFailed { path: display_path(path), reason: error.to_string() });
+    }
+
+    Ok(EditTextFileResult { path: path.to_path_buf(), original_content, updated_content, replacements_made })
+}
+
+fn display_path(path: &Path) -> String {
+    path.to_string_lossy().into_owned()
+}

--- a/packages/mcp-servers/src/lib.rs
+++ b/packages/mcp-servers/src/lib.rs
@@ -5,6 +5,9 @@ pub mod setup;
 #[cfg(any(feature = "all", feature = "subagents"))]
 pub use setup::McpBuilderExt;
 
+#[cfg(feature = "file-ops")]
+pub mod file_ops;
+
 #[cfg(feature = "coding")]
 pub mod coding;
 

--- a/packages/mcp-servers/src/plan/README.md
+++ b/packages/mcp-servers/src/plan/README.md
@@ -1,45 +1,73 @@
 # PlanMcp
 
-MCP server that exposes a `submit_plan` tool that allows your agent to submit plans for user approval/feedback. By default, calling this tool triggers an MCP elicitation request to the client (e.g. Wisp renders a plan-review TUI panel).
+MCP server that exposes plan-specific tools for writing, editing, and submitting implementation plans for user approval/feedback. Agents refer to plans by `planName`; the server maps that name to `<planName>-plan.md` inside the configured plans directory.
 
-Alternatively, the server can hand the plan off to an arbitrary external CLI. Any trailing positional tokens in the `mcp.json` `args` array are treated as the submit command; the plan's absolute path is appended as its final argument, and its stdout is forwarded verbatim to the agent as `feedback`.
+By default, built-in Aether wiring stores plans at `${WORKSPACE}/docs/aether/plans`. Standalone `plan-mcp` defaults to `docs/aether/plans` relative to the server process cwd. Configure another directory with `--plans-dir`.
+
+Alternatively, the server can hand submitted plans off to an arbitrary external CLI. Any trailing positional tokens in the `mcp.json` `args` array are treated as the submit command; the resolved absolute plan path is appended as its final argument, and stdout is forwarded verbatim to the agent as `feedback`.
 
 ```json
 {
   "servers": {
     "plan": {
       "type": "in-memory",
-      "args": ["contextbridge", "plan", "--project", "foo"]
+      "args": ["--plans-dir", "docs/plans", "contextbridge", "plan", "--project", "foo"]
     }
   }
 }
 ```
 
-With the above config, calling `submit_plan` with `planPath=/tmp/plan.md` invokes:
+With the above config, calling `submit_plan` with `planName=docs-site-refresh` invokes:
 
 ```
-contextbridge plan --project foo /tmp/plan.md
+contextbridge plan --project foo <absolute-path-to>/docs/plans/docs-site-refresh-plan.md
 ```
 
 A non-zero exit code surfaces as a tool error; an exit code of `0` returns `{ "approved": false, "feedback": "<stdout>" }` regardless of stdout content — the agent reads the feedback and decides how to proceed.
-
-## Table of Contents
-
-<!-- START doctoc generated TOC please keep comment here to allow auto update -->
-<!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
-
-- [Tools](#tools)
-- [submit_plan](#submit_plan)
-  - [Input](#input)
-  - [Output](#output)
-
-<!-- END doctoc generated TOC please keep comment here to allow auto update -->
 
 ## Tools
 
 | Tool | Description |
 |------|-------------|
-| `submit_plan` | Submit a markdown plan file for review and approval. |
+| `write_plan` | Write a markdown plan file for a plan name. |
+| `edit_plan` | Edit an existing plan file by exact string replacement. |
+| `submit_plan` | Submit a named markdown plan file for review and approval. |
+
+## write_plan
+
+### Input
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `planName` | string | Stable plan identifier, using only letters, numbers, dashes, and underscores. |
+| `content` | string | Markdown plan body to write. |
+
+### Output
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `planName` | string | Plan identifier. |
+| `planPath` | string | Absolute path written by the server. |
+| `bytesWritten` | number | Number of bytes written. |
+
+## edit_plan
+
+### Input
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `planName` | string | Stable plan identifier originally passed to `write_plan`. |
+| `oldString` | string | Exact string to replace. |
+| `newString` | string | Replacement string. |
+| `replaceAll` | bool | Whether to replace all occurrences. Defaults to false. |
+
+### Output
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `planName` | string | Plan identifier. |
+| `planPath` | string | Absolute path edited by the server. |
+| `replacementsMade` | number | Number of replacements made. |
 
 ## submit_plan
 
@@ -47,7 +75,7 @@ A non-zero exit code surfaces as a tool error; an exit code of `0` returns `{ "a
 
 | Field | Type | Description |
 |-------|------|-------------|
-| `planPath` | string | Absolute path to a markdown plan file. |
+| `planName` | string | Stable plan identifier originally passed to `write_plan`. |
 
 ### Output
 

--- a/packages/mcp-servers/src/plan/default_prompt.md
+++ b/packages/mcp-servers/src/plan/default_prompt.md
@@ -20,7 +20,7 @@ First you must:
 
 ### Step 3: Generate Implementation Plan
 
-Generate an implementation plan and save it to a markdown file in a subdirectory named `docs/aether/plans/`. within the `cwd`. Save your plan file with a `-plan.md` suffix. Then present your plan to the user via the `submit_plan` tool. It must include the following sections:
+Generate an implementation plan and save it with the `write_plan` tool. Choose a short stable `planName` such as `auth-refactor`; the MCP server stores it in the configured plans directory. Then present your plan to the user via the `submit_plan` tool using the same `planName`. It must include the following sections:
 
 **Overview**
 - Clear problem statement
@@ -54,7 +54,7 @@ A markdown table that lists:
 
 ### Updating a plan
 
-The user may ask you to revise or update a plan based on feedback. Use your edit file tools to update the plan file and call the `submit_plan` tool again.
+The user may ask you to revise or update a plan based on feedback. Use the `edit_plan` tool with the plan's `planName` to update the plan file and call the `submit_plan` tool again.
 
 ## Task
 

--- a/packages/mcp-servers/src/plan/edit_plan_description.md
+++ b/packages/mcp-servers/src/plan/edit_plan_description.md
@@ -1,0 +1,3 @@
+# Edit Plan
+
+Edits an existing markdown implementation plan in Plan mode. Pass the same `planName` used with `write_plan`.

--- a/packages/mcp-servers/src/plan/mod.rs
+++ b/packages/mcp-servers/src/plan/mod.rs
@@ -1,3 +1,3 @@
 mod server;
 
-pub use server::{DEFAULT_PLAN_PROMPT, PlanMcp, PlanMcpArgs};
+pub use server::{DEFAULT_PLAN_PROMPT, DEFAULT_PLANS_DIR, PlanMcp, PlanMcpArgs, default_plans_dir};

--- a/packages/mcp-servers/src/plan/server.rs
+++ b/packages/mcp-servers/src/plan/server.rs
@@ -1,4 +1,6 @@
+use crate::file_ops::{FileError, edit_text_file, read_text_file, write_text_file};
 use clap::Parser;
+use mcp_utils::display_meta::{FileDiff, ToolDisplayMeta, ToolResultMeta, basename};
 use rmcp::{
     ErrorData as McpError, RoleServer, ServerHandler,
     handler::server::{
@@ -16,15 +18,16 @@ use rmcp::{
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
-use std::fmt::{Display, Formatter};
-use std::io::ErrorKind;
-use std::path::PathBuf;
+use std::env::current_dir;
+use std::path::{Path, PathBuf};
+use thiserror::Error;
 use tokio::fs::read_to_string;
 use tokio::process::Command;
 use utils::plan_review::{PlanReviewDecision, PlanReviewElicitationMeta};
 use utils::substitution::substitute_parameters;
 
 pub const DEFAULT_PLAN_PROMPT: &str = include_str!("./default_prompt.md");
+pub const DEFAULT_PLANS_DIR: &str = "docs/aether/plans";
 
 const DECISION: &str = "decision";
 const FEEDBACK: &str = "feedback";
@@ -34,6 +37,11 @@ const ARGUMENTS: &str = "ARGUMENTS";
 #[derive(Debug, Clone, Parser)]
 #[command(name = "plan-mcp")]
 pub struct PlanMcpArgs {
+    /// Directory where plan markdown files are written and read.
+    /// Defaults to `docs/aether/plans` relative to the server process cwd.
+    #[arg(long)]
+    pub plans_dir: Option<PathBuf>,
+
     /// Markdown file whose body is returned as the `plan` MCP prompt.
     /// When the flag is absent or the file is missing at invocation time,
     /// `DEFAULT_PLAN_PROMPT` is used instead.
@@ -62,6 +70,7 @@ impl PlanMcpArgs {
 #[derive(Clone)]
 pub struct PlanMcp {
     tool_router: ToolRouter<Self>,
+    plans_dir: PathBuf,
     prompt_file: Option<PathBuf>,
     submit_command: Vec<String>,
 }
@@ -69,12 +78,30 @@ pub struct PlanMcp {
 #[tool_router]
 impl PlanMcp {
     pub fn new() -> Self {
-        Self { tool_router: Self::tool_router(), prompt_file: None, submit_command: Vec::new() }
+        Self {
+            tool_router: Self::tool_router(),
+            plans_dir: default_plans_dir(),
+            prompt_file: None,
+            submit_command: Vec::new(),
+        }
     }
 
-    pub fn from_args(args: Vec<String>) -> Result<Self, String> {
-        let PlanMcpArgs { prompt_file, submit_command } = PlanMcpArgs::from_args(args)?;
-        Ok(Self { tool_router: Self::tool_router(), prompt_file, submit_command })
+    /// Builds a server from raw `mcp.json` args. `default_plans_dir` is used
+    /// when the caller did not pass `--plans-dir`; it lets the embedder anchor
+    /// plans at a workspace path that differs from the process cwd.
+    pub fn from_args(args: Vec<String>, default_plans_dir: PathBuf) -> Result<Self, String> {
+        let PlanMcpArgs { plans_dir, prompt_file, submit_command } = PlanMcpArgs::from_args(args)?;
+        Ok(Self {
+            tool_router: Self::tool_router(),
+            plans_dir: absolutize(plans_dir.unwrap_or(default_plans_dir)),
+            prompt_file,
+            submit_command,
+        })
+    }
+
+    pub fn with_plans_dir(mut self, path: PathBuf) -> Self {
+        self.plans_dir = absolutize(path);
+        self
     }
 
     pub fn with_prompt_file(mut self, path: PathBuf) -> Self {
@@ -87,6 +114,20 @@ impl PlanMcp {
         self
     }
 
+    #[doc = include_str!("./write_plan_description.md")]
+    #[tool]
+    pub async fn write_plan(&self, request: Parameters<WritePlanInput>) -> Result<Json<WritePlanOutput>, String> {
+        let Parameters(input) = request;
+        write_plan_file(&self.plans_dir, input).await.map(Json).map_err(|e| e.to_string())
+    }
+
+    #[doc = include_str!("./edit_plan_description.md")]
+    #[tool]
+    pub async fn edit_plan(&self, request: Parameters<EditPlanInput>) -> Result<Json<EditPlanOutput>, String> {
+        let Parameters(input) = request;
+        edit_plan_file(&self.plans_dir, input).await.map(Json).map_err(|e| e.to_string())
+    }
+
     #[doc = include_str!("./submit_plan_description.md")]
     #[tool]
     pub async fn submit_plan(
@@ -95,7 +136,7 @@ impl PlanMcp {
         context: RequestContext<RoleServer>,
     ) -> Result<Json<SubmitPlanOutput>, String> {
         let Parameters(input) = request;
-        let plan = Plan::load(&input.plan_path).await.map_err(|e| e.to_string())?;
+        let plan = Plan::load_by_name(&self.plans_dir, &input.plan_name).await.map_err(|e| e.to_string())?;
 
         if !self.submit_command.is_empty() {
             return run_external_submit(&plan, &self.submit_command).await.map(Json).map_err(|e| e.to_string());
@@ -208,10 +249,59 @@ impl ServerHandler for PlanMcp {
 
 #[derive(Debug, Deserialize, JsonSchema)]
 #[serde(rename_all = "camelCase")]
-pub struct SubmitPlanInput {
-    /// Absolute path to the markdown plan file to review.
-    #[serde(alias = "planPath")]
+pub struct WritePlanInput {
+    /// Stable plan identifier chosen by the agent, e.g. `auth-refactor`.
+    #[serde(alias = "planName")]
+    pub plan_name: String,
+    /// Markdown plan body to write.
+    pub content: String,
+}
+
+#[derive(Debug, Serialize, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct WritePlanOutput {
+    pub plan_name: String,
     pub plan_path: String,
+    pub bytes_written: usize,
+    #[serde(rename = "_meta", skip_serializing_if = "Option::is_none")]
+    #[schemars(skip)]
+    pub meta: Option<ToolResultMeta>,
+}
+
+#[derive(Debug, Deserialize, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct EditPlanInput {
+    /// Stable plan identifier originally passed to `write_plan`.
+    #[serde(alias = "planName")]
+    pub plan_name: String,
+    /// Exact string to find and replace in the plan file.
+    #[serde(alias = "old_string")]
+    pub old_string: String,
+    /// String to replace it with.
+    #[serde(alias = "new_string")]
+    pub new_string: String,
+    /// Replace all occurrences. Defaults to replacing the first occurrence.
+    #[serde(default, alias = "replace_all")]
+    pub replace_all: bool,
+}
+
+#[derive(Debug, Serialize, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct EditPlanOutput {
+    pub plan_name: String,
+    pub plan_path: String,
+    pub replacements_made: usize,
+    #[serde(rename = "_meta", skip_serializing_if = "Option::is_none")]
+    #[schemars(skip)]
+    pub meta: Option<ToolResultMeta>,
+}
+
+#[derive(Debug, Deserialize, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct SubmitPlanInput {
+    /// Stable plan identifier originally passed to `write_plan`.
+    #[serde(alias = "planName")]
+    pub plan_name: String,
 }
 
 #[derive(Debug, Serialize, JsonSchema)]
@@ -222,31 +312,67 @@ pub struct SubmitPlanOutput {
     pub feedback: Option<String>,
 }
 
-#[derive(Debug)]
-pub enum SubmitPlanError {
-    RelativePath,
-    Io { path: PathBuf, source: std::io::Error },
+#[derive(Debug, Error)]
+pub enum PlanError {
+    #[error("Invalid planName `{0}`; use only letters, numbers, dashes, and underscores")]
+    InvalidPlanName(String),
+
+    #[error(transparent)]
+    File(#[from] FileError),
+
+    #[error("Plan file is empty: {}", .0.display())]
     EmptyPlan(PathBuf),
+
+    #[error("submit_command is empty; expected at least a program name")]
     EmptySubmitCommand,
+
+    #[error("Failed to spawn submit command `{program}`: {source}")]
     SubmitCommandSpawn { program: String, source: std::io::Error },
+
+    #[error("Submit command `{program}` exited with {status}{}", stderr_suffix(.stderr))]
     SubmitCommandFailed { program: String, status: std::process::ExitStatus, stderr: String },
 }
+
+struct PlanName(String);
 
 struct Plan {
     path: PathBuf,
     content: String,
 }
 
-impl Plan {
-    async fn load(plan_path: &str) -> Result<Self, SubmitPlanError> {
-        let path = PathBuf::from(plan_path);
-        if !path.is_absolute() {
-            return Err(SubmitPlanError::RelativePath);
+impl PlanName {
+    fn parse(value: &str) -> Result<Self, PlanError> {
+        if Self::is_valid_plan_name(value) {
+            Ok(Self(value.to_string()))
+        } else {
+            Err(PlanError::InvalidPlanName(value.to_string()))
         }
+    }
 
-        let content = read_to_string(&path).await.map_err(|e| SubmitPlanError::from((e, path.clone())))?;
+    fn into_string(self) -> String {
+        self.0
+    }
+
+    fn file_name(&self) -> String {
+        format!("{}-plan.md", self.0)
+    }
+
+    fn is_valid_plan_name(value: &str) -> bool {
+        let is_boundary = |c: char| c == '-' || c == '_';
+        !value.is_empty()
+            && value.chars().all(|c| c.is_ascii_alphanumeric() || is_boundary(c))
+            && !value.starts_with(is_boundary)
+            && !value.ends_with(is_boundary)
+    }
+}
+
+impl Plan {
+    async fn load_by_name(plans_dir: &Path, plan_name: &str) -> Result<Self, PlanError> {
+        let plan_name = PlanName::parse(plan_name)?;
+        let path = plan_path(plans_dir, &plan_name);
+        let content = read_text_file(&path).await?;
         if content.trim().is_empty() {
-            return Err(SubmitPlanError::EmptyPlan(path));
+            return Err(PlanError::EmptyPlan(path));
         }
 
         Ok(Self { path, content })
@@ -259,55 +385,71 @@ impl Default for PlanMcp {
     }
 }
 
-impl From<(std::io::Error, PathBuf)> for SubmitPlanError {
-    fn from((source, path): (std::io::Error, PathBuf)) -> Self {
-        Self::Io { path, source }
+async fn write_plan_file(plans_dir: &Path, input: WritePlanInput) -> Result<WritePlanOutput, PlanError> {
+    let plan_name = PlanName::parse(&input.plan_name)?;
+    let path = plan_path(plans_dir, &plan_name);
+    if input.content.trim().is_empty() {
+        return Err(PlanError::EmptyPlan(path));
     }
+
+    let result = write_text_file(&path, &input.content).await?;
+    let plan_path = result.path.to_string_lossy().into_owned();
+    let display_meta = ToolDisplayMeta::new("Write plan", basename(&plan_path));
+    let file_diff = FileDiff { path: plan_path.clone(), old_text: None, new_text: input.content };
+
+    Ok(WritePlanOutput {
+        plan_name: plan_name.into_string(),
+        plan_path,
+        bytes_written: result.bytes_written,
+        meta: Some(ToolResultMeta::with_file_diff(display_meta, file_diff)),
+    })
 }
 
-impl Display for SubmitPlanError {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-        match self {
-            SubmitPlanError::RelativePath => {
-                write!(f, "planPath must be an absolute path")
-            }
-            SubmitPlanError::Io { path, source } => match source.kind() {
-                ErrorKind::NotFound => write!(f, "Plan file does not exist: {}", path.display()),
-                ErrorKind::InvalidData => write!(f, "Plan file is not valid UTF-8: {}", path.display()),
-                _ => write!(f, "Failed to read plan file {}: {source}", path.display()),
-            },
-            SubmitPlanError::EmptyPlan(path) => {
-                write!(f, "Plan file is empty: {}", path.display())
-            }
-            SubmitPlanError::EmptySubmitCommand => {
-                write!(f, "submit_command is empty; expected at least a program name")
-            }
-            SubmitPlanError::SubmitCommandSpawn { program, source } => {
-                write!(f, "Failed to spawn submit command `{program}`: {source}")
-            }
-            SubmitPlanError::SubmitCommandFailed { program, status, stderr } => {
-                let stderr_trimmed = stderr.trim();
-                if stderr_trimmed.is_empty() {
-                    write!(f, "Submit command `{program}` exited with {status}")
-                } else {
-                    write!(f, "Submit command `{program}` exited with {status}: {stderr_trimmed}")
-                }
-            }
-        }
-    }
+async fn edit_plan_file(plans_dir: &Path, input: EditPlanInput) -> Result<EditPlanOutput, PlanError> {
+    let plan_name = PlanName::parse(&input.plan_name)?;
+    let path = plan_path(plans_dir, &plan_name);
+    let result = edit_text_file(&path, &input.old_string, &input.new_string, input.replace_all).await?;
+    let plan_path = result.path.to_string_lossy().into_owned();
+    let display_meta = ToolDisplayMeta::new("Edit plan", basename(&plan_path));
+    let file_diff =
+        FileDiff { path: plan_path.clone(), old_text: Some(result.original_content), new_text: result.updated_content };
+
+    Ok(EditPlanOutput {
+        plan_name: plan_name.into_string(),
+        plan_path,
+        replacements_made: result.replacements_made,
+        meta: Some(ToolResultMeta::with_file_diff(display_meta, file_diff)),
+    })
 }
 
-async fn run_external_submit(plan: &Plan, command: &[String]) -> Result<SubmitPlanOutput, SubmitPlanError> {
-    let (program, extra_args) = command.split_first().ok_or(SubmitPlanError::EmptySubmitCommand)?;
+pub fn default_plans_dir() -> PathBuf {
+    absolutize(PathBuf::from(DEFAULT_PLANS_DIR))
+}
+
+fn plan_path(plans_dir: &Path, plan_name: &PlanName) -> PathBuf {
+    plans_dir.join(plan_name.file_name())
+}
+
+fn absolutize(path: PathBuf) -> PathBuf {
+    if path.is_absolute() { path } else { current_dir().unwrap_or_else(|_| PathBuf::from(".")).join(path) }
+}
+
+fn stderr_suffix(stderr: &str) -> String {
+    let trimmed = stderr.trim();
+    if trimmed.is_empty() { String::new() } else { format!(": {trimmed}") }
+}
+
+async fn run_external_submit(plan: &Plan, command: &[String]) -> Result<SubmitPlanOutput, PlanError> {
+    let (program, extra_args) = command.split_first().ok_or(PlanError::EmptySubmitCommand)?;
     let output = Command::new(program)
         .args(extra_args)
         .arg(&plan.path)
         .output()
         .await
-        .map_err(|source| SubmitPlanError::SubmitCommandSpawn { program: program.clone(), source })?;
+        .map_err(|source| PlanError::SubmitCommandSpawn { program: program.clone(), source })?;
 
     if !output.status.success() {
-        return Err(SubmitPlanError::SubmitCommandFailed {
+        return Err(PlanError::SubmitCommandFailed {
             program: program.clone(),
             status: output.status,
             stderr: String::from_utf8_lossy(&output.stderr).into_owned(),
@@ -321,78 +463,61 @@ async fn run_external_submit(plan: &Plan, command: &[String]) -> Result<SubmitPl
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::fs;
-    use tempfile::TempDir;
 
-    #[tokio::test]
-    async fn resolve_plan_rejects_relative_path() {
-        let result = Plan::load("./example-plan.md").await;
-        assert!(matches!(result, Err(SubmitPlanError::RelativePath)));
-    }
+    const TEST_DEFAULT: &str = "/workspace/docs/aether/plans";
 
-    #[tokio::test]
-    async fn resolve_plan_rejects_missing_file() {
-        let temp_dir = TempDir::new().expect("tempdir");
-        let path = temp_dir.path().join("missing-plan.md");
-
-        let result = Plan::load(path.to_string_lossy().as_ref()).await;
-        assert!(matches!(
-            result,
-            Err(SubmitPlanError::Io { source, .. }) if source.kind() == std::io::ErrorKind::NotFound
-        ));
-    }
-
-    #[tokio::test]
-    async fn resolve_plan_rejects_invalid_utf8() {
-        let temp_dir = TempDir::new().expect("tempdir");
-        let path = temp_dir.path().join("invalid-plan.md");
-        fs::write(&path, vec![0xff, 0xfe, 0xfd]).expect("write invalid bytes");
-
-        let result = Plan::load(path.to_string_lossy().as_ref()).await;
-        assert!(matches!(
-            result,
-            Err(SubmitPlanError::Io { source, .. }) if source.kind() == std::io::ErrorKind::InvalidData
-        ));
-    }
-
-    #[tokio::test]
-    async fn resolve_plan_rejects_empty_file() {
-        let temp_dir = TempDir::new().expect("tempdir");
-        let path = temp_dir.path().join("empty-plan.md");
-        fs::write(&path, "   \n\n\t").expect("write empty markdown");
-
-        let result = Plan::load(path.to_string_lossy().as_ref()).await;
-        assert!(matches!(result, Err(SubmitPlanError::EmptyPlan(_))));
+    fn default() -> PathBuf {
+        PathBuf::from(TEST_DEFAULT)
     }
 
     #[test]
     fn from_args_parses_prompt_file() {
-        let server = PlanMcp::from_args(vec!["--prompt-file".into(), "/tmp/plan.md".into()]).unwrap();
+        let server = PlanMcp::from_args(vec!["--prompt-file".into(), "/tmp/plan.md".into()], default()).unwrap();
         assert_eq!(server.prompt_file, Some(PathBuf::from("/tmp/plan.md")));
     }
 
     #[test]
-    fn from_args_empty_is_ok() {
-        let server = PlanMcp::from_args(vec![]).unwrap();
+    fn from_args_uses_default_plans_dir_when_flag_absent() {
+        let server = PlanMcp::from_args(vec![], default()).unwrap();
+        assert_eq!(server.plans_dir, default());
         assert_eq!(server.prompt_file, None);
         assert!(server.submit_command.is_empty());
     }
 
     #[test]
+    fn from_args_explicit_plans_dir_overrides_default() {
+        let server = PlanMcp::from_args(vec!["--plans-dir".into(), "/tmp/plans".into()], default()).unwrap();
+        assert_eq!(server.plans_dir, PathBuf::from("/tmp/plans"));
+    }
+
+    #[test]
+    fn from_args_keeps_submit_command_separate_from_plans_dir() {
+        let server = PlanMcp::from_args(
+            vec!["contextbridge".into(), "plan".into(), "--plans-dir".into(), "external".into()],
+            default(),
+        )
+        .unwrap();
+
+        assert_eq!(server.plans_dir, default());
+        assert_eq!(server.submit_command, vec!["contextbridge", "plan", "--plans-dir", "external"]);
+    }
+
+    #[test]
     fn from_args_parses_trailing_submit_command() {
-        let server =
-            PlanMcp::from_args(vec!["contextbridge".into(), "plan".into(), "--project".into(), "foo".into()]).unwrap();
+        let server = PlanMcp::from_args(
+            vec!["contextbridge".into(), "plan".into(), "--project".into(), "foo".into()],
+            default(),
+        )
+        .unwrap();
         assert_eq!(server.submit_command, vec!["contextbridge", "plan", "--project", "foo"]);
     }
 
     #[test]
     fn from_args_parses_prompt_file_followed_by_submit_command() {
-        let server = PlanMcp::from_args(vec![
-            "--prompt-file".into(),
-            "/tmp/plan.md".into(),
-            "contextbridge".into(),
-            "plan".into(),
-        ])
+        let server = PlanMcp::from_args(
+            vec!["--prompt-file".into(), "/tmp/plan.md".into(), "contextbridge".into(), "plan".into()],
+            default(),
+        )
         .unwrap();
         assert_eq!(server.prompt_file, Some(PathBuf::from("/tmp/plan.md")));
         assert_eq!(server.submit_command, vec!["contextbridge", "plan"]);

--- a/packages/mcp-servers/src/plan/submit_plan_description.md
+++ b/packages/mcp-servers/src/plan/submit_plan_description.md
@@ -2,9 +2,11 @@
 
 Submits a plan for user approval and/or feedback when in Plan mode.
 
+Pass the `planName` previously used with `write_plan` or `edit_plan`. The server reads the corresponding `<planName>-plan.md` file from the configured plans directory and presents it for review.
+
 Always call this tool when: 
 
 1. You're in plan mode
-2. You've completed a plan and are ready for the user to review it
+2. You've written or updated a plan and are ready for the user to review it
 
 Never call this tool when you're not in Plan mode.

--- a/packages/mcp-servers/src/plan/write_plan_description.md
+++ b/packages/mcp-servers/src/plan/write_plan_description.md
@@ -1,0 +1,3 @@
+# Write Plan
+
+Writes a markdown implementation plan in Plan mode. Pass a unique `planName` such as `auth-refactor`; this tool handles persisting the plan to disk for you. Use this after drafting a new plan.

--- a/packages/mcp-servers/src/setup.rs
+++ b/packages/mcp-servers/src/setup.rs
@@ -1,3 +1,4 @@
+use crate::plan::DEFAULT_PLANS_DIR;
 use crate::{CodingMcp, CodingMcpArgs, DefaultCodingTools, PlanMcp, SkillsMcp, SubAgentsMcp, SurveyMcp, TasksMcp};
 use aether_auth::OAuthCredentialStorage;
 use aether_core::mcp::McpBuilder;
@@ -25,6 +26,7 @@ impl McpBuilderExt for McpBuilder {
         roots_path: &Path,
         oauth_credential_store: Option<Arc<dyn OAuthCredentialStorage>>,
     ) -> Self {
+        let plan_cwd = cwd.clone();
         self.register_in_memory_server(
             "coding",
             Box::new(move |args, _input| {
@@ -80,8 +82,12 @@ impl McpBuilderExt for McpBuilder {
         )
         .register_in_memory_server(
             "plan",
-            Box::new(|args, _input| {
-                async move { PlanMcp::from_args(args).expect("Failed to parse PlanMcp args").into_dyn() }.boxed()
+            Box::new(move |args, _input| {
+                let default_plans_dir = plan_cwd.join(DEFAULT_PLANS_DIR);
+                async move {
+                    PlanMcp::from_args(args, default_plans_dir).expect("Failed to parse PlanMcp args").into_dyn()
+                }
+                .boxed()
             }),
         )
         .register_in_memory_server(

--- a/packages/mcp-servers/tests/plan_mcp.rs
+++ b/packages/mcp-servers/tests/plan_mcp.rs
@@ -17,9 +17,11 @@ use utils::plan_review::PlanReviewElicitationMeta;
 #[tokio::test]
 async fn submit_plan_attaches_plan_review_metadata_and_preserves_schema() {
     let temp_dir = TempDir::new().expect("create temp dir");
-    let plan_path = temp_dir.path().join("example-plan.md");
     let plan_content = "# Plan\n\nShip the feature.";
-    fs::write(&plan_path, plan_content).expect("write plan file");
+
+    let server = PlanMcp::new().with_plans_dir(temp_dir.path().to_path_buf());
+    let (_server_handle, client_handle) = connect(server, silent_client()).await.expect("connect client");
+    write_plan(&client_handle, "example", plan_content).await;
 
     let (event_tx, event_rx) = mpsc::channel(8);
     let client =
@@ -34,13 +36,14 @@ async fn submit_plan_attaches_plan_review_metadata_and_preserves_schema() {
         },
     );
 
-    let server = PlanMcp::new();
+    let server = PlanMcp::new().with_plans_dir(temp_dir.path().to_path_buf());
     let (_server_handle, client_handle) = connect(server, client).await.expect("connect client");
 
-    let result = submit_plan(&client_handle, plan_path.to_string_lossy().as_ref()).await;
+    let result = submit_plan(&client_handle, "example").await;
     assert_eq!(result["approved"], true);
     assert!(result["feedback"].is_null());
 
+    let plan_path = temp_dir.path().join("example-plan.md");
     let elicitation_request = task_handle.await.expect("script task panicked").expect("expected elicitation request");
     let CreateElicitationRequestParams::FormElicitationParams { meta, requested_schema, .. } = elicitation_request
     else {
@@ -57,6 +60,64 @@ async fn submit_plan_attaches_plan_review_metadata_and_preserves_schema() {
     assert_eq!(parsed_meta.ui, "planReview");
     assert_eq!(parsed_meta.plan_path, plan_path.display().to_string());
     assert_eq!(parsed_meta.markdown, plan_content);
+}
+
+#[tokio::test]
+async fn write_plan_creates_plan_file_from_name() {
+    let temp_dir = TempDir::new().expect("create temp dir");
+    let server = PlanMcp::new().with_plans_dir(temp_dir.path().to_path_buf());
+    let (_server_handle, client_handle) = connect(server, silent_client()).await.expect("connect client");
+    let result = write_plan(&client_handle, "auth-refactor", "# Plan\n\nDo it.").await;
+    let plan_path = temp_dir.path().join("auth-refactor-plan.md");
+
+    assert_eq!(result["planName"], "auth-refactor");
+    assert_eq!(result["planPath"], plan_path.display().to_string());
+    assert_eq!(fs::read_to_string(plan_path).expect("read plan"), "# Plan\n\nDo it.");
+}
+
+#[tokio::test]
+async fn edit_plan_updates_existing_plan_file_from_name() {
+    let temp_dir = TempDir::new().expect("create temp dir");
+    let server = PlanMcp::new().with_plans_dir(temp_dir.path().to_path_buf());
+    let (_server_handle, client_handle) = connect(server, silent_client()).await.expect("connect client");
+    write_plan(&client_handle, "auth-refactor", "# Plan\n\nOld approach.").await;
+
+    let result = edit_plan(&client_handle, "auth-refactor", "Old approach", "New approach", false).await;
+    let plan_path = temp_dir.path().join("auth-refactor-plan.md");
+    assert_eq!(result["replacementsMade"], 1);
+    assert_eq!(fs::read_to_string(plan_path).expect("read plan"), "# Plan\n\nNew approach.");
+}
+
+#[tokio::test]
+async fn plan_name_rejects_path_traversal() {
+    let temp_dir = TempDir::new().expect("create temp dir");
+    let server = PlanMcp::new().with_plans_dir(temp_dir.path().to_path_buf());
+    let (_server_handle, client_handle) = connect(server, silent_client()).await.expect("connect client");
+    let request = CallToolRequestParams::new("write_plan")
+        .with_arguments(json!({ "planName": "../escape", "content": "# Plan" }).as_object().unwrap().clone());
+    let result = client_handle.call_tool(request).await.expect("call write_plan");
+    assert!(result.is_error.unwrap_or(false), "expected invalid plan name to be rejected: {result:?}");
+}
+
+#[tokio::test]
+async fn write_plan_rejects_empty_content() {
+    let temp_dir = TempDir::new().expect("create temp dir");
+    let server = PlanMcp::new().with_plans_dir(temp_dir.path().to_path_buf());
+    let (_server_handle, client_handle) = connect(server, silent_client()).await.expect("connect client");
+    let request = CallToolRequestParams::new("write_plan")
+        .with_arguments(json!({ "planName": "blank", "content": "   \n\t" }).as_object().unwrap().clone());
+    let result = client_handle.call_tool(request).await.expect("call write_plan");
+
+    assert!(result.is_error.unwrap_or(false), "expected empty content to be rejected: {result:?}");
+}
+
+#[tokio::test]
+async fn submit_plan_errors_on_missing_plan() {
+    let temp_dir = TempDir::new().expect("create temp dir");
+    let server = PlanMcp::new().with_plans_dir(temp_dir.path().to_path_buf());
+    let (_server_handle, client_handle) = connect(server, silent_client()).await.expect("connect client");
+    let result = submit_plan_raw(&client_handle, "missing").await;
+    assert!(result.is_error.unwrap_or(false), "expected error for missing plan: {result:?}");
 }
 
 fn test_client_info() -> ClientInfo {
@@ -81,10 +142,10 @@ fn respond_to_elicitation_request(
 
 async fn submit_plan<T: Service<RoleClient>>(
     client: &RunningService<RoleClient, T>,
-    plan_path: &str,
+    plan_name: &str,
 ) -> serde_json::Value {
     let request = CallToolRequestParams::new("submit_plan")
-        .with_arguments(json!({ "planPath": plan_path }).as_object().unwrap().clone());
+        .with_arguments(json!({ "planName": plan_name }).as_object().unwrap().clone());
 
     let result = client.call_tool(request).await.expect("call submit_plan");
     let content = result.content.first().expect("Expected content");
@@ -94,11 +155,50 @@ async fn submit_plan<T: Service<RoleClient>>(
 
 async fn submit_plan_raw<T: Service<RoleClient>>(
     client: &RunningService<RoleClient, T>,
-    plan_path: &str,
+    plan_name: &str,
 ) -> CallToolResult {
     let request = CallToolRequestParams::new("submit_plan")
-        .with_arguments(json!({ "planPath": plan_path }).as_object().unwrap().clone());
+        .with_arguments(json!({ "planName": plan_name }).as_object().unwrap().clone());
     client.call_tool(request).await.expect("call submit_plan")
+}
+
+async fn write_plan<T: Service<RoleClient>>(
+    client: &RunningService<RoleClient, T>,
+    plan_name: &str,
+    content: &str,
+) -> serde_json::Value {
+    let request = CallToolRequestParams::new("write_plan")
+        .with_arguments(json!({ "planName": plan_name, "content": content }).as_object().unwrap().clone());
+
+    let result = client.call_tool(request).await.expect("call write_plan");
+    let content = result.content.first().expect("Expected content");
+    let text = content.as_text().expect("Expected text content");
+    serde_json::from_str(&text.text).expect("Invalid JSON response")
+}
+
+async fn edit_plan<T: Service<RoleClient>>(
+    client: &RunningService<RoleClient, T>,
+    plan_name: &str,
+    old_string: &str,
+    new_string: &str,
+    replace_all: bool,
+) -> serde_json::Value {
+    let request = CallToolRequestParams::new("edit_plan").with_arguments(
+        json!({
+            "planName": plan_name,
+            "oldString": old_string,
+            "newString": new_string,
+            "replaceAll": replace_all
+        })
+        .as_object()
+        .unwrap()
+        .clone(),
+    );
+
+    let result = client.call_tool(request).await.expect("call edit_plan");
+    let content = result.content.first().expect("Expected content");
+    let text = content.as_text().expect("Expected text content");
+    serde_json::from_str(&text.text).expect("Invalid JSON response")
 }
 
 fn silent_client() -> McpClient {
@@ -177,10 +277,10 @@ fn extract_user_text(message: &rmcp::model::PromptMessage) -> String {
 #[tokio::test]
 async fn submit_plan_runs_external_command_and_forwards_stdout_as_feedback() {
     let temp_dir = TempDir::new().expect("tempdir");
-    let plan_path = temp_dir.path().join("plan.md");
+    let plan_path = temp_dir.path().join("plan-plan.md");
     fs::write(&plan_path, "# Plan\n\nDo the thing.").expect("write plan");
 
-    let server = PlanMcp::new().with_submit_command(vec![
+    let server = PlanMcp::new().with_plans_dir(temp_dir.path().to_path_buf()).with_submit_command(vec![
         "/bin/sh".into(),
         "-c".into(),
         r#"printf "feedback for %s" "$1""#.into(),
@@ -188,7 +288,7 @@ async fn submit_plan_runs_external_command_and_forwards_stdout_as_feedback() {
     ]);
     let (_server, client) = connect(server, silent_client()).await.expect("connect");
 
-    let result = submit_plan(&client, plan_path.to_string_lossy().as_ref()).await;
+    let result = submit_plan(&client, "plan").await;
     assert_eq!(result["approved"], false);
     let feedback = result["feedback"].as_str().expect("feedback string");
     let expected = format!("feedback for {}", plan_path.display());
@@ -198,13 +298,14 @@ async fn submit_plan_runs_external_command_and_forwards_stdout_as_feedback() {
 #[tokio::test]
 async fn submit_plan_external_command_forwards_empty_stdout() {
     let temp_dir = TempDir::new().expect("tempdir");
-    let plan_path = temp_dir.path().join("plan.md");
+    let plan_path = temp_dir.path().join("plan-plan.md");
     fs::write(&plan_path, "# Plan").expect("write plan");
 
-    let server = PlanMcp::new().with_submit_command(vec!["/usr/bin/true".into()]);
+    let server =
+        PlanMcp::new().with_plans_dir(temp_dir.path().to_path_buf()).with_submit_command(vec!["/usr/bin/true".into()]);
     let (_server, client) = connect(server, silent_client()).await.expect("connect");
 
-    let result = submit_plan(&client, plan_path.to_string_lossy().as_ref()).await;
+    let result = submit_plan(&client, "plan").await;
     assert_eq!(result["approved"], false);
     assert_eq!(result["feedback"], "", "empty stdout should still be forwarded as empty feedback");
 }
@@ -212,25 +313,28 @@ async fn submit_plan_external_command_forwards_empty_stdout() {
 #[tokio::test]
 async fn submit_plan_external_command_errors_on_nonzero_exit() {
     let temp_dir = TempDir::new().expect("tempdir");
-    let plan_path = temp_dir.path().join("plan.md");
+    let plan_path = temp_dir.path().join("plan-plan.md");
     fs::write(&plan_path, "# Plan").expect("write plan");
 
-    let server = PlanMcp::new().with_submit_command(vec!["/usr/bin/false".into()]);
+    let server =
+        PlanMcp::new().with_plans_dir(temp_dir.path().to_path_buf()).with_submit_command(vec!["/usr/bin/false".into()]);
     let (_server, client) = connect(server, silent_client()).await.expect("connect");
 
-    let result = submit_plan_raw(&client, plan_path.to_string_lossy().as_ref()).await;
+    let result = submit_plan_raw(&client, "plan").await;
     assert!(result.is_error.unwrap_or(false), "expected tool error for nonzero exit: {result:?}");
 }
 
 #[tokio::test]
 async fn submit_plan_external_command_errors_on_missing_binary() {
     let temp_dir = TempDir::new().expect("tempdir");
-    let plan_path = temp_dir.path().join("plan.md");
+    let plan_path = temp_dir.path().join("plan-plan.md");
     fs::write(&plan_path, "# Plan").expect("write plan");
 
-    let server = PlanMcp::new().with_submit_command(vec!["aether-plan-mcp-does-not-exist-xyz".into()]);
+    let server = PlanMcp::new()
+        .with_plans_dir(temp_dir.path().to_path_buf())
+        .with_submit_command(vec!["aether-plan-mcp-does-not-exist-xyz".into()]);
     let (_server, client) = connect(server, silent_client()).await.expect("connect");
 
-    let result = submit_plan_raw(&client, plan_path.to_string_lossy().as_ref()).await;
+    let result = submit_plan_raw(&client, "plan").await;
     assert!(result.is_error.unwrap_or(false), "expected tool error for missing binary: {result:?}");
 }

--- a/website/src/content/docs/aether/built-in-servers/plan.mdx
+++ b/website/src/content/docs/aether/built-in-servers/plan.mdx
@@ -3,7 +3,7 @@ title: Plan
 description: Plan-mode prompts and markdown plan review.
 ---
 
-The `plan` server gives Aether a "plan mode".
+The `plan` server gives Aether a "plan mode" with scoped tools for writing, editing, and submitting markdown implementation plans. Agents address plans by `planName`; the server stores each plan as `<planName>-plan.md` in the configured plans directory.
 
 ## Configuration
 
@@ -12,6 +12,19 @@ The `plan` server gives Aether a "plan mode".
   "servers": {
     "plan": {
       "type": "in-memory"
+    }
+  }
+}
+```
+
+When registered through Aether's built-in server wiring, plans default to `${WORKSPACE}/docs/aether/plans`. Standalone `plan-mcp` defaults to `docs/aether/plans` relative to its process cwd. Pass `--plans-dir` to override it:
+
+```json title=".aether/mcp.json"
+{
+  "servers": {
+    "plan": {
+      "type": "in-memory",
+      "args": ["--plans-dir", "docs/plans"]
     }
   }
 }
@@ -36,7 +49,7 @@ The server advertises one MCP prompt named `plan`. It accepts one required `ARGU
 
 ## Submit command override
 
-Any trailing args after plan flags are treated as an external submit command. When `submit_plan` is called, Aether appends the absolute plan path as the final command argument and returns the command's stdout as feedback.
+Any trailing args after plan flags are treated as an external submit command. When `submit_plan` is called, Aether appends the resolved absolute plan path as the final command argument and returns the command's stdout as feedback.
 
 ```json title=".aether/mcp.json"
 {
@@ -53,19 +66,55 @@ Without a submit command, `submit_plan` uses MCP elicitation and the client disp
 
 ## Tools
 
-| Tool          | Description                                            |
-| ------------- | ------------------------------------------------------ |
-| `submit_plan` | Submit an absolute-path markdown plan file for review. |
+| Tool          | Description                                                   |
+| ------------- | ------------------------------------------------------------- |
+| `write_plan`  | Write a named markdown plan in the configured plans directory. |
+| `edit_plan`   | Edit a named plan by exact string replacement.                |
+| `submit_plan` | Submit a named markdown plan file for review.                 |
+
+## `write_plan`
+
+### Input
+
+| Field      | Type     | Description                                                              |
+| ---------- | -------- | ------------------------------------------------------------------------ |
+| `planName` | `string` | Stable plan identifier using only letters, numbers, dashes, underscores. |
+| `content`  | `string` | Markdown plan body.                                                      |
+
+### Output
+
+| Field          | Type     | Description                         |
+| -------------- | -------- | ----------------------------------- |
+| `planName`     | `string` | Plan identifier.                    |
+| `planPath`     | `string` | Absolute path written by the server. |
+| `bytesWritten` | `number` | Number of bytes written.            |
+
+## `edit_plan`
+
+### Input
+
+| Field        | Type      | Description                                          |
+| ------------ | --------- | ---------------------------------------------------- |
+| `planName`   | `string`  | Stable plan identifier originally used by the plan.  |
+| `oldString`  | `string`  | Exact string to replace.                             |
+| `newString`  | `string`  | Replacement string.                                  |
+| `replaceAll` | `boolean` | Replace every occurrence. Defaults to `false`.       |
+
+### Output
+
+| Field              | Type     | Description                        |
+| ------------------ | -------- | ---------------------------------- |
+| `planName`         | `string` | Plan identifier.                   |
+| `planPath`         | `string` | Absolute path edited by the server. |
+| `replacementsMade` | `number` | Number of replacements made.       |
 
 ## `submit_plan`
 
 ### Input
 
-| Field      | Type     | Description                                              |
-| ---------- | -------- | -------------------------------------------------------- |
-| `planPath` | `string` | Absolute path to the non-empty UTF-8 markdown plan file. |
-
-`plan_path` is accepted as an input alias.
+| Field      | Type     | Description                                         |
+| ---------- | -------- | --------------------------------------------------- |
+| `planName` | `string` | Stable plan identifier originally used by the plan. |
 
 ### Output
 
@@ -78,7 +127,7 @@ Without a submit command, `submit_plan` uses MCP elicitation and the client disp
 
 ```json
 {
-  "planPath": "/absolute/path/to/docs-site-refresh-plan.md"
+  "planName": "docs-site-refresh"
 }
 ```
 
@@ -99,9 +148,7 @@ Without a submit command, `submit_plan` uses MCP elicitation and the client disp
 
 ## Typical review flow
 
-1. The planner writes a markdown file, such as `feature-plan.md`.
-2. The planner calls `submit_plan` with the absolute file path.
+1. The planner calls `write_plan` with a stable plan name, such as `feature`.
+2. The planner calls `submit_plan` with the same `planName`.
 3. The client shows an approve / request-changes review form with the rendered markdown.
-4. The tool returns `{ approved, feedback }` so the planner can continue or revise the plan.
-
-A relative path, missing file, invalid UTF-8 file, or empty plan is rejected before review.
+4. If changes are requested, the planner calls `edit_plan` and then `submit_plan` again.


### PR DESCRIPTION
We recently added a default Plan agent that's generated via `aether settings init`. That agent was gimped because it didn't have any tools to create/edit a plan file on the filesystem.

This PR fixes that by giving the agent scoped tools to work with plan files, without exposing the ability to modify non-plan files on disk. 