### PR TITLE
feat(aether-cli): Settings init command now offers to load config fro…

### DIFF
--- a/packages/aether-cli/src/init/build_settings.rs
+++ b/packages/aether-cli/src/init/build_settings.rs
@@ -1,4 +1,5 @@
 use super::InitScope;
+use super::harness::HarnessIntegration;
 use super::recommendations::{ProviderRecommendations, recommended_for_provider};
 use aether_core::agent_spec::ToolFilter;
 use aether_project::{AetherSettings, AgentConfig, McpSourceSpec, PromptSource};
@@ -6,20 +7,10 @@ use llm::catalog::Provider;
 use mcp_utils::client::{InMemoryServerConfig, InMemoryType, McpServerConfig};
 
 const SYSTEM_PATH: &str = "SYSTEM.md";
-const PROJECT_AGENTS_PATH: &str = "${WORKSPACE}/AGENTS.md";
 const SYSTEM_MD: &str = include_str!("templates/SYSTEM.md");
 
 const EXPLORER_AGENTS_MD: &str = include_str!("templates/agents/codebase-explorer/AGENTS.md");
 const EXPLORER_AGENTS_PATH: &str = "agents/codebase-explorer/AGENTS.md";
-
-const SKILLS_ARGS: &[&str] = &[
-    "--dir",
-    "${AETHER_HOME}/skills",
-    "--dir",
-    "${WORKSPACE}/.aether/skills",
-    "--notes-dir",
-    "${WORKSPACE}/.aether/notes",
-];
 
 const READ_ONLY_DENIED_CODING_TOOLS: &[&str] =
     &["coding__bash", "coding__edit_file", "coding__lsp_rename", "coding__write_file"];
@@ -52,10 +43,11 @@ pub(crate) fn build_preset(
     provider: Provider,
     recs: &ProviderRecommendations,
     scope: InitScope,
+    harnesses: &[HarnessIntegration],
 ) -> ResolvedPreset {
     match preset {
         Preset::Minimal => minimal_preset(provider, recs, scope),
-        Preset::BatteriesIncluded => build_batteries_included_preset(provider, recs, scope),
+        Preset::BatteriesIncluded => batteries_included_preset(provider, recs, scope, harnesses),
     }
 }
 
@@ -67,7 +59,7 @@ fn minimal_preset(provider: Provider, recs: &ProviderRecommendations, scope: Ini
         model: recs.plan.model.to_string(),
         reasoning_effort: recs.plan.reasoning_effort,
         user_invocable: true,
-        mcps: vec![mcps(&[("coding", &[]), ("skills", SKILLS_ARGS)])],
+        mcps: vec![mcps(vec![("coding", vec![]), ("skills", skills_args(&[]))])],
         tools: ToolFilter { allow: vec!["coding__bash".to_string(), "skills__*".to_string()], deny: vec![] },
         ..AgentConfig::default()
     };
@@ -78,25 +70,29 @@ fn minimal_preset(provider: Provider, recs: &ProviderRecommendations, scope: Ini
     }
 }
 
-fn build_batteries_included_preset(
+fn batteries_included_preset(
     provider: Provider,
     recs: &ProviderRecommendations,
     scope: InitScope,
+    harnesses: &[HarnessIntegration],
 ) -> ResolvedPreset {
     let display = provider.display_name();
+    let coding = coding_args(harnesses);
+    let skills = skills_args(harnesses);
+
     let plan = AgentConfig {
         name: "Plan".to_string(),
         description: format!("{display} planner (read-only except plan files)"),
         model: recs.plan.model.to_string(),
         reasoning_effort: recs.plan.reasoning_effort,
         user_invocable: true,
-        mcps: vec![mcps(&[
-            ("plan", &[]),
-            ("coding", &[]),
-            ("skills", SKILLS_ARGS),
-            ("subagents", &[]),
-            ("tasks", &[]),
-            ("survey", &[]),
+        mcps: vec![mcps(vec![
+            ("plan", vec![]),
+            ("coding", coding.clone()),
+            ("skills", skills.clone()),
+            ("subagents", vec![]),
+            ("tasks", vec![]),
+            ("survey", vec![]),
         ])],
         tools: read_only_coding_tools(),
         ..AgentConfig::default()
@@ -108,12 +104,12 @@ fn build_batteries_included_preset(
         model: recs.build.model.to_string(),
         reasoning_effort: recs.build.reasoning_effort,
         user_invocable: true,
-        mcps: vec![mcps(&[
-            ("coding", &[]),
-            ("skills", SKILLS_ARGS),
-            ("subagents", &[]),
-            ("tasks", &[]),
-            ("survey", &[]),
+        mcps: vec![mcps(vec![
+            ("coding", coding.clone()),
+            ("skills", skills),
+            ("subagents", vec![]),
+            ("tasks", vec![]),
+            ("survey", vec![]),
         ])],
         ..AgentConfig::default()
     };
@@ -124,8 +120,8 @@ fn build_batteries_included_preset(
         model: recs.explore.model.to_string(),
         reasoning_effort: recs.explore.reasoning_effort,
         agent_invocable: true,
-        prompts: vec![PromptSource::file(settings_asset_path(scope, EXPLORER_AGENTS_PATH))],
-        mcps: vec![mcps(&[("coding", &[])])],
+        prompts: vec![PromptSource::file(scope.asset_path(EXPLORER_AGENTS_PATH))],
+        mcps: vec![mcps(vec![("coding", coding)])],
         tools: read_only_coding_tools(),
         ..AgentConfig::default()
     };
@@ -136,40 +132,67 @@ fn build_batteries_included_preset(
             TemplateFile { path: EXPLORER_AGENTS_PATH, body: EXPLORER_AGENTS_MD },
         ],
         settings: AetherSettings {
-            prompts: default_prompts(scope),
+            prompts: batteries_prompts(scope, harnesses),
             agents: vec![plan, build, explore],
             ..AetherSettings::default()
         },
     }
 }
 
-fn read_only_coding_tools() -> ToolFilter {
-    ToolFilter { allow: vec![], deny: READ_ONLY_DENIED_CODING_TOOLS.iter().map(|tool| (*tool).to_string()).collect() }
+fn skills_args(harnesses: &[HarnessIntegration]) -> Vec<String> {
+    let mut args = vec!["--dir".to_string(), "${AETHER_HOME}/skills".to_string()];
+    for harness in harnesses {
+        for dir in harness.skills_dirs() {
+            args.extend(["--dir".to_string(), dir]);
+        }
+    }
+
+    args.extend([
+        "--dir".to_string(),
+        "${WORKSPACE}/.aether/skills".to_string(),
+        "--notes-dir".to_string(),
+        "${WORKSPACE}/.aether/notes".to_string(),
+    ]);
+
+    args
+}
+
+fn coding_args(harnesses: &[HarnessIntegration]) -> Vec<String> {
+    let mut args = Vec::new();
+    for harness in harnesses {
+        for dir in harness.rules_dirs() {
+            args.extend(["--rules-dir".to_string(), dir]);
+        }
+    }
+    args
+}
+
+fn batteries_prompts(scope: InitScope, harnesses: &[HarnessIntegration]) -> Vec<PromptSource> {
+    let mut prompts = vec![PromptSource::file(scope.asset_path(SYSTEM_PATH))];
+    for harness in harnesses {
+        if let Some(source) = harness.prompt_source() {
+            prompts.push(source);
+        }
+    }
+
+    prompts
 }
 
 fn default_prompts(scope: InitScope) -> Vec<PromptSource> {
-    vec![
-        PromptSource::file(settings_asset_path(scope, SYSTEM_PATH)),
-        PromptSource::file(PROJECT_AGENTS_PATH).optional(),
-    ]
+    let mut prompts = vec![PromptSource::file(scope.asset_path(SYSTEM_PATH))];
+    prompts.extend(HarnessIntegration::Agents.prompt_source());
+    prompts
 }
 
-fn settings_asset_path(scope: InitScope, asset_rel_path: &str) -> String {
-    match scope {
-        InitScope::User => asset_rel_path.to_string(),
-        InitScope::Project => format!(".aether/{asset_rel_path}"),
-    }
-}
-
-fn mcps(servers: &[(&str, &[&str])]) -> McpSourceSpec {
+fn mcps(servers: Vec<(&str, Vec<String>)>) -> McpSourceSpec {
     let servers = servers
-        .iter()
+        .into_iter()
         .map(|(name, args)| {
             (
-                (*name).to_string(),
+                name.to_string(),
                 McpServerConfig::InMemory(InMemoryServerConfig {
                     type_: InMemoryType::InMemory,
-                    args: args.iter().map(|s| (*s).to_string()).collect(),
+                    args,
                     input: None,
                     proxy: false,
                 }),
@@ -177,4 +200,8 @@ fn mcps(servers: &[(&str, &[&str])]) -> McpSourceSpec {
         })
         .collect();
     McpSourceSpec::Inline { servers }
+}
+
+fn read_only_coding_tools() -> ToolFilter {
+    ToolFilter { allow: vec![], deny: READ_ONLY_DENIED_CODING_TOOLS.iter().map(|tool| (*tool).to_string()).collect() }
 }

--- a/packages/aether-cli/src/init/harness.rs
+++ b/packages/aether-cli/src/init/harness.rs
@@ -1,0 +1,49 @@
+use aether_project::PromptSource;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, clap::ValueEnum)]
+#[clap(rename_all = "kebab-case")]
+pub enum HarnessIntegration {
+    Claude,
+    Agents,
+}
+
+impl HarnessIntegration {
+    fn dir_name(self) -> &'static str {
+        match self {
+            Self::Claude => ".claude",
+            Self::Agents => ".agents",
+        }
+    }
+
+    fn file_name(self) -> &'static str {
+        match self {
+            Self::Claude => "CLAUDE",
+            Self::Agents => "AGENTS",
+        }
+    }
+
+    pub fn title(self) -> String {
+        format!("{}.md + {}/", self.file_name(), self.dir_name())
+    }
+
+    pub fn description(self) -> String {
+        format!("load {}.md, {}/skills, and {}/rules", self.file_name(), self.dir_name(), self.dir_name())
+    }
+
+    pub fn prompt_source(self) -> Option<PromptSource> {
+        Some(PromptSource::file(format!("${{WORKSPACE}}/{}.md", self.file_name())).optional())
+    }
+
+    pub fn skills_dirs(self) -> Vec<String> {
+        self.dirs("skills")
+    }
+
+    pub fn rules_dirs(self) -> Vec<String> {
+        self.dirs("rules")
+    }
+
+    fn dirs(self, subdir: &str) -> Vec<String> {
+        let dir = self.dir_name();
+        vec![format!("${{HOME}}/{dir}/{subdir}"), format!("${{WORKSPACE}}/{dir}/{subdir}")]
+    }
+}

--- a/packages/aether-cli/src/init/mod.rs
+++ b/packages/aether-cli/src/init/mod.rs
@@ -1,8 +1,10 @@
 mod build_settings;
+mod harness;
 mod recommendations;
 mod tui_runner;
 use aether_project::user_settings_path;
 pub use build_settings::Preset;
+pub use harness::HarnessIntegration;
 use llm::catalog::Provider;
 use recommendations::recommended_for_provider;
 use std::fs;
@@ -18,6 +20,15 @@ pub enum InitScope {
     Project,
 }
 
+impl InitScope {
+    pub fn asset_path(self, asset_rel_path: &str) -> String {
+        match self {
+            Self::User => asset_rel_path.to_string(),
+            Self::Project => format!(".aether/{asset_rel_path}"),
+        }
+    }
+}
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct InitTarget {
     pub scope: InitScope,
@@ -30,6 +41,7 @@ pub struct InitRequest {
     pub target: InitTargetRequest,
     pub provider: Option<Provider>,
     pub preset: Option<Preset>,
+    pub harnesses: Vec<HarnessIntegration>,
     pub force: bool,
 }
 
@@ -77,7 +89,7 @@ impl InitTarget {
 
 impl InitRequest {
     pub fn user_onboarding() -> Self {
-        Self { target: InitTargetRequest::User, provider: None, preset: None, force: false }
+        Self { target: InitTargetRequest::User, provider: None, preset: None, harnesses: vec![], force: false }
     }
 }
 
@@ -85,6 +97,7 @@ pub fn apply_init(
     target: InitTarget,
     provider: Provider,
     preset: Preset,
+    harnesses: &[HarnessIntegration],
     force: bool,
 ) -> Result<InitOutcome, InitError> {
     if target.settings_path.is_file() && !force {
@@ -96,7 +109,7 @@ pub fn apply_init(
         supported: supported_providers().map(Provider::parser_name).collect::<Vec<_>>().join(", "),
     })?;
 
-    let built = build_settings::build_preset(preset, provider, &recs, target.scope);
+    let built = build_settings::build_preset(preset, provider, &recs, target.scope, harnesses);
 
     fs::create_dir_all(&target.asset_root).map_err(|e| InitError::Io { path: target.asset_root.clone(), source: e })?;
 
@@ -123,11 +136,13 @@ pub async fn run_init(request: InitRequest) -> Result<InitOutcome, InitError> {
         return Ok(InitOutcome::AlreadyInitialized { settings_path: target.settings_path });
     }
 
-    let Some((provider, preset)) = tui_runner::run_wizard(request.provider, request.preset).await? else {
+    let Some((provider, preset, harnesses)) =
+        tui_runner::run_wizard(request.provider, request.preset, request.harnesses).await?
+    else {
         return Ok(InitOutcome::Cancelled);
     };
 
-    apply_init(target, provider, preset, request.force)
+    apply_init(target, provider, preset, &harnesses, request.force)
 }
 
 pub fn next_steps_message(outcome: &InitOutcome) -> Option<String> {

--- a/packages/aether-cli/src/init/tui_runner.rs
+++ b/packages/aether-cli/src/init/tui_runner.rs
@@ -1,18 +1,21 @@
 use super::InitError;
 use super::build_settings::{Preset, supported_providers};
+use super::harness::HarnessIntegration;
+use clap::ValueEnum;
 use llm::catalog::Provider;
 use std::io;
 use tui::{
-    Component, CrosstermEvent, Event, Frame, KeyCode, Line, MouseCapture, RadioSelect, SelectOption, Style,
-    TerminalConfig, TerminalRuntime, Theme, ViewContext, terminal_size,
+    Component, CrosstermEvent, Event, Frame, KeyCode, Line, MouseCapture, MultiSelect, RadioSelect, SelectOption,
+    Style, TerminalConfig, TerminalRuntime, Theme, ViewContext, terminal_size,
 };
 
 pub async fn run_wizard(
     provider: Option<Provider>,
     preset: Option<Preset>,
-) -> Result<Option<(Provider, Preset)>, InitError> {
+    harnesses: Vec<HarnessIntegration>,
+) -> Result<Option<(Provider, Preset, Vec<HarnessIntegration>)>, InitError> {
     if let (Some(p), Some(t)) = (provider, preset) {
-        return Ok(Some((p, t)));
+        return Ok(Some((p, t, harnesses)));
     }
 
     let mut terminal = TerminalRuntime::new(
@@ -40,7 +43,47 @@ pub async fn run_wizard(
         },
     };
 
-    Ok(Some((provider, resolved_preset)))
+    let selected_harnesses = if resolved_preset == Preset::BatteriesIncluded && harnesses.is_empty() {
+        match run_multi_select(&mut terminal).await? {
+            Some(h) => h,
+            None => return Ok(None),
+        }
+    } else {
+        harnesses
+    };
+
+    Ok(Some((provider, resolved_preset, selected_harnesses)))
+}
+
+fn harness_options() -> Vec<(SelectOption, HarnessIntegration)> {
+    HarnessIntegration::value_variants()
+        .iter()
+        .map(|h| {
+            let value = h.to_possible_value().map(|v| v.get_name().to_string()).unwrap_or_default();
+            (SelectOption { value, title: h.title(), description: Some(h.description()) }, *h)
+        })
+        .collect()
+}
+
+async fn run_multi_select(
+    terminal: &mut TerminalRuntime<io::Stdout>,
+) -> Result<Option<Vec<HarnessIntegration>>, InitError> {
+    let options = harness_options();
+    let select_options: Vec<SelectOption> = options.iter().map(|(opt, _)| opt.clone()).collect();
+    let all_selected = vec![true; options.len()];
+    let mut select = MultiSelect::new(select_options, all_selected);
+    let header = "Load prompts, skills, and rules from other harness conventions?";
+    let footer =
+        "  \u{2191}/\u{2193} to move \u{00b7} Space to toggle \u{00b7} Enter to confirm \u{00b7} Esc to cancel";
+
+    let render = |s: &MultiSelect, ctx: &ViewContext| render_select(s, header, footer, ctx);
+    if !run_event_loop(terminal, &mut select, render).await? {
+        return Ok(None);
+    }
+
+    let selected: Vec<HarnessIntegration> =
+        select.selected.iter().enumerate().filter(|(_, s)| **s).map(|(i, _)| options[i].1).collect();
+    Ok(Some(selected))
 }
 
 fn preset_options() -> Vec<(String, Preset)> {
@@ -73,11 +116,26 @@ async fn run_select<T: Clone>(
         .collect();
 
     let mut select = RadioSelect::new(select_options, 0);
-    terminal.render_frame(|ctx| render(&select, prompt, ctx)).map_err(InitError::Terminal)?;
+    let footer = "  \u{2191}/\u{2193} to move \u{00b7} Enter to confirm \u{00b7} Esc to cancel";
+
+    let render = |s: &RadioSelect, ctx: &ViewContext| render_select(s, prompt, footer, ctx);
+    if !run_event_loop(terminal, &mut select, render).await? {
+        return Ok(None);
+    }
+
+    Ok(options.get(select.selected).map(|(_, v)| v.clone()))
+}
+
+async fn run_event_loop<W: Component>(
+    terminal: &mut TerminalRuntime<io::Stdout>,
+    widget: &mut W,
+    render_fn: impl Fn(&W, &ViewContext) -> Frame,
+) -> Result<bool, InitError> {
+    draw(terminal, widget, &render_fn)?;
 
     loop {
         let Some(event) = terminal.next_event().await else {
-            return Ok(None);
+            return Ok(false);
         };
 
         if let CrosstermEvent::Resize(c, r) = &event {
@@ -89,29 +147,52 @@ async fn run_select<T: Clone>(
             match key.code {
                 KeyCode::Esc => {
                     let _ = terminal.clear_screen();
-                    return Ok(None);
+                    return Ok(false);
                 }
-
                 KeyCode::Enter => {
                     let _ = terminal.clear_screen();
-                    return Ok(options.get(select.selected).map(|(_, v)| v.clone()));
+                    return Ok(true);
                 }
                 _ => {}
             }
         }
 
-        select.on_event(&tui_event).await;
-        terminal.render_frame(|ctx| render(&select, prompt, ctx)).map_err(InitError::Terminal)?;
+        widget.on_event(&tui_event).await;
+        draw(terminal, widget, &render_fn)?;
     }
 }
 
-fn render(select: &RadioSelect, header: &str, ctx: &ViewContext) -> Frame {
+fn draw<T>(
+    terminal: &mut TerminalRuntime<io::Stdout>,
+    widget: &T,
+    render_fn: &impl Fn(&T, &ViewContext) -> Frame,
+) -> Result<(), InitError> {
+    terminal.render_frame(|ctx| render_fn(widget, ctx)).map_err(InitError::Terminal)
+}
+
+fn render_select<T>(widget: &T, header: &str, footer: &str, ctx: &ViewContext) -> Frame
+where
+    T: SelectField,
+{
     let mut lines = vec![Line::with_style(header.to_string(), Style::fg(ctx.theme.primary())), Line::default()];
-    lines.extend(select.render_field(ctx, true));
+    lines.extend(widget.field_lines(ctx));
     lines.push(Line::default());
-    lines.push(Line::styled(
-        "  \u{2191}/\u{2193} to move \u{00b7} Enter to confirm \u{00b7} Esc to cancel",
-        ctx.theme.muted(),
-    ));
+    lines.push(Line::styled(footer.to_string(), ctx.theme.muted()));
     Frame::new(lines)
+}
+
+trait SelectField {
+    fn field_lines(&self, ctx: &ViewContext) -> Vec<Line>;
+}
+
+impl SelectField for RadioSelect {
+    fn field_lines(&self, ctx: &ViewContext) -> Vec<Line> {
+        RadioSelect::render_field(self, ctx, true)
+    }
+}
+
+impl SelectField for MultiSelect {
+    fn field_lines(&self, ctx: &ViewContext) -> Vec<Line> {
+        MultiSelect::render_field(self, ctx, true)
+    }
 }

--- a/packages/aether-cli/src/settings/mod.rs
+++ b/packages/aether-cli/src/settings/mod.rs
@@ -1,4 +1,4 @@
-use crate::init::{InitRequest, InitTargetRequest, Preset};
+use crate::init::{HarnessIntegration, InitRequest, InitTargetRequest, Preset};
 use clap::{Args, Subcommand};
 use llm::catalog::Provider;
 use std::path::PathBuf;
@@ -36,6 +36,10 @@ pub struct SettingsInitArgs {
     #[arg(long)]
     pub preset: Option<Preset>,
 
+    /// Harness conventions to auto-load (only with `batteries-included` preset).
+    #[arg(long = "harness", value_enum)]
+    pub harnesses: Vec<HarnessIntegration>,
+
     /// Overwrite an existing settings file at the selected target.
     #[arg(long)]
     pub force: bool,
@@ -44,7 +48,7 @@ pub struct SettingsInitArgs {
 impl From<SettingsInitArgs> for InitRequest {
     fn from(args: SettingsInitArgs) -> Self {
         let target = if args.user { InitTargetRequest::User } else { InitTargetRequest::Project { path: args.path } };
-        Self { target, provider: args.provider, preset: args.preset, force: args.force }
+        Self { target, provider: args.provider, preset: args.preset, harnesses: args.harnesses, force: args.force }
     }
 }
 
@@ -101,5 +105,14 @@ mod tests {
     #[test]
     fn rejects_user_path() {
         assert!(parse(&["init", "--user", "--path", "/tmp/repo"]).is_err());
+    }
+
+    #[test]
+    fn accepts_repeated_harness_flags() {
+        let cli =
+            parse(&["init", "--user", "--preset", "batteries-included", "--harness", "claude", "--harness", "agents"])
+                .unwrap();
+        let SettingsCommand::Init(args) = cli.command;
+        assert_eq!(args.harnesses, vec![HarnessIntegration::Claude, HarnessIntegration::Agents]);
     }
 }

--- a/packages/aether-cli/tests/run_init.rs
+++ b/packages/aether-cli/tests/run_init.rs
@@ -1,4 +1,4 @@
-use aether_cli::init::{InitError, InitOutcome, InitTarget, Preset, apply_init};
+use aether_cli::init::{HarnessIntegration, InitError, InitOutcome, InitTarget, Preset, apply_init};
 use aether_core::core::Prompt;
 use aether_project::{AetherSettings, AgentCatalog, McpSourceSpec, PromptSource};
 use llm::catalog::Provider;
@@ -17,11 +17,25 @@ fn agent_provider(agent: &aether_project::AgentConfig) -> Provider {
     agent.model.parse::<LlmModel>().expect("model parses").provider_enum()
 }
 
+fn inline_args(servers: &BTreeMap<String, McpServerConfig>, name: &str) -> Vec<String> {
+    let McpServerConfig::InMemory(in_memory) = servers.get(name).unwrap_or_else(|| panic!("{name} server")) else {
+        panic!("expected in-memory {name}");
+    };
+    in_memory.args.clone()
+}
+
+fn inline_servers(spec: &McpSourceSpec) -> &BTreeMap<String, McpServerConfig> {
+    let McpSourceSpec::Inline { servers } = spec else {
+        panic!("expected inline MCPs, got a file spec");
+    };
+    servers
+}
+
 #[test]
 fn writes_user_minimal_preset_for_codex() {
     let dir = tempfile::tempdir().unwrap();
     let outcome =
-        apply_init(InitTarget::user(dir.path()), Provider::Codex, Preset::Minimal, false).expect("apply_init");
+        apply_init(InitTarget::user(dir.path()), Provider::Codex, Preset::Minimal, &[], false).expect("apply_init");
 
     assert!(matches!(outcome, InitOutcome::Applied { .. }), "{outcome:?}");
     assert!(dir.path().join("settings.json").is_file());
@@ -46,7 +60,7 @@ fn writes_user_minimal_preset_for_codex() {
 fn writes_project_minimal_preset_for_codex() {
     let dir = tempfile::tempdir().unwrap();
     let outcome =
-        apply_init(InitTarget::project(dir.path()), Provider::Codex, Preset::Minimal, false).expect("apply_init");
+        apply_init(InitTarget::project(dir.path()), Provider::Codex, Preset::Minimal, &[], false).expect("apply_init");
 
     assert!(matches!(outcome, InitOutcome::Applied { .. }), "{outcome:?}");
     assert!(dir.path().join(".aether/settings.json").is_file());
@@ -73,10 +87,11 @@ fn writes_project_minimal_preset_for_codex() {
 }
 
 #[test]
-fn writes_project_batteries_preset_for_anthropic() -> Result<(), String> {
+fn writes_project_batteries_preset_for_anthropic() {
     let dir = tempfile::tempdir().unwrap();
-    let outcome = apply_init(InitTarget::project(dir.path()), Provider::Anthropic, Preset::BatteriesIncluded, false)
-        .expect("apply_init");
+    let outcome =
+        apply_init(InitTarget::project(dir.path()), Provider::Anthropic, Preset::BatteriesIncluded, &[], false)
+            .expect("apply_init");
 
     assert!(matches!(outcome, InitOutcome::Applied { .. }), "{outcome:?}");
     assert!(dir.path().join(".aether/agents/codebase-explorer/AGENTS.md").is_file());
@@ -94,7 +109,7 @@ fn writes_project_batteries_preset_for_anthropic() -> Result<(), String> {
     let plan = &settings.agents[0];
     assert_read_only_coding_tools(plan);
 
-    let plan_servers = inline_servers(&plan.mcps[0])?;
+    let plan_servers = inline_servers(&plan.mcps[0]);
     let plan_server_names: Vec<&str> = plan_servers.keys().map(String::as_str).collect();
     assert_eq!(plan_server_names, vec!["coding", "plan", "skills", "subagents", "survey", "tasks"]);
     assert!(!plan.tools.deny.iter().any(|tool| tool.starts_with("plan__")));
@@ -104,10 +119,81 @@ fn writes_project_batteries_preset_for_anthropic() -> Result<(), String> {
     assert!(!explore.user_invocable);
     assert_eq!(explore.prompts[0].path(), Some(".aether/agents/codebase-explorer/AGENTS.md"));
     assert_read_only_coding_tools(explore);
-    let explore_servers = inline_servers(&explore.mcps[0])?;
+    let explore_servers = inline_servers(&explore.mcps[0]);
     let server_names: Vec<&str> = explore_servers.keys().map(String::as_str).collect();
     assert_eq!(server_names, vec!["coding"]);
-    Ok(())
+}
+
+#[test]
+fn batteries_included_harness_configurations() {
+    for case in &harness_cases() {
+        let dir = tempfile::tempdir().unwrap();
+        apply_init(
+            InitTarget::project(dir.path()),
+            Provider::Anthropic,
+            Preset::BatteriesIncluded,
+            &case.harnesses,
+            false,
+        )
+        .unwrap_or_else(|e| panic!("{}: apply_init failed: {e}", case.name));
+
+        let settings = load(&dir.path().join(".aether/settings.json"));
+
+        assert_eq!(settings.prompts.len(), case.expected_prompt_paths.len(), "{}: prompt count mismatch", case.name);
+        for (i, expected) in case.expected_prompt_paths.iter().enumerate() {
+            assert_eq!(settings.prompts[i].path(), Some(*expected), "{}: prompt[{i}] path mismatch", case.name);
+        }
+
+        let plan = &settings.agents[0];
+        let servers = inline_servers(&plan.mcps[0]);
+
+        if !case.skills_fragments.is_empty() {
+            let args = inline_args(servers, "skills");
+            assert_contains_all(&args, &case.skills_fragments, &format!("{}: skills args", case.name));
+        }
+
+        if !case.rules_fragments.is_empty() {
+            let args = inline_args(servers, "coding");
+            assert_contains_all(&args, &case.rules_fragments, &format!("{}: rules args", case.name));
+        }
+
+        for fragment in &case.excluded_fragments {
+            let skills = inline_args(servers, "skills");
+            let coding = inline_args(servers, "coding");
+            assert_does_not_contain(&skills, fragment, &format!("{}: skills should exclude", case.name));
+            assert_does_not_contain(&coding, fragment, &format!("{}: rules should exclude", case.name));
+        }
+    }
+}
+
+#[test]
+fn batteries_included_harness_skills_dirs_are_ordered_before_project_skills() {
+    let dir = tempfile::tempdir().unwrap();
+    apply_init(
+        InitTarget::project(dir.path()),
+        Provider::Anthropic,
+        Preset::BatteriesIncluded,
+        &[HarnessIntegration::Agents],
+        false,
+    )
+    .expect("apply_init");
+
+    let settings = load(&dir.path().join(".aether/settings.json"));
+    let plan = &settings.agents[0];
+    let servers = inline_servers(&plan.mcps[0]);
+    let skills_args = inline_args(servers, "skills");
+
+    let aether_home_pos = skills_args.iter().position(|a| a == "${AETHER_HOME}/skills").unwrap();
+    let home_agents_pos = skills_args.iter().position(|a| a == "${HOME}/.agents/skills").unwrap();
+    let workspace_agents_pos = skills_args.iter().position(|a| a == "${WORKSPACE}/.agents/skills").unwrap();
+    let project_skills_pos = skills_args.iter().position(|a| a == "${WORKSPACE}/.aether/skills").unwrap();
+
+    assert!(aether_home_pos < home_agents_pos, "AETHER_HOME skills should come before harness user skills");
+    assert!(home_agents_pos < workspace_agents_pos, "harness user skills should come before harness project skills");
+    assert!(
+        workspace_agents_pos < project_skills_pos,
+        "harness project skills should come before native project skills"
+    );
 }
 
 #[test]
@@ -116,7 +202,7 @@ fn refuses_to_overwrite_existing_user_settings_without_force() {
     std::fs::write(dir.path().join("settings.json"), "{}").unwrap();
 
     let outcome =
-        apply_init(InitTarget::user(dir.path()), Provider::Codex, Preset::Minimal, false).expect("apply_init");
+        apply_init(InitTarget::user(dir.path()), Provider::Codex, Preset::Minimal, &[], false).expect("apply_init");
 
     assert!(matches!(outcome, InitOutcome::AlreadyInitialized { .. }), "{outcome:?}");
     assert_eq!(std::fs::read_to_string(dir.path().join("settings.json")).unwrap(), "{}");
@@ -129,7 +215,7 @@ fn refuses_to_overwrite_existing_project_settings_without_force() {
     std::fs::write(dir.path().join(".aether/settings.json"), "{}").unwrap();
 
     let outcome =
-        apply_init(InitTarget::project(dir.path()), Provider::Codex, Preset::Minimal, false).expect("apply_init");
+        apply_init(InitTarget::project(dir.path()), Provider::Codex, Preset::Minimal, &[], false).expect("apply_init");
 
     assert!(matches!(outcome, InitOutcome::AlreadyInitialized { .. }), "{outcome:?}");
     assert_eq!(std::fs::read_to_string(dir.path().join(".aether/settings.json")).unwrap(), "{}");
@@ -143,7 +229,7 @@ fn force_overwrites_selected_target_only() {
     std::fs::write(dir.path().join(".aether/settings.json"), "{}").unwrap();
 
     let outcome =
-        apply_init(InitTarget::user(dir.path()), Provider::Anthropic, Preset::Minimal, true).expect("apply_init");
+        apply_init(InitTarget::user(dir.path()), Provider::Anthropic, Preset::Minimal, &[], true).expect("apply_init");
 
     assert!(matches!(outcome, InitOutcome::Applied { .. }), "{outcome:?}");
     let settings = load(&dir.path().join("settings.json"));
@@ -154,44 +240,37 @@ fn force_overwrites_selected_target_only() {
 #[test]
 fn every_inline_mcp_in_init_presets_parses_its_args() {
     for preset in [Preset::Minimal, Preset::BatteriesIncluded] {
-        let dir = tempfile::tempdir().unwrap();
-        apply_init(InitTarget::user(dir.path()), Provider::Anthropic, preset, false).expect("apply_init");
-        let settings = load(&dir.path().join("settings.json"));
+        for harnesses in
+            [vec![], vec![HarnessIntegration::Claude], vec![HarnessIntegration::Claude, HarnessIntegration::Agents]]
+        {
+            let dir = tempfile::tempdir().unwrap();
+            apply_init(InitTarget::user(dir.path()), Provider::Anthropic, preset, &harnesses, false)
+                .expect("apply_init");
+            let settings = load(&dir.path().join("settings.json"));
 
-        for agent in &settings.agents {
-            for mcp in &agent.mcps {
-                let McpSourceSpec::Inline { servers } = mcp else { continue };
-                for (name, config) in servers {
-                    let McpServerConfig::InMemory(in_memory) = config else { continue };
-                    let args = in_memory.args.clone();
-                    if name == "skills" {
-                        assert_eq!(
-                            args,
-                            vec![
-                                "--dir",
-                                "${AETHER_HOME}/skills",
-                                "--dir",
-                                "${WORKSPACE}/.aether/skills",
-                                "--notes-dir",
-                                "${WORKSPACE}/.aether/notes",
-                            ],
-                            "skills MCP should read user and project skill directories"
+            for agent in &settings.agents {
+                for mcp in &agent.mcps {
+                    let McpSourceSpec::Inline { servers } = mcp else { continue };
+                    for (name, config) in servers {
+                        let McpServerConfig::InMemory(in_memory) = config else { continue };
+                        let args = in_memory.args.clone();
+                        let parse_result = match name.as_str() {
+                            "coding" => CodingMcpArgs::from_args(args).map(|_| ()),
+                            "skills" => SkillsMcpArgs::from_args(args).map(|_| ()),
+                            "subagents" => SubAgentsMcpArgs::from_args(args).map(|_| ()),
+                            "tasks" => TasksMcpArgs::from_args(args).map(|_| ()),
+                            "plan" => PlanMcpArgs::from_args(args).map(|_| ()),
+                            "survey" => Ok(()),
+                            other => {
+                                panic!("preset references unknown in-memory MCP `{other}`; add a parse check")
+                            }
+                        };
+                        assert!(
+                            parse_result.is_ok(),
+                            "{preset:?} agent `{}` server `{name}` harnesses={harnesses:?} args failed to parse: {parse_result:?}",
+                            agent.name
                         );
                     }
-                    let parse_result = match name.as_str() {
-                        "coding" => CodingMcpArgs::from_args(args).map(|_| ()),
-                        "skills" => SkillsMcpArgs::from_args(args).map(|_| ()),
-                        "subagents" => SubAgentsMcpArgs::from_args(args).map(|_| ()),
-                        "tasks" => TasksMcpArgs::from_args(args).map(|_| ()),
-                        "plan" => PlanMcpArgs::from_args(args).map(|_| ()),
-                        "survey" => Ok(()),
-                        other => panic!("preset references unknown in-memory MCP `{other}`; add a parse check"),
-                    };
-                    assert!(
-                        parse_result.is_ok(),
-                        "{preset:?} agent `{}` server `{name}` args failed to parse: {parse_result:?}",
-                        agent.name
-                    );
                 }
             }
         }
@@ -201,19 +280,12 @@ fn every_inline_mcp_in_init_presets_parses_its_args() {
 #[test]
 fn unsupported_provider_returns_error_without_writing_files() {
     let dir = tempfile::tempdir().unwrap();
-    let err = apply_init(InitTarget::user(dir.path()), Provider::Gemini, Preset::Minimal, false)
+    let err = apply_init(InitTarget::user(dir.path()), Provider::Gemini, Preset::Minimal, &[], false)
         .expect_err("Gemini has no preset");
 
     assert!(matches!(err, InitError::UnsupportedProvider { provider: Provider::Gemini, .. }), "{err:?}");
     assert!(!dir.path().join("settings.json").exists(), "no settings.json should be written");
     assert!(!dir.path().join("SYSTEM.md").exists(), "no SYSTEM.md should be written");
-}
-
-fn inline_servers(spec: &McpSourceSpec) -> Result<&BTreeMap<String, McpServerConfig>, String> {
-    match spec {
-        McpSourceSpec::Inline { servers } => Ok(servers),
-        McpSourceSpec::File(_) => Err("expected inline MCPs, got a file spec".to_string()),
-    }
 }
 
 fn assert_read_only_coding_tools(agent: &aether_project::AgentConfig) {
@@ -227,4 +299,84 @@ fn assert_minimal_mcp_and_tools(agent: &aether_project::AgentConfig) {
     assert_eq!(names, vec!["coding", "skills"]);
     assert_eq!(agent.tools.allow, vec!["coding__bash", "skills__*"]);
     assert!(agent.tools.deny.is_empty());
+}
+
+fn assert_contains_all(args: &[String], expected: &[&str], context: &str) {
+    for expected_item in expected {
+        assert!(
+            args.iter().any(|a| a == expected_item),
+            "{context}: expected args to contain `{expected_item}`, got: {args:?}"
+        );
+    }
+}
+
+fn assert_does_not_contain(args: &[String], fragment: &str, context: &str) {
+    assert!(
+        !args.iter().any(|a| a.contains(fragment)),
+        "{context}: expected args not to contain `{fragment}`, got: {args:?}"
+    );
+}
+
+struct HarnessCase {
+    name: &'static str,
+    harnesses: Vec<HarnessIntegration>,
+    expected_prompt_paths: Vec<&'static str>,
+    skills_fragments: Vec<&'static str>,
+    rules_fragments: Vec<&'static str>,
+    excluded_fragments: Vec<&'static str>,
+}
+
+fn harness_cases() -> Vec<HarnessCase> {
+    vec![
+        HarnessCase {
+            name: "no harnesses",
+            harnesses: vec![],
+            expected_prompt_paths: vec![".aether/SYSTEM.md"],
+            skills_fragments: vec![],
+            rules_fragments: vec![],
+            excluded_fragments: vec![],
+        },
+        HarnessCase {
+            name: "claude only",
+            harnesses: vec![HarnessIntegration::Claude],
+            expected_prompt_paths: vec![".aether/SYSTEM.md", "${WORKSPACE}/CLAUDE.md"],
+            skills_fragments: vec!["--dir", "${HOME}/.claude/skills", "--dir", "${WORKSPACE}/.claude/skills"],
+            rules_fragments: vec!["--rules-dir", "${HOME}/.claude/rules", "--rules-dir", "${WORKSPACE}/.claude/rules"],
+            excluded_fragments: vec![".agents/"],
+        },
+        HarnessCase {
+            name: "agents only",
+            harnesses: vec![HarnessIntegration::Agents],
+            expected_prompt_paths: vec![".aether/SYSTEM.md", "${WORKSPACE}/AGENTS.md"],
+            skills_fragments: vec!["--dir", "${HOME}/.agents/skills", "--dir", "${WORKSPACE}/.agents/skills"],
+            rules_fragments: vec!["--rules-dir", "${HOME}/.agents/rules", "--rules-dir", "${WORKSPACE}/.agents/rules"],
+            excluded_fragments: vec![".claude/"],
+        },
+        HarnessCase {
+            name: "both harnesses",
+            harnesses: vec![HarnessIntegration::Claude, HarnessIntegration::Agents],
+            expected_prompt_paths: vec![".aether/SYSTEM.md", "${WORKSPACE}/CLAUDE.md", "${WORKSPACE}/AGENTS.md"],
+            skills_fragments: vec![
+                "--dir",
+                "${HOME}/.claude/skills",
+                "--dir",
+                "${WORKSPACE}/.claude/skills",
+                "--dir",
+                "${HOME}/.agents/skills",
+                "--dir",
+                "${WORKSPACE}/.agents/skills",
+            ],
+            rules_fragments: vec![
+                "--rules-dir",
+                "${HOME}/.claude/rules",
+                "--rules-dir",
+                "${WORKSPACE}/.claude/rules",
+                "--rules-dir",
+                "${HOME}/.agents/rules",
+                "--rules-dir",
+                "${WORKSPACE}/.agents/rules",
+            ],
+            excluded_fragments: vec![],
+        },
+    ]
 }


### PR DESCRIPTION
This PR improves user onboarding via `aether settings init` when the user chooses the batteries included preset by offering to auto-load prompts, skills and rules from other harnesses -- e.g. `CLAUDE.md`, `.claude/skills`, `.claude/rules`. both at the user and project level. 