### PR TITLE
fix: model override switches to default agent

### DIFF
--- a/packages/aether-cli/src/acp/config_setting.rs
+++ b/packages/aether-cli/src/acp/config_setting.rs
@@ -26,14 +26,6 @@ impl ConfigSetting {
             }
         }
     }
-
-    pub fn config_id(&self) -> ConfigOptionId {
-        match self {
-            Self::Mode(_) => ConfigOptionId::Mode,
-            Self::Model(_) => ConfigOptionId::Model,
-            Self::ReasoningEffort(_) => ConfigOptionId::ReasoningEffort,
-        }
-    }
 }
 
 #[derive(Debug, Error)]
@@ -52,21 +44,18 @@ mod tests {
     fn parse_mode() {
         let setting = ConfigSetting::parse("mode", "Planner").unwrap();
         assert_eq!(setting, ConfigSetting::Mode("Planner".to_string()));
-        assert_eq!(setting.config_id(), ConfigOptionId::Mode);
     }
 
     #[test]
     fn parse_model() {
         let setting = ConfigSetting::parse("model", "anthropic:claude-sonnet-4-5").unwrap();
         assert_eq!(setting, ConfigSetting::Model("anthropic:claude-sonnet-4-5".to_string()));
-        assert_eq!(setting.config_id(), ConfigOptionId::Model);
     }
 
     #[test]
     fn parse_reasoning_effort_high() {
         let setting = ConfigSetting::parse("reasoning_effort", "high").unwrap();
         assert_eq!(setting, ConfigSetting::ReasoningEffort(Some(ReasoningEffort::High)));
-        assert_eq!(setting.config_id(), ConfigOptionId::ReasoningEffort);
     }
 
     #[test]
@@ -94,14 +83,5 @@ mod tests {
         assert!(matches!(err, ConfigSettingError::InvalidValue { .. }));
         assert!(err.to_string().contains("max"));
         assert!(err.to_string().contains("reasoning_effort"));
-    }
-
-    #[test]
-    fn config_id_round_trip() {
-        let cases: Vec<(&str, &str)> = vec![("mode", "test"), ("model", "test"), ("reasoning_effort", "low")];
-        for (id_str, value) in cases {
-            let setting = ConfigSetting::parse(id_str, value).unwrap();
-            assert_eq!(setting.config_id().as_str(), id_str);
-        }
     }
 }

--- a/packages/aether-cli/src/acp/model_config.rs
+++ b/packages/aether-cli/src/acp/model_config.rs
@@ -183,14 +183,6 @@ impl Modes {
         self.iter().find(|mode| mode.name == mode_name).map(|mode| (mode.model.clone(), mode.reasoning_effort))
     }
 
-    /// The mode whose `(model, reasoning_effort)` matches the given selection, if
-    /// any — used to keep the Mode dropdown in sync after a Model change.
-    pub(crate) fn name_for(&self, model: &str, reasoning_effort: Option<ReasoningEffort>) -> Option<String> {
-        self.iter()
-            .find(|mode| mode.model == model && mode.reasoning_effort == reasoning_effort)
-            .map(|mode| mode.name.clone())
-    }
-
     fn config_option(&self, selected_mode: Option<&str>) -> Option<SessionConfigOption> {
         if self.is_empty() {
             return None;
@@ -364,12 +356,6 @@ mod tests {
     #[test]
     fn resolve_rejects_unknown_mode() {
         assert!(test_validated_modes().resolve("Unknown").is_none());
-    }
-
-    #[test]
-    fn name_for_matches_valid_tuple() {
-        let selected = test_validated_modes().name_for("anthropic:claude-sonnet-4-5", Some(ReasoningEffort::High));
-        assert_eq!(selected.as_deref(), Some("Planner"));
     }
 
     #[test]

--- a/packages/aether-cli/src/acp/session_actor.rs
+++ b/packages/aether-cli/src/acp/session_actor.rs
@@ -745,6 +745,24 @@ mod tests {
         assert!(matches!(switch, Switch::Model(ref model) if model == DEEPSEEK));
         assert_eq!(s.active_model, DEEPSEEK);
         assert!(s.pending.is_none());
+        assert_eq!(s.selected_mode.as_deref(), Some("Planner"));
+        assert_eq!(s.effective_model(&validated_modes()), DEEPSEEK);
+    }
+
+    #[test]
+    fn model_change_preserves_selected_mode() {
+        let modes = Modes::new(vec![
+            ValidatedMode { name: "Planner".into(), model: SONNET.into(), reasoning_effort: None },
+            ValidatedMode { name: "Coder".into(), model: DEEPSEEK.into(), reasoning_effort: None },
+        ]);
+        let mut s = SessionConfigState::with_selection(DEEPSEEK.into(), Some("Coder".into()), None);
+
+        s.apply_config_change(&modes, &available_models(), &ConfigSetting::Model(SONNET.into()))
+            .expect("model switch should apply");
+
+        assert_eq!(s.pending, Some(Pending::Model(SONNET.into())));
+        assert_eq!(s.selected_mode.as_deref(), Some("Coder"));
+        assert_eq!(s.effective_model(&modes), SONNET);
     }
 
     #[test]
@@ -754,7 +772,7 @@ mod tests {
     }
 
     #[test]
-    fn effort_change_preserves_mode_and_model_change_clears_it() {
+    fn effort_and_model_changes_preserve_mode_selection() {
         let (res, s) = apply(SONNET, Some(RE::High), Some("Planner"), &ConfigSetting::ReasoningEffort(Some(RE::Low)));
         assert!(res.is_ok());
         assert_eq!(s.reasoning_effort, Some(RE::Low));
@@ -763,7 +781,8 @@ mod tests {
         let (res, s) = apply(SONNET, Some(RE::Medium), Some("Planner"), &ConfigSetting::Model(DEEPSEEK.into()));
         assert!(res.is_ok());
         assert_eq!(s.pending, Some(Pending::Model(DEEPSEEK.into())));
-        assert!(s.selected_mode.is_none());
+        assert_eq!(s.selected_mode.as_deref(), Some("Planner"));
+        assert_eq!(s.effective_model(&validated_modes()), DEEPSEEK);
     }
 
     #[test]

--- a/packages/aether-cli/src/acp/session_config_state.rs
+++ b/packages/aether-cli/src/acp/session_config_state.rs
@@ -42,13 +42,13 @@ impl SessionConfigState {
     }
 
     pub(crate) fn effective_model(&self, modes: &Modes) -> String {
-        if let Some(Pending::Model(target)) = &self.pending {
-            return target.clone();
+        match &self.pending {
+            Some(Pending::Model(target)) => target.clone(),
+            Some(Pending::Mode(agent)) => {
+                modes.resolve(agent).map_or_else(|| self.active_model.clone(), |(model, _)| model)
+            }
+            None => self.active_model.clone(),
         }
-        self.selected_mode
-            .as_deref()
-            .and_then(|mode| modes.resolve(mode).map(|(model, _)| model))
-            .unwrap_or_else(|| self.active_model.clone())
     }
 
     pub(crate) fn begin_prompt(&mut self, modes: &Modes) -> Switch {
@@ -78,7 +78,6 @@ impl SessionConfigState {
         available: &[LlmModel],
         setting: &ConfigSetting,
     ) -> Result<(), acp::Error> {
-        use acp_utils::config_option_id::ConfigOptionId;
         match setting {
             ConfigSetting::Mode(value) => {
                 let Some((_mode_model, mode_reasoning_effort)) = modes.resolve(value) else {
@@ -101,14 +100,6 @@ impl SessionConfigState {
             ConfigSetting::ReasoningEffort(effort) => {
                 self.reasoning_effort = *effort;
             }
-        }
-
-        if setting.config_id() == ConfigOptionId::Model {
-            let effective = match &self.pending {
-                Some(Pending::Model(target)) => target.as_str(),
-                _ => self.active_model.as_str(),
-            };
-            self.selected_mode = modes.name_for(effective, self.reasoning_effort);
         }
 
         Ok(())

--- a/packages/mcp-servers/src/plan/README.md
+++ b/packages/mcp-servers/src/plan/README.md
@@ -1,3 +1,20 @@
+<!-- START doctoc generated TOC please keep comment here to allow auto update -->
+<!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
+
+- [PlanMcp](#planmcp)
+  - [Tools](#tools)
+  - [write_plan](#write_plan)
+    - [Input](#input)
+    - [Output](#output)
+  - [edit_plan](#edit_plan)
+    - [Input](#input-1)
+    - [Output](#output-1)
+  - [submit_plan](#submit_plan)
+    - [Input](#input-2)
+    - [Output](#output-2)
+
+<!-- END doctoc generated TOC please keep comment here to allow auto update -->
+
 # PlanMcp
 
 MCP server that exposes plan-specific tools for writing, editing, and submitting implementation plans for user approval/feedback. Agents refer to plans by `planName`; the server maps that name to `<planName>-plan.md` inside the configured plans directory.


### PR DESCRIPTION
This PR fixes an issue where if you had agent B selected and agent A was the "default" agent, switching the LLM model in the TUI would flip to agent A instead of staying on B. 