### PR TITLE
fix: Status line wrapping

### DIFF
--- a/packages/wisp/src/components/status_line.rs
+++ b/packages/wisp/src/components/status_line.rs
@@ -240,20 +240,25 @@ mod tests {
         )
     }
 
-    #[test]
-    fn reasoning_bar_hidden_without_reasoning_option() {
-        let options = vec![model_option()];
-        let workspace_status = test_workspace_status();
-        let status = StatusLine {
-            workspace_status: &workspace_status,
+    fn status_line() -> StatusLine<'static> {
+        static WORKSPACE_STATUS: std::sync::LazyLock<WorkspaceStatus> = std::sync::LazyLock::new(test_workspace_status);
+
+        StatusLine {
+            workspace_status: &WORKSPACE_STATUS,
             agent_name: "test-agent",
-            config_options: &options,
+            config_options: &[],
             context_usage: None,
             waiting_for_response: false,
             unhealthy_server_count: 0,
             content_padding: DEFAULT_CONTENT_PADDING,
             exit_confirmation_active: false,
-        };
+        }
+    }
+
+    #[test]
+    fn reasoning_bar_hidden_without_reasoning_option() {
+        let options = vec![model_option()];
+        let status = StatusLine { config_options: &options, ..status_line() };
 
         let context = ViewContext::new((120, 40));
         let frame = status.render(&context);
@@ -267,17 +272,7 @@ mod tests {
     #[test]
     fn reasoning_bar_shown_with_reasoning_option() {
         let options = vec![model_option(), reasoning_option()];
-        let workspace_status = test_workspace_status();
-        let status = StatusLine {
-            workspace_status: &workspace_status,
-            agent_name: "test-agent",
-            config_options: &options,
-            context_usage: None,
-            waiting_for_response: false,
-            unhealthy_server_count: 0,
-            content_padding: DEFAULT_CONTENT_PADDING,
-            exit_confirmation_active: false,
-        };
+        let status = StatusLine { config_options: &options, ..status_line() };
 
         let context = ViewContext::new((120, 40));
         let frame = status.render(&context);
@@ -289,17 +284,7 @@ mod tests {
     #[test]
     fn wraps_right_side_onto_second_line_when_too_narrow() {
         let options = vec![model_option(), reasoning_option()];
-        let workspace_status = test_workspace_status();
-        let status = StatusLine {
-            workspace_status: &workspace_status,
-            agent_name: "test-agent",
-            config_options: &options,
-            context_usage: None,
-            waiting_for_response: false,
-            unhealthy_server_count: 0,
-            content_padding: DEFAULT_CONTENT_PADDING,
-            exit_confirmation_active: false,
-        };
+        let status = StatusLine { config_options: &options, ..status_line() };
 
         let context = ViewContext::new((60, 40));
         let frame = status.render(&context);
@@ -316,17 +301,7 @@ mod tests {
     #[test]
     fn stays_on_one_line_when_it_fits() {
         let options = vec![model_option(), reasoning_option()];
-        let workspace_status = test_workspace_status();
-        let status = StatusLine {
-            workspace_status: &workspace_status,
-            agent_name: "test-agent",
-            config_options: &options,
-            context_usage: None,
-            waiting_for_response: false,
-            unhealthy_server_count: 0,
-            content_padding: DEFAULT_CONTENT_PADDING,
-            exit_confirmation_active: false,
-        };
+        let status = StatusLine { config_options: &options, ..status_line() };
 
         let context = ViewContext::new((120, 40));
         let frame = status.render(&context);

--- a/packages/wisp/src/components/status_line.rs
+++ b/packages/wisp/src/components/status_line.rs
@@ -5,7 +5,7 @@ use acp_utils::config_option_id::ConfigOptionId;
 use agent_client_protocol::schema::{
     self as acp, SessionConfigKind, SessionConfigOption, SessionConfigOptionCategory, SessionConfigSelectOptions,
 };
-use tui::{Color, FitOptions, Frame, Line, ViewContext, display_width_text};
+use tui::{Color, FitOptions, Frame, Line, ViewContext};
 use utils::ReasoningEffort;
 
 pub use crate::components::context_bar::ContextUsageDisplay;
@@ -23,21 +23,18 @@ pub struct StatusLine<'a> {
 }
 
 impl StatusLine<'_> {
-    #[allow(clippy::similar_names)]
     pub fn render(&self, context: &ViewContext) -> Frame {
-        let mut line = render_left(self.workspace_status, context, self.content_padding);
-        let right_parts = render_right(self, context);
+        let left = render_left(self.workspace_status, context, self.content_padding);
+        let right = render_right(self, context);
         let width = context.size.width as usize;
-        let right_len: usize = right_parts.iter().map(|(s, _)| display_width_text(s)).sum();
-        let left_len = line.display_width();
 
-        let padding = width.saturating_sub(left_len + right_len);
-        line.push_text(" ".repeat(padding));
-        for (text, color) in right_parts {
-            line.push_styled(text, color);
-        }
+        let lines = if left.display_width() + right.display_width() <= width {
+            vec![join_aligned(left, &right, width)]
+        } else {
+            vec![left, align_right(&right, width)]
+        };
 
-        Frame::new(vec![line]).fit(context.size.width, FitOptions::truncate())
+        Frame::new(lines).fit(context.size.width, FitOptions::truncate())
     }
 }
 
@@ -52,57 +49,71 @@ fn render_left(status: &WorkspaceStatus, context: &ViewContext, content_padding:
     line
 }
 
-fn render_right(status: &StatusLine<'_>, context: &ViewContext) -> Vec<(String, Color)> {
+fn render_right(status: &StatusLine<'_>, context: &ViewContext) -> Line {
     let sep = context.theme.text_secondary();
     let mode_text = extract_mode_display(status.config_options);
     let model_summary = extract_model_display(status.config_options);
     let reasoning_effort = extract_reasoning_effort(status.config_options);
 
-    let mut parts = Vec::new();
+    let mut line = Line::default();
 
     if status.exit_confirmation_active {
-        parts.push(("Ctrl-C again to exit".to_string(), context.theme.warning()));
+        line.push_styled("Ctrl-C again to exit", context.theme.warning());
     } else {
-        parts.push((status.agent_name.to_string(), context.theme.info()));
+        line.push_styled(status.agent_name, context.theme.info());
 
         if let Some(ref mode) = mode_text {
-            push_separator(&mut parts, sep);
-            parts.push((mode.clone(), context.theme.secondary()));
+            push_separator(&mut line, sep);
+            line.push_styled(mode.clone(), context.theme.secondary());
         }
 
         if let Some(ref model) = model_summary {
-            push_separator(&mut parts, sep);
-            parts.push((model.clone(), context.theme.success()));
+            push_separator(&mut line, sep);
+            line.push_styled(model.clone(), context.theme.success());
         }
     }
 
     let reasoning_levels = extract_reasoning_levels(status.config_options);
     if model_summary.is_some() && !reasoning_levels.is_empty() {
-        push_separator(&mut parts, sep);
-        parts.push((
+        push_separator(&mut line, sep);
+        line.push_styled(
             reasoning_bar(reasoning_effort, reasoning_levels.len()),
             reasoning_color(reasoning_effort, reasoning_levels.len(), &context.theme),
-        ));
+        );
     }
 
     if let Some(usage) = status.context_usage {
-        push_separator(&mut parts, sep);
-        parts.push((context_bar(usage), context_color(usage, &context.theme)));
+        push_separator(&mut line, sep);
+        line.push_styled(context_bar(usage), context_color(usage, &context.theme));
     }
 
     if !status.waiting_for_response && status.unhealthy_server_count > 0 {
         let count = status.unhealthy_server_count;
         let msg = if count == 1 { "1 server needs auth".to_string() } else { format!("{count} servers unhealthy") };
-        push_separator(&mut parts, sep);
-        parts.push((msg, context.theme.warning()));
+        push_separator(&mut line, sep);
+        line.push_styled(msg, context.theme.warning());
     }
 
-    parts
+    line
 }
 
-fn push_separator(parts: &mut Vec<(String, Color)>, color: Color) {
-    if !parts.is_empty() {
-        parts.push((" · ".to_string(), color));
+fn join_aligned(mut left: Line, right: &Line, width: usize) -> Line {
+    let padding = width.saturating_sub(left.display_width() + right.display_width());
+    left.push_text(" ".repeat(padding));
+    left.append_line(right);
+    left
+}
+
+fn align_right(right: &Line, width: usize) -> Line {
+    let mut line = Line::default();
+    line.push_text(" ".repeat(width.saturating_sub(right.display_width())));
+    line.append_line(right);
+    line
+}
+
+fn push_separator(line: &mut Line, color: Color) {
+    if !line.is_empty() {
+        line.push_styled(" · ", color);
     }
 }
 
@@ -273,6 +284,53 @@ mod tests {
         let text = frame.lines()[0].plain_text();
         assert!(text.contains("medium"), "reasoning bar should use current reasoning effort as its label, got: {text}");
         assert!(!text.contains("reasoning"), "reasoning bar should not use a generic reasoning label, got: {text}");
+    }
+
+    #[test]
+    fn wraps_right_side_onto_second_line_when_too_narrow() {
+        let options = vec![model_option(), reasoning_option()];
+        let workspace_status = test_workspace_status();
+        let status = StatusLine {
+            workspace_status: &workspace_status,
+            agent_name: "test-agent",
+            config_options: &options,
+            context_usage: None,
+            waiting_for_response: false,
+            unhealthy_server_count: 0,
+            content_padding: DEFAULT_CONTENT_PADDING,
+            exit_confirmation_active: false,
+        };
+
+        let context = ViewContext::new((60, 40));
+        let frame = status.render(&context);
+        let left = frame.lines()[0].plain_text();
+        let right = frame.lines()[1].plain_text();
+
+        assert_eq!(frame.lines().len(), 2);
+        assert!(left.contains("aether-2"));
+        assert!(right.contains("test-agent"));
+        assert!(right.contains("Claude Sonnet"));
+        assert!(right.starts_with(' '));
+    }
+
+    #[test]
+    fn stays_on_one_line_when_it_fits() {
+        let options = vec![model_option(), reasoning_option()];
+        let workspace_status = test_workspace_status();
+        let status = StatusLine {
+            workspace_status: &workspace_status,
+            agent_name: "test-agent",
+            config_options: &options,
+            context_usage: None,
+            waiting_for_response: false,
+            unhealthy_server_count: 0,
+            content_padding: DEFAULT_CONTENT_PADDING,
+            exit_confirmation_active: false,
+        };
+
+        let context = ViewContext::new((120, 40));
+        let frame = status.render(&context);
+        assert_eq!(frame.lines().len(), 1, "wide status line should stay on a single row");
     }
 
     #[test]

--- a/packages/wisp/src/components/status_line.rs
+++ b/packages/wisp/src/components/status_line.rs
@@ -31,7 +31,7 @@ impl StatusLine<'_> {
         let lines = if left.display_width() + right.display_width() <= width {
             vec![join_aligned(left, &right, width)]
         } else {
-            vec![left, align_right(&right, width)]
+            vec![left, align_left(&right, self.content_padding)]
         };
 
         Frame::new(lines).fit(context.size.width, FitOptions::truncate())
@@ -104,9 +104,9 @@ fn join_aligned(mut left: Line, right: &Line, width: usize) -> Line {
     left
 }
 
-fn align_right(right: &Line, width: usize) -> Line {
+fn align_left(right: &Line, content_padding: usize) -> Line {
     let mut line = Line::default();
-    line.push_text(" ".repeat(width.saturating_sub(right.display_width())));
+    line.push_text(" ".repeat(content_padding));
     line.append_line(right);
     line
 }
@@ -295,7 +295,7 @@ mod tests {
         assert!(left.contains("aether-2"));
         assert!(right.contains("test-agent"));
         assert!(right.contains("Claude Sonnet"));
-        assert!(right.starts_with(' '));
+        assert_eq!(right.find("test-agent"), Some(DEFAULT_CONTENT_PADDING));
     }
 
     #[test]

--- a/packages/wisp/tests/app_tests/common.rs
+++ b/packages/wisp/tests/app_tests/common.rs
@@ -35,6 +35,18 @@ pub(super) fn expected_status_line(width: u16, agent_name: &str) -> String {
     truncate_to_display_width(&line, usize::from(width))
 }
 
+/// Expected status-line rows, wrapping the right side onto a second line when
+/// the left and right clusters do not fit together on one row.
+pub(super) fn expected_status_line_rows(width: u16, agent_name: &str) -> Vec<String> {
+    let left = format!("{}{} · {}", " ".repeat(DEFAULT_CONTENT_PADDING), TEST_WORKSPACE_DIR, TEST_GIT_REF);
+    let w = usize::from(width);
+    if display_width_text(&left) + display_width_text(agent_name) <= w {
+        return vec![expected_status_line(width, agent_name)];
+    }
+    let pad = w.saturating_sub(display_width_text(agent_name));
+    vec![truncate_to_display_width(&left, w), truncate_to_display_width(&format!("{}{agent_name}", " ".repeat(pad)), w)]
+}
+
 fn truncate_to_display_width(text: &str, width: usize) -> String {
     let mut truncated = String::new();
     for ch in text.chars() {

--- a/packages/wisp/tests/app_tests/common.rs
+++ b/packages/wisp/tests/app_tests/common.rs
@@ -43,8 +43,8 @@ pub(super) fn expected_status_line_rows(width: u16, agent_name: &str) -> Vec<Str
     if display_width_text(&left) + display_width_text(agent_name) <= w {
         return vec![expected_status_line(width, agent_name)];
     }
-    let pad = w.saturating_sub(display_width_text(agent_name));
-    vec![truncate_to_display_width(&left, w), truncate_to_display_width(&format!("{}{agent_name}", " ".repeat(pad)), w)]
+    let pad = " ".repeat(DEFAULT_CONTENT_PADDING);
+    vec![truncate_to_display_width(&left, w), truncate_to_display_width(&format!("{pad}{agent_name}"), w)]
 }
 
 fn truncate_to_display_width(text: &str, width: usize) -> String {

--- a/packages/wisp/tests/app_tests/input_prompt_tests.rs
+++ b/packages/wisp/tests/app_tests/input_prompt_tests.rs
@@ -199,13 +199,8 @@ async fn test_cursor_position_after_whitespace_wrap() {
     type_string(&mut renderer, "abc def ghi").await;
 
     let rule = "─".repeat(width as usize);
-    let expected = vec![
-        rule.clone(),
-        "> abc def".to_string(),
-        "  ghi".to_string(),
-        rule.clone(),
-        expected_status_line(width, TEST_AGENT),
-    ];
+    let mut expected = vec![rule.clone(), "> abc def".to_string(), "  ghi".to_string(), rule.clone()];
+    expected.extend(expected_status_line_rows(width, TEST_AGENT));
     assert_buffer_eq(renderer.writer(), &expected);
 
     let (cursor_col, cursor_row) = renderer.writer().cursor_position();
@@ -214,13 +209,8 @@ async fn test_cursor_position_after_whitespace_wrap() {
 
     type_string(&mut renderer, "j").await;
 
-    let expected_after = vec![
-        rule.clone(),
-        "> abc def".to_string(),
-        "  ghij".to_string(),
-        rule,
-        expected_status_line(width, TEST_AGENT),
-    ];
+    let mut expected_after = vec![rule.clone(), "> abc def".to_string(), "  ghij".to_string(), rule];
+    expected_after.extend(expected_status_line_rows(width, TEST_AGENT));
     assert_buffer_eq(renderer.writer(), &expected_after);
 
     let (cursor_col_after, cursor_row_after) = renderer.writer().cursor_position();

--- a/packages/wisp/tests/component_tests/status_line.rs
+++ b/packages/wisp/tests/component_tests/status_line.rs
@@ -151,25 +151,30 @@ fn renders_workspace_with_expected_colors() {
 }
 
 #[test]
-fn keeps_status_area_to_one_line_when_narrow() {
-    let workspace_status = WorkspaceStatus::new(
-        "~/very/long/path/that/would/wrap/without/truncation",
-        Some("feature/very-long-branch".to_string()),
-    );
-    let options = vec![model_option("model", "very-long-model-name")];
+fn wraps_right_side_to_second_line_when_narrow() {
+    let workspace_status = WorkspaceStatus::new("~/code/project", Some("main".to_string()));
+    let options = vec![model_option("model", "Claude Sonnet")];
     let status = StatusLine {
         workspace_status: &workspace_status,
         agent_name: "agent-name",
         config_options: &options,
-        context_usage: Some(ContextUsageDisplay::new(100_000, 200_000)),
+        context_usage: None,
         waiting_for_response: false,
         unhealthy_server_count: 0,
         content_padding: DEFAULT_CONTENT_PADDING,
         exit_confirmation_active: false,
     };
-    let ctx = ViewContext::new((24, 24));
+    let ctx = ViewContext::new((40, 24));
 
-    assert_eq!(status.render(&ctx).lines().len(), 1);
+    let frame = status.render(&ctx);
+    assert_eq!(frame.lines().len(), 2, "the right cluster should wrap onto a second row instead of truncating");
+
+    let left = frame.lines()[0].plain_text();
+    let right = frame.lines()[1].plain_text();
+    assert!(left.contains("~/code/project"), "left row keeps the workspace, got: {left}");
+    assert!(right.contains("agent-name"), "right row keeps the agent, got: {right}");
+    assert!(right.contains("Claude Sonnet"), "right row keeps the model, got: {right}");
+    assert!(right.starts_with(' '), "wrapped right row should be right-aligned, got: {right:?}");
 }
 
 #[test]

--- a/packages/wisp/tests/component_tests/status_line.rs
+++ b/packages/wisp/tests/component_tests/status_line.rs
@@ -186,7 +186,11 @@ fn wraps_right_side_to_second_line_when_narrow() {
     assert!(left.contains("~/code/project"), "left row keeps the workspace, got: {left}");
     assert!(right.contains("agent-name"), "right row keeps the agent, got: {right}");
     assert!(right.contains("Claude Sonnet"), "right row keeps the model, got: {right}");
-    assert!(right.starts_with(' '), "wrapped right row should be right-aligned, got: {right:?}");
+    assert_eq!(
+        right.find("agent-name"),
+        Some(DEFAULT_CONTENT_PADDING),
+        "wrapped right row should align to content padding, got: {right:?}"
+    );
 }
 
 #[test]

--- a/packages/wisp/tests/component_tests/status_line.rs
+++ b/packages/wisp/tests/component_tests/status_line.rs
@@ -35,6 +35,22 @@ fn reasoning_option(value: impl Into<String>) -> SessionConfigOption {
     )
 }
 
+fn status_line() -> StatusLine<'static> {
+    static WORKSPACE_STATUS: std::sync::LazyLock<WorkspaceStatus> =
+        std::sync::LazyLock::new(|| WorkspaceStatus::new("~/code/aether-2", Some("main".to_string())));
+
+    StatusLine {
+        workspace_status: &WORKSPACE_STATUS,
+        agent_name: "test-agent",
+        config_options: &[],
+        context_usage: None,
+        waiting_for_response: false,
+        unhealthy_server_count: 0,
+        content_padding: DEFAULT_CONTENT_PADDING,
+        exit_confirmation_active: false,
+    }
+}
+
 struct StatusBuilder<'a> {
     name: &'a str,
     options: Vec<SessionConfigOption>,
@@ -158,11 +174,7 @@ fn wraps_right_side_to_second_line_when_narrow() {
         workspace_status: &workspace_status,
         agent_name: "agent-name",
         config_options: &options,
-        context_usage: None,
-        waiting_for_response: false,
-        unhealthy_server_count: 0,
-        content_padding: DEFAULT_CONTENT_PADDING,
-        exit_confirmation_active: false,
+        ..status_line()
     };
     let ctx = ViewContext::new((40, 24));
 
@@ -183,12 +195,8 @@ fn exit_confirmation_keeps_workspace_and_moves_warning_right() {
     let status = StatusLine {
         workspace_status: &workspace_status,
         agent_name: "agent-name",
-        config_options: &[],
-        context_usage: None,
-        waiting_for_response: false,
-        unhealthy_server_count: 0,
-        content_padding: DEFAULT_CONTENT_PADDING,
         exit_confirmation_active: true,
+        ..status_line()
     };
     let ctx = ViewContext::new((100, 24));
     let text = status.render(&ctx).lines()[0].plain_text();


### PR DESCRIPTION
Fixes #109 .  Previously status lines would get truncated if they overflowed past the terminal screen width, now they wrap. 