### PR TITLE
fix(wisp): Mouse scroll in git diff view no longer jumps

### DIFF
--- a/packages/wisp/src/components/file_list_panel.rs
+++ b/packages/wisp/src/components/file_list_panel.rs
@@ -15,6 +15,7 @@ pub struct FileListPanel {
     deletions: usize,
     focused: bool,
     file_comment_counts: Vec<usize>,
+    scroll_consumed_this_frame: bool,
 }
 
 pub enum FileListMessage {
@@ -33,6 +34,7 @@ impl Default for FileListPanel {
             deletions: 0,
             focused: false,
             file_comment_counts: Vec::new(),
+            scroll_consumed_this_frame: false,
         }
     }
 }
@@ -125,9 +127,17 @@ impl Component for FileListPanel {
         if let Event::Mouse(mouse) = event {
             return match mouse.kind {
                 MouseEventKind::ScrollUp => {
+                    if self.scroll_consumed_this_frame {
+                        return Some(vec![]);
+                    }
+                    self.scroll_consumed_this_frame = true;
                     Some(self.select_relative(-1).map(|idx| vec![FileListMessage::Selected(idx)]).unwrap_or_default())
                 }
                 MouseEventKind::ScrollDown => {
+                    if self.scroll_consumed_this_frame {
+                        return Some(vec![]);
+                    }
+                    self.scroll_consumed_this_frame = true;
                     Some(self.select_relative(1).map(|idx| vec![FileListMessage::Selected(idx)]).unwrap_or_default())
                 }
                 _ => None,
@@ -161,6 +171,7 @@ impl Component for FileListPanel {
 
     fn render(&mut self, ctx: &ViewContext) -> Frame {
         let theme = &ctx.theme;
+        self.scroll_consumed_this_frame = false;
         let width = ctx.size.width as usize;
         let height = ctx.size.height as usize;
         if width < 2 {

--- a/packages/wisp/tests/component_tests/file_list_panel.rs
+++ b/packages/wisp/tests/component_tests/file_list_panel.rs
@@ -1,5 +1,5 @@
 use tui::testing::{TestTerminal, assert_buffer_eq, cols, key, render_component};
-use tui::{Component, Event, KeyCode, ViewContext};
+use tui::{Component, Event, KeyCode, KeyModifiers, MouseEvent, MouseEventKind, ViewContext};
 use wisp::components::file_list_panel::FileListPanel;
 use wisp::git_diff::{FileDiff, FileStatus, Hunk, PatchLine, PatchLineKind};
 
@@ -7,6 +7,10 @@ const W: u16 = 40;
 
 fn ev(code: KeyCode) -> Event {
     Event::Key(key(code))
+}
+
+fn mouse_scroll(kind: MouseEventKind) -> Event {
+    Event::Mouse(MouseEvent { kind, column: 0, row: 0, modifiers: KeyModifiers::NONE })
 }
 
 fn rule() -> String {
@@ -358,6 +362,24 @@ async fn arrow_keys_navigate() {
     panel.on_event(&ev(KeyCode::Up)).await;
     let term = render_component(|ctx| panel.render(ctx), W, 4);
     assert_selected_tree_row(&term, 2, 3);
+}
+
+#[tokio::test]
+async fn mouse_scroll_moves_once_until_next_render() {
+    let files = (0..5).map(|i| file(&format!("file-{i}.rs"), FileStatus::Modified, 1, 1)).collect::<Vec<_>>();
+    let mut panel = FileListPanel::new();
+    panel.rebuild_from_files(&files);
+
+    panel.on_event(&mouse_scroll(MouseEventKind::ScrollDown)).await;
+    panel.on_event(&mouse_scroll(MouseEventKind::ScrollDown)).await;
+    let term = render_component(|ctx| panel.render(ctx), W, 7);
+
+    assert_selected_tree_row(&term, 3, 2);
+
+    panel.on_event(&mouse_scroll(MouseEventKind::ScrollDown)).await;
+    let term = render_component(|ctx| panel.render(ctx), W, 7);
+
+    assert_selected_tree_row(&term, 4, 3);
 }
 
 #[tokio::test]


### PR DESCRIPTION
This PR fixes a bug whee scrolling the mouse wheel in the git diff view would jump multiple lines in the file pane due to multiple mouse wheel events occurring within a single frame. 