### PR TITLE
chore: Upgrade deps

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -419,9 +419,9 @@ dependencies = [
 
 [[package]]
 name = "agent-client-protocol"
-version = "0.12.1"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4361ba6627e51de955b10f3c77fb9eb959c85191a236c1c2c84e32f4ff240faf"
+checksum = "5efba6592048ef8a9ac97de8d79b2d9933d8ac4d94f7a2de102348fed0c61103"
 dependencies = [
  "agent-client-protocol-derive",
  "agent-client-protocol-schema",
@@ -430,23 +430,20 @@ dependencies = [
  "futures",
  "futures-concurrency",
  "jsonrpcmsg",
- "rmcp",
  "rustc-hash 2.1.2",
  "schemars 1.2.1",
  "serde",
  "serde_json",
  "shell-words",
- "tokio",
- "tokio-util",
  "tracing",
  "uuid",
 ]
 
 [[package]]
 name = "agent-client-protocol-derive"
-version = "0.11.1"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cabdc9d845d08ec7ed2d0c9de1ae4a1b198301407d55855261572761be90ec9f"
+checksum = "4d176a10d4cb06e0262a738c3c5bf21ff0968db13a666e31cbca94a3d3d72e7c"
 dependencies = [
  "quote",
  "syn",
@@ -454,9 +451,9 @@ dependencies = [
 
 [[package]]
 name = "agent-client-protocol-schema"
-version = "0.13.2"
+version = "0.13.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b957d8391ac3933e2a940446171c508d2b8ffc386d8fa7d0b9c936a2575b463e"
+checksum = "c290bfa00c6b52339db66f8e9cf711d5f08530800529f7d619ff24d6cba253d0"
 dependencies = [
  "anyhow",
  "derive_more",
@@ -605,9 +602,9 @@ dependencies = [
 
 [[package]]
 name = "async-openai"
-version = "0.40.3"
+version = "0.41.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "278af84d3d19995d440ea7b401a4b121c780c8d37f5eb6e883d987c17b523aa4"
+checksum = "3ec57a13b36ba76764870363a9182d8bc9fb49538dc5a948dd2e5224fe65ce40"
 dependencies = [
  "async-openai-macros",
  "base64 0.22.1",
@@ -1288,9 +1285,9 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
-version = "2.12.1"
+version = "2.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "84d7ced0ae9557296835c32bf1b1e02b44c746701f898460fb000d7eaa84f00a"
+checksum = "b4388bee8683e3d04af747c73422af53102d2bd24d9eadb6cbc100baef4b43f8"
 
 [[package]]
 name = "block-buffer"
@@ -1649,7 +1646,7 @@ version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d8b9f2e4c67f833b660cdb0a3523065869fb35570177239812ed4c905aeff87b"
 dependencies = [
- "bitflags 2.12.1",
+ "bitflags 2.13.0",
  "crossterm_winapi",
  "derive_more",
  "document-features",
@@ -1709,9 +1706,9 @@ dependencies = [
 
 [[package]]
 name = "cssparser"
-version = "0.36.0"
+version = "0.37.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dae61cf9c0abb83bd659dab65b7e4e38d8236824c85f0f804f173567bda257d2"
+checksum = "8c9cdaae01d5ed7882b04d795e7f752f46ff52d2fa3b50a20d28c464510bba98"
 dependencies = [
  "cssparser-macros",
  "dtoa-short",
@@ -1722,9 +1719,9 @@ dependencies = [
 
 [[package]]
 name = "cssparser-macros"
-version = "0.6.1"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13b588ba4ac1a99f7f2964d24b3d896ddc6bf847ee3855dbd4366f058cfcd331"
+checksum = "10a2a99df6e410a8ff4245aa2006499ea662245f967cc7c0a38c83ef8eb44dbf"
 dependencies = [
  "quote",
  "syn",
@@ -2003,14 +2000,14 @@ dependencies = [
 
 [[package]]
 name = "dom_query"
-version = "0.27.0"
+version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "521e380c0c8afb8d9a1e83a1822ee03556fc3e3e7dbc1fd30be14e37f9cb3f89"
+checksum = "fac5fca71e65e94cc718a6e2af65d6e0f9c6027751c2aa562fbb5087fda639bc"
 dependencies = [
  "bit-set",
  "cssparser",
  "foldhash 0.2.0",
- "html5ever",
+ "html5ever 0.39.0",
  "nom 8.0.0",
  "precomputed-hash",
  "selectors",
@@ -2019,9 +2016,9 @@ dependencies = [
 
 [[package]]
 name = "dom_smoothie"
-version = "0.17.0"
+version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f21cad308997c8c518aaee15c8b38bb04dc699bbcf30da4176443c9ef40c1bb5"
+checksum = "cf8b9b294aabb8010b37c49a07d6f82175152f4927855d534979a38737721875"
 dependencies = [
  "dom_query",
  "flagset",
@@ -2676,7 +2673,7 @@ version = "0.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7eee9b00ee2e599b4f86507157e3db786e7a3319fc225f0e9584151dbea2291d"
 dependencies = [
- "html5ever",
+ "html5ever 0.38.0",
  "markup5ever_rcdom",
  "phf",
 ]
@@ -2697,7 +2694,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1054432bae2f14e0061e33d23402fbaa67a921d319d56adc6bcf887ddad1cbc2"
 dependencies = [
  "log",
- "markup5ever",
+ "markup5ever 0.38.0",
+]
+
+[[package]]
+name = "html5ever"
+version = "0.39.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46a1761807faccc9a19e86944bbf40610014066306f96edcdedc2fb714bcb7b8"
+dependencies = [
+ "log",
+ "markup5ever 0.39.0",
 ]
 
 [[package]]
@@ -3127,7 +3134,7 @@ version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "533e68a5842e734946fe159fb03fc9bbbb254f590dd0d8ad321ae5ff7beca2c1"
 dependencies = [
- "bitflags 2.12.1",
+ "bitflags 2.13.0",
  "inotify-sys",
  "libc",
 ]
@@ -3300,7 +3307,7 @@ version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "07293a4e297ac234359b510362495713f75ea345d5307140414f20c69ffeb087"
 dependencies = [
- "bitflags 2.12.1",
+ "bitflags 2.13.0",
  "libc",
 ]
 
@@ -3338,16 +3345,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f02ab6bace2054fb888a3c16f990117b579d14a3088e472d63c6011fa185c9d3"
 dependencies = [
  "libc",
-]
-
-[[package]]
-name = "libyml"
-version = "0.0.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3302702afa434ffa30847a83305f0a69d6abd74293b6554c18ec85c7ef30c980"
-dependencies = [
- "anyhow",
- "version_check",
 ]
 
 [[package]]
@@ -3420,13 +3417,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "markup5ever"
+version = "0.39.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7122d987ec5f704ee56f6e5b41a7d93722e9aae27ae07cafa4036c4d3f9757de"
+dependencies = [
+ "log",
+ "tendril",
+ "web_atoms",
+]
+
+[[package]]
 name = "markup5ever_rcdom"
 version = "0.38.0+unofficial"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "333171ccdf66e915257740d44e38ea5b1b19ce7b45d33cc35cb6f118fbd981ff"
 dependencies = [
- "html5ever",
- "markup5ever",
+ "html5ever 0.38.0",
+ "markup5ever 0.38.0",
  "tendril",
  "xml5ever",
 ]
@@ -3517,7 +3525,7 @@ version = "0.31.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf20d2fde8ff38632c426f1165ed7436270b44f199fc55284c38276f9db47c3d"
 dependencies = [
- "bitflags 2.12.1",
+ "bitflags 2.13.0",
  "cfg-if",
  "cfg_aliases",
  "libc",
@@ -3548,7 +3556,7 @@ version = "8.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4d3d07927151ff8575b7087f245456e549fea62edf0ec4e565a5ee50c8402bc3"
 dependencies = [
- "bitflags 2.12.1",
+ "bitflags 2.13.0",
  "fsevent-sys",
  "inotify",
  "kqueue",
@@ -3566,7 +3574,20 @@ version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42b8cfee0e339a0337359f3c88165702ac6e600dc01c0cc9579a92d62b08477a"
 dependencies = [
- "bitflags 2.12.1",
+ "bitflags 2.13.0",
+]
+
+[[package]]
+name = "noyalib"
+version = "0.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e493c05128df7a83b9676b709d590e0ebc285c7ed3152bc679668e8c1e506af5"
+dependencies = [
+ "indexmap 2.14.0",
+ "memchr",
+ "rustc-hash 2.1.2",
+ "serde",
+ "smallvec",
 ]
 
 [[package]]
@@ -3684,7 +3705,7 @@ version = "5.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "51e219e79014df21a225b1860a479e2dcd7cbd9130f4defd4bd0e191ea31d67d"
 dependencies = [
- "base64 0.22.1",
+ "base64 0.21.7",
  "chrono",
  "getrandom 0.2.17",
  "http 1.4.1",
@@ -4016,7 +4037,7 @@ version = "0.13.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e9f068eba8e7071c5f9511831b44f32c740d5adf574e990f946ddb53db2f314e"
 dependencies = [
- "bitflags 2.12.1",
+ "bitflags 2.13.0",
  "getopts",
  "memchr",
  "pulldown-cmark-escape",
@@ -4200,7 +4221,7 @@ version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
 dependencies = [
- "bitflags 2.12.1",
+ "bitflags 2.13.0",
 ]
 
 [[package]]
@@ -4467,7 +4488,7 @@ version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
 dependencies = [
- "bitflags 2.12.1",
+ "bitflags 2.13.0",
  "errno",
  "libc",
  "linux-raw-sys",
@@ -4692,7 +4713,7 @@ version = "3.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
 dependencies = [
- "bitflags 2.12.1",
+ "bitflags 2.13.0",
  "core-foundation",
  "core-foundation-sys",
  "libc",
@@ -4711,11 +4732,11 @@ dependencies = [
 
 [[package]]
 name = "selectors"
-version = "0.36.1"
+version = "0.38.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c5d9c0c92a92d33f08817311cf3f2c29a3538a8240e94a6a3c622ce652d7e00c"
+checksum = "8adfa1c298912827b8a28b223b3b874357397ae706e6190acd9bf28cee99114d"
 dependencies = [
- "bitflags 2.12.1",
+ "bitflags 2.13.0",
  "cssparser",
  "derive_more",
  "log",
@@ -4871,17 +4892,12 @@ dependencies = [
 
 [[package]]
 name = "serde_yml"
-version = "0.0.12"
+version = "0.0.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59e2dd588bf1597a252c3b920e0143eb99b0f76e4e082f4c92ce34fbc9e71ddd"
+checksum = "909764a65f86829ccdb5eea9ab355843aa02c019a7bfd47465092953565caa05"
 dependencies = [
- "indexmap 2.14.0",
- "itoa",
- "libyml",
- "memchr",
- "ryu",
+ "noyalib",
  "serde",
- "version_check",
 ]
 
 [[package]]
@@ -5425,7 +5441,7 @@ version = "0.6.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4cfcf7e2740e6fc6d4d688b4ef00650406bb94adf4731e43c096c3a19fe40840"
 dependencies = [
- "bitflags 2.12.1",
+ "bitflags 2.13.0",
  "bytes",
  "futures-util",
  "http 1.4.1",
@@ -5845,7 +5861,7 @@ version = "0.244.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
 dependencies = [
- "bitflags 2.12.1",
+ "bitflags 2.13.0",
  "hashbrown 0.15.5",
  "indexmap 2.14.0",
  "semver",
@@ -6275,7 +6291,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
 dependencies = [
  "anyhow",
- "bitflags 2.12.1",
+ "bitflags 2.13.0",
  "indexmap 2.14.0",
  "log",
  "serde",
@@ -6330,7 +6346,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3dc9559429edf0cd3f327cc0afd9d6b36fa8cec6d93107b7fbe64f806b5f2d9"
 dependencies = [
  "log",
- "markup5ever",
+ "markup5ever 0.38.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,9 +31,9 @@ absolute_paths = "warn"
 
 [workspace.dependencies]
 # AWS SDK
-aws-config = { version = "1.8.16", features = ["behavior-version-latest"] }
-aws-sdk-bedrockruntime = "1.130.0"
-aws-smithy-types = "1.4.7"
+aws-config = { version = "1.8.18", features = ["behavior-version-latest"] }
+aws-sdk-bedrockruntime = "1.133.0"
+aws-smithy-types = "1.4.9"
 
 # Async runtime
 tokio = { version = "^1.52.3", features = ["full"] }
@@ -45,7 +45,7 @@ eventsource-stream = "^0.2"
 
 # Serialization
 serde = { version = "1.0.228", features = ["derive"] }
-serde_json = "1.0.149"
+serde_json = "1.0.150"
 
 # CLI
 clap = { version = "4.6", features = ["derive"] }
@@ -56,12 +56,12 @@ tracing-subscriber = { version = "0.3.23", features = ["env-filter", "json"] }
 tracing-appender = "0.2"
 
 # ACP
-agent-client-protocol = "0.12.1"
+agent-client-protocol = "0.14.0"
 
 # MCP and API clients
 rmcp = { version = "^1.7.0", features = ["client", "server", "macros", "schemars", "auth", "elicitation", "transport-io"] }
-async-openai = { version = "^0.40.2", features = ["byot", "chat-completion", "responses"] }
-reqwest = { version = "^0.13.3", default-features = false, features = ["json", "query", "rustls", "http2", "stream"] }
+async-openai = { version = "^0.41.0", features = ["byot", "chat-completion", "responses"] }
+reqwest = { version = "^0.13.4", default-features = false, features = ["json", "query", "rustls", "http2", "stream"] }
 oauth2 = "5.0"
 keyring-core = "1.0.0"
 apple-native-keyring-store = { version = "1.0.0", features = ["keychain"] }
@@ -70,7 +70,7 @@ dbus-secret-service-keyring-store = { version = "1.0.0", features = ["crypto-rus
 url = "2.5"
 axum = "0.8.9"
 tower = "0.5.3"
-tower-http = "0.6.10"
+tower-http = "0.6.11"
 
 # LSP types - shared across packages
 lsp-types = "0.97"
@@ -80,16 +80,16 @@ schemars = { version = "^1.2.1", features = ["derive"] }
 secrecy = "0.10"
 
 # Utilities
-chrono = { version = "^0.4.44", features = ["serde"] }
+chrono = { version = "^0.4.45", features = ["serde"] }
 uuid = { version = "1.23", features = ["v4"] }
 regex = "^1.12.3"
 sha2 = "0.11"
 base64 = "0.22"
 rand = "0.10"
 dirs = "6.0"
-serde_yml = "0.0.12"
+serde_yml = "0.0.13"
 htmd = "0.5"
-dom_smoothie = "0.17"
+dom_smoothie = "0.18"
 
 # Encryption
 age = "0.11.3"

--- a/packages/aether-cli/src/acp/protocol/events.rs
+++ b/packages/aether-cli/src/acp/protocol/events.rs
@@ -1,9 +1,9 @@
 use acp_utils::notifications::{ContextClearedParams, ContextUsageParams, SubAgentProgressParams};
 use aether_core::events::{AgentMessage, SubAgentProgressPayload};
 use agent_client_protocol::schema::{
-    self as acp, Content, ContentBlock, ContentChunk, Diff, PlanEntry, PlanEntryPriority, PlanEntryStatus, SessionId,
-    SessionNotification, SessionUpdate, StopReason, TextContent, ToolCall, ToolCallContent, ToolCallId, ToolCallStatus,
-    ToolCallUpdate, ToolCallUpdateFields,
+    self as acp, Content, ContentBlock, ContentChunk, Diff, MessageId, PlanEntry, PlanEntryPriority, PlanEntryStatus,
+    SessionId, SessionNotification, SessionUpdate, StopReason, TextContent, ToolCall, ToolCallContent, ToolCallId,
+    ToolCallStatus, ToolCallUpdate, ToolCallUpdateFields,
 };
 use llm::{ToolCallError, ToolCallRequest, ToolCallResult};
 use mcp_utils::display_meta::{PlanMetaStatus, ToolResultMeta};
@@ -98,13 +98,23 @@ pub(crate) fn map_agent_message_to_notification(
     mode: NotificationMode,
 ) -> Option<SessionNotification> {
     match msg {
-        AgentMessage::Text { chunk, is_complete, .. } => {
-            map_chunk_to_notification(session_id, chunk, *is_complete, mode, SessionUpdate::AgentMessageChunk)
-        }
+        AgentMessage::Text { message_id, chunk, is_complete, .. } => map_chunk_to_notification(
+            session_id,
+            chunk,
+            *is_complete,
+            mode,
+            SessionUpdate::AgentMessageChunk,
+            Some(message_id.as_str()),
+        ),
 
-        AgentMessage::Thought { chunk, is_complete, .. } => {
-            map_chunk_to_notification(session_id, chunk, *is_complete, mode, SessionUpdate::AgentThoughtChunk)
-        }
+        AgentMessage::Thought { message_id, chunk, is_complete, .. } => map_chunk_to_notification(
+            session_id,
+            chunk,
+            *is_complete,
+            mode,
+            SessionUpdate::AgentThoughtChunk,
+            Some(message_id.as_str()),
+        ),
 
         AgentMessage::ToolCall { request, .. } => Some(map_tool_call_to_notification(session_id, request)),
 
@@ -156,6 +166,7 @@ fn map_chunk_to_notification(
     is_complete: bool,
     mode: NotificationMode,
     wrap: fn(ContentChunk) -> SessionUpdate,
+    message_id: Option<&str>,
 ) -> Option<SessionNotification> {
     match mode {
         // Skip the final completion message to avoid sending duplicate content.
@@ -165,10 +176,12 @@ fn map_chunk_to_notification(
         NotificationMode::Live | NotificationMode::Replay => {}
     }
 
-    Some(acp::SessionNotification::new(
-        session_id,
-        wrap(ContentChunk::new(ContentBlock::Text(TextContent::new(chunk.to_owned())))),
-    ))
+    let mut content_chunk = ContentChunk::new(ContentBlock::Text(TextContent::new(chunk.to_owned())));
+    if let Some(mid) = message_id {
+        content_chunk = content_chunk.message_id(MessageId::new(mid));
+    }
+
+    Some(acp::SessionNotification::new(session_id, wrap(content_chunk)))
 }
 
 fn map_tool_call_to_notification(session_id: SessionId, request: &ToolCallRequest) -> SessionNotification {
@@ -321,7 +334,50 @@ mod tests {
     use llm::ToolCallRequest;
 
     #[test]
-    fn test_tool_progress_with_sub_agent_payload_emits_ext_notification() {
+    fn test_text_includes_message_id() -> Result<(), String> {
+        let session_id = SessionId::new("test-session");
+        let msg = AgentMessage::Text {
+            message_id: "msg_42".to_string(),
+            chunk: "hello".to_string(),
+            is_complete: false,
+            model_name: "TestModel".to_string(),
+        };
+
+        let notification =
+            map_agent_message_to_notification(session_id, &msg, NotificationMode::Live).ok_or("live notification")?;
+
+        let chunk = match notification.update {
+            SessionUpdate::AgentMessageChunk(chunk) => chunk,
+            other => return Err(format!("Expected AgentMessageChunk, got {other:?}")),
+        };
+
+        assert_eq!(chunk.message_id, Some(MessageId::new("msg_42")));
+        Ok(())
+    }
+
+    #[test]
+    fn test_thought_includes_message_id() -> Result<(), String> {
+        let session_id = acp::SessionId::new("test-session");
+        let msg = AgentMessage::Thought {
+            message_id: "msg_99".to_string(),
+            chunk: "hmm...".to_string(),
+            is_complete: false,
+            model_name: "TestModel".to_string(),
+        };
+
+        let notification =
+            map_agent_message_to_notification(session_id, &msg, NotificationMode::Live).ok_or("live notification")?;
+
+        let chunk = match notification.update {
+            acp::SessionUpdate::AgentThoughtChunk(chunk) => chunk,
+            other => return Err(format!("Expected AgentThoughtChunk, got {other:?}")),
+        };
+        assert_eq!(chunk.message_id, Some(acp::MessageId::new("msg_99")));
+        Ok(())
+    }
+
+    #[test]
+    fn test_tool_progress_emits_ext_notification() -> Result<(), String> {
         let session_id = acp::SessionId::new("test-session");
 
         let payload = SubAgentProgressPayload {
@@ -347,24 +403,21 @@ mod tests {
             message: Some(serialized_msg.clone()),
         };
 
-        let notification = map_agent_message_to_session_notification(session_id.clone(), &tool_progress);
+        assert!(map_agent_message_to_session_notification(session_id.clone(), &tool_progress).is_none());
 
-        assert!(notification.is_none());
-
-        let agent_notif = try_into_agent_notification(&tool_progress).expect("agent notification");
-        match agent_notif {
-            AgentExtNotification::SubAgentProgress(params) => {
-                assert_eq!(params.parent_tool_id, "call_123");
-                assert_eq!(params.task_id, "task_1");
-                assert_eq!(params.agent_name, "sub-agent");
-                assert!(matches!(params.event, SubAgentEvent::Other));
-            }
-            _ => panic!("expected SubAgentProgress"),
-        }
+        let agent_notif = try_into_agent_notification(&tool_progress).ok_or("agent notification")?;
+        let AgentExtNotification::SubAgentProgress(params) = agent_notif else {
+            return Err("expected SubAgentProgress".to_string());
+        };
+        assert_eq!(params.parent_tool_id, "call_123");
+        assert_eq!(params.task_id, "task_1");
+        assert_eq!(params.agent_name, "sub-agent");
+        assert!(matches!(params.event, SubAgentEvent::Other));
+        Ok(())
     }
 
     #[test]
-    fn test_thought_maps_to_agent_thought_chunk() {
+    fn test_thought_maps_to_agent_thought_chunk_with_message_id() -> Result<(), String> {
         let session_id = acp::SessionId::new("test-session");
         let thought = AgentMessage::Thought {
             message_id: "msg_1".to_string(),
@@ -373,19 +426,23 @@ mod tests {
             model_name: "TestModel".to_string(),
         };
 
-        let notification = map_agent_message_to_session_notification(session_id, &thought).expect("notification");
+        let notification = map_agent_message_to_session_notification(session_id, &thought).ok_or("notification")?;
 
-        match notification.update {
-            acp::SessionUpdate::AgentThoughtChunk(chunk) => match chunk.content {
-                acp::ContentBlock::Text(text) => assert_eq!(text.text, "thinking..."),
-                other => panic!("Expected text content, got {other:?}"),
-            },
-            other => panic!("Expected AgentThoughtChunk, got {other:?}"),
-        }
+        let chunk = match notification.update {
+            SessionUpdate::AgentThoughtChunk(chunk) => chunk,
+            other => return Err(format!("Expected AgentThoughtChunk, got {other:?}")),
+        };
+        assert_eq!(chunk.message_id, Some(MessageId::new("msg_1")),);
+        let text = match chunk.content {
+            acp::ContentBlock::Text(text) => text,
+            other => return Err(format!("Expected text content, got {other:?}")),
+        };
+        assert_eq!(text.text, "thinking...");
+        Ok(())
     }
 
     #[test]
-    fn test_tool_call_maps_to_tool_call_notification() {
+    fn test_tool_call_maps_to_tool_call_notification() -> Result<(), String> {
         let session_id = acp::SessionId::new("test-session");
         let message = AgentMessage::ToolCall {
             request: ToolCallRequest {
@@ -396,20 +453,20 @@ mod tests {
             model_name: "TestModel".to_string(),
         };
 
-        let notification = map_agent_message_to_session_notification(session_id, &message).expect("notification");
+        let notification = map_agent_message_to_session_notification(session_id, &message).ok_or("notification")?;
 
-        match notification.update {
-            acp::SessionUpdate::ToolCall(tool_call) => {
-                assert_eq!(tool_call.tool_call_id.0.as_ref(), "call_1");
-                assert_eq!(tool_call.title, "Read file");
-                assert_eq!(tool_call.status, acp::ToolCallStatus::InProgress);
-            }
-            other => panic!("Expected ToolCall, got {other:?}"),
-        }
+        let tool_call = match notification.update {
+            acp::SessionUpdate::ToolCall(tool_call) => tool_call,
+            other => return Err(format!("Expected ToolCall, got {other:?}")),
+        };
+        assert_eq!(tool_call.tool_call_id.0.as_ref(), "call_1");
+        assert_eq!(tool_call.title, "Read file");
+        assert_eq!(tool_call.status, acp::ToolCallStatus::InProgress);
+        Ok(())
     }
 
     #[test]
-    fn test_tool_call_update_maps_to_tool_call_update_notification() {
+    fn test_tool_call_update_maps_to_tool_call_update_notification() -> Result<(), String> {
         let session_id = acp::SessionId::new("test-session");
         let message = AgentMessage::ToolCallUpdate {
             tool_call_id: "call_1".to_string(),
@@ -417,20 +474,20 @@ mod tests {
             model_name: "TestModel".to_string(),
         };
 
-        let notification = map_agent_message_to_session_notification(session_id, &message).expect("notification");
+        let notification = map_agent_message_to_session_notification(session_id, &message).ok_or("notification")?;
 
-        match notification.update {
-            acp::SessionUpdate::ToolCallUpdate(update) => {
-                assert_eq!(update.tool_call_id.0.as_ref(), "call_1");
-                assert_eq!(update.fields.status, Some(acp::ToolCallStatus::InProgress));
-                assert_eq!(update.fields.raw_input, Some(serde_json::json!({ "filePath": "Cargo.toml" })));
-            }
-            other => panic!("Expected ToolCallUpdate, got {other:?}"),
-        }
+        let update = match notification.update {
+            acp::SessionUpdate::ToolCallUpdate(update) => update,
+            other => return Err(format!("Expected ToolCallUpdate, got {other:?}")),
+        };
+        assert_eq!(update.tool_call_id.0.as_ref(), "call_1");
+        assert_eq!(update.fields.status, Some(acp::ToolCallStatus::InProgress));
+        assert_eq!(update.fields.raw_input, Some(serde_json::json!({ "filePath": "Cargo.toml" })));
+        Ok(())
     }
 
     #[test]
-    fn test_tool_call_update_has_same_live_and_replay_mapping() {
+    fn test_tool_call_update_has_same_live_and_replay_mapping() -> Result<(), String> {
         let session_id = acp::SessionId::new("test-session");
         let message = AgentMessage::ToolCallUpdate {
             tool_call_id: "call_1".to_string(),
@@ -439,22 +496,22 @@ mod tests {
         };
 
         let live = map_agent_message_to_notification(session_id.clone(), &message, NotificationMode::Live)
-            .expect("live notification");
+            .ok_or("live notification")?;
         let replay = map_agent_message_to_notification(session_id, &message, NotificationMode::Replay)
-            .expect("replay notification");
+            .ok_or("replay notification")?;
 
-        match (live.update, replay.update) {
-            (acp::SessionUpdate::ToolCallUpdate(live), acp::SessionUpdate::ToolCallUpdate(replay)) => {
-                assert_eq!(live.tool_call_id.0, replay.tool_call_id.0);
-                assert_eq!(live.fields.status, replay.fields.status);
-                assert_eq!(live.fields.raw_input, replay.fields.raw_input);
-            }
-            other => panic!("Expected ToolCallUpdate pair, got {other:?}"),
-        }
+        let (live_update, replay_update) = match (live.update, replay.update) {
+            (acp::SessionUpdate::ToolCallUpdate(live), acp::SessionUpdate::ToolCallUpdate(replay)) => (live, replay),
+            other => return Err(format!("Expected ToolCallUpdate pair, got {other:?}")),
+        };
+        assert_eq!(live_update.tool_call_id.0, replay_update.tool_call_id.0);
+        assert_eq!(live_update.fields.status, replay_update.fields.status);
+        assert_eq!(live_update.fields.raw_input, replay_update.fields.raw_input);
+        Ok(())
     }
 
     #[test]
-    fn test_live_mapping_skips_completed_chunks_but_replay_keeps_them() {
+    fn test_live_mapping_skips_completed_chunks_but_replay_keeps_them() -> Result<(), String> {
         let cases: Vec<(AgentMessage, &str)> = vec![
             (
                 AgentMessage::Text {
@@ -484,29 +541,38 @@ mod tests {
             );
 
             let notification = map_agent_message_to_notification(session_id, &message, NotificationMode::Replay)
-                .expect("replay notification");
+                .ok_or("replay notification")?;
 
-            match notification.update {
-                acp::SessionUpdate::AgentMessageChunk(chunk) | acp::SessionUpdate::AgentThoughtChunk(chunk) => {
-                    match chunk.content {
-                        acp::ContentBlock::Text(text) => assert_eq!(text.text, expected_text),
-                        other => panic!("Expected text content, got {other:?}"),
-                    }
-                }
-                other => panic!("Expected chunk update, got {other:?}"),
-            }
+            let chunk = match notification.update {
+                SessionUpdate::AgentMessageChunk(chunk) | SessionUpdate::AgentThoughtChunk(chunk) => chunk,
+                other => return Err(format!("Expected chunk update, got {other:?}")),
+            };
+            assert_eq!(
+                chunk.message_id,
+                Some(acp::MessageId::new("msg_1")),
+                "replay should preserve original message_id"
+            );
+            let text = match chunk.content {
+                acp::ContentBlock::Text(text) => text,
+                other => return Err(format!("Expected text content, got {other:?}")),
+            };
+            assert_eq!(text.text, expected_text);
+        }
+        Ok(())
+    }
+
+    #[test]
+    fn test_context_cleared_maps_to_agent_notification() -> Result<(), String> {
+        let notif = try_into_agent_notification(&AgentMessage::ContextCleared)
+            .ok_or("context cleared should emit agent notification")?;
+        match notif {
+            AgentExtNotification::ContextCleared(_) => Ok(()),
+            _ => Err("expected ContextCleared".to_string()),
         }
     }
 
     #[test]
-    fn test_context_cleared_maps_to_agent_notification() {
-        let notif = try_into_agent_notification(&AgentMessage::ContextCleared)
-            .expect("context cleared should emit agent notification");
-        assert!(matches!(notif, AgentExtNotification::ContextCleared(_)));
-    }
-
-    #[test]
-    fn test_tool_progress_with_invalid_json_falls_back_to_simple_message() {
+    fn test_tool_progress_with_invalid_json_falls_back_to_simple_message() -> Result<(), String> {
         let session_id = acp::SessionId::new("test-session");
 
         // Simulate a tool progress message with invalid JSON
@@ -526,19 +592,18 @@ mod tests {
         assert!(notification.is_some());
 
         // Should still produce a notification with the message as-is
-        let notification = notification.unwrap();
-        match notification.update {
-            acp::SessionUpdate::ToolCallUpdate(update) => {
-                if let Some(content) = &update.fields.content
-                    && let acp::ToolCallContent::Content(c) = &content[0]
-                    && let acp::ContentBlock::Text(text) = &c.content
-                {
-                    // Should contain the original message
-                    assert!(text.text.contains("not valid json"));
-                }
-            }
-            _ => panic!("Expected ToolCallUpdate"),
+        let notification = notification.ok_or("expected notification")?;
+        let SessionUpdate::ToolCallUpdate(update) = notification.update else {
+            return Err("Expected ToolCallUpdate".to_string());
+        };
+        if let Some(content) = &update.fields.content
+            && let acp::ToolCallContent::Content(c) = &content[0]
+            && let acp::ContentBlock::Text(text) = &c.content
+        {
+            // Should contain the original message
+            assert!(text.text.contains("not valid json"));
         }
+        Ok(())
     }
 
     #[test]
@@ -550,7 +615,7 @@ mod tests {
     }
 
     #[test]
-    fn test_result_with_result_meta_sets_meta() {
+    fn test_result_with_result_meta_sets_meta() -> Result<(), String> {
         use mcp_utils::display_meta::ToolDisplayMeta;
 
         let session_id = acp::SessionId::new("test-session");
@@ -563,23 +628,23 @@ mod tests {
         let rm: ToolResultMeta = ToolDisplayMeta::new("Read file", "Cargo.toml, 156 lines").into();
 
         let notification = map_tool_result_to_notification(session_id, &result, Some(&rm));
-        match notification.update {
-            acp::SessionUpdate::ToolCallUpdate(update) => {
-                assert_eq!(update.fields.title.as_deref(), Some("Read file"), "native title should be set");
-                let meta = update.meta.expect("meta should be present");
-                assert_eq!(
-                    meta.get("display_value").and_then(|v| v.as_str()),
-                    Some("Cargo.toml, 156 lines"),
-                    "display_value should be a flat key in _meta"
-                );
-                assert!(meta.get("display").is_none(), "old nested display object should not be in _meta");
-            }
-            other => panic!("Expected ToolCallUpdate, got {other:?}"),
-        }
+        let update = match notification.update {
+            SessionUpdate::ToolCallUpdate(update) => update,
+            other => return Err(format!("Expected ToolCallUpdate, got {other:?}")),
+        };
+        assert_eq!(update.fields.title.as_deref(), Some("Read file"), "native title should be set");
+        let meta = update.meta.ok_or("meta should be present")?;
+        assert_eq!(
+            meta.get("display_value").and_then(|v| v.as_str()),
+            Some("Cargo.toml, 156 lines"),
+            "display_value should be a flat key in _meta"
+        );
+        assert!(meta.get("display").is_none(), "old nested display object should not be in _meta");
+        Ok(())
     }
 
     #[test]
-    fn test_result_without_result_meta() {
+    fn test_result_without_result_meta() -> Result<(), String> {
         let session_id = acp::SessionId::new("test-session");
         let result = ToolCallResult {
             id: "call_1".to_string(),
@@ -589,17 +654,17 @@ mod tests {
         };
 
         let notification = map_tool_result_to_notification(session_id, &result, None);
-        match notification.update {
-            acp::SessionUpdate::ToolCallUpdate(update) => {
-                assert!(update.fields.title.is_none());
-                assert!(update.meta.is_none());
-            }
-            other => panic!("Expected ToolCallUpdate, got {other:?}"),
-        }
+        let update = match notification.update {
+            acp::SessionUpdate::ToolCallUpdate(update) => update,
+            other => return Err(format!("Expected ToolCallUpdate, got {other:?}")),
+        };
+        assert!(update.fields.title.is_none());
+        assert!(update.meta.is_none());
+        Ok(())
     }
 
     #[test]
-    fn test_plan_notification_extracted_from_result_meta() {
+    fn test_plan_notification_extracted_from_result_meta() -> Result<(), String> {
         use mcp_utils::display_meta::{PlanMeta, PlanMetaEntry, PlanMetaStatus, ToolDisplayMeta};
 
         let session_id = acp::SessionId::new("test-session");
@@ -613,17 +678,17 @@ mod tests {
             },
         );
 
-        let notification = try_extract_plan_notification(session_id, Some(&meta)).expect("should produce plan");
-        match notification.update {
-            acp::SessionUpdate::Plan(plan) => {
-                assert_eq!(plan.entries.len(), 2);
-                assert_eq!(plan.entries[0].content, "Research AI agents");
-                assert_eq!(plan.entries[0].status, acp::PlanEntryStatus::InProgress);
-                assert_eq!(plan.entries[1].content, "Write tests");
-                assert_eq!(plan.entries[1].status, acp::PlanEntryStatus::Pending);
-            }
-            other => panic!("Expected Plan, got {other:?}"),
-        }
+        let notification = try_extract_plan_notification(session_id, Some(&meta)).ok_or("should produce plan")?;
+        let plan = match notification.update {
+            acp::SessionUpdate::Plan(plan) => plan,
+            other => return Err(format!("Expected Plan, got {other:?}")),
+        };
+        assert_eq!(plan.entries.len(), 2);
+        assert_eq!(plan.entries[0].content, "Research AI agents");
+        assert_eq!(plan.entries[0].status, acp::PlanEntryStatus::InProgress);
+        assert_eq!(plan.entries[1].content, "Write tests");
+        assert_eq!(plan.entries[1].status, acp::PlanEntryStatus::Pending);
+        Ok(())
     }
 
     #[test]
@@ -637,7 +702,7 @@ mod tests {
     }
 
     #[test]
-    fn test_tool_progress_with_display_meta_emits_meta_update() {
+    fn test_tool_progress_with_display_meta_emits_meta_update() -> Result<(), String> {
         use mcp_utils::display_meta::ToolDisplayMeta;
 
         let session_id = acp::SessionId::new("test-session");
@@ -651,24 +716,24 @@ mod tests {
         };
 
         let notification = map_tool_progress_to_notification(session_id, &request, 0.0, None, Some(&serialized))
-            .expect("should produce notification");
+            .ok_or("should produce notification")?;
 
-        match notification.update {
-            acp::SessionUpdate::ToolCallUpdate(update) => {
-                assert_eq!(&*update.tool_call_id.0, "call_789");
-                assert_eq!(update.fields.title.as_deref(), Some("Read file"), "native title should be set");
-                let meta_map = update.meta.expect("meta should be present");
-                assert_eq!(
-                    meta_map.get("display_value").and_then(|v| v.as_str()),
-                    Some("main.rs"),
-                    "display_value should be a flat key in _meta"
-                );
-                assert!(meta_map.get("display").is_none(), "old nested display object should not be in _meta");
-                assert_eq!(update.fields.status, Some(acp::ToolCallStatus::InProgress));
-                // Should NOT have content (no text progress fallback)
-                assert!(update.fields.content.is_none());
-            }
-            other => panic!("Expected ToolCallUpdate, got {other:?}"),
-        }
+        let update = match notification.update {
+            acp::SessionUpdate::ToolCallUpdate(update) => update,
+            other => return Err(format!("Expected ToolCallUpdate, got {other:?}")),
+        };
+        assert_eq!(&*update.tool_call_id.0, "call_789");
+        assert_eq!(update.fields.title.as_deref(), Some("Read file"), "native title should be set");
+        let meta_map = update.meta.ok_or("meta should be present")?;
+        assert_eq!(
+            meta_map.get("display_value").and_then(|v| v.as_str()),
+            Some("main.rs"),
+            "display_value should be a flat key in _meta"
+        );
+        assert!(meta_map.get("display").is_none(), "old nested display object should not be in _meta");
+        assert_eq!(update.fields.status, Some(acp::ToolCallStatus::InProgress));
+        // Should NOT have content (no text progress fallback)
+        assert!(update.fields.content.is_none());
+        Ok(())
     }
 }

--- a/packages/aether-project/src/prompt_file.rs
+++ b/packages/aether-project/src/prompt_file.rs
@@ -149,9 +149,13 @@ impl PromptFile {
         };
 
         let yaml = serde_yml::to_string(&frontmatter).map_err(|e| PromptFileError::Yaml(e.to_string()))?;
+        let yaml = normalize_frontmatter_yaml(&yaml);
 
-        let file_content =
-            if self.body.is_empty() { format!("---\n{yaml}---\n") } else { format!("---\n{yaml}---\n{}\n", self.body) };
+        let file_content = if self.body.is_empty() {
+            format!("---\n{yaml}\n---\n")
+        } else {
+            format!("---\n{yaml}\n---\n{}\n", self.body)
+        };
         fs::write(path, file_content)?;
         Ok(())
     }
@@ -266,6 +270,12 @@ impl From<std::io::Error> for PromptFileError {
     fn from(e: std::io::Error) -> Self {
         PromptFileError::Io(e)
     }
+}
+
+fn normalize_frontmatter_yaml(yaml: &str) -> &str {
+    let yaml = yaml.trim();
+    let yaml = yaml.strip_prefix("---\n").unwrap_or(yaml);
+    yaml.strip_suffix("\n...").unwrap_or(yaml).trim()
 }
 
 #[expect(clippy::trivially_copy_pass_by_ref)]


### PR DESCRIPTION
- Upgrades dependencies
- ACP crate now supports passing message ids, so we wire those in
- Serde yaml create had a breaking change, so we update code to make tests pass here