### PR TITLE
feat(aether-cli): Add /move command to switch workspaces and bring yo…

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -69,6 +69,7 @@ dependencies = [
  "crossterm",
  "dirs",
  "futures",
+ "libc",
  "rmcp",
  "serde",
  "serde_json",

--- a/packages/acp-utils/src/client/event.rs
+++ b/packages/acp-utils/src/client/event.rs
@@ -6,7 +6,8 @@ use agent_client_protocol::schema::{SessionConfigOption, SessionId, SessionInfo}
 
 use crate::notifications::{
     AuthMethodsUpdatedParams, ContextClearedParams, ContextUsageParams, ElicitationParams, ElicitationResponse,
-    McpNotification, PromptSearchResponse, SessionPreviewResponse, SubAgentProgressParams,
+    McpNotification, PromptSearchResponse, SessionPreviewResponse, SubAgentProgressParams, WorkspaceListResponse,
+    WorkspaceMoveResponse,
 };
 
 /// Events forwarded from the ACP connection to the main event loop.
@@ -29,5 +30,9 @@ pub enum AcpEvent {
     PromptSearchFailed { query: String, error: String },
     SessionPreviewLoaded(SessionPreviewResponse),
     SessionPreviewFailed { session_id: String, error: String },
+    WorkspacesListed(WorkspaceListResponse),
+    WorkspaceListFailed { error: String },
+    WorkspaceMoved(WorkspaceMoveResponse),
+    WorkspaceMoveFailed { error: String },
     ConnectionClosed,
 }

--- a/packages/acp-utils/src/client/prompt_handle.rs
+++ b/packages/acp-utils/src/client/prompt_handle.rs
@@ -3,7 +3,9 @@ use std::path::{Path, PathBuf};
 use tokio::sync::mpsc;
 
 use super::error::AcpClientError;
-use crate::notifications::{PromptSearchParams, SessionPreviewParams};
+use crate::notifications::{
+    PromptSearchParams, SessionPreviewParams, WorkspaceListParams, WorkspaceMoveParams, WorkspaceMoveTarget,
+};
 
 /// Commands sent from the main thread to the ACP client task.
 #[derive(Debug)]
@@ -18,6 +20,8 @@ pub enum PromptCommand {
     NewSession { cwd: std::path::PathBuf },
     SearchPrompts(PromptSearchParams),
     SessionPreview(SessionPreviewParams),
+    ListWorkspaces(WorkspaceListParams),
+    MoveWorkspace(WorkspaceMoveParams),
 }
 
 /// Send-safe handle for issuing prompt commands to the ACP client task.
@@ -97,6 +101,14 @@ impl AcpPromptHandle {
 
     pub fn session_preview(&self, session_id: &SessionId) -> Result<(), AcpClientError> {
         self.send(PromptCommand::SessionPreview(SessionPreviewParams { session_id: session_id.0.to_string() }))
+    }
+
+    pub fn list_workspaces(&self, session_id: &SessionId) -> Result<(), AcpClientError> {
+        self.send(PromptCommand::ListWorkspaces(WorkspaceListParams { session_id: session_id.0.to_string() }))
+    }
+
+    pub fn move_workspace(&self, session_id: &SessionId, target: WorkspaceMoveTarget) -> Result<(), AcpClientError> {
+        self.send(PromptCommand::MoveWorkspace(WorkspaceMoveParams { session_id: session_id.0.to_string(), target }))
     }
 
     fn send(&self, cmd: PromptCommand) -> Result<(), AcpClientError> {
@@ -215,6 +227,35 @@ mod tests {
                 assert_eq!(cwd, std::path::PathBuf::from("/tmp/project"));
             }
             _ => panic!("Expected LoadSession command"),
+        }
+    }
+
+    #[test]
+    fn test_list_workspaces_sends_command() {
+        let (tx, mut rx) = mpsc::unbounded_channel();
+        let handle = AcpPromptHandle { cmd_tx: tx };
+        handle.list_workspaces(&SessionId::new("sess-1")).unwrap();
+
+        let cmd = rx.try_recv().unwrap();
+        match cmd {
+            PromptCommand::ListWorkspaces(params) => assert_eq!(params.session_id, "sess-1"),
+            _ => panic!("Expected ListWorkspaces command"),
+        }
+    }
+
+    #[test]
+    fn test_move_workspace_sends_command() {
+        let (tx, mut rx) = mpsc::unbounded_channel();
+        let handle = AcpPromptHandle { cmd_tx: tx };
+        handle.move_workspace(&SessionId::new("sess-1"), WorkspaceMoveTarget::New { name: "ws".into() }).unwrap();
+
+        let cmd = rx.try_recv().unwrap();
+        match cmd {
+            PromptCommand::MoveWorkspace(params) => {
+                assert_eq!(params.session_id, "sess-1");
+                assert_eq!(params.target, WorkspaceMoveTarget::New { name: "ws".into() });
+            }
+            _ => panic!("Expected MoveWorkspace command"),
         }
     }
 

--- a/packages/acp-utils/src/client/session.rs
+++ b/packages/acp-utils/src/client/session.rs
@@ -13,7 +13,7 @@ use agent_client_protocol::schema::{
     RequestPermissionRequest, RequestPermissionResponse, SelectedPermissionOutcome, SessionCapabilities,
     SessionConfigOption, SessionId, SessionNotification, SessionUpdate, SetSessionConfigOptionRequest, TextContent,
 };
-use agent_client_protocol::{self as acp, Client, ConnectionTo};
+use agent_client_protocol::{self as acp, Client, ConnectionTo, JsonRpcRequest};
 use std::str::FromStr;
 use tokio::sync::mpsc;
 use tracing::info;
@@ -237,40 +237,46 @@ async fn run_main(
                 }
             }
             PromptCommand::ListSessions => {
-                let req = ListSessionsRequest::new();
-                match cx.send_request(req).block_task().await {
-                    Ok(resp) => {
-                        let _ = event_tx.send(AcpEvent::SessionsListed { sessions: resp.sessions });
-                    }
-                    Err(e) => {
-                        let _ = event_tx.send(AcpEvent::PromptError(e));
-                    }
-                }
+                request_to_event(
+                    &cx,
+                    &event_tx,
+                    ListSessionsRequest::new(),
+                    |resp| AcpEvent::SessionsListed { sessions: resp.sessions },
+                    AcpEvent::PromptError,
+                )
+                .await;
             }
             PromptCommand::LoadSession { session_id, cwd } => {
-                let req = LoadSessionRequest::new(session_id.clone(), cwd);
-                match cx.send_request(req).block_task().await {
-                    Ok(resp) => {
-                        let config_options = resp.config_options.unwrap_or_default();
-                        let _ = event_tx.send(AcpEvent::SessionLoaded { session_id, config_options });
-                    }
-                    Err(e) => {
-                        let _ = event_tx.send(AcpEvent::PromptError(e));
-                    }
-                }
+                request_to_event(
+                    &cx,
+                    &event_tx,
+                    LoadSessionRequest::new(session_id.clone(), cwd),
+                    |resp| AcpEvent::SessionLoaded {
+                        session_id,
+                        config_options: resp.config_options.unwrap_or_default(),
+                    },
+                    AcpEvent::PromptError,
+                )
+                .await;
             }
             PromptCommand::NewSession { cwd } => {
-                let req = NewSessionRequest::new(cwd);
-                match cx.send_request(req).block_task().await {
-                    Ok(resp) => {
-                        let config_options = resp.config_options.unwrap_or_default();
-                        let _ =
-                            event_tx.send(AcpEvent::NewSessionCreated { session_id: resp.session_id, config_options });
-                    }
-                    Err(e) => {
-                        let _ = event_tx.send(AcpEvent::PromptError(e));
-                    }
-                }
+                request_to_event(
+                    &cx,
+                    &event_tx,
+                    NewSessionRequest::new(cwd),
+                    |resp| AcpEvent::NewSessionCreated {
+                        session_id: resp.session_id,
+                        config_options: resp.config_options.unwrap_or_default(),
+                    },
+                    AcpEvent::PromptError,
+                )
+                .await;
+            }
+            PromptCommand::MoveWorkspace(params) => {
+                request_to_event(&cx, &event_tx, params, AcpEvent::WorkspaceMoved, |e| AcpEvent::WorkspaceMoveFailed {
+                    error: format!("{e}"),
+                })
+                .await;
             }
             cmd => handle_side_command(&cx, &event_tx, cmd).await,
         }
@@ -332,27 +338,44 @@ async fn handle_side_command(
         }
         PromptCommand::SearchPrompts(params) => {
             let query = params.query.clone();
-            match cx.send_request(params).block_task().await {
-                Ok(resp) => {
-                    let _ = event_tx.send(AcpEvent::PromptSearchResults(resp));
-                }
-                Err(e) => {
-                    let _ = event_tx.send(AcpEvent::PromptSearchFailed { query, error: format!("{e}") });
-                }
-            }
+            request_to_event(cx, event_tx, params, AcpEvent::PromptSearchResults, |e| AcpEvent::PromptSearchFailed {
+                query,
+                error: format!("{e}"),
+            })
+            .await;
         }
         PromptCommand::SessionPreview(params) => {
             let session_id = params.session_id.clone();
-            match cx.send_request(params).block_task().await {
-                Ok(resp) => {
-                    let _ = event_tx.send(AcpEvent::SessionPreviewLoaded(resp));
-                }
-                Err(e) => {
-                    let _ = event_tx.send(AcpEvent::SessionPreviewFailed { session_id, error: format!("{e}") });
-                }
-            }
+            request_to_event(cx, event_tx, params, AcpEvent::SessionPreviewLoaded, |e| {
+                AcpEvent::SessionPreviewFailed { session_id, error: format!("{e}") }
+            })
+            .await;
+        }
+        PromptCommand::ListWorkspaces(params) => {
+            request_to_event(cx, event_tx, params, AcpEvent::WorkspacesListed, |e| AcpEvent::WorkspaceListFailed {
+                error: format!("{e}"),
+            })
+            .await;
+        }
+        PromptCommand::MoveWorkspace(_) => {
+            tracing::warn!("ignoring MoveWorkspace while prompt is in-flight");
+            let _ = event_tx.send(AcpEvent::WorkspaceMoveFailed { error: "a prompt is in flight".to_string() });
         }
     }
+}
+
+async fn request_to_event<T: JsonRpcRequest>(
+    cx: &ConnectionTo<acp::Agent>,
+    event_tx: &mpsc::UnboundedSender<AcpEvent>,
+    params: T,
+    ok: impl FnOnce(T::Response) -> AcpEvent,
+    err: impl FnOnce(acp::Error) -> AcpEvent,
+) {
+    let event = match cx.send_request(params).block_task().await {
+        Ok(resp) => ok(resp),
+        Err(e) => err(e),
+    };
+    let _ = event_tx.send(event);
 }
 
 fn auto_approve_option(req: &RequestPermissionRequest) -> PermissionOptionId {

--- a/packages/acp-utils/src/notifications.rs
+++ b/packages/acp-utils/src/notifications.rs
@@ -140,6 +140,51 @@ pub enum SessionPreviewRole {
     Assistant,
 }
 
+/// Parameters for the `_aether/workspace_list` request.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, JsonRpcRequest)]
+#[request(method = "_aether/workspace_list", response = WorkspaceListResponse)]
+#[serde(rename_all = "camelCase")]
+pub struct WorkspaceListParams {
+    pub session_id: String,
+}
+
+/// Response for the `_aether/workspace_list` request: every managed workspace
+/// originating from the same git repository as the session's working directory.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, JsonRpcResponse)]
+#[serde(rename_all = "camelCase")]
+pub struct WorkspaceListResponse {
+    pub workspaces: Vec<WorkspaceEntry>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct WorkspaceEntry {
+    pub path: PathBuf,
+    pub is_current: bool,
+}
+
+/// Parameters for the `_aether/workspace_move` request.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, JsonRpcRequest)]
+#[request(method = "_aether/workspace_move", response = WorkspaceMoveResponse)]
+#[serde(rename_all = "camelCase")]
+pub struct WorkspaceMoveParams {
+    pub session_id: String,
+    pub target: WorkspaceMoveTarget,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(tag = "kind", rename_all = "camelCase")]
+pub enum WorkspaceMoveTarget {
+    Existing { path: PathBuf },
+    New { name: String },
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, JsonRpcResponse)]
+#[serde(rename_all = "camelCase")]
+pub struct WorkspaceMoveResponse {
+    pub new_cwd: PathBuf,
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Default)]
 #[serde(rename_all = "camelCase")]
 pub struct SessionDisplayMeta {
@@ -166,26 +211,18 @@ impl SessionDisplayMeta {
     }
 }
 
-#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq, Default)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Default)]
 #[serde(rename_all = "camelCase")]
 pub struct AetherCapabilities {
     #[serde(default, skip_serializing_if = "std::ops::Not::not")]
     pub prompt_search: bool,
     #[serde(default, skip_serializing_if = "std::ops::Not::not")]
     pub session_preview: bool,
+    #[serde(default, skip_serializing_if = "std::ops::Not::not")]
+    pub workspace_move: bool,
 }
 
 impl AetherCapabilities {
-    #[must_use]
-    pub fn prompt_search() -> Self {
-        Self { prompt_search: true, session_preview: false }
-    }
-
-    #[must_use]
-    pub fn session_preview() -> Self {
-        Self { prompt_search: false, session_preview: true }
-    }
-
     #[must_use]
     pub fn to_meta(self) -> agent_client_protocol::schema::Meta {
         to_aether_meta(&self)
@@ -305,17 +342,10 @@ mod tests {
         );
         assert_eq!(PromptSearchParams { query: String::new(), limit: None }.method(), "_aether/prompt_search");
         assert_eq!(SessionPreviewParams { session_id: String::new() }.method(), "_aether/session_preview");
-    }
-
-    #[test]
-    fn prompt_search_capability_meta_roundtrip() {
-        let meta = AetherCapabilities::prompt_search().to_meta();
-        assert!(AetherCapabilities::from_meta(Some(&meta)).prompt_search);
-        assert!(!AetherCapabilities::from_meta(None).prompt_search);
-        assert!(!AetherCapabilities::from_meta(Some(&agent_client_protocol::schema::Meta::new())).prompt_search);
-        let raw = serde_json::to_string(meta.get(AETHER_META_NAMESPACE).unwrap()).unwrap();
-        assert!(raw.contains("promptSearch"));
-        assert!(!raw.contains("sessionPreview"));
+        assert_eq!(WorkspaceListParams { session_id: String::new() }.method(), "_aether/workspace_list");
+        let move_params =
+            WorkspaceMoveParams { session_id: String::new(), target: WorkspaceMoveTarget::New { name: String::new() } };
+        assert_eq!(move_params.method(), "_aether/workspace_move");
     }
 
     #[test]

--- a/packages/aether-cli/Cargo.toml
+++ b/packages/aether-cli/Cargo.toml
@@ -59,5 +59,8 @@ tempfile = { workspace = true }
 crossterm = { workspace = true }
 url = { workspace = true }
 
+[target.'cfg(target_os = "macos")'.dependencies]
+libc = { workspace = true }
+
 [dev-dependencies]
 acp_utils = { package = "aether-acp-utils", path = "../acp-utils", features = ["testing"], version = "0.3.20" }

--- a/packages/aether-cli/src/acp/agent.rs
+++ b/packages/aether-cli/src/acp/agent.rs
@@ -1,5 +1,7 @@
 use super::state::AcpState;
-use acp_utils::notifications::{McpRequest, PromptSearchParams, SessionPreviewParams};
+use acp_utils::notifications::{
+    McpRequest, PromptSearchParams, SessionPreviewParams, WorkspaceListParams, WorkspaceMoveParams,
+};
 use agent_client_protocol::schema::{
     AuthenticateRequest, CancelNotification, InitializeRequest, ListSessionsRequest, LoadSessionRequest,
     NewSessionRequest, PromptRequest, SetSessionConfigOptionRequest,
@@ -109,6 +111,26 @@ pub(crate) fn acp_agent_builder(state: Arc<AcpState>) -> Builder<Agent, impl Han
                 async move |req: SessionPreviewParams, responder, cx| {
                     let state = state.clone();
                     spawn_response(&cx, responder, async move { state.session_preview(&req) })
+                }
+            },
+            acp::on_receive_request!(),
+        )
+        .on_receive_request(
+            {
+                let state = state.clone();
+                async move |req: WorkspaceListParams, responder, cx| {
+                    let state = state.clone();
+                    spawn_response(&cx, responder, async move { state.workspace_list(&req).await })
+                }
+            },
+            acp::on_receive_request!(),
+        )
+        .on_receive_request(
+            {
+                let state = state.clone();
+                async move |req: WorkspaceMoveParams, responder, cx| {
+                    let state = state.clone();
+                    spawn_response(&cx, responder, async move { state.workspace_move(&req).await })
                 }
             },
             acp::on_receive_request!(),

--- a/packages/aether-cli/src/acp/mod.rs
+++ b/packages/aether-cli/src/acp/mod.rs
@@ -26,6 +26,7 @@ use crate::settings_args::SettingsSourceArgs;
 use agent_client_protocol as acp;
 use llm::ReasoningEffort;
 use std::env::current_dir;
+use std::io;
 use std::sync::Arc;
 use std::{fs::create_dir_all, path::PathBuf};
 use thiserror::Error;
@@ -34,6 +35,7 @@ use tracing_appender::rolling::daily;
 use tracing_subscriber::EnvFilter;
 
 use crate::credentials::build_oauth_credential_store;
+use crate::workspace::WorkspaceManager;
 use aether_auth::OAuthError;
 use session_factory::InitialSessionSelection;
 use session_store::SessionStore;
@@ -79,6 +81,12 @@ pub enum AcpRunError {
 
     #[error("Failed to initialize OAuth credential store: {0}")]
     CredentialStore(#[from] OAuthError),
+
+    #[error("Failed to initialize session store: {0}")]
+    SessionStore(#[source] io::Error),
+
+    #[error("Failed to initialize workspace manager: {0}")]
+    WorkspaceManager(#[source] io::Error),
 }
 
 pub async fn run_acp(args: AcpArgs) -> Result<AcpRunOutcome, AcpRunError> {
@@ -93,13 +101,14 @@ pub async fn run_acp(args: AcpArgs) -> Result<AcpRunOutcome, AcpRunError> {
     } else {
         InitialSessionSelection::default()
     };
-    let session_store =
-        SessionStore::new().map_or_else(|e| panic!("Failed to initialize session store: {e}"), Arc::new);
+    let session_store = Arc::new(SessionStore::new().map_err(AcpRunError::SessionStore)?);
+    let workspace_manager = Arc::new(WorkspaceManager::new().map_err(AcpRunError::WorkspaceManager)?);
     let cwd = current_dir().unwrap_or_else(|_| PathBuf::from("."));
     let oauth_credential_store = build_oauth_credential_store(&args.settings_source, &cwd)?;
     let provider_connections = args.provider_connection.into_overrides();
     let state = Arc::new(AcpState::new(AcpStateConfig {
         session_store,
+        workspace_manager,
         oauth_credential_store,
         initial_selection,
         settings_source: args.settings_source,

--- a/packages/aether-cli/src/acp/prompt_history_index.rs
+++ b/packages/aether-cli/src/acp/prompt_history_index.rs
@@ -36,6 +36,19 @@ impl PromptHistoryIndex {
         }
     }
 
+    pub(super) fn relocate_session(&self, session_id: &str, new_cwd: &Path) -> io::Result<()> {
+        let mut state = self.lock_state();
+        let entries = self.ensure_loaded(&mut state)?;
+
+        let mut changed = false;
+        for entry in entries.iter_mut().filter(|entry| entry.session_id == session_id) {
+            entry.cwd = new_cwd.to_path_buf();
+            changed = true;
+        }
+
+        if changed { self.rewrite_file(entries.iter()) } else { Ok(()) }
+    }
+
     pub(super) fn search(&self, params: &PromptSearchParams) -> io::Result<PromptSearchResponse> {
         let query = params.query.trim();
         let limit = prompt_search_limit(params.limit);

--- a/packages/aether-cli/src/acp/session_store.rs
+++ b/packages/aether-cli/src/acp/session_store.rs
@@ -82,6 +82,39 @@ impl SessionStore {
         Some((scan.meta, scan.events))
     }
 
+    pub(crate) fn session_cwd(&self, session_id: &str) -> Option<PathBuf> {
+        self.session_meta(session_id).map(|meta| meta.cwd)
+    }
+
+    /// Rewrites the session's recorded working directory to `new_cwd`, updating the
+    /// metadata line and any matching prompt-history entries. Event lines are left
+    /// unchanged.
+    pub fn relocate(&self, session_id: &str, new_cwd: &Path) -> io::Result<()> {
+        let path = self.session_path(session_id);
+        let content = fs::read_to_string(&path)?;
+        let mut lines = content.lines();
+        let first =
+            lines.next().ok_or_else(|| io::Error::new(io::ErrorKind::UnexpectedEof, "session file is empty"))?;
+
+        let mut meta: SessionMeta = serde_json::from_str(first.trim())
+            .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, format!("invalid session metadata: {e}")))?;
+        meta.cwd = new_cwd.to_path_buf();
+        let meta_line = serde_json::to_string(&meta)
+            .map_err(|e| io::Error::other(format!("Failed to serialize session metadata: {e}")))?;
+
+        let tmp_path = path.with_extension("jsonl.tmp");
+        {
+            let mut file = File::create(&tmp_path)?;
+            writeln!(file, "{meta_line}")?;
+            for line in lines {
+                writeln!(file, "{line}")?;
+            }
+        }
+        fs::rename(tmp_path, &path)?;
+
+        self.prompt_history.relocate_session(session_id, new_cwd)
+    }
+
     pub fn list(&self) -> Vec<SessionSummary> {
         let Ok(entries) = fs::read_dir(&self.dir) else {
             return Vec::new();
@@ -468,6 +501,40 @@ mod tests {
 
         let (_, events) = store.load("s1").unwrap();
         assert_eq!(events, kept);
+    }
+
+    #[test]
+    fn relocate_rewrites_cwd_in_meta_and_prompt_history_for_target_session_only() {
+        let (_dir, store) = temp_store();
+        store.append_meta("s1", &default_meta()).unwrap();
+        store.append_event("s1", &user_msg("hello world")).unwrap();
+        store.append_event("s1", &agent_text("m", "hi there", true)).unwrap();
+        store.append_meta("s2", &meta("s2", "2026-01-02T00:00:00Z", None)).unwrap();
+        store.append_event("s2", &user_msg("other prompt")).unwrap();
+
+        store.relocate("s1", Path::new("/new/workspace")).unwrap();
+
+        let (meta1, events1) = store.load("s1").unwrap();
+        assert_eq!(meta1.cwd, PathBuf::from("/new/workspace"));
+        assert_eq!(events1, vec![user_msg("hello world"), agent_text("m", "hi there", true)]);
+
+        let (meta2, _) = store.load("s2").unwrap();
+        assert_eq!(meta2.cwd, PathBuf::from("/tmp"));
+
+        let moved =
+            store.search_prompts(&PromptSearchParams { query: "hello world".to_string(), limit: None }).unwrap();
+        assert_eq!(moved.results[0].cwd, PathBuf::from("/new/workspace"));
+        let untouched =
+            store.search_prompts(&PromptSearchParams { query: "other prompt".to_string(), limit: None }).unwrap();
+        assert_eq!(untouched.results[0].cwd, PathBuf::from("/tmp"));
+    }
+
+    #[test]
+    fn session_cwd_reads_recorded_directory() {
+        let (_dir, store) = temp_store();
+        store.append_meta("s1", &default_meta()).unwrap();
+        assert_eq!(store.session_cwd("s1"), Some(PathBuf::from("/tmp")));
+        assert_eq!(store.session_cwd("missing"), None);
     }
 
     #[test]

--- a/packages/aether-cli/src/acp/state.rs
+++ b/packages/aether-cli/src/acp/state.rs
@@ -1,6 +1,7 @@
 use acp_utils::notifications::{
     AetherCapabilities, AuthMethodsUpdatedParams, McpRequest, PromptSearchParams, PromptSearchResponse,
-    SessionDisplayMeta, SessionPreviewParams, SessionPreviewResponse,
+    SessionDisplayMeta, SessionPreviewParams, SessionPreviewResponse, WorkspaceListParams, WorkspaceListResponse,
+    WorkspaceMoveParams, WorkspaceMoveResponse,
 };
 use acp_utils::server::AcpServerError;
 use aether_auth::OAuthCredentialStorage;
@@ -15,8 +16,11 @@ use agent_client_protocol::{Client, ConnectionTo, Responder};
 use llm::catalog::{LlmModel, get_local_models};
 use llm::{ContentBlock, ProviderConnectionOverrides};
 use std::collections::{HashMap, HashSet};
+use std::io;
+use std::path::PathBuf;
 use std::sync::Arc;
 use tokio::sync::{Mutex, mpsc};
+use tokio::task::spawn_blocking;
 use tracing::{error, info};
 
 use super::config_setting::ConfigSetting;
@@ -27,6 +31,7 @@ use super::session_actor::{ConfigSnapshot, SessionCommand, SessionHandle};
 use super::session_factory::{InitialSessionSelection, SessionFactory};
 use super::session_store::SessionStore;
 use crate::settings_args::SettingsSourceArgs;
+use crate::workspace::{WorkspaceError, WorkspaceManager};
 
 /// Global, connection-scoped ACP server state: the live session map plus the
 /// dependencies needed to create sessions and answer global requests. There is
@@ -35,12 +40,14 @@ use crate::settings_args::SettingsSourceArgs;
 pub(crate) struct AcpState {
     sessions: Mutex<HashMap<String, SessionHandle>>,
     session_store: Arc<SessionStore>,
+    workspace_manager: Arc<WorkspaceManager>,
     oauth_credential_store: Arc<dyn OAuthCredentialStorage>,
     factory: SessionFactory,
 }
 
 pub(crate) struct AcpStateConfig {
     pub(crate) session_store: Arc<SessionStore>,
+    pub(crate) workspace_manager: Arc<WorkspaceManager>,
     pub(crate) oauth_credential_store: Arc<dyn OAuthCredentialStorage>,
     pub(crate) initial_selection: InitialSessionSelection,
     pub(crate) settings_source: SettingsSourceArgs,
@@ -59,6 +66,7 @@ impl AcpState {
         Self {
             sessions: Mutex::new(HashMap::new()),
             session_store: config.session_store,
+            workspace_manager: config.workspace_manager,
             oauth_credential_store: config.oauth_credential_store,
             factory,
         }
@@ -68,12 +76,12 @@ impl AcpState {
         info!("Received initialize request: {:?}", args);
         let auth_methods = build_auth_methods(self.oauth_credential_store.as_ref());
         let available = get_local_models().await;
-        let prompt_capabilities =
-            prompt_capabilities_for_models(&available).meta(Some(AetherCapabilities::prompt_search().to_meta()));
-
+        let prompt_capabilities = prompt_capabilities_for_models(&available);
+        let aether_capabilities =
+            AetherCapabilities { prompt_search: true, session_preview: true, workspace_move: true };
         let session_capabilities = acp::SessionCapabilities::new()
             .list(acp::SessionListCapabilities::new())
-            .meta(Some(AetherCapabilities::session_preview().to_meta()));
+            .meta(Some(aether_capabilities.to_meta()));
 
         Ok(InitializeResponse::new(ProtocolVersion::V1)
             .agent_info(Implementation::new("Aether", "0.1.0"))
@@ -175,6 +183,58 @@ impl AcpState {
                 _ => acp::Error::internal_error(),
             }
         })
+    }
+
+    /// Lists managed workspaces sharing the session's repository.
+    pub(crate) async fn workspace_list(
+        &self,
+        params: &WorkspaceListParams,
+    ) -> Result<WorkspaceListResponse, acp::Error> {
+        self.run_workspace_request(params.session_id.clone(), |_session_store, manager, src_cwd| {
+            manager
+                .list(&src_cwd)
+                .map(|workspaces| WorkspaceListResponse { workspaces })
+                .map_err(WorkspaceRequestError::Workspace)
+        })
+        .await
+    }
+
+    /// Moves the session's uncommitted changes to the target workspace, then
+    /// relocates the stored session to the target directory.
+    pub(crate) async fn workspace_move(
+        &self,
+        params: &WorkspaceMoveParams,
+    ) -> Result<WorkspaceMoveResponse, acp::Error> {
+        let target = params.target.clone();
+        let session_id = params.session_id.clone();
+        let response = self
+            .run_workspace_request(session_id.clone(), move |session_store, manager, src_cwd| {
+                let new_cwd = manager.move_to(&src_cwd, &target).map_err(WorkspaceRequestError::Workspace)?;
+                session_store.relocate(&session_id, &new_cwd).map_err(WorkspaceRequestError::Relocate)?;
+                Ok(WorkspaceMoveResponse { new_cwd })
+            })
+            .await?;
+
+        info!("Moved session {} to workspace {}", params.session_id, response.new_cwd.display());
+        Ok(response)
+    }
+
+    async fn run_workspace_request<T, F>(&self, session_id: String, op: F) -> Result<T, acp::Error>
+    where
+        T: Send + 'static,
+        F: FnOnce(&SessionStore, &WorkspaceManager, PathBuf) -> Result<T, WorkspaceRequestError> + Send + 'static,
+    {
+        let session_store = Arc::clone(&self.session_store);
+        let manager = Arc::clone(&self.workspace_manager);
+        spawn_blocking(move || {
+            let src_cwd = session_store
+                .session_cwd(&session_id)
+                .ok_or_else(|| WorkspaceRequestError::UnknownSession(session_id.clone()))?;
+            op(&session_store, &manager, src_cwd)
+        })
+        .await
+        .map_err(|e| internal_error(format!("workspace task failed: {e}")))?
+        .map_err(workspace_request_error)
     }
 
     /// Route a prompt to its session actor. Validates media support against the
@@ -281,7 +341,9 @@ impl AcpState {
     }
 
     pub(crate) async fn register_session(&self, session_id: &SessionId, handle: SessionHandle) {
-        self.sessions.lock().await.insert(session_id.0.to_string(), handle);
+        if let Some(old) = self.sessions.lock().await.insert(session_id.0.to_string(), handle) {
+            old.cancel();
+        }
     }
 
     async fn lookup(&self, session_id: &str) -> Option<(mpsc::Sender<SessionCommand>, ConfigSnapshot)> {
@@ -312,6 +374,34 @@ fn respond_err<T: agent_client_protocol::JsonRpcResponse>(responder: Responder<T
     if let Err(e) = responder.respond_with_error(error) {
         error!("failed to send error response: {e:?}");
     }
+}
+
+enum WorkspaceRequestError {
+    UnknownSession(String),
+    Workspace(WorkspaceError),
+    Relocate(io::Error),
+}
+
+fn workspace_request_error(e: WorkspaceRequestError) -> acp::Error {
+    match e {
+        WorkspaceRequestError::UnknownSession(session_id) => {
+            invalid_params_error(format!("unknown session: {session_id}"))
+        }
+        WorkspaceRequestError::Workspace(e) => workspace_error(&e),
+        WorkspaceRequestError::Relocate(e) => internal_error(format!("failed to relocate session: {e}")),
+    }
+}
+
+fn workspace_error(e: &WorkspaceError) -> acp::Error {
+    if e.is_invalid_input() { invalid_params_error(e.to_string()) } else { internal_error(e.to_string()) }
+}
+
+fn invalid_params_error(message: impl Into<String>) -> acp::Error {
+    acp::Error::new(i32::from(acp::ErrorCode::InvalidParams), message)
+}
+
+fn internal_error(message: impl Into<String>) -> acp::Error {
+    acp::Error::new(i32::from(acp::ErrorCode::InternalError), message)
 }
 
 fn build_auth_methods(store: &dyn OAuthCredentialStorage) -> Vec<AuthMethod> {
@@ -400,10 +490,12 @@ mod tests {
     }
 
     fn test_state() -> AcpState {
-        let session_store =
-            SessionStore::new().map_or_else(|e| panic!("Failed to initialize session store: {e}"), Arc::new);
+        let session_store = Arc::new(SessionStore::from_path(PathBuf::from("/tmp/aether-test-sessions")));
+        let workspace_manager =
+            Arc::new(WorkspaceManager::from_registry_path(PathBuf::from("/tmp/aether-test-workspaces.json")));
         AcpState::new(AcpStateConfig {
             session_store,
+            workspace_manager,
             oauth_credential_store: fake_oauth_store(),
             initial_selection: InitialSessionSelection::default(),
             settings_source: SettingsSourceArgs::default(),
@@ -421,17 +513,19 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn initialize_advertises_prompt_search_capability() {
+    async fn initialize_advertises_aether_capabilities_once() {
         let state = test_state();
         let response =
             state.initialize(InitializeRequest::new(ProtocolVersion::LATEST)).await.expect("initialize succeeds");
-        assert!(
-            AetherCapabilities::from_meta(response.agent_capabilities.prompt_capabilities.meta.as_ref()).prompt_search
+        assert_eq!(
+            AetherCapabilities::from_meta(response.agent_capabilities.prompt_capabilities.meta.as_ref()),
+            AetherCapabilities::default()
         );
-        assert!(
-            AetherCapabilities::from_meta(response.agent_capabilities.session_capabilities.meta.as_ref())
-                .session_preview
-        );
+        let capabilities =
+            AetherCapabilities::from_meta(response.agent_capabilities.session_capabilities.meta.as_ref());
+        assert!(capabilities.prompt_search);
+        assert!(capabilities.session_preview);
+        assert!(capabilities.workspace_move);
     }
 
     #[test]

--- a/packages/aether-cli/src/acp/testing.rs
+++ b/packages/aether-cli/src/acp/testing.rs
@@ -11,6 +11,8 @@ use super::state::{AcpState, AcpStateConfig};
 use crate::acp::session_store::{SessionMeta, SessionStore};
 use crate::error::CliError;
 use crate::settings_args::SettingsSourceArgs;
+use crate::workspace::WorkspaceManager;
+use crate::workspace::testing::StdCopyCloner;
 use acp_utils::notifications::McpNotification;
 use acp_utils::testing::{TestPeer, duplex_pair};
 use aether_auth::OAuthCredentialStorage;
@@ -65,8 +67,13 @@ impl AcpTestHarness {
     pub async fn start() -> Self {
         let tmp = tempfile::tempdir().expect("tempdir for session store");
         let session_store = Arc::new(SessionStore::from_path(tmp.path().to_path_buf()));
+        let workspace_manager = Arc::new(WorkspaceManager::from_registry_path_with_cloner(
+            tmp.path().join("workspaces.json"),
+            Arc::new(StdCopyCloner),
+        ));
         let state = Arc::new(AcpState::new(AcpStateConfig {
             session_store: session_store.clone(),
+            workspace_manager,
             oauth_credential_store: fake_oauth_store(),
             initial_selection: InitialSessionSelection::default(),
             settings_source: SettingsSourceArgs::default(),
@@ -196,9 +203,13 @@ impl AcpTestHarness {
     }
 
     pub fn append_stored_session(&self, session_id: &str, created_at: &str) {
+        self.append_stored_session_in(session_id, created_at, std::path::Path::new("/tmp"));
+    }
+
+    pub fn append_stored_session_in(&self, session_id: &str, created_at: &str, cwd: &std::path::Path) {
         let meta = SessionMeta {
             session_id: session_id.to_string(),
-            cwd: PathBuf::from("/tmp"),
+            cwd: cwd.to_path_buf(),
             model: "test-model".to_string(),
             selected_mode: None,
             created_at: created_at.to_string(),

--- a/packages/aether-cli/src/lib.rs
+++ b/packages/aether-cli/src/lib.rs
@@ -15,5 +15,6 @@ pub mod sandbox;
 pub mod settings;
 pub mod settings_args;
 pub mod show_prompt;
+pub mod workspace;
 
 pub use acp::map_mcp_prompt_to_available_command;

--- a/packages/aether-cli/src/workspace/git.rs
+++ b/packages/aether-cli/src/workspace/git.rs
@@ -1,0 +1,167 @@
+use std::fs;
+use std::io::Write;
+use std::path::{Path, PathBuf};
+use std::process::{Command, Output, Stdio};
+use thiserror::Error;
+
+#[derive(Debug, Error)]
+pub enum GitError {
+    #[error("failed to spawn `git {args}`: {source}")]
+    Spawn { args: String, source: std::io::Error },
+    #[error("`git {args}` failed: {stderr}")]
+    Failed { args: String, stderr: String },
+    #[error("filesystem error: {0}")]
+    Io(#[from] std::io::Error),
+}
+
+/// Resolves the root of the git working tree containing `path`.
+pub fn repo_root(path: &Path) -> Result<PathBuf, GitError> {
+    let output = git(path, &["rev-parse", "--show-toplevel"])?;
+    Ok(PathBuf::from(String::from_utf8_lossy(&output.stdout).trim()))
+}
+
+/// Returns the hash of the repository's first root commit, a stable identity
+/// shared by every clone and copy of the same repository.
+pub fn root_commit_hash(repo: &Path) -> Result<String, GitError> {
+    let output = git(repo, &["rev-list", "--max-parents=0", "HEAD"])?;
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    Ok(stdout.lines().next().unwrap_or_default().trim().to_string())
+}
+
+pub fn head_commit_hash(repo: &Path) -> Result<String, GitError> {
+    let output = git(repo, &["rev-parse", "HEAD"])?;
+    Ok(String::from_utf8_lossy(&output.stdout).trim().to_string())
+}
+
+pub fn is_clean(repo: &Path) -> Result<bool, GitError> {
+    Ok(git(repo, &["status", "--porcelain=v1", "-z"])?.stdout.is_empty())
+}
+
+pub fn untracked_files(repo: &Path) -> Result<Vec<PathBuf>, GitError> {
+    use std::os::unix::ffi::OsStrExt;
+
+    Ok(git(repo, &["ls-files", "--others", "--exclude-standard", "-z"])?
+        .stdout
+        .split(|b| *b == 0)
+        .filter(|chunk| !chunk.is_empty())
+        .map(|chunk| PathBuf::from(std::ffi::OsStr::from_bytes(chunk)))
+        .collect())
+}
+
+pub fn diff_head(repo: &Path) -> Result<Vec<u8>, GitError> {
+    Ok(git(repo, &["diff", "HEAD", "--binary", "--no-color"])?.stdout)
+}
+
+pub fn apply_patch(repo: &Path, patch: &[u8]) -> Result<(), GitError> {
+    if patch.is_empty() {
+        return Ok(());
+    }
+
+    git_with_stdin(repo, &["apply", "--binary", "--whitespace=nowarn"], patch)?;
+    Ok(())
+}
+
+pub fn copy_untracked_files(src: &Path, dst: &Path, files: &[PathBuf]) -> Result<(), GitError> {
+    for rel in files {
+        let src_file = src.join(rel);
+        let dst_file = dst.join(rel);
+
+        if let Some(parent) = dst_file.parent() {
+            fs::create_dir_all(parent)?;
+        }
+
+        fs::copy(src_file, dst_file)?;
+    }
+
+    Ok(())
+}
+
+pub fn reset_clean(repo: &Path) -> Result<(), GitError> {
+    git(repo, &["reset", "--hard", "HEAD"])?;
+    git(repo, &["clean", "-fd"])?;
+    Ok(())
+}
+
+fn git(repo: &Path, args: &[&str]) -> Result<std::process::Output, GitError> {
+    let output = Command::new("git")
+        .arg("-C")
+        .arg(repo)
+        .args(args)
+        .output()
+        .map_err(|e| GitError::Spawn { args: args.join(" "), source: e })?;
+
+    git_output(args, output)
+}
+
+fn git_with_stdin(repo: &Path, args: &[&str], stdin: &[u8]) -> Result<Output, GitError> {
+    let args_string = args.join(" ");
+    let mut child = Command::new("git")
+        .arg("-C")
+        .arg(repo)
+        .args(args)
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .map_err(|e| GitError::Spawn { args: args_string.clone(), source: e })?;
+
+    child
+        .stdin
+        .take()
+        .expect("stdin was piped")
+        .write_all(stdin)
+        .map_err(|e| GitError::Spawn { args: args_string.clone(), source: e })?;
+
+    let output = child.wait_with_output().map_err(|e| GitError::Spawn { args: args_string, source: e })?;
+    git_output(args, output)
+}
+
+fn git_output(args: &[&str], output: std::process::Output) -> Result<Output, GitError> {
+    if output.status.success() {
+        Ok(output)
+    } else {
+        Err(GitError::Failed {
+            args: args.join(" "),
+            stderr: String::from_utf8_lossy(&output.stderr).trim().to_string(),
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::workspace::testing::{clone_repo, git, init_repo};
+    use std::fs;
+    use tempfile::TempDir;
+
+    #[test]
+    fn repo_root_resolves_from_subdirectory() {
+        let tmp = TempDir::new().unwrap();
+        let repo = init_repo(tmp.path(), "repo");
+        let sub = repo.join("nested/dir");
+        fs::create_dir_all(&sub).unwrap();
+        assert_eq!(repo_root(&sub).unwrap(), repo.canonicalize().unwrap());
+    }
+
+    #[test]
+    fn root_commit_hash_is_stable_across_clones() {
+        let tmp = TempDir::new().unwrap();
+        let repo = init_repo(tmp.path(), "repo");
+        let clone = clone_repo(&repo, tmp.path().join("clone"));
+        fs::write(clone.join("extra.txt"), "diverged\n").unwrap();
+        git(&clone, &["add", "."]);
+        git(&clone, &["commit", "-m", "diverge"]);
+
+        let original = root_commit_hash(&repo).unwrap();
+        assert!(!original.is_empty());
+        assert_eq!(root_commit_hash(&clone).unwrap(), original);
+    }
+
+    #[test]
+    fn root_commit_hash_differs_between_unrelated_repos() {
+        let tmp = TempDir::new().unwrap();
+        let a = init_repo(tmp.path(), "a");
+        let b = init_repo(tmp.path(), "b");
+        assert_ne!(root_commit_hash(&a).unwrap(), root_commit_hash(&b).unwrap());
+    }
+}

--- a/packages/aether-cli/src/workspace/mod.rs
+++ b/packages/aether-cli/src/workspace/mod.rs
@@ -1,0 +1,316 @@
+use acp_utils::notifications::{WorkspaceEntry, WorkspaceMoveTarget};
+use std::io;
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+use thiserror::Error;
+
+mod git;
+mod registry;
+#[doc(hidden)]
+pub mod testing;
+
+use git::GitError;
+use registry::{RegistryError, WorkspaceRegistry};
+
+/// Manages the workspaces of a repository: listing the known clones and
+/// moving uncommitted changes between them.
+pub struct WorkspaceManager {
+    registry: WorkspaceRegistry,
+    cloner: Arc<dyn DirectoryCloner>,
+}
+
+/// Clones a directory into a new destination path.
+pub trait DirectoryCloner: Send + Sync {
+    fn clone_dir(&self, src: &Path, dst: &Path) -> Result<(), CloneError>;
+}
+
+/// Production directory cloner selected for the current platform.
+pub struct PlatformDirectoryCloner;
+
+/// Errors returned by [`WorkspaceManager`] operations.
+#[derive(Debug, Error)]
+pub enum WorkspaceError {
+    #[error("{} is not a git repository: {source}", .path.display())]
+    NotARepository { path: PathBuf, source: GitError },
+    #[error("failed to resolve repository identity: {0}")]
+    RepositoryIdentity(GitError),
+    #[error("target workspace does not exist: {}", .0.display())]
+    TargetMissing(PathBuf),
+    #[error("workspace belongs to a different repository: {}", .0.display())]
+    DifferentRepository(PathBuf),
+    #[error("target workspace is on a different commit: {}", .0.display())]
+    DifferentHead(PathBuf),
+    #[error("session is already in that workspace")]
+    AlreadyInWorkspace,
+    #[error("workspace name must not be empty")]
+    EmptyName,
+    #[error("workspace name must not contain path separators: {0}")]
+    NameSeparator(String),
+    #[error("workspace name is reserved: {0}")]
+    ReservedName(String),
+    #[error("source repository root has no parent directory: {}", .0.display())]
+    NoParent(PathBuf),
+    #[error("target path already exists: {}", .0.display())]
+    TargetPathExists(PathBuf),
+    #[error("target workspace has uncommitted changes: {}", .0.display())]
+    TargetDirty(PathBuf),
+    #[error(transparent)]
+    Registry(#[from] RegistryError),
+    #[error(transparent)]
+    Clone(#[from] CloneError),
+    #[error(transparent)]
+    Git(#[from] GitError),
+    #[error("filesystem error: {0}")]
+    Io(#[from] io::Error),
+}
+
+/// Errors returned when cloning a workspace directory.
+#[derive(Debug, Error)]
+pub enum CloneError {
+    #[error("path contains an interior NUL byte: {}", .0.display())]
+    InvalidPath(PathBuf),
+    #[error("failed to clone {} to {}: {source}", .src.display(), .dst.display())]
+    Clone { src: PathBuf, dst: PathBuf, source: io::Error },
+}
+
+impl WorkspaceManager {
+    pub fn new() -> io::Result<Self> {
+        Ok(Self::from_registry_and_cloner(WorkspaceRegistry::new()?, Arc::new(PlatformDirectoryCloner)))
+    }
+
+    pub fn from_registry_path(path: PathBuf) -> Self {
+        Self::from_registry_and_cloner(WorkspaceRegistry::from_path(path), Arc::new(PlatformDirectoryCloner))
+    }
+
+    #[doc(hidden)]
+    pub fn from_registry_path_with_cloner(path: PathBuf, cloner: Arc<dyn DirectoryCloner>) -> Self {
+        Self::from_registry_and_cloner(WorkspaceRegistry::from_path(path), cloner)
+    }
+
+    fn from_registry_and_cloner(registry: WorkspaceRegistry, cloner: Arc<dyn DirectoryCloner>) -> Self {
+        Self { registry, cloner }
+    }
+
+    /// Lists every managed workspace sharing `cwd`'s repository, registering
+    /// `cwd`'s own repo root as a side effect so it becomes a known move
+    /// target for other workspaces.
+    pub fn list(&self, cwd: &Path) -> Result<Vec<WorkspaceEntry>, WorkspaceError> {
+        let (src_root, repo_key) = resolve_repo(cwd)?;
+        self.registry.register(&repo_key, &src_root)?;
+        Ok(self
+            .registry
+            .workspaces_for(&repo_key)?
+            .into_iter()
+            .map(|record| WorkspaceEntry { is_current: record.path == src_root, path: record.path })
+            .collect())
+    }
+
+    /// Moves the uncommitted changes from `cwd`'s workspace to `target`
+    /// (cloning a new sibling directory when the target is new) and
+    /// returns the directory within the target corresponding to `cwd`.
+    pub fn move_to(&self, cwd: &Path, target: &WorkspaceMoveTarget) -> Result<PathBuf, WorkspaceError> {
+        let (src_root, repo_key) = resolve_repo(cwd)?;
+
+        let dst_root = match target {
+            WorkspaceMoveTarget::Existing { path } => {
+                if !path.exists() {
+                    return Err(WorkspaceError::TargetMissing(path.clone()));
+                }
+                let (dst_root, dst_key) = resolve_repo(path)?;
+                if dst_key != repo_key {
+                    return Err(WorkspaceError::DifferentRepository(path.clone()));
+                }
+                if dst_root == src_root {
+                    return Err(WorkspaceError::AlreadyInWorkspace);
+                }
+                if git::head_commit_hash(&src_root)? != git::head_commit_hash(&dst_root)? {
+                    return Err(WorkspaceError::DifferentHead(path.clone()));
+                }
+                dst_root
+            }
+            WorkspaceMoveTarget::New { name } => sibling_workspace_path(&src_root, name)?,
+        };
+
+        move_changes(&src_root, &dst_root, self.cloner.as_ref())?;
+        self.registry.register(&repo_key, &src_root)?;
+        self.registry.register(&repo_key, &dst_root)?;
+        let canonical_cwd = cwd.canonicalize().unwrap_or_else(|_| cwd.to_path_buf());
+        let relocated = canonical_cwd
+            .strip_prefix(&src_root)
+            .ok()
+            .filter(|relative| !relative.as_os_str().is_empty())
+            .map(|relative| dst_root.join(relative));
+        Ok(relocated.filter(|candidate| candidate.exists()).unwrap_or(dst_root))
+    }
+}
+
+impl WorkspaceError {
+    pub fn is_invalid_input(&self) -> bool {
+        match self {
+            Self::NotARepository { .. }
+            | Self::RepositoryIdentity(_)
+            | Self::TargetMissing(_)
+            | Self::DifferentRepository(_)
+            | Self::DifferentHead(_)
+            | Self::AlreadyInWorkspace
+            | Self::EmptyName
+            | Self::NameSeparator(_)
+            | Self::ReservedName(_)
+            | Self::NoParent(_)
+            | Self::TargetPathExists(_)
+            | Self::TargetDirty(_) => true,
+            Self::Registry(_) | Self::Clone(_) | Self::Git(_) | Self::Io(_) => false,
+        }
+    }
+}
+
+fn resolve_repo(cwd: &Path) -> Result<(PathBuf, String), WorkspaceError> {
+    let root =
+        git::repo_root(cwd).map_err(|source| WorkspaceError::NotARepository { path: cwd.to_path_buf(), source })?;
+    let root = root.canonicalize().unwrap_or(root);
+    let key = git::root_commit_hash(&root).map_err(WorkspaceError::RepositoryIdentity)?;
+    Ok((root, key))
+}
+
+fn sibling_workspace_path(src_root: &Path, name: &str) -> Result<PathBuf, WorkspaceError> {
+    if name.is_empty() {
+        return Err(WorkspaceError::EmptyName);
+    }
+    if name.chars().any(std::path::is_separator) {
+        return Err(WorkspaceError::NameSeparator(name.to_string()));
+    }
+    if name == "." || name == ".." {
+        return Err(WorkspaceError::ReservedName(name.to_string()));
+    }
+
+    let parent = src_root.parent().ok_or_else(|| WorkspaceError::NoParent(src_root.to_path_buf()))?;
+    let dst = parent.join(name);
+    if dst.exists() {
+        return Err(WorkspaceError::TargetPathExists(dst));
+    }
+    Ok(dst)
+}
+
+fn move_changes(src: &Path, dst: &Path, cloner: &dyn DirectoryCloner) -> Result<(), WorkspaceError> {
+    if dst.exists() {
+        if !git::is_clean(dst)? {
+            return Err(WorkspaceError::TargetDirty(dst.to_path_buf()));
+        }
+
+        let untracked = git::untracked_files(src)?;
+        for rel in &untracked {
+            let dst_file = dst.join(rel);
+            if dst_file.exists() {
+                return Err(WorkspaceError::TargetPathExists(dst_file));
+            }
+        }
+
+        let patch = git::diff_head(src)?;
+        git::apply_patch(dst, &patch)?;
+        git::copy_untracked_files(src, dst, &untracked)?;
+    } else {
+        cloner.clone_dir(src, dst)?;
+    }
+
+    git::reset_clean(src)?;
+    Ok(())
+}
+
+impl DirectoryCloner for PlatformDirectoryCloner {
+    fn clone_dir(&self, src: &Path, dst: &Path) -> Result<(), CloneError> {
+        platform_clone_dir(src, dst)
+    }
+}
+
+#[cfg(target_os = "macos")]
+fn platform_clone_dir(src: &Path, dst: &Path) -> Result<(), CloneError> {
+    use std::ffi::CString;
+    use std::os::unix::ffi::OsStrExt;
+
+    let src_c = CString::new(src.as_os_str().as_bytes()).map_err(|_| CloneError::InvalidPath(src.to_path_buf()))?;
+
+    let dst_c = CString::new(dst.as_os_str().as_bytes()).map_err(|_| CloneError::InvalidPath(dst.to_path_buf()))?;
+
+    let ret = unsafe { libc::clonefile(src_c.as_ptr(), dst_c.as_ptr(), 0) };
+    if ret != 0 {
+        return Err(CloneError::Clone {
+            src: src.to_path_buf(),
+            dst: dst.to_path_buf(),
+            source: io::Error::last_os_error(),
+        });
+    }
+
+    Ok(())
+}
+
+#[cfg(not(target_os = "macos"))]
+fn platform_clone_dir(src: &Path, dst: &Path) -> Result<(), CloneError> {
+    use std::process::Command;
+
+    let output = Command::new("cp")
+        .arg("-a")
+        .arg("--reflink=auto")
+        .arg(src)
+        .arg(dst)
+        .output()
+        .map_err(|e| CloneError::Clone { src: src.to_path_buf(), dst: dst.to_path_buf(), source: e })?;
+
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        let detail = stderr.trim();
+        let message = if detail.is_empty() {
+            "failed to clone workspace directory".to_string()
+        } else {
+            format!("failed to clone workspace directory: {detail}")
+        };
+        return Err(CloneError::Clone {
+            src: src.to_path_buf(),
+            dst: dst.to_path_buf(),
+            source: io::Error::other(message),
+        });
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::workspace::testing::{StdCopyCloner, init_repo};
+    use std::fs;
+    use tempfile::TempDir;
+
+    #[test]
+    fn move_to_rejects_invalid_new_names() {
+        let tmp = TempDir::new().unwrap();
+        let repo = init_repo(tmp.path(), "repo");
+        fs::create_dir_all(tmp.path().join("taken")).unwrap();
+        let manager = WorkspaceManager::from_registry_path_with_cloner(
+            tmp.path().join("workspaces.json"),
+            Arc::new(StdCopyCloner),
+        );
+
+        let move_to = |name: &str| manager.move_to(&repo, &WorkspaceMoveTarget::New { name: name.to_string() });
+
+        assert!(matches!(move_to(""), Err(WorkspaceError::EmptyName)));
+        assert!(matches!(move_to("a/b"), Err(WorkspaceError::NameSeparator(_))));
+        assert!(matches!(move_to("."), Err(WorkspaceError::ReservedName(_))));
+        assert!(matches!(move_to(".."), Err(WorkspaceError::ReservedName(_))));
+        assert!(matches!(move_to("taken"), Err(WorkspaceError::TargetPathExists(_))));
+    }
+
+    #[test]
+    fn list_registers_repo_root_and_marks_it_current() {
+        let tmp = TempDir::new().unwrap();
+        let repo = init_repo(tmp.path(), "repo");
+        let manager = WorkspaceManager::from_registry_path_with_cloner(
+            tmp.path().join("workspaces.json"),
+            Arc::new(StdCopyCloner),
+        );
+
+        let workspaces = manager.list(&repo).unwrap();
+
+        assert_eq!(workspaces.len(), 1);
+        assert!(workspaces[0].is_current);
+        assert_eq!(workspaces[0].path, repo.canonicalize().unwrap());
+    }
+}

--- a/packages/aether-cli/src/workspace/registry.rs
+++ b/packages/aether-cli/src/workspace/registry.rs
@@ -1,0 +1,174 @@
+use serde::{Deserialize, Serialize};
+use std::fs;
+use std::io;
+use std::path::{Path, PathBuf};
+use thiserror::Error;
+
+/// Persistent registry of managed workspaces, grouped by repository identity.
+///
+/// Stored as a JSON array at `~/.aether/workspaces.json`.
+pub struct WorkspaceRegistry {
+    path: PathBuf,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct WorkspaceRecord {
+    pub path: PathBuf,
+    pub repo_key: String,
+}
+
+#[derive(Debug, Error)]
+pub enum RegistryError {
+    #[error("failed to access workspace registry {}: {source}", .path.display())]
+    Io { path: PathBuf, source: io::Error },
+    #[error("invalid workspace registry {}: {source}", .path.display())]
+    Parse { path: PathBuf, source: serde_json::Error },
+}
+
+impl WorkspaceRegistry {
+    pub fn new() -> io::Result<Self> {
+        let home =
+            dirs::home_dir().ok_or_else(|| io::Error::new(io::ErrorKind::NotFound, "Home directory not found"))?;
+        Ok(Self::from_path(home.join(".aether/workspaces.json")))
+    }
+
+    pub fn from_path(path: PathBuf) -> Self {
+        Self { path }
+    }
+
+    /// Adds `path` under `repo_key`, deduplicating by canonicalized path. An
+    /// existing entry for the same path has its `repo_key` refreshed instead.
+    pub fn register(&self, repo_key: &str, path: &Path) -> Result<(), RegistryError> {
+        let canonical = path.canonicalize().map_err(|e| self.io_error(e))?;
+        let mut records = self.read()?;
+
+        if let Some(existing) = records.iter_mut().find(|record| record.path == canonical) {
+            if existing.repo_key == repo_key {
+                return Ok(());
+            }
+            existing.repo_key = repo_key.to_string();
+        } else {
+            records.push(WorkspaceRecord { path: canonical, repo_key: repo_key.to_string() });
+        }
+
+        self.write(&records)
+    }
+
+    /// Returns every registered workspace for `repo_key`, pruning entries
+    /// whose directory no longer exists.
+    pub fn workspaces_for(&self, repo_key: &str) -> Result<Vec<WorkspaceRecord>, RegistryError> {
+        let records = self.read()?;
+        let live: Vec<WorkspaceRecord> = records.iter().filter(|record| record.path.exists()).cloned().collect();
+        if live.len() != records.len() {
+            self.write(&live)?;
+        }
+        Ok(live.into_iter().filter(|record| record.repo_key == repo_key).collect())
+    }
+
+    fn read(&self) -> Result<Vec<WorkspaceRecord>, RegistryError> {
+        match fs::read_to_string(&self.path) {
+            Ok(content) => serde_json::from_str(&content)
+                .map_err(|source| RegistryError::Parse { path: self.path.clone(), source }),
+            Err(e) if e.kind() == io::ErrorKind::NotFound => Ok(Vec::new()),
+            Err(e) => Err(self.io_error(e)),
+        }
+    }
+
+    fn write(&self, records: &[WorkspaceRecord]) -> Result<(), RegistryError> {
+        if let Some(parent) = self.path.parent() {
+            fs::create_dir_all(parent).map_err(|e| self.io_error(e))?;
+        }
+        let content = serde_json::to_string_pretty(records)
+            .map_err(|source| RegistryError::Parse { path: self.path.clone(), source })?;
+        let tmp_path = self.path.with_extension("json.tmp");
+        fs::write(&tmp_path, content).map_err(|e| self.io_error(e))?;
+        fs::rename(&tmp_path, &self.path).map_err(|e| self.io_error(e))
+    }
+
+    fn io_error(&self, source: io::Error) -> RegistryError {
+        RegistryError::Io { path: self.path.clone(), source }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::TempDir;
+
+    fn temp_registry() -> (TempDir, WorkspaceRegistry) {
+        let dir = TempDir::new().unwrap();
+        let registry = WorkspaceRegistry::from_path(dir.path().join("workspaces.json"));
+        (dir, registry)
+    }
+
+    fn make_dir(base: &TempDir, name: &str) -> PathBuf {
+        let path = base.path().join(name);
+        fs::create_dir_all(&path).unwrap();
+        path
+    }
+
+    #[test]
+    fn register_and_list_groups_by_repo_key() {
+        let (dir, registry) = temp_registry();
+        let a = make_dir(&dir, "a");
+        let b = make_dir(&dir, "b");
+        let other = make_dir(&dir, "other");
+
+        registry.register("repo1", &a).unwrap();
+        registry.register("repo1", &b).unwrap();
+        registry.register("repo2", &other).unwrap();
+
+        let repo1 = registry.workspaces_for("repo1").unwrap();
+        let paths: Vec<&Path> = repo1.iter().map(|record| record.path.as_path()).collect();
+        assert_eq!(paths, vec![a.canonicalize().unwrap(), b.canonicalize().unwrap()]);
+        assert_eq!(registry.workspaces_for("repo2").unwrap().len(), 1);
+    }
+
+    #[test]
+    fn register_same_path_twice_keeps_single_entry() {
+        let (dir, registry) = temp_registry();
+        let a = make_dir(&dir, "a");
+
+        registry.register("repo1", &a).unwrap();
+        registry.register("repo1", &a).unwrap();
+
+        assert_eq!(registry.workspaces_for("repo1").unwrap().len(), 1);
+    }
+
+    #[test]
+    fn register_updates_repo_key_for_existing_path() {
+        let (dir, registry) = temp_registry();
+        let a = make_dir(&dir, "a");
+
+        registry.register("old", &a).unwrap();
+        registry.register("new", &a).unwrap();
+
+        assert!(registry.workspaces_for("old").unwrap().is_empty());
+        assert_eq!(registry.workspaces_for("new").unwrap().len(), 1);
+    }
+
+    #[test]
+    fn workspaces_for_prunes_deleted_directories() {
+        let (dir, registry) = temp_registry();
+        let a = make_dir(&dir, "a");
+        let b = make_dir(&dir, "b");
+        registry.register("repo1", &a).unwrap();
+        registry.register("repo1", &b).unwrap();
+
+        fs::remove_dir_all(&b).unwrap();
+
+        let live = registry.workspaces_for("repo1").unwrap();
+        assert_eq!(live.len(), 1);
+        assert_eq!(live[0].path, a.canonicalize().unwrap());
+
+        let reread = registry.workspaces_for("repo1").unwrap();
+        assert_eq!(reread.len(), 1);
+    }
+
+    #[test]
+    fn missing_registry_file_lists_empty() {
+        let (_dir, registry) = temp_registry();
+        assert!(registry.workspaces_for("repo1").unwrap().is_empty());
+    }
+}

--- a/packages/aether-cli/src/workspace/testing.rs
+++ b/packages/aether-cli/src/workspace/testing.rs
@@ -1,0 +1,59 @@
+use super::{CloneError, DirectoryCloner};
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+/// Platform-agnostic directory cloner for tests: a plain recursive `cp -R`.
+pub struct StdCopyCloner;
+
+impl DirectoryCloner for StdCopyCloner {
+    fn clone_dir(&self, src: &Path, dst: &Path) -> Result<(), CloneError> {
+        let output = Command::new("cp").arg("-R").arg(src).arg(dst).output().map_err(|e| CloneError::Clone {
+            src: src.to_path_buf(),
+            dst: dst.to_path_buf(),
+            source: e,
+        })?;
+
+        if !output.status.success() {
+            let stderr = String::from_utf8_lossy(&output.stderr);
+            return Err(CloneError::Clone {
+                src: src.to_path_buf(),
+                dst: dst.to_path_buf(),
+                source: std::io::Error::other(stderr.trim().to_string()),
+            });
+        }
+
+        Ok(())
+    }
+}
+
+pub fn init_repo(parent: &Path, name: &str) -> PathBuf {
+    let repo = parent.join(name);
+    fs::create_dir_all(&repo).unwrap();
+    git(&repo, &["init"]);
+    git(&repo, &["config", "user.email", "test@example.com"]);
+    git(&repo, &["config", "user.name", "Test"]);
+    fs::write(repo.join("committed.txt"), format!("original {name}\n")).unwrap();
+    git(&repo, &["add", "."]);
+    git(&repo, &["commit", "-m", "initial"]);
+    repo
+}
+
+pub fn clone_repo(src: &Path, dst: PathBuf) -> PathBuf {
+    let output = Command::new("git").arg("clone").arg(src).arg(&dst).output().expect("git clone spawns");
+    assert!(output.status.success(), "git clone failed: {}", String::from_utf8_lossy(&output.stderr));
+    git(&dst, &["config", "user.email", "test@example.com"]);
+    git(&dst, &["config", "user.name", "Test"]);
+    dst
+}
+
+pub fn git(repo: &Path, args: &[&str]) {
+    let output = Command::new("git").arg("-C").arg(repo).args(args).output().expect("git spawns");
+    assert!(output.status.success(), "git {args:?} failed: {}", String::from_utf8_lossy(&output.stderr));
+}
+
+pub fn git_status(repo: &Path) -> String {
+    let output =
+        Command::new("git").arg("-C").arg(repo).args(["status", "--porcelain"]).output().expect("git status spawns");
+    String::from_utf8_lossy(&output.stdout).trim().to_string()
+}

--- a/packages/aether-cli/tests/acp_workspace_move.rs
+++ b/packages/aether-cli/tests/acp_workspace_move.rs
@@ -1,0 +1,232 @@
+use acp_utils::notifications::{
+    WorkspaceListParams, WorkspaceListResponse, WorkspaceMoveParams, WorkspaceMoveResponse, WorkspaceMoveTarget,
+};
+use aether_cli::acp::testing::AcpTestHarness;
+use aether_cli::workspace::testing::{clone_repo, git, git_status, init_repo};
+use agent_client_protocol::schema::ListSessionsRequest;
+use std::fs;
+use std::future::Future;
+use tokio::task::LocalSet;
+
+#[tokio::test(flavor = "current_thread")]
+async fn workspace_list_registers_source_repo_and_marks_it_current() {
+    with_harness(|harness| async move {
+        let tmp = tempfile::tempdir().unwrap();
+        let repo = init_repo(tmp.path(), "repo");
+        let sub = repo.join("sub");
+        fs::create_dir_all(&sub).unwrap();
+        harness.append_stored_session_in("s1", "2026-05-01T00:00:00Z", &sub);
+
+        let response = list(&harness, "s1").await;
+
+        assert_eq!(response.workspaces.len(), 1);
+        let entry = &response.workspaces[0];
+        assert!(entry.is_current);
+        assert_eq!(entry.path, repo.canonicalize().unwrap());
+    })
+    .await;
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn workspace_move_to_new_sibling_clones_changes_and_resets_source() {
+    with_harness(|harness| async move {
+        let tmp = tempfile::tempdir().unwrap();
+        let repo = init_repo(tmp.path(), "repo");
+        harness.append_stored_session_in("s1", "2026-05-01T00:00:00Z", &repo);
+
+        fs::write(repo.join("committed.txt"), "modified\n").unwrap();
+        git(&repo, &["add", "committed.txt"]);
+        fs::write(repo.join("untracked.txt"), "new file\n").unwrap();
+
+        let response = move_workspace(&harness, "s1", WorkspaceMoveTarget::New { name: "repo-2".to_string() })
+            .await
+            .expect("move succeeds");
+
+        let clone = tmp.path().join("repo-2");
+        assert_eq!(response.new_cwd, clone.canonicalize().unwrap());
+        assert_eq!(fs::read_to_string(clone.join("committed.txt")).unwrap(), "modified\n");
+        assert_eq!(fs::read_to_string(clone.join("untracked.txt")).unwrap(), "new file\n");
+        assert!(git_status(&repo).is_empty(), "source should be clean after move");
+
+        let sessions =
+            harness.client_cx.send_request(ListSessionsRequest::new()).block_task().await.expect("list sessions");
+        let session = sessions.sessions.iter().find(|s| s.session_id.0.as_ref() == "s1").expect("session exists");
+        assert_eq!(session.cwd, response.new_cwd);
+    })
+    .await;
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn workspace_move_to_existing_clean_target_applies_changes() {
+    with_harness(|harness| async move {
+        let tmp = tempfile::tempdir().unwrap();
+        let repo = init_repo(tmp.path(), "repo");
+        let clone = clone_repo(&repo, tmp.path().join("clone"));
+        harness.append_stored_session_in("s1", "2026-05-01T00:00:00Z", &repo);
+
+        fs::write(repo.join("committed.txt"), "edited\n").unwrap();
+
+        let response = move_workspace(&harness, "s1", WorkspaceMoveTarget::Existing { path: clone.clone() })
+            .await
+            .expect("move succeeds");
+
+        assert_eq!(response.new_cwd, clone.canonicalize().unwrap());
+        assert_eq!(fs::read_to_string(clone.join("committed.txt")).unwrap(), "edited\n");
+        assert!(git_status(&repo).is_empty(), "source should be clean after move");
+    })
+    .await;
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn workspace_move_to_existing_target_on_different_head_fails_actionably() {
+    with_harness(|harness| async move {
+        let tmp = tempfile::tempdir().unwrap();
+        let repo = init_repo(tmp.path(), "repo");
+        let clone = clone_repo(&repo, tmp.path().join("clone"));
+        harness.append_stored_session_in("s1", "2026-05-01T00:00:00Z", &repo);
+
+        fs::write(clone.join("target-only.txt"), "target commit\n").unwrap();
+        git(&clone, &["add", "."]);
+        git(&clone, &["commit", "-m", "target diverges"]);
+        fs::write(repo.join("committed.txt"), "edited\n").unwrap();
+
+        let error = move_workspace(&harness, "s1", WorkspaceMoveTarget::Existing { path: clone })
+            .await
+            .expect_err("move should fail");
+
+        assert!(error.message.contains("different commit"), "unexpected error: {}", error.message);
+        assert_eq!(fs::read_to_string(repo.join("committed.txt")).unwrap(), "edited\n");
+    })
+    .await;
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn workspace_move_to_dirty_target_fails_and_leaves_source_untouched() {
+    with_harness(|harness| async move {
+        let tmp = tempfile::tempdir().unwrap();
+        let repo = init_repo(tmp.path(), "repo");
+        let clone = clone_repo(&repo, tmp.path().join("clone"));
+        harness.append_stored_session_in("s1", "2026-05-01T00:00:00Z", &repo);
+
+        fs::write(repo.join("committed.txt"), "edited\n").unwrap();
+        fs::write(clone.join("dirty.txt"), "target change\n").unwrap();
+
+        let error = move_workspace(&harness, "s1", WorkspaceMoveTarget::Existing { path: clone })
+            .await
+            .expect_err("move should fail");
+
+        assert!(error.message.contains("uncommitted changes"), "unexpected error: {}", error.message);
+        assert_eq!(fs::read_to_string(repo.join("committed.txt")).unwrap(), "edited\n");
+    })
+    .await;
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn workspace_move_rejects_workspace_from_different_repository() {
+    with_harness(|harness| async move {
+        let tmp = tempfile::tempdir().unwrap();
+        let repo = init_repo(tmp.path(), "repo");
+        let other = init_repo(tmp.path(), "other");
+        harness.append_stored_session_in("s1", "2026-05-01T00:00:00Z", &repo);
+
+        let error = move_workspace(&harness, "s1", WorkspaceMoveTarget::Existing { path: other })
+            .await
+            .expect_err("move should fail");
+
+        assert!(error.message.contains("different repository"), "unexpected error: {}", error.message);
+    })
+    .await;
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn workspace_move_rejects_invalid_new_names() {
+    with_harness(|harness| async move {
+        let tmp = tempfile::tempdir().unwrap();
+        let repo = init_repo(tmp.path(), "repo");
+        init_repo(tmp.path(), "taken");
+        harness.append_stored_session_in("s1", "2026-05-01T00:00:00Z", &repo);
+
+        for name in ["", "a/b", "..", "taken"] {
+            let result = move_workspace(&harness, "s1", WorkspaceMoveTarget::New { name: name.to_string() }).await;
+            assert!(result.is_err(), "name {name:?} should be rejected");
+        }
+    })
+    .await;
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn workspace_list_omits_deleted_workspaces() {
+    with_harness(|harness| async move {
+        let tmp = tempfile::tempdir().unwrap();
+        let repo = init_repo(tmp.path(), "repo");
+        harness.append_stored_session_in("s1", "2026-05-01T00:00:00Z", &repo);
+
+        move_workspace(&harness, "s1", WorkspaceMoveTarget::New { name: "repo-2".to_string() })
+            .await
+            .expect("move succeeds");
+        harness.append_stored_session_in("s2", "2026-05-02T00:00:00Z", &repo);
+        assert_eq!(list(&harness, "s2").await.workspaces.len(), 2);
+
+        fs::remove_dir_all(tmp.path().join("repo-2")).unwrap();
+
+        let response = list(&harness, "s2").await;
+        assert_eq!(response.workspaces.len(), 1);
+        assert!(response.workspaces[0].is_current);
+    })
+    .await;
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn workspace_move_relocates_session_to_matching_subdirectory() {
+    with_harness(|harness| async move {
+        let tmp = tempfile::tempdir().unwrap();
+        let repo = init_repo(tmp.path(), "repo");
+        let sub = repo.join("sub");
+        fs::create_dir_all(&sub).unwrap();
+        fs::write(sub.join("file.txt"), "content\n").unwrap();
+        git(&repo, &["add", "."]);
+        git(&repo, &["commit", "-m", "add subdir"]);
+        harness.append_stored_session_in("s1", "2026-05-01T00:00:00Z", &sub);
+
+        let response = move_workspace(&harness, "s1", WorkspaceMoveTarget::New { name: "repo-2".to_string() })
+            .await
+            .expect("move succeeds");
+
+        assert_eq!(response.new_cwd, tmp.path().join("repo-2").canonicalize().unwrap().join("sub"));
+    })
+    .await;
+}
+
+async fn with_harness<F, Fut>(body: F)
+where
+    F: FnOnce(AcpTestHarness) -> Fut,
+    Fut: Future<Output = ()>,
+{
+    LocalSet::new()
+        .run_until(async move {
+            let harness = AcpTestHarness::start().await;
+            body(harness).await;
+        })
+        .await;
+}
+
+async fn list(harness: &AcpTestHarness, session_id: &str) -> WorkspaceListResponse {
+    harness
+        .client_cx
+        .send_request(WorkspaceListParams { session_id: session_id.to_string() })
+        .block_task()
+        .await
+        .expect("workspace list succeeds")
+}
+
+async fn move_workspace(
+    harness: &AcpTestHarness,
+    session_id: &str,
+    target: WorkspaceMoveTarget,
+) -> Result<WorkspaceMoveResponse, agent_client_protocol::schema::Error> {
+    harness
+        .client_cx
+        .send_request(WorkspaceMoveParams { session_id: session_id.to_string(), target })
+        .block_task()
+        .await
+}

--- a/packages/mcp-servers/src/coding/default_tools.rs
+++ b/packages/mcp-servers/src/coding/default_tools.rs
@@ -2,9 +2,10 @@ use super::error::CodingError;
 use super::{
     BackgroundProcessHandle, BashInput, BashResult, EditFileArgs, EditFileResponse, FindInput, FindOutput, GrepInput,
     GrepOutput, ListFilesArgs, ListFilesResult, ReadBackgroundBashOutput, ReadFileArgs, ReadFileResult, WriteFileArgs,
-    WriteFileResponse, edit_file_contents, execute_command, find_files_by_name, list_files, perform_grep,
+    WriteFileResponse, edit_file_contents, execute_command_in_dir, find_files_by_name, list_files, perform_grep,
     read_background_bash, read_file_contents, tools_trait::CodingTools, write_file_contents,
 };
+use std::path::PathBuf;
 
 /// Default implementation that uses local filesystem operations.
 ///
@@ -37,8 +38,8 @@ impl CodingTools for DefaultCodingTools {
         list_files(args).await.map_err(CodingError::from)
     }
 
-    async fn bash(&self, args: BashInput) -> Result<BashResult, CodingError> {
-        execute_command(args).await.map_err(CodingError::from)
+    async fn bash(&self, args: BashInput, cwd: Option<PathBuf>) -> Result<BashResult, CodingError> {
+        execute_command_in_dir(args, cwd.as_deref()).await.map_err(CodingError::from)
     }
 
     async fn read_background_bash(

--- a/packages/mcp-servers/src/coding/mod.rs
+++ b/packages/mcp-servers/src/coding/mod.rs
@@ -35,21 +35,27 @@ pub mod tools_trait;
 pub use default_tools::DefaultCodingTools;
 pub use tools_trait::CodingTools;
 
-use crate::lsp::tools::check_errors::{
-    LspDiagnosticsInput, LspDiagnosticsOutput, LspDiagnosticsRequest, execute_lsp_diagnostics,
-};
-use crate::lsp::tools::document_info::{LspDocumentInput, LspDocumentOutput, execute_lsp_document};
 use crate::lsp::tools::rename::{LspRenameInput, LspRenameOutput, execute_lsp_rename};
 use crate::lsp::tools::symbol_lookup::{LspSymbolInput, LspSymbolOutput, execute_lsp_symbol};
 use crate::lsp::tools::workspace_search::{
     LspWorkspaceSearchInput, LspWorkspaceSearchOutput, execute_lsp_workspace_search,
 };
 use crate::{coding::prompt_rule_matcher::PromptRuleMatcher, lsp::registry::LspRegistry};
+use crate::{
+    lsp::tools::check_errors::{
+        LspDiagnosticsInput, LspDiagnosticsOutput, LspDiagnosticsRequest, execute_lsp_diagnostics,
+    },
+    workspace_paths::primary_root,
+};
+use crate::{
+    lsp::tools::document_info::{LspDocumentInput, LspDocumentOutput, execute_lsp_document},
+    workspace_paths::{resolve_dir, resolve_file},
+};
 
 use mcp_utils::display_meta::{ToolDisplayMeta, ToolResultMeta, basename, truncate};
 use tools::bash::{
     BackgroundProcessHandle, BashInput, BashOutput, BashResult, ReadBackgroundBashInput, ReadBackgroundBashOutput,
-    execute_command, read_background_bash,
+    execute_command_in_dir, read_background_bash,
 };
 use tools::edit_file::{EditFileArgs, EditFileResponse, edit_file_contents};
 use tools::find::{FindInput, FindOutput, find_files_by_name};
@@ -297,6 +303,11 @@ impl<T: CodingTools + 'static> CodingMcp<T> {
         self.roots.try_read().ok().and_then(|roots| roots.first().cloned())
     }
 
+    async fn primary_workspace_root(&self) -> PathBuf {
+        let roots = self.roots.read().await;
+        primary_root(&roots)
+    }
+
     fn build_instructions(&self) -> String {
         let mut base = String::from(
             r"# Coding MCP Server
@@ -414,39 +425,16 @@ When using tools that take file paths, always use absolute paths from:
         }
     }
 
-    #[doc = include_str!("tools/grep/description.md")]
-    #[tool]
-    pub async fn grep(
-        &self,
-        request: Parameters<GrepInput>,
-        context: RequestContext<RoleServer>,
-    ) -> Result<Json<GrepOutput>, String> {
-        let Parameters(args) = request;
-        notify_preview(&context, ToolDisplayMeta::new("Grep", format!("'{}'", args.pattern))).await;
-        self.tools.grep(args).await.into_mcp()
+    /// Resolves a required file-path argument against the primary workspace root,
+    /// returning the normalized absolute path as a string.
+    async fn resolve_file_arg(&self, raw: &str) -> Result<String, String> {
+        let root = self.primary_workspace_root().await;
+        Ok(resolve_file(&root, raw)?.to_string_lossy().to_string())
     }
 
-    #[doc = include_str!("tools/find/description.md")]
-    #[tool]
-    pub async fn find(
-        &self,
-        request: Parameters<FindInput>,
-        context: RequestContext<RoleServer>,
-    ) -> Result<Json<FindOutput>, String> {
-        let Parameters(args) = request;
-        notify_preview(&context, ToolDisplayMeta::new("Find", format!("'{}'", args.pattern))).await;
-        self.tools.find(args).await.into_mcp()
-    }
-
-    #[doc = include_str!("tools/read_file/description.md")]
-    #[tool]
-    pub async fn read_file(
-        &self,
-        request: Parameters<ReadFileArgs>,
-        context: RequestContext<RoleServer>,
-    ) -> Result<Json<ReadFileResult>, String> {
-        let Parameters(args) = request;
-        notify_preview(&context, ToolDisplayMeta::new("Read file", basename(&args.file_path))).await;
+    /// Reads `args.file_path` (already resolved against the workspace root),
+    /// records it in the read set, and appends any matching read-rule reminders.
+    async fn read_and_track(&self, args: ReadFileArgs) -> Result<Json<ReadFileResult>, String> {
         let file_path = args.file_path.clone();
         let mut result = self.tools.read_file(args).await.map_err(|e| e.to_string())?;
         self.files_read.write().await.insert(file_path.clone());
@@ -468,6 +456,72 @@ When using tools that take file paths, always use absolute paths from:
         Ok(Json(result))
     }
 
+    /// Read-before-overwrite safety check: an existing file must have been read
+    /// first, preventing accidental data loss.
+    async fn ensure_read_before_overwrite(&self, file_path: &str) -> Result<(), String> {
+        if try_exists(file_path).await.map_err(|e| format!("Failed to check existence of {file_path}: {e}"))?
+            && !self.files_read.read().await.contains(file_path)
+        {
+            return Err(format!(
+                "Safety check failed: File '{file_path}' already exists. You must use read_file on it before overwriting. This prevents accidental data loss."
+            ));
+        }
+        Ok(())
+    }
+
+    /// Read-before-edit safety check: a file must have been read before editing.
+    async fn ensure_read_before_edit(&self, file_path: &str) -> Result<(), String> {
+        if !self.files_read.read().await.contains(file_path) {
+            return Err(format!(
+                "Safety check failed: You must use read_file on '{file_path}' before editing it. This ensures you understand the current file contents before making changes."
+            ));
+        }
+        Ok(())
+    }
+
+    #[doc = include_str!("tools/grep/description.md")]
+    #[tool]
+    pub async fn grep(
+        &self,
+        request: Parameters<GrepInput>,
+        context: RequestContext<RoleServer>,
+    ) -> Result<Json<GrepOutput>, String> {
+        let Parameters(mut args) = request;
+        let root = self.primary_workspace_root().await;
+        let normalized_path = resolve_dir(&root, args.path.as_deref());
+        args.path = Some(normalized_path.to_string_lossy().to_string());
+        notify_preview(&context, ToolDisplayMeta::new("Grep", format!("'{}'", args.pattern))).await;
+        self.tools.grep(args).await.into_mcp()
+    }
+
+    #[doc = include_str!("tools/find/description.md")]
+    #[tool]
+    pub async fn find(
+        &self,
+        request: Parameters<FindInput>,
+        context: RequestContext<RoleServer>,
+    ) -> Result<Json<FindOutput>, String> {
+        let Parameters(mut args) = request;
+        let root = self.primary_workspace_root().await;
+        let normalized_path = resolve_dir(&root, args.path.as_deref());
+        args.path = Some(normalized_path.to_string_lossy().to_string());
+        notify_preview(&context, ToolDisplayMeta::new("Find", format!("'{}'", args.pattern))).await;
+        self.tools.find(args).await.into_mcp()
+    }
+
+    #[doc = include_str!("tools/read_file/description.md")]
+    #[tool]
+    pub async fn read_file(
+        &self,
+        request: Parameters<ReadFileArgs>,
+        context: RequestContext<RoleServer>,
+    ) -> Result<Json<ReadFileResult>, String> {
+        let Parameters(mut args) = request;
+        args.file_path = self.resolve_file_arg(&args.file_path).await?;
+        notify_preview(&context, ToolDisplayMeta::new("Read file", basename(&args.file_path))).await;
+        self.read_and_track(args).await
+    }
+
     #[doc = include_str!("tools/write_file/description.md")]
     #[tool]
     pub async fn write_file(
@@ -475,24 +529,12 @@ When using tools that take file paths, always use absolute paths from:
         request: Parameters<WriteFileArgs>,
         context: RequestContext<RoleServer>,
     ) -> Result<Json<WriteFileResponse>, String> {
-        let Parameters(args) = request;
+        let Parameters(mut args) = request;
+        args.file_path = self.resolve_file_arg(&args.file_path).await?;
         notify_preview(&context, ToolDisplayMeta::new("Write file", basename(&args.file_path))).await;
 
         self.check_write_permission(&context, "write_file", &args.file_path).await?;
-
-        // Safety check: if file exists, ensure it has been read first
-        if try_exists(&args.file_path)
-            .await
-            .map_err(|e| format!("Failed to check existence of {}: {e}", args.file_path))?
-        {
-            let files_read = self.files_read.read().await;
-            if !files_read.contains(&args.file_path) {
-                return Err(format!(
-                    "Safety check failed: File '{}' already exists. You must use read_file on it before overwriting. This prevents accidental data loss.",
-                    args.file_path
-                ));
-            }
-        }
+        self.ensure_read_before_overwrite(&args.file_path).await?;
 
         let response = self.tools.write_file(args).await.map_err(|e| e.to_string())?;
 
@@ -508,21 +550,12 @@ When using tools that take file paths, always use absolute paths from:
         request: Parameters<EditFileArgs>,
         context: RequestContext<RoleServer>,
     ) -> Result<Json<EditFileResponse>, String> {
-        let Parameters(args) = request;
+        let Parameters(mut args) = request;
+        args.file_path = self.resolve_file_arg(&args.file_path).await?;
         notify_preview(&context, ToolDisplayMeta::new("Edit file", basename(&args.file_path))).await;
 
         self.check_write_permission(&context, "edit_file", &args.file_path).await?;
-
-        // Safety check: ensure file has been read first
-        {
-            let files_read = self.files_read.read().await;
-            if !files_read.contains(&args.file_path) {
-                return Err(format!(
-                    "Safety check failed: You must use read_file on '{}' before editing it. This ensures you understand the current file contents before making changes.",
-                    args.file_path
-                ));
-            }
-        }
+        self.ensure_read_before_edit(&args.file_path).await?;
 
         let response = self.tools.edit_file(args).await.map_err(|e| e.to_string())?;
 
@@ -538,8 +571,11 @@ When using tools that take file paths, always use absolute paths from:
         request: Parameters<ListFilesArgs>,
         context: RequestContext<RoleServer>,
     ) -> Result<Json<ListFilesResult>, String> {
-        let Parameters(args) = request;
-        let preview_value = args.path.as_deref().map_or_else(|| ".".to_string(), basename);
+        let Parameters(mut args) = request;
+        let root = self.primary_workspace_root().await;
+        let normalized_path = resolve_dir(&root, args.path.as_deref());
+        let preview_value = basename(&normalized_path.to_string_lossy());
+        args.path = Some(normalized_path.to_string_lossy().to_string());
         notify_preview(&context, ToolDisplayMeta::new("List files", preview_value)).await;
         self.tools.list_files(args).await.into_mcp()
     }
@@ -557,7 +593,8 @@ When using tools that take file paths, always use absolute paths from:
         self.check_bash_permission(&context, &args.command).await?;
 
         let command = args.command.clone();
-        let result = self.tools.bash(args).await.map_err(|e| e.to_string())?;
+        let cwd = self.primary_workspace_root().await;
+        let result = self.tools.bash(args, Some(cwd)).await.map_err(|e| e.to_string())?;
 
         match result {
             BashResult::Completed(output) => Ok(Json(output)),
@@ -718,56 +755,22 @@ impl Default for CodingMcp<DefaultCodingTools> {
 #[cfg(feature = "test-helpers")]
 impl<T: CodingTools + 'static> CodingMcp<T> {
     /// Read a file and track it in the read set (test helper, no MCP context needed).
-    pub async fn test_read_file(&self, args: ReadFileArgs) -> Result<Json<ReadFileResult>, String> {
-        let file_path = args.file_path.clone();
-        let mut result = self.tools.read_file(args).await.map_err(|e| e.to_string())?;
-        self.files_read.write().await.insert(file_path.clone());
-
-        let total_lines = result.total_lines;
-        let roots = self.roots.read().await;
-        let matched = self.read_rule_state.get_matched_rules(&roots, &file_path);
-        for rule in &matched {
-            write!(result.content, "\n\n<system-reminder>\n{}\n</system-reminder>", rule.body).unwrap();
-        }
-
-        if !matched.is_empty() {
-            let rule_names: Vec<&str> = matched.iter().map(|r| r.name.as_str()).collect();
-            let base = format!("{}, {total_lines} lines", basename(&file_path));
-            let value = format!("{base} +rules: {}", rule_names.join(", "));
-            result.meta = Some(ToolDisplayMeta::new("Read file", value).into());
-        }
-
-        Ok(Json(result))
+    pub async fn test_read_file(&self, mut args: ReadFileArgs) -> Result<Json<ReadFileResult>, String> {
+        args.file_path = self.resolve_file_arg(&args.file_path).await?;
+        self.read_and_track(args).await
     }
 
     /// Write a file with read-before-write safety check (test helper, no MCP context needed).
-    pub async fn test_write_file(&self, args: WriteFileArgs) -> Result<Json<WriteFileResponse>, String> {
-        if try_exists(&args.file_path)
-            .await
-            .map_err(|e| format!("Failed to check existence of {}: {e}", args.file_path))?
-        {
-            let files_read = self.files_read.read().await;
-            if !files_read.contains(&args.file_path) {
-                return Err(format!(
-                    "Safety check failed: File '{}' already exists. You must use read_file on it before overwriting. This prevents accidental data loss.",
-                    args.file_path
-                ));
-            }
-        }
+    pub async fn test_write_file(&self, mut args: WriteFileArgs) -> Result<Json<WriteFileResponse>, String> {
+        args.file_path = self.resolve_file_arg(&args.file_path).await?;
+        self.ensure_read_before_overwrite(&args.file_path).await?;
         self.tools.write_file(args).await.map(Json).map_err(|e| e.to_string())
     }
 
     /// Edit a file with read-before-edit safety check (test helper, no MCP context needed).
-    pub async fn test_edit_file(&self, args: EditFileArgs) -> Result<Json<EditFileResponse>, String> {
-        {
-            let files_read = self.files_read.read().await;
-            if !files_read.contains(&args.file_path) {
-                return Err(format!(
-                    "Safety check failed: You must use read_file on '{}' before editing it. This ensures you understand the current file contents before making changes.",
-                    args.file_path
-                ));
-            }
-        }
+    pub async fn test_edit_file(&self, mut args: EditFileArgs) -> Result<Json<EditFileResponse>, String> {
+        args.file_path = self.resolve_file_arg(&args.file_path).await?;
+        self.ensure_read_before_edit(&args.file_path).await?;
         self.tools.edit_file(args).await.map(Json).map_err(|e| e.to_string())
     }
 }

--- a/packages/mcp-servers/src/coding/tools/bash/mod.rs
+++ b/packages/mcp-servers/src/coding/tools/bash/mod.rs
@@ -1,5 +1,6 @@
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
+use std::path::Path;
 use std::time::Duration;
 use tokio::io::{AsyncBufReadExt, BufReader};
 use tokio::process::Command;
@@ -133,9 +134,13 @@ async fn run_command_with_timeout(
     command: String,
     timeout: Option<Duration>,
     output_tx: mpsc::UnboundedSender<String>,
+    cwd: Option<&std::path::Path>,
 ) -> (i32, bool) {
     let mut cmd = Command::new("bash");
     cmd.arg("-c").arg(&command);
+    if let Some(dir) = cwd {
+        cmd.current_dir(dir);
+    }
     cmd.stdout(std::process::Stdio::piped());
     cmd.stderr(std::process::Stdio::piped());
 
@@ -185,6 +190,10 @@ async fn run_command_with_timeout(
 }
 
 pub async fn execute_command(args: BashInput) -> Result<BashResult, BashError> {
+    execute_command_in_dir(args, None).await
+}
+
+pub async fn execute_command_in_dir(args: BashInput, cwd: Option<&std::path::Path>) -> Result<BashResult, BashError> {
     if args.command.trim() == "rm" {
         return Err(BashError::Forbidden("No you can't fucking delete files".to_string()));
     }
@@ -202,11 +211,13 @@ pub async fn execute_command(args: BashInput) -> Result<BashResult, BashError> {
     if run_in_background {
         let shell_id = Uuid::new_v4().to_string();
         let command = args.command.clone();
+        let cwd = cwd.map(Path::to_path_buf);
 
         let (output_tx, output_rx) = mpsc::unbounded_channel();
 
-        let task_handle =
-            tokio::spawn(async move { run_command_with_timeout(command, timeout_duration, output_tx).await });
+        let task_handle = tokio::spawn(async move {
+            run_command_with_timeout(command, timeout_duration, output_tx, cwd.as_deref()).await
+        });
 
         Ok(BashResult::Background(BackgroundProcessHandle { shell_id, output_rx, task_handle }))
     } else {
@@ -217,6 +228,9 @@ pub async fn execute_command(args: BashInput) -> Result<BashResult, BashError> {
         // Collect output in-memory for synchronous case
         let mut cmd = Command::new("bash");
         cmd.arg("-c").arg(&command);
+        if let Some(dir) = cwd {
+            cmd.current_dir(dir);
+        }
 
         let result = if let Some(timeout_duration) = timeout {
             tokio::time::timeout(timeout_duration, cmd.output()).await

--- a/packages/mcp-servers/src/coding/tools_trait.rs
+++ b/packages/mcp-servers/src/coding/tools_trait.rs
@@ -1,5 +1,6 @@
 use std::fmt::Debug;
 use std::future::Future;
+use std::path::PathBuf;
 
 use super::error::CodingError;
 use super::tools::bash::{BackgroundProcessHandle, BashInput, BashResult, ReadBackgroundBashOutput};
@@ -24,8 +25,12 @@ pub trait CodingTools: Send + Sync + Debug {
     /// List files in a directory
     fn list_files(&self, args: ListFilesArgs) -> impl Future<Output = Result<ListFilesResult, CodingError>> + Send;
 
-    /// Execute a bash command
-    fn bash(&self, args: BashInput) -> impl Future<Output = Result<BashResult, CodingError>> + Send;
+    /// Execute a bash command with an optional working directory
+    fn bash(
+        &self,
+        args: BashInput,
+        cwd: Option<PathBuf>,
+    ) -> impl Future<Output = Result<BashResult, CodingError>> + Send;
 
     /// Read output from a background bash process
     fn read_background_bash(

--- a/packages/mcp-servers/src/lib.rs
+++ b/packages/mcp-servers/src/lib.rs
@@ -1,5 +1,7 @@
 #![doc = include_str!("../README.md")]
 
+pub mod workspace_paths;
+
 #[cfg(any(feature = "all", feature = "subagents"))]
 pub mod setup;
 #[cfg(any(feature = "all", feature = "subagents"))]

--- a/packages/mcp-servers/src/plan/server.rs
+++ b/packages/mcp-servers/src/plan/server.rs
@@ -1,4 +1,5 @@
 use crate::file_ops::{FileError, edit_text_file, read_text_file, write_text_file};
+use crate::workspace_paths::resolve_path;
 use clap::Parser;
 use mcp_utils::display_meta::{FileDiff, ToolDisplayMeta, ToolResultMeta, basename};
 use rmcp::{
@@ -95,6 +96,20 @@ impl PlanMcp {
             tool_router: Self::tool_router(),
             plans_dir: absolutize(plans_dir.unwrap_or(default_plans_dir)),
             prompt_file,
+            submit_command,
+        })
+    }
+
+    pub fn from_args_with_workspace_root(
+        args: Vec<String>,
+        default_plans_dir: PathBuf,
+        workspace_root: &Path,
+    ) -> Result<Self, String> {
+        let PlanMcpArgs { plans_dir, prompt_file, submit_command } = PlanMcpArgs::from_args(args)?;
+        Ok(Self {
+            tool_router: Self::tool_router(),
+            plans_dir: plans_dir.map_or(default_plans_dir, |path| resolve_path(workspace_root, path)),
+            prompt_file: prompt_file.map(|path| resolve_path(workspace_root, path)),
             submit_command,
         })
     }
@@ -488,6 +503,34 @@ mod tests {
     fn from_args_explicit_plans_dir_overrides_default() {
         let server = PlanMcp::from_args(vec!["--plans-dir".into(), "/tmp/plans".into()], default()).unwrap();
         assert_eq!(server.plans_dir, PathBuf::from("/tmp/plans"));
+    }
+
+    #[test]
+    fn from_args_with_workspace_root_resolves_relative_paths() {
+        let workspace = PathBuf::from("/workspace");
+        let server = PlanMcp::from_args_with_workspace_root(
+            vec!["--plans-dir".into(), "plans".into(), "--prompt-file".into(), "prompts/plan.md".into()],
+            default(),
+            &workspace,
+        )
+        .unwrap();
+
+        assert_eq!(server.plans_dir, PathBuf::from("/workspace/plans"));
+        assert_eq!(server.prompt_file, Some(PathBuf::from("/workspace/prompts/plan.md")));
+    }
+
+    #[test]
+    fn from_args_with_workspace_root_keeps_absolute_paths() {
+        let workspace = PathBuf::from("/workspace");
+        let server = PlanMcp::from_args_with_workspace_root(
+            vec!["--plans-dir".into(), "/tmp/plans".into(), "--prompt-file".into(), "/tmp/plan.md".into()],
+            default(),
+            &workspace,
+        )
+        .unwrap();
+
+        assert_eq!(server.plans_dir, PathBuf::from("/tmp/plans"));
+        assert_eq!(server.prompt_file, Some(PathBuf::from("/tmp/plan.md")));
     }
 
     #[test]

--- a/packages/mcp-servers/src/setup.rs
+++ b/packages/mcp-servers/src/setup.rs
@@ -1,4 +1,5 @@
 use crate::plan::DEFAULT_PLANS_DIR;
+use crate::workspace_paths;
 use crate::{CodingMcp, CodingMcpArgs, DefaultCodingTools, PlanMcp, SkillsMcp, SubAgentsMcp, SurveyMcp, TasksMcp};
 use aether_auth::OAuthCredentialStorage;
 use aether_core::mcp::McpBuilder;
@@ -22,15 +23,20 @@ pub trait McpBuilderExt {
 impl McpBuilderExt for McpBuilder {
     fn with_builtin_servers(
         self,
-        cwd: PathBuf,
+        _cwd: PathBuf,
         roots_path: &Path,
         oauth_credential_store: Option<Arc<dyn OAuthCredentialStorage>>,
     ) -> Self {
-        let plan_cwd = cwd.clone();
+        let workspace_root = roots_path.to_path_buf();
+        let coding_cwd = workspace_root.clone();
+        let plan_cwd = workspace_root.clone();
+        let subagents_cwd = workspace_root.clone();
+        let skills_cwd = workspace_root.clone();
+        let tasks_cwd = workspace_root.clone();
         self.register_in_memory_server(
             "coding",
             Box::new(move |args, _input| {
-                let project_path = cwd.clone();
+                let project_path = coding_cwd.clone();
                 async move {
                     let parsed = match CodingMcpArgs::from_args(args) {
                         Ok(args) => args,
@@ -39,7 +45,9 @@ impl McpBuilderExt for McpBuilder {
                             CodingMcpArgs::default()
                         }
                     };
-                    let CodingMcpArgs { permission_mode, rules_dirs, disable_lsp, .. } = parsed;
+                    let CodingMcpArgs { permission_mode, mut rules_dirs, disable_lsp, .. } = parsed;
+                    rules_dirs =
+                        rules_dirs.into_iter().map(|path| workspace_paths::resolve_path(&project_path, path)).collect();
                     debug!(
                         "CodingMcp created, disable_lsp={}, permission_mode={:?}, rules_dirs={}",
                         disable_lsp,
@@ -58,16 +66,24 @@ impl McpBuilderExt for McpBuilder {
         )
         .register_in_memory_server(
             "skills",
-            Box::new(|args, _input| {
-                async move { SkillsMcp::from_args(args).expect("Failed to parse SkillsMcp args").into_dyn() }.boxed()
+            Box::new(move |args, _input| {
+                let cwd = skills_cwd.clone();
+                async move {
+                    SkillsMcp::from_args_with_workspace_root(args, &cwd)
+                        .expect("Failed to parse SkillsMcp args")
+                        .into_dyn()
+                }
+                .boxed()
             }),
         )
         .register_in_memory_server(
             "subagents",
             Box::new(move |args, _input| {
                 let store = oauth_credential_store.clone();
+                let cwd = subagents_cwd.clone();
                 async move {
-                    let mut mcp = SubAgentsMcp::from_args(args).expect("Failed to parse SubAgentsMcp args");
+                    let mut mcp = SubAgentsMcp::from_args_with_default_project_root(args, &cwd)
+                        .expect("Failed to parse SubAgentsMcp args");
                     if let Some(store) = store {
                         mcp = mcp.with_oauth_credential_store(store);
                     }
@@ -84,8 +100,11 @@ impl McpBuilderExt for McpBuilder {
             "plan",
             Box::new(move |args, _input| {
                 let default_plans_dir = plan_cwd.join(DEFAULT_PLANS_DIR);
+                let workspace_root = plan_cwd.clone();
                 async move {
-                    PlanMcp::from_args(args, default_plans_dir).expect("Failed to parse PlanMcp args").into_dyn()
+                    PlanMcp::from_args_with_workspace_root(args, default_plans_dir, &workspace_root)
+                        .expect("Failed to parse PlanMcp args")
+                        .into_dyn()
                 }
                 .boxed()
             }),
@@ -93,8 +112,9 @@ impl McpBuilderExt for McpBuilder {
         .register_in_memory_server(
             "tasks",
             Box::new(move |args, _input| {
+                let cwd = tasks_cwd.clone();
                 async move {
-                    TasksMcp::from_args(args)
+                    TasksMcp::from_args_with_workspace_root(args, &cwd)
                         .unwrap_or_else(|e| {
                             tracing::warn!("Failed to parse TasksMcp args: {e}, using defaults");
                             TasksMcp::new()

--- a/packages/mcp-servers/src/skills/server.rs
+++ b/packages/mcp-servers/src/skills/server.rs
@@ -25,7 +25,8 @@ use super::tools::{
     ListSkillsInput, ListSkillsOutput, LoadSkillsInput, LoadSkillsOutput, SaveNoteInput, SaveNoteOutput,
     SearchNotesInput, SearchNotesOutput, SkillFile, SkillListItem, SkillRequest, save_note,
 };
-use crate::skills::tools::search_notes::search_notes;
+use crate::workspace_paths::primary_root;
+use crate::{skills::tools::search_notes::search_notes, workspace_paths::resolve_path};
 use aether_project::{PromptCatalog, PromptFile, SKILL_FILENAME};
 use mcp_utils::display_meta::ToolDisplayMeta;
 
@@ -115,6 +116,13 @@ impl SkillsMcp {
     pub fn from_args(args: Vec<String>) -> Result<Self, String> {
         let parsed_args = SkillsMcpArgs::from_args(args)?;
         Ok(Self::new(&parsed_args.dirs, parsed_args.notes_dir))
+    }
+
+    pub fn from_args_with_workspace_root(args: Vec<String>, workspace_root: &Path) -> Result<Self, String> {
+        let parsed_args = SkillsMcpArgs::from_args(args)?;
+        let dirs = parsed_args.dirs.into_iter().map(|path| resolve_path(workspace_root, path)).collect::<Vec<_>>();
+        let notes_dir = resolve_path(workspace_root, parsed_args.notes_dir);
+        Ok(Self::new(&dirs, notes_dir).with_roots(vec![workspace_root.to_path_buf()]))
     }
 
     pub fn with_roots(mut self, roots: Vec<PathBuf>) -> Self {
@@ -315,7 +323,8 @@ impl ServerHandler for SkillsMcp {
 
         let content = substitute_parameters(&body, &arguments);
         let expander = ShellExpander::new();
-        let cwd = self.roots.read().await.first().cloned().unwrap_or_else(|| PathBuf::from("."));
+        let roots = self.roots.read().await;
+        let cwd = primary_root(&roots);
         let content = expander.expand(&content, &cwd).await;
         let messages = vec![PromptMessage::new_text(PromptMessageRole::User, content)];
 
@@ -441,6 +450,20 @@ mod tests {
 
         assert_eq!(parsed.dirs, vec![PathBuf::from(".aether/skills"), PathBuf::from(".claude/rules")]);
         assert_eq!(parsed.notes_dir, PathBuf::from(".aether/notes"));
+    }
+
+    #[test]
+    fn from_args_with_workspace_root_resolves_relative_dirs() {
+        let workspace = PathBuf::from("/workspace");
+        let server = SkillsMcp::from_args_with_workspace_root(
+            vec!["--dir".into(), ".aether/skills".into(), "--notes-dir".into(), ".aether/notes".into()],
+            &workspace,
+        )
+        .unwrap();
+
+        assert_eq!(server.notes_dir, PathBuf::from("/workspace/.aether/notes"));
+        let roots = server.roots.blocking_read();
+        assert_eq!(*roots, vec![workspace]);
     }
 
     #[tokio::test]

--- a/packages/mcp-servers/src/subagents/server.rs
+++ b/packages/mcp-servers/src/subagents/server.rs
@@ -13,12 +13,13 @@ use rmcp::{
     service::RequestContext,
     tool, tool_handler, tool_router,
 };
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use std::sync::atomic::{AtomicU64, Ordering};
 use tokio::sync::RwLock;
 
 use super::tools::{AgentExecutor, SpawnSubAgentsInput, SpawnSubAgentsOutput};
+use crate::workspace_paths::resolve_path;
 
 type ProgressCallback = Box<dyn Fn(&str, &str, &AgentMessage) + Send + Sync>;
 
@@ -76,6 +77,14 @@ impl SubAgentsMcp {
     pub fn from_args(args: Vec<String>) -> Result<Self, String> {
         let parsed_args = SubAgentsMcpArgs::from_args(args)?;
         let project_root = parsed_args.project_root.unwrap_or_else(|| PathBuf::from("."));
+        Self::from_project_root(project_root)
+    }
+
+    pub fn from_args_with_default_project_root(args: Vec<String>, default_root: &Path) -> Result<Self, String> {
+        let parsed_args = SubAgentsMcpArgs::from_args(args)?;
+        let project_root = parsed_args
+            .project_root
+            .map_or_else(|| default_root.to_path_buf(), |path| resolve_path(default_root, path));
         Self::from_project_root(project_root)
     }
 

--- a/packages/mcp-servers/src/tasks/server.rs
+++ b/packages/mcp-servers/src/tasks/server.rs
@@ -8,13 +8,17 @@ use rmcp::{
     model::{Implementation, ServerCapabilities, ServerInfo},
     tool, tool_handler, tool_router,
 };
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use tempfile::TempDir;
 use tokio::sync::{Mutex, RwLock};
 
-use crate::tasks::{
-    TaskCreateInput, TaskCreateOutput, TaskGetInput, TaskGetOutput, TaskListInput, TaskListOutput, TaskStore,
-    TaskUpdateInput, TaskUpdateOutput, execute_task_create, execute_task_get, execute_task_list, execute_task_update,
+use crate::{
+    tasks::{
+        TaskCreateInput, TaskCreateOutput, TaskGetInput, TaskGetOutput, TaskListInput, TaskListOutput, TaskStore,
+        TaskUpdateInput, TaskUpdateOutput, execute_task_create, execute_task_get, execute_task_list,
+        execute_task_update,
+    },
+    workspace_paths::resolve_path,
 };
 
 /// CLI arguments for `TasksMcp` server
@@ -94,6 +98,14 @@ impl TasksMcp {
         Ok(match parsed_args.dir {
             Some(dir) => Self::new_persistent(dir),
             None => Self::new(),
+        })
+    }
+
+    pub fn from_args_with_workspace_root(args: Vec<String>, workspace_root: &Path) -> Result<Self, String> {
+        let parsed_args = TasksMcpArgs::from_args(args)?;
+        Ok(match parsed_args.dir {
+            Some(dir) => Self::new_persistent(resolve_path(workspace_root, dir)),
+            None => Self::new().with_roots(vec![workspace_root.to_path_buf()]),
         })
     }
 
@@ -195,10 +207,19 @@ mod tests {
     }
 
     #[test]
-    fn test_from_args_with_dir_is_persistent() {
-        let temp = TempDir::new().unwrap();
-        let dir = temp.path().to_str().unwrap().to_string();
-        let server = TasksMcp::from_args(vec!["--dir".into(), dir]).unwrap();
+    fn test_from_args_with_workspace_root_resolves_relative_dir() {
+        let server =
+            TasksMcp::from_args_with_workspace_root(vec!["--dir".into(), "tasks".into()], Path::new("/workspace"))
+                .unwrap();
+
         assert!(!server.is_session_scoped());
+        assert_eq!(server.roots.blocking_read().as_slice(), &[PathBuf::from("/workspace/tasks")]);
+    }
+
+    #[test]
+    fn test_from_args_with_workspace_root_no_dir_stays_session_scoped() {
+        let server = TasksMcp::from_args_with_workspace_root(vec![], Path::new("/workspace")).unwrap();
+        assert!(server.is_session_scoped());
+        assert_eq!(server.roots.blocking_read().as_slice(), &[PathBuf::from("/workspace")]);
     }
 }

--- a/packages/mcp-servers/src/workspace_paths.rs
+++ b/packages/mcp-servers/src/workspace_paths.rs
@@ -1,0 +1,73 @@
+use std::path::{Path, PathBuf};
+
+/// Returns the primary (first) workspace root, falling back to `.` when none
+/// are configured.
+pub fn primary_root(roots: &[PathBuf]) -> PathBuf {
+    roots.first().cloned().unwrap_or_else(|| PathBuf::from("."))
+}
+
+/// Resolves `path` against `root`, leaving absolute paths untouched.
+pub fn resolve_path(root: &Path, path: PathBuf) -> PathBuf {
+    if path.is_absolute() { path } else { root.join(path) }
+}
+
+/// Resolves a required file path against `root`. Whitespace-only input is
+/// rejected; otherwise the text (including any surrounding spaces) is preserved
+/// so unusual-but-valid file names round-trip unchanged.
+pub fn resolve_file(root: &Path, raw: &str) -> Result<PathBuf, String> {
+    if raw.trim().is_empty() {
+        return Err("file path is required and cannot be empty".to_string());
+    }
+    Ok(resolve_path(root, PathBuf::from(raw)))
+}
+
+/// Resolves an optional directory against `root`. Missing or whitespace-only
+/// input resolves to `root` itself.
+pub fn resolve_dir(root: &Path, raw: Option<&str>) -> PathBuf {
+    match raw {
+        Some(raw) if !raw.trim().is_empty() => resolve_path(root, PathBuf::from(raw)),
+        _ => root.to_path_buf(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn primary_root_falls_back_to_dot_when_empty() {
+        assert_eq!(primary_root(&[]), PathBuf::from("."));
+        assert_eq!(primary_root(&[PathBuf::from("/a"), PathBuf::from("/b")]), PathBuf::from("/a"));
+    }
+
+    #[test]
+    fn resolves_relative_path_against_root() {
+        assert_eq!(
+            resolve_path(Path::new("/workspace"), PathBuf::from("src/main.rs")),
+            PathBuf::from("/workspace/src/main.rs")
+        );
+    }
+
+    #[test]
+    fn leaves_absolute_path_untouched() {
+        assert_eq!(resolve_path(Path::new("/workspace"), PathBuf::from("/etc/passwd")), PathBuf::from("/etc/passwd"));
+    }
+
+    #[test]
+    fn preserves_non_empty_file_path_text() {
+        let resolved = resolve_file(Path::new("/workspace"), " leading space.txt ").unwrap();
+        assert_eq!(resolved, PathBuf::from("/workspace/ leading space.txt "));
+    }
+
+    #[test]
+    fn rejects_whitespace_only_required_file_path() {
+        let err = resolve_file(Path::new("/workspace"), "  \t ").unwrap_err();
+        assert!(err.contains("file path is required"));
+    }
+
+    #[test]
+    fn optional_empty_dir_resolves_to_root() {
+        assert_eq!(resolve_dir(Path::new("/workspace"), Some("  ")), PathBuf::from("/workspace"));
+        assert_eq!(resolve_dir(Path::new("/workspace"), None), PathBuf::from("/workspace"));
+    }
+}

--- a/packages/mcp-servers/tests/coding_mcp_tools.rs
+++ b/packages/mcp-servers/tests/coding_mcp_tools.rs
@@ -1,7 +1,7 @@
 use mcp_servers::coding::CodingMcp;
 use mcp_utils::testing::connect;
 use rmcp::model::{CallToolRequestParams, ClientCapabilities, ClientInfo, Implementation};
-use std::fs;
+use std::fs::{self, canonicalize};
 
 #[tokio::test]
 async fn test_read_file_tool() {
@@ -337,4 +337,138 @@ async fn test_list_files_tool() {
 
     // Clean up
     let _ = fs::remove_dir_all(test_dir);
+}
+
+#[tokio::test]
+async fn test_list_files_uses_workspace_root_when_no_path_given() -> Result<(), Box<dyn std::error::Error>> {
+    let temp = tempfile::tempdir()?;
+    let workspace = temp.path().to_path_buf();
+
+    fs::write(temp.path().join("alpha.txt"), "a")?;
+    fs::write(temp.path().join("beta.rs"), "b")?;
+
+    let server_service = CodingMcp::new().with_root_dir(workspace.clone());
+    let client_info = ClientInfo::new(ClientCapabilities::default(), Implementation::new("test-client", "0.1.0"));
+    let (_server_handle, client) = connect(server_service, client_info).await?;
+    let result = client
+        .call_tool(
+            CallToolRequestParams::new("list_files").with_arguments(serde_json::json!({}).as_object().unwrap().clone()),
+        )
+        .await?;
+
+    let text_content = result.content.first().and_then(|c| c.as_text()).ok_or("Expected text content")?;
+    let parsed: serde_json::Value = serde_json::from_str(&text_content.text)?;
+    let files = parsed["files"].as_array().ok_or("Files should be an array")?;
+    let file_names: Vec<String> = files.iter().map(|f| f["name"].as_str().unwrap().to_string()).collect();
+
+    assert!(file_names.contains(&"alpha.txt".to_string()));
+    assert!(file_names.contains(&"beta.rs".to_string()));
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_bash_pwd_uses_workspace_root() -> Result<(), Box<dyn std::error::Error>> {
+    let temp = tempfile::tempdir()?;
+    let workspace = temp.path().to_path_buf();
+    let server_service = CodingMcp::new().with_root_dir(workspace.clone());
+    let client_info = ClientInfo::new(ClientCapabilities::default(), Implementation::new("test-client", "0.1.0"));
+    let (_server_handle, client) = connect(server_service, client_info).await?;
+    let result = client
+        .call_tool(
+            CallToolRequestParams::new("bash").with_arguments(
+                serde_json::json!({
+                    "command": "pwd"
+                })
+                .as_object()
+                .unwrap()
+                .clone(),
+            ),
+        )
+        .await?;
+
+    let text_content = result.content.first().and_then(|c| c.as_text()).ok_or("Expected text content")?;
+    let parsed: serde_json::Value = serde_json::from_str(&text_content.text)?;
+    let pwd = parsed["output"].as_str().ok_or("Expected output string")?.trim();
+    assert_eq!(canonicalize(pwd)?, canonicalize(&workspace)?);
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_grep_and_find_use_workspace_root_when_no_path_given() -> Result<(), Box<dyn std::error::Error>> {
+    let temp = tempfile::tempdir()?;
+    let workspace = temp.path().to_path_buf();
+    fs::write(temp.path().join("root_only.txt"), "needle\n")?;
+    fs::write(temp.path().join("other.rs"), "fn main() {}\n")?;
+
+    let server_service = CodingMcp::new().with_root_dir(workspace.clone());
+    let client_info = ClientInfo::new(ClientCapabilities::default(), Implementation::new("test-client", "0.1.0"));
+    let (_server_handle, client) = connect(server_service, client_info).await?;
+    let grep_result = client
+        .call_tool(
+            CallToolRequestParams::new("grep").with_arguments(
+                serde_json::json!({
+                    "pattern": "needle"
+                })
+                .as_object()
+                .unwrap()
+                .clone(),
+            ),
+        )
+        .await?;
+
+    let text_content = grep_result.content.first().and_then(|c| c.as_text()).ok_or("Expected text content")?;
+    let parsed: serde_json::Value = serde_json::from_str(&text_content.text)?;
+    let matches = parsed["matches"].as_array().ok_or("matches should be an array")?;
+    assert!(matches.iter().any(|m| m["file"].as_str().unwrap().ends_with("root_only.txt")));
+
+    let find_result = client
+        .call_tool(
+            CallToolRequestParams::new("find").with_arguments(
+                serde_json::json!({
+                    "pattern": "*.rs"
+                })
+                .as_object()
+                .unwrap()
+                .clone(),
+            ),
+        )
+        .await?;
+
+    let text_content = find_result.content.first().and_then(|c| c.as_text()).ok_or("Expected text content")?;
+    let parsed: serde_json::Value = serde_json::from_str(&text_content.text)?;
+    assert_eq!(parsed["searchPath"].as_str().unwrap(), workspace.to_str().unwrap());
+    let matches = parsed["matches"].as_array().ok_or("matches should be an array")?;
+
+    assert!(matches.iter().any(|m| m.as_str().unwrap().ends_with("other.rs")));
+    Ok(())
+}
+
+#[cfg(feature = "test-helpers")]
+#[tokio::test]
+async fn test_read_before_edit_safety_with_relative_path_normalization() {
+    use mcp_servers::coding::tools::edit_file::EditFileArgs;
+    use mcp_servers::coding::tools::read_file::ReadFileArgs;
+
+    let temp = tempfile::tempdir().unwrap();
+    let workspace = temp.path().to_path_buf();
+    let test_file = temp.path().join("test.txt");
+    fs::write(&test_file, "hello world").unwrap();
+
+    let server = CodingMcp::new().with_root_dir(workspace);
+
+    server
+        .test_read_file(ReadFileArgs { file_path: "test.txt".to_string(), offset: None, limit: None })
+        .await
+        .expect("read_file should succeed with relative path");
+
+    let result = server
+        .test_edit_file(EditFileArgs {
+            file_path: "test.txt".to_string(),
+            old_string: "hello".to_string(),
+            new_string: "goodbye".to_string(),
+            replace_all: false,
+        })
+        .await;
+
+    assert!(result.is_ok());
 }

--- a/packages/mcp-servers/tests/test_bash.rs
+++ b/packages/mcp-servers/tests/test_bash.rs
@@ -1,5 +1,6 @@
 use mcp_servers::coding::error::BashError;
 use mcp_servers::coding::tools::bash::{BashInput, BashResult, execute_command, read_background_bash};
+use std::fs::canonicalize;
 use std::time::Duration;
 
 #[tokio::test]
@@ -275,4 +276,21 @@ async fn test_read_background_bash_failed_status() {
         }
         BashResult::Completed(_) => panic!("Expected background result"),
     }
+}
+
+#[tokio::test]
+async fn test_execute_command_in_dir_foreground() -> Result<(), Box<dyn std::error::Error>> {
+    use mcp_servers::coding::tools::bash::execute_command_in_dir;
+
+    let temp = tempfile::tempdir()?;
+    let args = BashInput { command: "pwd".to_string(), timeout: None, description: None, run_in_background: None };
+    let result = execute_command_in_dir(args, Some(temp.path())).await?;
+    let BashResult::Completed(output) = result else {
+        return Err("Expected completed result".into());
+    };
+
+    let pwd = output.output.trim();
+
+    assert_eq!(canonicalize(pwd)?, canonicalize(temp.path())?);
+    Ok(())
 }

--- a/packages/mcp-utils/src/client/connection.rs
+++ b/packages/mcp-utils/src/client/connection.rs
@@ -2,6 +2,7 @@ use super::{
     McpClientEvent, McpError, OAuthHandlerFactory, Result,
     config::{McpServer, McpTransport},
     mcp_client::McpClient,
+    roots::primary_root_path,
 };
 use crate::{client::OAuthHandlerContext, transport::create_in_memory_transport};
 use aether_auth::{OAuthCredentialStorage, create_auth_manager_from_store, perform_oauth_flow};
@@ -17,6 +18,7 @@ use rmcp::{
 };
 use serde_json::Value;
 use std::collections::HashMap;
+use std::path::PathBuf;
 use std::process::Stdio;
 use std::sync::Arc;
 use tokio::{
@@ -118,7 +120,11 @@ pub(super) async fn connect_server(server: McpServer, ctx: &ConnectConfig) -> Mc
         McpClient::new(ctx.client_info.clone(), name.clone(), ctx.event_sender.clone(), Arc::clone(&ctx.roots));
 
     let outcome = match transport {
-        McpTransport::Stdio { command, args, env } => connect_stdio(&name, command, args, env, mcp_client).await,
+        McpTransport::Stdio { command, args, env } => {
+            let roots = ctx.roots.read().await;
+            let cwd = primary_root_path(&roots);
+            connect_stdio(&name, command, args, env, mcp_client, cwd).await
+        }
         McpTransport::InMemory { server } => connect_in_memory(&name, server, mcp_client).await,
         McpTransport::Http { config } => {
             connect_http(
@@ -180,9 +186,14 @@ async fn connect_stdio(
     args: Vec<String>,
     env: HashMap<String, String>,
     mcp_client: McpClient,
+    cwd: Option<PathBuf>,
 ) -> McpConnectOutcome {
     let mut cmd = Command::new(&command);
     cmd.args(&args).envs(&env);
+
+    if let Some(ref dir) = cwd {
+        cmd.current_dir(dir);
+    }
 
     let (proc, stderr) = match TokioChildProcess::builder(cmd).stderr(Stdio::piped()).spawn() {
         Ok(parts) => parts,

--- a/packages/mcp-utils/src/client/mod.rs
+++ b/packages/mcp-utils/src/client/mod.rs
@@ -25,7 +25,7 @@ pub use mcp_client::{McpClient, cancel_result};
 pub use naming::{SERVERNAME_DELIMITER, split_on_server_name};
 pub use oauth_handler::{AETHER_OAUTH_ELICITATION_ID, ElicitingOAuthHandler};
 pub use rmcp::model::Root;
-pub use roots::root_from_path;
+pub use roots::{path_to_file_uri, root_from_path, root_to_path};
 
 use std::path::PathBuf;
 

--- a/packages/mcp-utils/src/client/roots.rs
+++ b/packages/mcp-utils/src/client/roots.rs
@@ -1,7 +1,5 @@
 use rmcp::model::Root;
-use std::path::Path;
-#[cfg(test)]
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
 /// Convert a `PathBuf` to a file:// URI string.
 ///
@@ -28,6 +26,41 @@ pub fn path_to_file_uri(path: &Path) -> String {
     }
 }
 
+/// Convert a Root's file:// URI back to a `PathBuf`.
+///
+/// Returns `None` if the URI is not a valid file URI or cannot be converted
+/// to a path on the current platform.
+pub fn root_to_path(root: &Root) -> Option<PathBuf> {
+    let uri = root.uri.as_str();
+    if !uri.starts_with("file://") {
+        return None;
+    }
+
+    let path_str = uri.strip_prefix("file://")?;
+
+    #[cfg(unix)]
+    {
+        Some(PathBuf::from(path_str))
+    }
+
+    #[cfg(windows)]
+    {
+        // Windows URIs have format file:///C:/path, so strip leading /
+        let path_str = path_str.strip_prefix('/').unwrap_or(path_str);
+        // Convert forward slashes back to backslashes
+        Some(PathBuf::from(path_str.replace('/', "\\")))
+    }
+
+    #[cfg(not(any(unix, windows)))]
+    {
+        Some(PathBuf::from(path_str))
+    }
+}
+
+pub fn primary_root_path(roots: &[Root]) -> Option<PathBuf> {
+    roots.iter().find_map(root_to_path)
+}
+
 /// Create a Root from a `PathBuf`.
 ///
 /// The path is converted to an absolute file:// URI.
@@ -49,6 +82,13 @@ mod tests {
         let path = PathBuf::from("/home/user/project");
         let uri = path_to_file_uri(&path);
         assert_eq!(uri, "file:///home/user/project");
+    }
+
+    #[test]
+    fn test_primary_root_path_uses_first_valid_file_root() {
+        let invalid = Root::new("https://example.com".to_string());
+        let root = root_from_path(&PathBuf::from("/tmp/test"), None);
+        assert_eq!(primary_root_path(&[invalid, root]), Some(PathBuf::from("/tmp/test")));
     }
 
     #[test]
@@ -76,5 +116,26 @@ mod tests {
 
         // The URI should preserve spaces (not percent-encoded in this simple implementation)
         assert_eq!(root.uri.as_str(), "file:///home/user/my project");
+    }
+
+    #[test]
+    fn test_root_to_path_unix() {
+        let root = Root::new("file:///home/user/project");
+        let path = root_to_path(&root).expect("Should convert to path");
+        assert_eq!(path, PathBuf::from("/home/user/project"));
+    }
+
+    #[test]
+    fn test_root_to_path_roundtrip() {
+        let original = PathBuf::from("/home/user/project");
+        let root = root_from_path(&original, None);
+        let converted = root_to_path(&root).expect("Should convert back to path");
+        assert_eq!(converted, original);
+    }
+
+    #[test]
+    fn test_root_to_path_invalid_uri() {
+        let root = Root::new("http://example.com");
+        assert!(root_to_path(&root).is_none());
     }
 }

--- a/packages/tui/src/lib.rs
+++ b/packages/tui/src/lib.rs
@@ -106,5 +106,7 @@ pub use fuzzy_matcher::Searchable;
 pub use fuzzy_matcher::FuzzyMatcher;
 
 // Terminal event types (re-exported from crossterm)
-pub use crossterm::event::{KeyCode, KeyEvent, KeyEventKind, KeyEventState, KeyModifiers, MouseEvent, MouseEventKind};
+pub use crossterm::event::{
+    KeyCode, KeyEvent, KeyEventKind, KeyEventState, KeyModifiers, MouseButton, MouseEvent, MouseEventKind,
+};
 pub use crossterm::style::Color;

--- a/packages/wisp/examples/wisp_gallery.rs
+++ b/packages/wisp/examples/wisp_gallery.rs
@@ -10,7 +10,7 @@ use wisp::components::command_picker::{CommandEntry, CommandPicker};
 use wisp::components::file_picker::{FileMatch, FilePicker};
 use wisp::components::plan_review::PlanDocument;
 use wisp::components::plan_view::PlanView;
-use wisp::components::progress_indicator::ProgressIndicator;
+use wisp::components::progress_indicator::{ProgressIndicator, WorkspaceProgress};
 use wisp::components::status_line::{ContextUsageDisplay, StatusLine};
 use wisp::components::text_input::TextInput;
 use wisp::components::thought_message::ThoughtMessage;
@@ -385,7 +385,7 @@ fn stories() -> Vec<(String, WispStory)> {
             "ProgressIndicator".into(),
             WispStory::ProgressIndicator({
                 let mut indicator = ProgressIndicator::default();
-                indicator.update(1, 3, true);
+                indicator.update(1, 3, true, WorkspaceProgress::None);
                 ProgressIndicatorStory { indicator }
             }),
         ),

--- a/packages/wisp/src/components/app/mod.rs
+++ b/packages/wisp/src/components/app/mod.rs
@@ -31,7 +31,7 @@ use acp_utils::notifications::{
 use agent_client_protocol::Responder;
 use agent_client_protocol::schema::{self as acp, SessionId};
 use attachments::build_attachment_blocks;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::time::{Duration, Instant};
 use tui::RendererCommand;
 use tui::{Component, Event, Frame, KeyEvent, ViewContext};
@@ -113,8 +113,7 @@ impl App {
         let keybindings = Keybindings::default();
         let content_padding = resolve_content_padding(&settings);
         let status_line_settings = resolve_status_line_settings(&settings);
-        let prompt_search_enabled = AetherCapabilities::from_meta(prompt_capabilities.meta.as_ref()).prompt_search;
-        let session_preview_enabled = AetherCapabilities::from_meta(session_capabilities.meta.as_ref()).session_preview;
+        let capabilities = AetherCapabilities::from_meta(session_capabilities.meta.as_ref());
         Self {
             agent_name,
             context_usage: None,
@@ -123,8 +122,8 @@ impl App {
             conversation_screen: ConversationScreen::new(
                 keybindings.clone(),
                 content_padding,
-                prompt_search_enabled,
-                session_preview_enabled,
+                working_dir.clone(),
+                capabilities,
             ),
             prompt_capabilities,
             config_options,
@@ -208,6 +207,7 @@ impl App {
             AcpEvent::SessionLoaded { session_id, config_options } => {
                 let replay_updates = self.session_loading_buffer.take(&session_id);
                 self.session_id = session_id;
+                self.conversation_screen.on_workspace_move_finished();
                 for update in replay_updates {
                     self.on_session_update(&update);
                 }
@@ -237,8 +237,46 @@ impl App {
             AcpEvent::SessionPreviewFailed { session_id, error } => {
                 self.conversation_screen.on_session_preview_failed(&session_id, error);
             }
+            AcpEvent::WorkspacesListed(response) => {
+                self.conversation_screen.open_workspace_picker(response.workspaces);
+            }
+            AcpEvent::WorkspaceListFailed { error } => {
+                self.conversation_screen.on_workspace_list_failed(&error);
+            }
+            AcpEvent::WorkspaceMoved(response) => {
+                self.on_workspace_moved(&response.new_cwd, &mut commands);
+            }
+            AcpEvent::WorkspaceMoveFailed { error } => {
+                self.conversation_screen.on_workspace_move_failed(&error);
+            }
         }
         EventOutcome::Render { commands }
+    }
+
+    fn on_workspace_moved(&mut self, new_cwd: &Path, commands: &mut Vec<RendererCommand>) {
+        self.working_dir = new_cwd.to_path_buf();
+        self.conversation_screen.set_working_dir(new_cwd.to_path_buf());
+        self.workspace_status = WorkspaceStatus::resolve(new_cwd);
+        self.screen_router.set_git_diff_working_dir(new_cwd.to_path_buf());
+
+        self.conversation_screen.reset_after_context_cleared();
+        commands.push(RendererCommand::ClearScreen);
+        let session_id = self.session_id.clone();
+        if self.start_session_load(&session_id, new_cwd) {
+            self.conversation_screen.on_workspace_session_loading();
+        } else {
+            self.conversation_screen.on_workspace_move_finished();
+        }
+    }
+
+    fn start_session_load(&mut self, session_id: &SessionId, cwd: &Path) -> bool {
+        self.session_loading_buffer.begin_load(session_id.clone());
+        if let Err(e) = self.prompt_handle.load_session(session_id, cwd) {
+            self.session_loading_buffer.remove(session_id);
+            tracing::warn!("Failed to load session: {e}");
+            return false;
+        }
+        true
     }
 
     async fn handle_key(&mut self, commands: &mut Vec<RendererCommand>, key_event: KeyEvent) {
@@ -324,12 +362,21 @@ impl App {
                 ConversationScreenMessage::OpenSessionPicker => {
                     let _ = self.prompt_handle.list_sessions();
                 }
-                ConversationScreenMessage::LoadSession { session_id, cwd } => {
-                    self.session_loading_buffer.begin_load(session_id.clone());
-                    if let Err(e) = self.prompt_handle.load_session(&session_id, &cwd) {
-                        self.session_loading_buffer.remove(&session_id);
-                        tracing::warn!("Failed to load session: {e}");
+                ConversationScreenMessage::OpenWorkspacePicker => {
+                    if let Err(e) = self.prompt_handle.list_workspaces(&self.session_id) {
+                        self.conversation_screen.on_workspace_list_failed(&e.to_string());
+                        tracing::warn!("Failed to request workspace list: {e}");
                     }
+                }
+                ConversationScreenMessage::MoveWorkspace { target } => {
+                    self.conversation_screen.on_workspace_move_started();
+                    if let Err(e) = self.prompt_handle.move_workspace(&self.session_id, target) {
+                        self.conversation_screen.on_workspace_move_failed(&e.to_string());
+                        tracing::warn!("Failed to request workspace move: {e}");
+                    }
+                }
+                ConversationScreenMessage::LoadSession { session_id, cwd } => {
+                    self.start_session_load(&session_id, &cwd);
                 }
                 ConversationScreenMessage::SearchPrompts(params) => {
                     if let Err(e) = self.prompt_handle.search_prompts(params) {
@@ -758,8 +805,9 @@ pub(crate) mod test_helpers {
             session_id: SessionId::new(session_id),
             agent_name: "test-agent".to_string(),
             prompt_capabilities,
-            session_capabilities: acp::SessionCapabilities::new()
-                .meta(Some(AetherCapabilities::session_preview().to_meta())),
+            session_capabilities: acp::SessionCapabilities::new().meta(Some(
+                AetherCapabilities { prompt_search: true, session_preview: true, workspace_move: true }.to_meta(),
+            )),
             config_options: config_options.to_vec(),
             auth_methods,
             working_dir: PathBuf::from("."),
@@ -778,6 +826,7 @@ mod tests {
     use crate::components::conversation_screen::Modal;
     use crate::components::conversation_window::SegmentContent;
     use crate::components::elicitation_form::ElicitationForm;
+    use crate::components::progress_indicator::WorkspaceProgress;
     use crate::settings::{DEFAULT_CONTENT_PADDING, save_settings};
     use crate::settings::{ThemeSettings, WispSettings};
     use crate::test_helpers::{elicitation_params, modified_key, url_elicitation_params, with_wisp_home};
@@ -1365,7 +1414,7 @@ mod tests {
         let mut app = make_app();
         let tool_call = acp::ToolCall::new("tool-1".to_string(), "test_tool");
         app.conversation_screen.tool_call_statuses.on_tool_call(&tool_call);
-        app.conversation_screen.progress_indicator.update(0, 1, true);
+        app.conversation_screen.progress_indicator.update(0, 1, true, WorkspaceProgress::default());
 
         let ctx = ViewContext::new((80, 24));
         let tool_before = app.conversation_screen.tool_call_statuses.render_tool("tool-1", &ctx);

--- a/packages/wisp/src/components/app/screen_router.rs
+++ b/packages/wisp/src/components/app/screen_router.rs
@@ -41,6 +41,10 @@ impl ScreenRouter {
         self.mode.is_some()
     }
 
+    pub fn set_git_diff_working_dir(&mut self, dir: PathBuf) {
+        self.git_diff_working_dir = dir;
+    }
+
     pub fn toggle_git_diff(&mut self) -> Option<ScreenRouterMessage> {
         match self.mode.take() {
             None => {

--- a/packages/wisp/src/components/common/input_box.rs
+++ b/packages/wisp/src/components/common/input_box.rs
@@ -1,0 +1,21 @@
+use tui::{BorderedTextField, Cursor, Frame, ViewContext, display_width_text, truncate_text};
+
+const INPUT_BOX_MAX_WIDTH: usize = 56;
+pub(crate) const INPUT_BOX_INDENT: u16 = 2;
+
+pub(crate) fn input_box_width(context: &ViewContext) -> usize {
+    (context.size.width as usize).saturating_sub(usize::from(INPUT_BOX_INDENT)).min(INPUT_BOX_MAX_WIDTH)
+}
+
+pub(crate) fn input_box_frame(label: &str, value: &str, placeholder: &str, context: &ViewContext) -> Frame {
+    let width = input_box_width(context);
+    let input_width = width.saturating_sub(4);
+    let visible_value = truncate_text(value, input_width);
+
+    let mut field = BorderedTextField::new(label, value.to_string()).placeholder(placeholder);
+    field.set_width(width);
+
+    Frame::new(field.render_field(context, false))
+        .with_cursor(Cursor::visible(1, 2 + display_width_text(&visible_value)))
+        .indent(INPUT_BOX_INDENT)
+}

--- a/packages/wisp/src/components/common/mod.rs
+++ b/packages/wisp/src/components/common/mod.rs
@@ -1,9 +1,11 @@
 mod anchored_surface_builder;
 mod cached_layer;
+mod input_box;
 mod key_hints;
 mod vertical_cursor;
 
 pub(crate) use anchored_surface_builder::AnchoredSurfaceBuilder;
 pub(crate) use cached_layer::CachedLayer;
+pub(crate) use input_box::{INPUT_BOX_INDENT, input_box_frame, input_box_width};
 pub(crate) use key_hints::render_key_hints;
 pub(crate) use vertical_cursor::VerticalCursor;

--- a/packages/wisp/src/components/conversation_screen.rs
+++ b/packages/wisp/src/components/conversation_screen.rs
@@ -4,13 +4,17 @@ use crate::components::conversation_window::{ConversationBuffer, ConversationWin
 use crate::components::elicitation_form::{ElicitationForm, ElicitationMessage};
 use crate::components::plan_tracker::PlanTracker;
 use crate::components::plan_view::PlanView;
-use crate::components::progress_indicator::ProgressIndicator;
+use crate::components::progress_indicator::{ProgressIndicator, WorkspaceProgress};
 use crate::components::prompt_composer::{PromptComposer, PromptComposerMessage};
 use crate::components::session_picker::{SessionEntry, SessionPicker, SessionPickerMessage};
 use crate::components::tool_call_statuses::ToolCallStatuses;
+use crate::components::workspace_picker::{WorkspacePicker, WorkspacePickerMessage};
 use crate::keybindings::Keybindings;
 use acp_utils::CreateElicitationRequestParams;
-use acp_utils::notifications::{ElicitationResponse, PromptSearchParams, PromptSearchResponse, SessionPreviewResponse};
+use acp_utils::notifications::{
+    AetherCapabilities, ElicitationResponse, PromptSearchParams, PromptSearchResponse, SessionPreviewResponse,
+    WorkspaceEntry, WorkspaceMoveTarget,
+};
 use agent_client_protocol::Responder;
 use agent_client_protocol::schema::{self as acp, SessionId};
 use std::collections::HashSet;
@@ -24,14 +28,41 @@ pub enum ConversationScreenMessage {
     NewSession,
     OpenSettings,
     OpenSessionPicker,
+    OpenWorkspacePicker,
+    MoveWorkspace { target: WorkspaceMoveTarget },
     LoadSession { session_id: SessionId, cwd: PathBuf },
     SearchPrompts(PromptSearchParams),
     RequestSessionPreview { session_id: SessionId },
 }
 
+#[derive(Clone, Debug, Default, Eq, PartialEq)]
+pub(crate) enum WorkspaceMoveState {
+    #[default]
+    Idle,
+    Listing,
+    Picking,
+    Moving,
+    LoadingSession,
+}
+
+impl WorkspaceMoveState {
+    fn progress(&self) -> WorkspaceProgress {
+        match self {
+            Self::Moving => WorkspaceProgress::Moving,
+            Self::LoadingSession => WorkspaceProgress::LoadingSession,
+            Self::Idle | Self::Listing | Self::Picking => WorkspaceProgress::None,
+        }
+    }
+
+    fn is_idle(&self) -> bool {
+        matches!(self, Self::Idle)
+    }
+}
+
 pub(crate) enum Modal {
     Elicitation(ElicitationForm),
     SessionPicker(SessionPicker),
+    WorkspacePicker(WorkspacePicker),
 }
 
 #[doc = include_str!("../docs/conversation_screen.md")]
@@ -41,31 +72,33 @@ pub struct ConversationScreen {
     pub(crate) prompt_composer: PromptComposer,
     pub(crate) plan_tracker: PlanTracker,
     pub(crate) progress_indicator: ProgressIndicator,
+    pub(crate) workspace_move_state: WorkspaceMoveState,
     pub(crate) waiting_for_response: bool,
     pub(crate) active_modal: Option<Modal>,
     pub(crate) content_padding: usize,
     pub(crate) pending_url_elicitations: HashSet<(String, String)>,
-    session_preview_enabled: bool,
+    capabilities: AetherCapabilities,
 }
 
 impl ConversationScreen {
     pub fn new(
         keybindings: Keybindings,
         content_padding: usize,
-        prompt_search_enabled: bool,
-        session_preview_enabled: bool,
+        working_dir: PathBuf,
+        capabilities: AetherCapabilities,
     ) -> Self {
         Self {
             conversation: ConversationBuffer::new(),
             tool_call_statuses: ToolCallStatuses::new(),
-            prompt_composer: PromptComposer::new(keybindings, prompt_search_enabled),
+            prompt_composer: PromptComposer::new(keybindings, working_dir, capabilities.clone()),
             plan_tracker: PlanTracker::default(),
             progress_indicator: ProgressIndicator::default(),
+            workspace_move_state: WorkspaceMoveState::Idle,
             waiting_for_response: false,
             active_modal: None,
             content_padding,
             pending_url_elicitations: HashSet::new(),
-            session_preview_enabled,
+            capabilities,
         }
     }
 
@@ -77,12 +110,17 @@ impl ConversationScreen {
         self.prompt_composer.clear_content();
     }
 
+    pub fn set_working_dir(&mut self, working_dir: PathBuf) {
+        self.prompt_composer.set_working_dir(working_dir);
+    }
+
     pub fn is_waiting(&self) -> bool {
         self.waiting_for_response
     }
 
     pub fn wants_tick(&self) -> bool {
         self.waiting_for_response
+            || self.workspace_move_state.progress() != WorkspaceProgress::None
             || self.tool_call_statuses.progress().running_any
             || self.plan_tracker_has_tick_driven_visibility()
     }
@@ -99,6 +137,7 @@ impl ConversationScreen {
             progress.completed_top_level,
             progress.total_top_level,
             self.waiting_for_response,
+            self.workspace_move_state.progress(),
         );
         self.plan_tracker.cached_visible_entries();
     }
@@ -107,14 +146,54 @@ impl ConversationScreen {
         self.conversation.clear();
         self.tool_call_statuses.clear();
         self.waiting_for_response = false;
+        self.workspace_move_state = WorkspaceMoveState::Idle;
         self.plan_tracker.clear();
         self.progress_indicator = ProgressIndicator::default();
         self.pending_url_elicitations.clear();
     }
 
+    pub fn request_workspace_picker(&mut self) -> Result<ConversationScreenMessage, &'static str> {
+        if self.waiting_for_response {
+            return Err("Cannot move workspaces while a prompt is running.");
+        }
+        if !self.workspace_move_state.is_idle() {
+            return Err("Cannot move workspaces while another workspace move is in progress.");
+        }
+        self.workspace_move_state = WorkspaceMoveState::Listing;
+        self.prompt_composer.clear_content();
+        Ok(ConversationScreenMessage::OpenWorkspacePicker)
+    }
+
+    pub fn open_workspace_picker(&mut self, workspaces: Vec<WorkspaceEntry>) {
+        self.workspace_move_state = WorkspaceMoveState::Picking;
+        self.active_modal = Some(Modal::WorkspacePicker(WorkspacePicker::new(workspaces)));
+    }
+
+    pub(crate) fn on_workspace_list_failed(&mut self, error: &str) {
+        self.conversation.push_user_message(&format!("[wisp] Failed to list workspaces: {error}"));
+        self.workspace_move_state = WorkspaceMoveState::Idle;
+    }
+
+    pub(crate) fn on_workspace_move_started(&mut self) {
+        self.workspace_move_state = WorkspaceMoveState::Moving;
+    }
+
+    pub(crate) fn on_workspace_session_loading(&mut self) {
+        self.workspace_move_state = WorkspaceMoveState::LoadingSession;
+    }
+
+    pub(crate) fn on_workspace_move_finished(&mut self) {
+        self.workspace_move_state = WorkspaceMoveState::Idle;
+    }
+
+    pub(crate) fn on_workspace_move_failed(&mut self, error: &str) {
+        self.conversation.push_user_message(&format!("[wisp] Workspace move failed: {error}"));
+        self.workspace_move_state = WorkspaceMoveState::Idle;
+    }
+
     pub fn open_session_picker(&mut self, sessions: Vec<acp::SessionInfo>) -> Vec<ConversationScreenMessage> {
         let entries = sessions.into_iter().map(SessionEntry).collect();
-        let mut picker = SessionPicker::new(entries, self.session_preview_enabled);
+        let mut picker = SessionPicker::new(entries, self.capabilities.session_preview);
         let messages = picker
             .initial_messages()
             .into_iter()
@@ -278,6 +357,23 @@ impl ConversationScreen {
                 }
                 Some(out)
             }
+            Modal::WorkspacePicker(picker) => {
+                let msgs = picker.on_event(event).await.unwrap_or_default();
+                let mut out = Vec::new();
+                for msg in msgs {
+                    match msg {
+                        WorkspacePickerMessage::Close => {
+                            self.active_modal = None;
+                            self.workspace_move_state = WorkspaceMoveState::Idle;
+                        }
+                        WorkspacePickerMessage::Move { target } => {
+                            self.active_modal = None;
+                            out.push(ConversationScreenMessage::MoveWorkspace { target });
+                        }
+                    }
+                }
+                Some(out)
+            }
         }
     }
 
@@ -299,6 +395,10 @@ impl ConversationScreen {
                 PromptComposerMessage::OpenSessionPicker => {
                     out.push(ConversationScreenMessage::OpenSessionPicker);
                 }
+                PromptComposerMessage::OpenWorkspacePicker => match self.request_workspace_picker() {
+                    Ok(msg) => out.push(msg),
+                    Err(message) => self.conversation.push_user_message(&format!("[wisp] {message}")),
+                },
                 PromptComposerMessage::SubmitRequested { user_input, attachments } => {
                     self.waiting_for_response = true;
                     out.push(ConversationScreenMessage::SendPrompt { user_input, attachments });
@@ -380,6 +480,7 @@ impl Component for ConversationScreen {
 
         let modal_frame = match &mut self.active_modal {
             Some(Modal::SessionPicker(picker)) => Some(picker.render(ctx)),
+            Some(Modal::WorkspacePicker(picker)) => Some(picker.render(ctx)),
             Some(Modal::Elicitation(form)) => Some(form.render(ctx)),
             None => None,
         };

--- a/packages/wisp/src/components/file_picker.rs
+++ b/packages/wisp/src/components/file_picker.rs
@@ -25,8 +25,8 @@ impl Searchable for FileMatch {
 }
 
 impl FilePicker {
-    pub fn new() -> Self {
-        let root = current_dir().unwrap_or_else(|_| PathBuf::from("."));
+    pub fn new(root: impl AsRef<Path>) -> Self {
+        let root = root.as_ref().to_path_buf();
         let mut entries = Vec::new();
 
         let walker = WalkBuilder::new(&root)
@@ -64,7 +64,7 @@ impl FilePicker {
 
 impl Default for FilePicker {
     fn default() -> Self {
-        Self::new()
+        Self::new(current_dir().unwrap_or_else(|_| PathBuf::from(".")))
     }
 }
 

--- a/packages/wisp/src/components/mod.rs
+++ b/packages/wisp/src/components/mod.rs
@@ -32,5 +32,6 @@ pub mod thought_message;
 pub mod tool_call_status_view;
 pub mod tool_call_statuses;
 pub(crate) mod tracked_tool_call;
+pub(crate) mod workspace_picker;
 
 pub use tui::wrap_selection;

--- a/packages/wisp/src/components/progress_indicator.rs
+++ b/packages/wisp/src/components/progress_indicator.rs
@@ -14,20 +14,36 @@ const MESSAGES: &[&str] = &[
 
 /// Renders a spinner with "(esc to interrupt)" when the agent is busy.
 /// Visible whenever we're waiting for a response OR tools are actively running.
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
+pub enum WorkspaceProgress {
+    #[default]
+    None,
+    Moving,
+    LoadingSession,
+}
+
 #[derive(Default)]
 pub struct ProgressIndicator {
     tools_running: bool,
     waiting_for_response: bool,
+    workspace_progress: WorkspaceProgress,
     tick: u16,
     was_active: bool,
     turn_count: usize,
 }
 
 impl ProgressIndicator {
-    pub fn update(&mut self, completed: usize, total: usize, waiting_for_response: bool) {
+    pub fn update(
+        &mut self,
+        completed: usize,
+        total: usize,
+        waiting_for_response: bool,
+        workspace_progress: WorkspaceProgress,
+    ) {
         let previously_active = self.was_active;
         self.tools_running = total > 0 && completed < total;
         self.waiting_for_response = waiting_for_response;
+        self.workspace_progress = workspace_progress;
         let now_active = self.is_active();
         self.was_active = now_active;
         if !previously_active && now_active {
@@ -46,11 +62,21 @@ impl ProgressIndicator {
     }
 
     fn is_active(&self) -> bool {
-        self.tools_running || self.waiting_for_response
+        self.tools_running || self.waiting_for_response || self.workspace_progress != WorkspaceProgress::None
     }
 
     fn current_message(&self) -> &'static str {
-        self.turn_count.checked_sub(1).and_then(|i| MESSAGES.get(i)).copied().unwrap_or("Working...")
+        match self.workspace_progress {
+            WorkspaceProgress::Moving => "Moving workspace...",
+            WorkspaceProgress::LoadingSession => "Loading session in new workspace...",
+            WorkspaceProgress::None => {
+                self.turn_count.checked_sub(1).and_then(|i| MESSAGES.get(i)).copied().unwrap_or("Working...")
+            }
+        }
+    }
+
+    fn agent_is_busy(&self) -> bool {
+        self.tools_running || self.waiting_for_response
     }
 
     /// Advance the animation state. Call this on tick events.
@@ -71,7 +97,9 @@ impl ProgressIndicator {
         let mut line = Line::default();
         line.push_styled(frame_char.to_string(), context.theme.info());
         line.push_styled(format!(" {}", self.current_message()), context.theme.text_secondary());
-        line.push_with_style("  (esc to interrupt)".to_string(), Style::fg(context.theme.muted()).italic());
+        if self.agent_is_busy() {
+            line.push_with_style("  (esc to interrupt)".to_string(), Style::fg(context.theme.muted()).italic());
+        }
 
         let lines = vec![Line::default(), line, Line::default()];
         Frame::new(lines).fit(context.size.width, FitOptions::wrap())
@@ -96,14 +124,14 @@ mod tests {
     #[test]
     fn renders_nothing_when_all_complete_and_not_waiting() {
         let mut indicator = ProgressIndicator::default();
-        indicator.update(3, 3, false);
+        indicator.update(3, 3, false, WorkspaceProgress::None);
         assert!(indicator.render(&ctx()).lines().is_empty());
     }
 
     #[test]
     fn renders_when_tools_running() {
         let mut indicator = ProgressIndicator::default();
-        indicator.update(1, 3, false);
+        indicator.update(1, 3, false, WorkspaceProgress::None);
         let frame = indicator.render(&ctx());
         let lines = frame.lines();
         assert_eq!(lines.len(), 3);
@@ -114,7 +142,7 @@ mod tests {
     #[test]
     fn renders_when_waiting_for_response_without_tools() {
         let mut indicator = ProgressIndicator::default();
-        indicator.update(0, 0, true);
+        indicator.update(0, 0, true, WorkspaceProgress::None);
         let frame = indicator.render(&ctx());
         let lines = frame.lines();
         assert_eq!(lines.len(), 3);
@@ -125,9 +153,9 @@ mod tests {
     #[test]
     fn spinner_animates_with_tick() {
         let mut a = ProgressIndicator::default();
-        a.update(0, 1, false);
+        a.update(0, 1, false, WorkspaceProgress::None);
         let mut b = ProgressIndicator::default();
-        b.update(0, 1, false);
+        b.update(0, 1, false, WorkspaceProgress::None);
         b.set_tick(1);
         let text_a = a.render(&ctx()).lines()[1].plain_text();
         let text_b = b.render(&ctx()).lines()[1].plain_text();
@@ -137,7 +165,7 @@ mod tests {
     #[test]
     fn on_tick_advances_when_running() {
         let mut indicator = ProgressIndicator::default();
-        indicator.update(1, 3, false);
+        indicator.update(1, 3, false, WorkspaceProgress::None);
         indicator.on_tick();
         let frame = indicator.render(&ctx());
         assert!(!frame.lines().is_empty());
@@ -146,7 +174,7 @@ mod tests {
     #[test]
     fn on_tick_advances_when_waiting() {
         let mut indicator = ProgressIndicator::default();
-        indicator.update(0, 0, true);
+        indicator.update(0, 0, true, WorkspaceProgress::None);
         let frame_before = indicator.tick;
         indicator.on_tick();
         assert_ne!(indicator.tick, frame_before);
@@ -155,7 +183,7 @@ mod tests {
     #[test]
     fn on_tick_noop_when_idle() {
         let mut indicator = ProgressIndicator::default();
-        indicator.update(3, 3, false);
+        indicator.update(3, 3, false, WorkspaceProgress::None);
         indicator.on_tick();
         assert!(indicator.render(&ctx()).lines().is_empty());
     }
@@ -163,7 +191,7 @@ mod tests {
     #[test]
     fn first_turn_shows_first_tip() {
         let mut indicator = ProgressIndicator::default();
-        indicator.update(0, 0, true);
+        indicator.update(0, 0, true, WorkspaceProgress::None);
         indicator.set_turn_count(1);
         let frame = indicator.render(&ctx());
         let text = frame.lines()[1].plain_text();
@@ -174,15 +202,15 @@ mod tests {
     fn tip_advances_each_turn() {
         let mut indicator = ProgressIndicator::default();
         // First turn: inactive → active
-        indicator.update(0, 0, true);
+        indicator.update(0, 0, true, WorkspaceProgress::None);
         assert_eq!(indicator.turn_count, 1);
         let tip_0 = indicator.render(&ctx()).lines()[1].plain_text();
 
         // Go inactive
-        indicator.update(0, 0, false);
+        indicator.update(0, 0, false, WorkspaceProgress::None);
 
         // Second turn: inactive → active
-        indicator.update(0, 0, true);
+        indicator.update(0, 0, true, WorkspaceProgress::None);
         assert_eq!(indicator.turn_count, 2);
         let tip_1 = indicator.render(&ctx()).lines()[1].plain_text();
 
@@ -194,7 +222,7 @@ mod tests {
     #[test]
     fn shows_working_after_tips_exhausted() {
         let mut indicator = ProgressIndicator::default();
-        indicator.update(0, 0, true);
+        indicator.update(0, 0, true, WorkspaceProgress::None);
         indicator.set_turn_count(MESSAGES.len() + 1);
         let text = indicator.render(&ctx()).lines()[1].plain_text();
         assert!(text.contains("Working..."));
@@ -203,7 +231,7 @@ mod tests {
     #[test]
     fn reset_restarts_tips() {
         let mut indicator = ProgressIndicator::default();
-        indicator.update(0, 0, true);
+        indicator.update(0, 0, true, WorkspaceProgress::None);
         assert_eq!(indicator.turn_count, 1);
 
         let indicator = ProgressIndicator::default();
@@ -211,15 +239,42 @@ mod tests {
     }
 
     #[test]
+    fn renders_workspace_move_without_interrupt_hint() {
+        let mut indicator = ProgressIndicator::default();
+        indicator.update(0, 0, false, WorkspaceProgress::Moving);
+        let text = indicator.render(&ctx()).lines()[1].plain_text();
+        assert!(text.contains("Moving workspace..."));
+        assert!(!text.contains("esc to interrupt"));
+    }
+
+    #[test]
+    fn workspace_move_message_takes_precedence_when_agent_is_busy() {
+        let mut indicator = ProgressIndicator::default();
+        indicator.update(0, 0, true, WorkspaceProgress::Moving);
+        let text = indicator.render(&ctx()).lines()[1].plain_text();
+        assert!(text.contains("Moving workspace..."));
+        assert!(text.contains("esc to interrupt"));
+    }
+
+    #[test]
+    fn renders_workspace_session_load_without_interrupt_hint() {
+        let mut indicator = ProgressIndicator::default();
+        indicator.update(0, 0, false, WorkspaceProgress::LoadingSession);
+        let text = indicator.render(&ctx()).lines()[1].plain_text();
+        assert!(text.contains("Loading session in new workspace..."));
+        assert!(!text.contains("esc to interrupt"));
+    }
+
+    #[test]
     fn staying_active_does_not_advance_tip() {
         let mut indicator = ProgressIndicator::default();
-        indicator.update(0, 0, true);
+        indicator.update(0, 0, true, WorkspaceProgress::None);
         assert_eq!(indicator.turn_count, 1);
 
         // Multiple updates while staying active
-        indicator.update(1, 3, true);
-        indicator.update(2, 3, true);
-        indicator.update(3, 3, true);
+        indicator.update(1, 3, true, WorkspaceProgress::None);
+        indicator.update(2, 3, true, WorkspaceProgress::None);
+        indicator.update(3, 3, true, WorkspaceProgress::None);
         // Still waiting_for_response so still active
         assert_eq!(indicator.turn_count, 1);
     }

--- a/packages/wisp/src/components/prompt_composer.rs
+++ b/packages/wisp/src/components/prompt_composer.rs
@@ -6,7 +6,7 @@ use crate::components::input_prompt::{InputPrompt, prompt_content_width};
 use crate::components::prompt_search_picker::{PromptSearchPicker, PromptSearchPickerMessage, cursor_at_match_end};
 use crate::components::text_input::{SelectedFileMention, TextInput, TextInputMessage, is_newline_modifier};
 use crate::keybindings::Keybindings;
-use acp_utils::notifications::{PromptSearchParams, PromptSearchResponse};
+use acp_utils::notifications::{AetherCapabilities, PromptSearchParams, PromptSearchResponse};
 use std::collections::HashSet;
 use std::path::PathBuf;
 use tui::{Component, Cursor, Event, Frame, KeyCode, Line, PickerMessage, ViewContext};
@@ -18,6 +18,7 @@ pub enum PromptComposerMessage {
     SubmitRequested { user_input: String, attachments: Vec<PromptAttachment> },
     OpenSettings,
     OpenSessionPicker,
+    OpenWorkspacePicker,
     NewSession,
     SearchPrompts(PromptSearchParams),
 }
@@ -27,7 +28,8 @@ pub struct PromptComposer {
     available_commands: Vec<CommandEntry>,
     active_overlay: Option<Overlay>,
     pending_media: Vec<PromptAttachment>,
-    prompt_search_enabled: bool,
+    working_dir: PathBuf,
+    capabilities: AetherCapabilities,
     keybindings: Keybindings,
 }
 
@@ -39,20 +41,29 @@ enum Overlay {
 
 impl Default for PromptComposer {
     fn default() -> Self {
-        Self::new(Keybindings::default(), true)
+        Self::new(
+            Keybindings::default(),
+            PathBuf::from("."),
+            AetherCapabilities { prompt_search: true, ..Default::default() },
+        )
     }
 }
 
 impl PromptComposer {
-    pub fn new(keybindings: Keybindings, prompt_search_enabled: bool) -> Self {
+    pub fn new(keybindings: Keybindings, working_dir: PathBuf, capabilities: AetherCapabilities) -> Self {
         Self {
             text_input: TextInput::new(keybindings.clone()),
             available_commands: Vec::new(),
             active_overlay: None,
             pending_media: Vec::new(),
-            prompt_search_enabled,
+            working_dir,
+            capabilities,
             keybindings,
         }
+    }
+
+    pub fn set_working_dir(&mut self, working_dir: PathBuf) {
+        self.working_dir = working_dir;
     }
 
     pub fn on_prompt_search_results(&mut self, response: PromptSearchResponse) {
@@ -281,13 +292,13 @@ impl PromptComposer {
         match msgs.into_iter().next() {
             Some(TextInputMessage::Submit) => Some(self.prepare_submit()),
             Some(TextInputMessage::OpenCommandPicker) => {
-                let mut commands = builtin_commands();
+                let mut commands = builtin_commands(&self.capabilities);
                 commands.extend(self.available_commands.clone());
                 self.active_overlay = Some(Overlay::Command(CommandPicker::new(commands)));
                 Some(vec![])
             }
             Some(TextInputMessage::OpenFilePicker) => {
-                self.active_overlay = Some(Overlay::File(FilePicker::new()));
+                self.active_overlay = Some(Overlay::File(FilePicker::new(&self.working_dir)));
                 Some(vec![])
             }
             None => Some(vec![]),
@@ -307,6 +318,9 @@ impl PromptComposer {
             self.text_input.clear();
             self.close_all();
             vec![PromptComposerMessage::OpenSessionPicker]
+        } else if cmd.builtin && cmd.name == "move" {
+            self.close_all();
+            vec![PromptComposerMessage::OpenWorkspacePicker]
         } else if cmd.has_input {
             self.text_input.set_input(format!("/{} ", cmd.name));
             vec![]
@@ -378,7 +392,7 @@ impl Component for PromptComposer {
                 Some(vec![])
             }
             Event::Key(key_event) => {
-                if self.prompt_search_enabled
+                if self.capabilities.prompt_search
                     && self.keybindings.open_prompt_search.matches(*key_event)
                     && self.active_overlay.is_none()
                 {
@@ -488,8 +502,8 @@ fn collect_submit_attachments(user_input: &str, selected_mentions: Vec<SelectedF
         .collect()
 }
 
-fn builtin_commands() -> Vec<CommandEntry> {
-    vec![
+fn builtin_commands(capabilities: &AetherCapabilities) -> Vec<CommandEntry> {
+    let mut commands = vec![
         CommandEntry {
             name: "clear".into(),
             description: "Clear screen and start a new session".into(),
@@ -511,7 +525,17 @@ fn builtin_commands() -> Vec<CommandEntry> {
             hint: None,
             builtin: true,
         },
-    ]
+    ];
+    if capabilities.workspace_move {
+        commands.push(CommandEntry {
+            name: "move".into(),
+            description: "Move changes to another workspace".into(),
+            has_input: false,
+            hint: None,
+            builtin: true,
+        });
+    }
+    commands
 }
 
 #[cfg(test)]

--- a/packages/wisp/src/components/session_picker.rs
+++ b/packages/wisp/src/components/session_picker.rs
@@ -1,11 +1,12 @@
+use crate::components::common::input_box_frame;
 use acp_utils::notifications::{SessionDisplayMeta, SessionPreviewResponse, SessionPreviewRole};
 use agent_client_protocol::schema as acp;
 use chrono::{DateTime, Utc};
 use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 use tui::{
-    BorderedTextField, Combobox, Component, Cursor, Event, Frame, FramePart, Line, MouseEventKind, PickerMessage,
-    Searchable, Style, ViewContext, display_width_text, pad_text_to_width, truncate_text,
+    Combobox, Component, Event, Frame, FramePart, Line, MouseEventKind, PickerMessage, Searchable, Style, ViewContext,
+    display_width_text, pad_text_to_width, truncate_text,
 };
 
 #[derive(Clone)]
@@ -119,7 +120,7 @@ impl Component for SessionPicker {
             return Frame::new(vec![Line::new(String::new()), Line::new("  No previous sessions found.")]);
         }
 
-        let search = search_box_frame(self.combobox.query(), context);
+        let search = input_box_frame(SEARCH_LABEL, self.combobox.query(), SEARCH_PLACEHOLDER, context);
         let now = Utc::now();
         let body_height = context.size.height.saturating_sub(u16::try_from(search.lines().len()).unwrap_or(0));
         let body_context = context.with_height(body_height);
@@ -142,8 +143,6 @@ impl Component for SessionPicker {
     }
 }
 
-const SEARCH_BOX_MAX_WIDTH: usize = 56;
-const SEARCH_BOX_INDENT: u16 = 2;
 const SEARCH_LABEL: &str = "🔍 Search";
 const SEARCH_PLACEHOLDER: &str = "type to search title or path";
 const WIDE_PREVIEW_THRESHOLD: u16 = 96;
@@ -218,19 +217,6 @@ impl SessionPicker {
         }
         Frame::new(lines)
     }
-}
-
-fn search_box_frame(query: &str, context: &ViewContext) -> Frame {
-    let width = (context.size.width as usize).saturating_sub(usize::from(SEARCH_BOX_INDENT)).min(SEARCH_BOX_MAX_WIDTH);
-    let input_width = width.saturating_sub(4);
-    let visible_query = truncate_text(query, input_width);
-
-    let mut field = BorderedTextField::new(SEARCH_LABEL, query.to_string()).placeholder(SEARCH_PLACEHOLDER);
-    field.set_width(width);
-
-    Frame::new(field.render_field(context, false))
-        .with_cursor(Cursor::visible(1, 2 + display_width_text(&visible_query)))
-        .indent(SEARCH_BOX_INDENT)
 }
 
 fn push_preview_lines(

--- a/packages/wisp/src/components/workspace_picker.rs
+++ b/packages/wisp/src/components/workspace_picker.rs
@@ -1,0 +1,191 @@
+use crate::components::common::{INPUT_BOX_INDENT, input_box_frame, input_box_width};
+use crate::workspace_status::home_relative_path;
+use acp_utils::notifications::{WorkspaceEntry, WorkspaceMoveTarget};
+use std::path::{Path, PathBuf};
+use tui::{
+    BorderedTextField, Combobox, Component, Event, Frame, KeyCode, Line, MouseEventKind, PickerMessage, Searchable,
+    Style, ViewContext, truncate_text,
+};
+
+pub struct WorkspacePicker {
+    rows: Vec<WorkspaceRow>,
+    parent_dir: Option<PathBuf>,
+    mode: Mode,
+}
+
+pub enum WorkspacePickerMessage {
+    Close,
+    Move { target: WorkspaceMoveTarget },
+}
+
+impl WorkspacePicker {
+    pub fn new(workspaces: Vec<WorkspaceEntry>) -> Self {
+        let parent_dir = workspaces.iter().find(|w| w.is_current).and_then(|w| w.path.parent().map(Path::to_path_buf));
+        let mut rows: Vec<WorkspaceRow> =
+            workspaces.into_iter().filter(|w| !w.is_current).map(WorkspaceRow::Existing).collect();
+        rows.push(WorkspaceRow::CreateNew);
+        let mode = Mode::List(Box::new(list_mode(&rows)));
+        Self { rows, parent_dir, mode }
+    }
+}
+
+impl Component for WorkspacePicker {
+    type Message = WorkspacePickerMessage;
+
+    async fn on_event(&mut self, event: &Event) -> Option<Vec<Self::Message>> {
+        match &mut self.mode {
+            Mode::List(combobox) => {
+                if let Event::Mouse(mouse) = event {
+                    match mouse.kind {
+                        MouseEventKind::ScrollUp => combobox.move_up(),
+                        MouseEventKind::ScrollDown => combobox.move_down(),
+                        MouseEventKind::Down(_) => {
+                            if let Some(index) = mouse.row.checked_sub(4).map(usize::from) {
+                                combobox.set_selected_index(index);
+                                if let Some(row) = combobox.selected().cloned() {
+                                    return Some(confirm_workspace_row(row));
+                                }
+                            }
+                        }
+                        _ => {}
+                    }
+                    return Some(vec![]);
+                }
+
+                let msgs = combobox.handle_picker_event(event)?;
+                let mut out = Vec::new();
+                let mut start_naming = false;
+                for msg in msgs {
+                    match msg {
+                        PickerMessage::Close | PickerMessage::CloseAndPopChar => {
+                            out.push(WorkspacePickerMessage::Close);
+                        }
+                        PickerMessage::Confirm(WorkspaceRow::Existing(entry)) => {
+                            out.push(WorkspacePickerMessage::Move {
+                                target: WorkspaceMoveTarget::Existing { path: entry.path },
+                            });
+                        }
+                        PickerMessage::Confirm(WorkspaceRow::CreateNew) => start_naming = true,
+                        _ => {}
+                    }
+                }
+                if start_naming {
+                    self.mode = Mode::NamingNew {
+                        field: BorderedTextField::new("New workspace name", String::new())
+                            .placeholder("directory name for the new workspace"),
+                    };
+                }
+                Some(out)
+            }
+            Mode::NamingNew { field } => {
+                let Event::Key(key) = event else {
+                    return Some(vec![]);
+                };
+                match key.code {
+                    KeyCode::Esc => {
+                        self.mode = Mode::List(Box::new(list_mode(&self.rows)));
+                        Some(vec![])
+                    }
+                    KeyCode::Enter => {
+                        let trimmed = field.value().trim();
+                        if trimmed.is_empty() {
+                            Some(vec![])
+                        } else {
+                            Some(vec![WorkspacePickerMessage::Move {
+                                target: WorkspaceMoveTarget::New { name: trimmed.to_string() },
+                            }])
+                        }
+                    }
+                    _ => {
+                        field.on_event(event).await;
+                        Some(vec![])
+                    }
+                }
+            }
+        }
+    }
+
+    fn render(&mut self, context: &ViewContext) -> Frame {
+        match &mut self.mode {
+            Mode::List(combobox) => render_list(combobox, context),
+            Mode::NamingNew { field } => render_name_input(field, self.parent_dir.as_deref(), context),
+        }
+    }
+}
+
+const CREATE_NEW_LABEL: &str = "Create new workspace…";
+
+enum Mode {
+    List(Box<Combobox<WorkspaceRow>>),
+    NamingNew { field: BorderedTextField },
+}
+
+#[derive(Clone)]
+enum WorkspaceRow {
+    Existing(WorkspaceEntry),
+    CreateNew,
+}
+
+impl Searchable for WorkspaceRow {
+    fn search_text(&self) -> String {
+        match self {
+            WorkspaceRow::Existing(entry) => home_relative_path(&entry.path),
+            WorkspaceRow::CreateNew => CREATE_NEW_LABEL.to_string(),
+        }
+    }
+}
+
+fn confirm_workspace_row(row: WorkspaceRow) -> Vec<WorkspacePickerMessage> {
+    match row {
+        WorkspaceRow::Existing(entry) => {
+            vec![WorkspacePickerMessage::Move { target: WorkspaceMoveTarget::Existing { path: entry.path } }]
+        }
+        WorkspaceRow::CreateNew => Vec::new(),
+    }
+}
+
+fn list_mode(rows: &[WorkspaceRow]) -> Combobox<WorkspaceRow> {
+    Combobox::new(rows.to_vec()).close_on_whitespace(false)
+}
+
+fn render_list(combobox: &mut Combobox<WorkspaceRow>, context: &ViewContext) -> Frame {
+    let search = input_box_frame("Move to workspace", combobox.query(), "type to filter workspaces", context);
+
+    let mut lines = vec![Line::new(String::new())];
+    if combobox.is_empty() {
+        lines.push(Line::new("  (no matching workspaces)"));
+    } else {
+        lines.extend(combobox.render_items(context, |row, is_selected, ctx| {
+            let text = match row {
+                WorkspaceRow::Existing(entry) => format!("  {}", home_relative_path(&entry.path)),
+                WorkspaceRow::CreateNew => format!("  {CREATE_NEW_LABEL}"),
+            };
+            let truncated = truncate_text(&text, ctx.size.width as usize);
+            if is_selected {
+                ctx.theme.selected_row_line(truncated)
+            } else if matches!(row, WorkspaceRow::CreateNew) {
+                Line::with_style(truncated, Style::fg(ctx.theme.info()))
+            } else {
+                Line::new(truncated)
+            }
+        }));
+    }
+
+    Frame::vstack([search, Frame::new(lines)])
+}
+
+fn render_name_input(field: &mut BorderedTextField, parent_dir: Option<&Path>, context: &ViewContext) -> Frame {
+    let width = input_box_width(context);
+    field.set_width(width);
+    let input = Frame::new(field.render_field(context, true)).indent(INPUT_BOX_INDENT);
+    let mut hint_lines = Vec::new();
+    if let Some(parent) = parent_dir {
+        let mut hint = Line::new("  ");
+        hint.push_with_style(
+            format!("will be created in {}/", home_relative_path(parent)),
+            Style::fg(context.theme.muted()),
+        );
+        hint_lines.push(hint);
+    }
+    Frame::vstack([input, Frame::new(hint_lines)])
+}

--- a/packages/wisp/src/runtime_state.rs
+++ b/packages/wisp/src/runtime_state.rs
@@ -30,7 +30,7 @@ pub struct RuntimeState {
 impl RuntimeState {
     pub async fn new(agent_command: &str, settings: WispSettings) -> Result<Self, AppError> {
         let cwd = current_dir().unwrap_or_else(|_| std::path::PathBuf::from("."));
-        let workspace_status = WorkspaceStatus::resolve(&cwd).await;
+        let workspace_status = WorkspaceStatus::resolve(&cwd);
         let new_session_request = NewSessionRequest::new(cwd.clone());
         let init_request = InitializeRequest::new(ProtocolVersion::LATEST)
             .client_info(Implementation::new("wisp", env!("CARGO_PKG_VERSION")));

--- a/packages/wisp/src/workspace_status.rs
+++ b/packages/wisp/src/workspace_status.rs
@@ -1,6 +1,5 @@
 use std::path::{Path, PathBuf};
-
-use tokio::process::Command;
+use std::process::Command;
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct WorkspaceStatus {
@@ -19,22 +18,22 @@ impl WorkspaceStatus {
             .map_or_else(|| self.display_dir.clone(), |git_ref| format!("{} · {git_ref}", self.display_dir))
     }
 
-    pub async fn resolve(cwd: &Path) -> Self {
+    pub fn resolve(cwd: &Path) -> Self {
         let display_dir = home_relative_path(cwd);
-        let git_ref = resolve_git_ref(cwd).await;
+        let git_ref = resolve_git_ref(cwd);
         Self::new(display_dir, git_ref)
     }
 }
 
-async fn resolve_git_ref(cwd: &Path) -> Option<String> {
-    if let Some(branch) = git_stdout(cwd, &["branch", "--show-current"]).await {
+fn resolve_git_ref(cwd: &Path) -> Option<String> {
+    if let Some(branch) = git_stdout(cwd, &["branch", "--show-current"]) {
         return Some(branch);
     }
-    git_stdout(cwd, &["rev-parse", "--short", "HEAD"]).await
+    git_stdout(cwd, &["rev-parse", "--short", "HEAD"])
 }
 
-async fn git_stdout(cwd: &Path, args: &[&str]) -> Option<String> {
-    let output = Command::new("git").args(args).current_dir(cwd).output().await.ok()?;
+fn git_stdout(cwd: &Path, args: &[&str]) -> Option<String> {
+    let output = Command::new("git").args(args).current_dir(cwd).output().ok()?;
 
     if !output.status.success() {
         return None;
@@ -44,7 +43,7 @@ async fn git_stdout(cwd: &Path, args: &[&str]) -> Option<String> {
     if text.is_empty() { None } else { Some(text) }
 }
 
-fn home_relative_path(path: &Path) -> String {
+pub fn home_relative_path(path: &Path) -> String {
     home_dir().map_or_else(|| path.display().to_string(), |home| home_relative_path_with_home(path, &home))
 }
 

--- a/packages/wisp/tests/app_tests.rs
+++ b/packages/wisp/tests/app_tests.rs
@@ -15,4 +15,5 @@ mod app_tests {
     mod small_terminal_tests;
     mod status_line_tests;
     mod tool_calls_tests;
+    mod workspace_move_tests;
 }

--- a/packages/wisp/tests/app_tests/common.rs
+++ b/packages/wisp/tests/app_tests/common.rs
@@ -1,8 +1,8 @@
 use acp_utils::client::{AcpEvent, AcpPromptHandle, PromptCommand};
-use acp_utils::notifications::AetherCapabilities;
-use acp_utils::notifications::ElicitationParams;
-use acp_utils::notifications::ElicitationResponse;
 use acp_utils::notifications::SessionPreviewResponse;
+use acp_utils::notifications::{AetherCapabilities, WorkspaceListResponse};
+use acp_utils::notifications::{ElicitationParams, WorkspaceEntry};
+use acp_utils::notifications::{ElicitationResponse, WorkspaceMoveResponse};
 use agent_client_protocol::Responder;
 use agent_client_protocol::schema as acp;
 use std::path::PathBuf;
@@ -80,7 +80,18 @@ pub(super) const PROGRESS_LINE: &str =
     "⠒ Tip: Hit Tab to adjust reasoning level (off → low → medium → high)  (esc to interrupt)";
 
 pub(super) fn preview_session_capabilities() -> acp::SessionCapabilities {
-    acp::SessionCapabilities::new().meta(Some(AetherCapabilities::session_preview().to_meta()))
+    acp::SessionCapabilities::new()
+        .meta(Some(AetherCapabilities { prompt_search: false, session_preview: true, workspace_move: false }.to_meta()))
+}
+
+pub(super) fn prompt_search_session_capabilities() -> acp::SessionCapabilities {
+    acp::SessionCapabilities::new()
+        .meta(Some(AetherCapabilities { prompt_search: true, session_preview: true, workspace_move: false }.to_meta()))
+}
+
+pub(super) fn workspace_session_capabilities() -> acp::SessionCapabilities {
+    acp::SessionCapabilities::new()
+        .meta(Some(AetherCapabilities { prompt_search: true, session_preview: true, workspace_move: true }.to_meta()))
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -138,14 +149,16 @@ impl Renderer {
         prompt_capabilities: acp::PromptCapabilities,
         size: (u16, u16),
     ) -> Self {
-        Self::new_with_prompt_capabilities_and_auth_methods(
+        Self::new_with_options(RendererOptions {
             terminal,
             agent_name,
-            &[],
+            config_options: &[],
             prompt_capabilities,
-            vec![],
+            session_capabilities: prompt_search_session_capabilities(),
+            auth_methods: vec![],
+            prompt_handle: AcpPromptHandle::noop(),
             size,
-        )
+        })
     }
 
     pub(super) fn new_recording(
@@ -178,7 +191,7 @@ impl Renderer {
         )
     }
 
-    fn new_recording_with_session_capabilities(
+    pub(super) fn new_recording_with_session_capabilities(
         terminal: TestTerminal,
         agent_name: String,
         config_options: &[acp::SessionConfigOption],
@@ -324,6 +337,20 @@ impl Renderer {
         self.handle_terminal_event(Event::Mouse(mouse)).await
     }
 
+    pub(super) async fn on_mouse_down(
+        &mut self,
+        row: u16,
+        column: u16,
+    ) -> Result<LoopAction, Box<dyn std::error::Error>> {
+        let mouse = MouseEvent {
+            kind: MouseEventKind::Down(tui::MouseButton::Left),
+            column,
+            row,
+            modifiers: KeyModifiers::NONE,
+        };
+        self.handle_terminal_event(Event::Mouse(mouse)).await
+    }
+
     pub(super) async fn on_paste(&mut self, text: &str) -> Result<(), Box<dyn std::error::Error>> {
         self.handle_terminal_event(Event::Paste(text.to_string())).await?;
         Ok(())
@@ -415,6 +442,27 @@ impl Renderer {
         notification: acp_utils::notifications::McpNotification,
     ) -> Result<(), Box<dyn std::error::Error>> {
         self.handle_acp_event(AcpEvent::McpNotification(notification))?;
+        Ok(())
+    }
+
+    pub(super) fn on_workspaces_listed(
+        &mut self,
+        workspaces: Vec<WorkspaceEntry>,
+    ) -> Result<(), Box<dyn std::error::Error>> {
+        self.handle_acp_event(AcpEvent::WorkspacesListed(WorkspaceListResponse { workspaces }))?;
+        Ok(())
+    }
+
+    pub(super) fn on_workspace_moved(&mut self, new_cwd: PathBuf) -> Result<(), Box<dyn std::error::Error>> {
+        self.handle_acp_event(AcpEvent::WorkspaceMoved(WorkspaceMoveResponse { new_cwd }))?;
+        Ok(())
+    }
+
+    pub(super) fn on_workspace_move_failed(
+        &mut self,
+        error: impl Into<String>,
+    ) -> Result<(), Box<dyn std::error::Error>> {
+        self.handle_acp_event(AcpEvent::WorkspaceMoveFailed { error: error.into() })?;
         Ok(())
     }
 

--- a/packages/wisp/tests/app_tests/prompt_search_tests.rs
+++ b/packages/wisp/tests/app_tests/prompt_search_tests.rs
@@ -1,5 +1,5 @@
 use super::common::*;
-use acp_utils::notifications::{AetherCapabilities, PromptSearchResponse, PromptSearchResult};
+use acp_utils::notifications::{PromptSearchResponse, PromptSearchResult};
 use agent_client_protocol::schema as acp;
 use std::path::PathBuf;
 use tui::testing::{TestTerminal, assert_buffer_eq};
@@ -310,7 +310,7 @@ async fn prompt_search_rows_truncate_prompt_and_show_cwd_basename() {
 }
 
 fn prompt_search_capabilities() -> acp::PromptCapabilities {
-    acp::PromptCapabilities::new().meta(Some(AetherCapabilities::prompt_search().to_meta()))
+    acp::PromptCapabilities::new()
 }
 
 fn result(prompt: &str, start: usize, end: usize) -> PromptSearchResult {

--- a/packages/wisp/tests/app_tests/workspace_move_tests.rs
+++ b/packages/wisp/tests/app_tests/workspace_move_tests.rs
@@ -1,0 +1,311 @@
+use acp_utils::client::PromptCommand;
+use acp_utils::notifications::{WorkspaceEntry, WorkspaceMoveTarget};
+use agent_client_protocol::schema as acp;
+use std::{io, path::PathBuf};
+use tokio::sync::mpsc::UnboundedReceiver;
+use tui::testing::TestTerminal;
+use tui::{KeyCode, KeyModifiers};
+
+use super::common::*;
+
+#[tokio::test]
+async fn move_command_is_listed_only_when_capability_advertised() {
+    let (mut renderer, _commands) = workspace_renderer();
+    renderer.initial_render().unwrap();
+    type_string(&mut renderer, "/").await;
+    let names = command_picker_visible_names(renderer.writer());
+    assert!(names.iter().any(|n| n == "move"), "expected /move in {names:?}");
+
+    let terminal = TestTerminal::new(TEST_WIDTH, 40);
+    let (mut renderer, _commands) = Renderer::new_recording(terminal, TEST_AGENT.to_string(), &[], (TEST_WIDTH, 40));
+    renderer.initial_render().unwrap();
+    type_string(&mut renderer, "/").await;
+    let names = command_picker_visible_names(renderer.writer());
+    assert!(!names.iter().any(|n| n == "move"), "did not expect /move in {names:?}");
+}
+
+#[tokio::test]
+async fn move_command_requests_workspace_list() {
+    let (mut renderer, mut commands) = workspace_renderer();
+    renderer.initial_render().unwrap();
+
+    type_string(&mut renderer, "/move").await;
+    press_enter(&mut renderer).await;
+
+    match commands.try_recv().expect("expected list workspaces command") {
+        PromptCommand::ListWorkspaces(params) => assert_eq!(params.session_id, "test"),
+        other => panic!("expected ListWorkspaces command, got {other:?}"),
+    }
+}
+
+#[tokio::test]
+async fn workspaces_listed_opens_picker_hiding_current_workspace() {
+    let (mut renderer, _commands) = workspace_renderer();
+    renderer.initial_render().unwrap();
+
+    type_string(&mut renderer, "/move").await;
+    press_enter(&mut renderer).await;
+    renderer
+        .on_workspaces_listed(vec![
+            entry("/repo/aether", true),
+            entry("/repo/aether-fix", false),
+            entry("/repo/aether-experiment", false),
+        ])
+        .unwrap();
+
+    assert_buffer_contains(renderer.writer(), "Move to workspace");
+    assert_buffer_contains(renderer.writer(), "aether-fix");
+    assert_buffer_contains(renderer.writer(), "aether-experiment");
+    assert_buffer_contains(renderer.writer(), "Create new workspace");
+    let lines = renderer.writer().get_lines();
+    assert!(!lines.iter().any(|l| l.trim() == "/repo/aether"), "current workspace should be hidden");
+}
+
+#[tokio::test]
+async fn selecting_existing_workspace_sends_move_command() {
+    let (mut renderer, mut commands) = workspace_renderer();
+    renderer.initial_render().unwrap();
+
+    type_string(&mut renderer, "/move").await;
+    press_enter(&mut renderer).await;
+    drain(&mut commands);
+    renderer.on_workspaces_listed(vec![entry("/repo/aether", true), entry("/repo/aether-fix", false)]).unwrap();
+
+    press_enter(&mut renderer).await;
+
+    match commands.try_recv().expect("expected move workspace command") {
+        PromptCommand::MoveWorkspace(params) => {
+            assert_eq!(params.session_id, "test");
+            assert_eq!(params.target, WorkspaceMoveTarget::Existing { path: PathBuf::from("/repo/aether-fix") });
+        }
+        other => panic!("expected MoveWorkspace command, got {other:?}"),
+    }
+    assert_buffer_not_contains(renderer.writer(), "Move to workspace");
+    assert_buffer_contains(renderer.writer(), "Moving workspace...");
+    assert_buffer_not_contains(renderer.writer(), "esc to interrupt");
+}
+
+#[tokio::test]
+async fn workspace_move_spinner_transitions_to_session_load_and_clears_when_loaded()
+-> Result<(), Box<dyn std::error::Error>> {
+    let (mut renderer, mut commands) = workspace_renderer();
+    renderer.initial_render()?;
+
+    type_string(&mut renderer, "/move").await;
+    press_enter(&mut renderer).await;
+    drain(&mut commands);
+    renderer.on_workspaces_listed(vec![entry("/repo/aether", true), entry("/repo/aether-fix", false)])?;
+    press_enter(&mut renderer).await;
+    drain(&mut commands);
+
+    assert_buffer_contains(renderer.writer(), "Moving workspace...");
+
+    renderer.on_workspace_moved(PathBuf::from("/elsewhere/aether-2"))?;
+
+    let command = commands.try_recv().map_err(|_| io::Error::other("expected load session command"))?;
+    let PromptCommand::LoadSession { session_id, cwd } = command else {
+        return Err(io::Error::other(format!("expected LoadSession command, got {command:?}")).into());
+    };
+    assert_eq!(session_id.0.as_ref(), "test");
+    assert_eq!(cwd, PathBuf::from("/elsewhere/aether-2"));
+
+    assert_buffer_not_contains(renderer.writer(), "Moving workspace...");
+    assert_buffer_contains(renderer.writer(), "Loading session in new workspace...");
+
+    renderer.on_session_loaded(acp::SessionId::new("test"), Vec::new())?;
+
+    assert_buffer_not_contains(renderer.writer(), "Loading session in new workspace...");
+    Ok(())
+}
+
+#[tokio::test]
+async fn create_new_workspace_flow_submits_typed_name() {
+    let (mut renderer, mut commands) = workspace_renderer();
+    renderer.initial_render().unwrap();
+
+    type_string(&mut renderer, "/move").await;
+    press_enter(&mut renderer).await;
+    drain(&mut commands);
+    renderer.on_workspaces_listed(vec![entry("/repo/aether", true), entry("/repo/aether-fix", false)]).unwrap();
+
+    send_key(&mut renderer, KeyCode::Down, KeyModifiers::NONE).await;
+    press_enter(&mut renderer).await;
+    assert_buffer_contains(renderer.writer(), "New workspace name");
+    assert_buffer_contains(renderer.writer(), "will be created in");
+
+    type_string(&mut renderer, "aether-2").await;
+    press_enter(&mut renderer).await;
+
+    match commands.try_recv().expect("expected move workspace command") {
+        PromptCommand::MoveWorkspace(params) => {
+            assert_eq!(params.target, WorkspaceMoveTarget::New { name: "aether-2".to_string() });
+        }
+        other => panic!("expected MoveWorkspace command, got {other:?}"),
+    }
+}
+
+#[tokio::test]
+async fn escape_in_name_input_returns_to_workspace_list() {
+    let (mut renderer, mut commands) = workspace_renderer();
+    renderer.initial_render().unwrap();
+
+    type_string(&mut renderer, "/move").await;
+    press_enter(&mut renderer).await;
+    drain(&mut commands);
+    renderer.on_workspaces_listed(vec![entry("/repo/aether", true), entry("/repo/aether-fix", false)]).unwrap();
+
+    send_key(&mut renderer, KeyCode::Down, KeyModifiers::NONE).await;
+    press_enter(&mut renderer).await;
+    assert_buffer_contains(renderer.writer(), "New workspace name");
+
+    send_key(&mut renderer, KeyCode::Esc, KeyModifiers::NONE).await;
+
+    assert_buffer_contains(renderer.writer(), "Move to workspace");
+    assert_buffer_contains(renderer.writer(), "aether-fix");
+    assert!(drain(&mut commands).is_empty(), "escape should not send commands");
+}
+
+#[tokio::test]
+async fn workspace_moved_updates_status_line_and_reloads_session() {
+    let (mut renderer, mut commands) = workspace_renderer();
+    renderer.initial_render().unwrap();
+
+    renderer.on_workspace_moved(PathBuf::from("/elsewhere/aether-2")).unwrap();
+
+    match commands.try_recv().expect("expected load session command") {
+        PromptCommand::LoadSession { session_id, cwd } => {
+            assert_eq!(session_id.0.as_ref(), "test");
+            assert_eq!(cwd, PathBuf::from("/elsewhere/aether-2"));
+        }
+        other => panic!("expected LoadSession command, got {other:?}"),
+    }
+    assert_buffer_contains(renderer.writer(), "/elsewhere/aether-2");
+}
+
+#[tokio::test]
+async fn workspace_move_failure_is_reported_in_conversation() {
+    let (mut renderer, _commands) = workspace_renderer();
+    renderer.initial_render().unwrap();
+
+    renderer.on_workspace_move_failed("target workspace has uncommitted changes: /repo/aether-fix").unwrap();
+
+    assert_buffer_not_contains(renderer.writer(), "Moving workspace...");
+    assert_buffer_contains(renderer.writer(), "[wisp] Workspace move failed:");
+    assert_buffer_contains(renderer.writer(), "uncommitted changes");
+}
+
+#[tokio::test]
+async fn move_command_is_rejected_while_waiting_for_response() {
+    let (mut renderer, mut commands) = workspace_renderer();
+    renderer.initial_render().unwrap();
+
+    type_string(&mut renderer, "hello").await;
+    press_enter(&mut renderer).await;
+    drain(&mut commands);
+
+    type_string(&mut renderer, "/move").await;
+    press_enter(&mut renderer).await;
+
+    assert_buffer_contains(renderer.writer(), "[wisp] Cannot move workspaces while a prompt is running.");
+    assert!(drain(&mut commands).is_empty(), "no command should be sent while waiting");
+}
+
+#[tokio::test]
+async fn closing_workspace_picker_allows_move_to_be_requested_again() {
+    let (mut renderer, mut commands) = workspace_renderer();
+    renderer.initial_render().unwrap();
+
+    type_string(&mut renderer, "/move").await;
+    press_enter(&mut renderer).await;
+    drain(&mut commands);
+    renderer.on_workspaces_listed(vec![entry("/repo/aether", true), entry("/repo/aether-fix", false)]).unwrap();
+
+    send_key(&mut renderer, KeyCode::Esc, KeyModifiers::NONE).await;
+    type_string(&mut renderer, "/move").await;
+    press_enter(&mut renderer).await;
+
+    match commands.try_recv().expect("expected list workspaces command") {
+        PromptCommand::ListWorkspaces(params) => assert_eq!(params.session_id, "test"),
+        other => panic!("expected ListWorkspaces command, got {other:?}"),
+    }
+}
+
+#[tokio::test]
+async fn mouse_selecting_existing_workspace_sends_move_command() {
+    let (mut renderer, mut commands) = workspace_renderer();
+    renderer.initial_render().unwrap();
+
+    type_string(&mut renderer, "/move").await;
+    press_enter(&mut renderer).await;
+    drain(&mut commands);
+    renderer.on_workspaces_listed(vec![entry("/repo/aether", true), entry("/repo/aether-fix", false)]).unwrap();
+
+    renderer.on_mouse_down(4, 4).await.unwrap();
+
+    match commands.try_recv().expect("expected move workspace command") {
+        PromptCommand::MoveWorkspace(params) => {
+            assert_eq!(params.target, WorkspaceMoveTarget::Existing { path: PathBuf::from("/repo/aether-fix") });
+        }
+        other => panic!("expected MoveWorkspace command, got {other:?}"),
+    }
+}
+
+#[tokio::test]
+async fn rejected_move_while_waiting_preserves_draft() {
+    let (mut renderer, mut commands) = workspace_renderer();
+    renderer.initial_render().unwrap();
+
+    type_string(&mut renderer, "hello").await;
+    press_enter(&mut renderer).await;
+    drain(&mut commands);
+
+    type_string(&mut renderer, "/move").await;
+    press_enter(&mut renderer).await;
+
+    assert_buffer_contains(renderer.writer(), "[wisp] Cannot move workspaces while a prompt is running.");
+    assert_buffer_contains(renderer.writer(), "> /move");
+    assert!(drain(&mut commands).is_empty(), "no command should be sent while waiting");
+}
+
+#[tokio::test]
+async fn move_command_is_rejected_while_workspace_list_is_pending() {
+    let (mut renderer, mut commands) = workspace_renderer();
+    renderer.initial_render().unwrap();
+
+    type_string(&mut renderer, "/move").await;
+    press_enter(&mut renderer).await;
+    drain(&mut commands);
+
+    type_string(&mut renderer, "/move").await;
+    press_enter(&mut renderer).await;
+
+    assert_buffer_contains(
+        renderer.writer(),
+        "[wisp] Cannot move workspaces while another workspace move is in progress.",
+    );
+    assert_buffer_contains(renderer.writer(), "> /move");
+    assert!(drain(&mut commands).is_empty(), "no second list command should be sent");
+}
+
+fn workspace_renderer() -> (Renderer, UnboundedReceiver<PromptCommand>) {
+    let terminal = TestTerminal::new(TEST_WIDTH, 40);
+    Renderer::new_recording_with_session_capabilities(
+        terminal,
+        TEST_AGENT.to_string(),
+        &[],
+        workspace_session_capabilities(),
+        (TEST_WIDTH, 40),
+    )
+}
+
+fn entry(path: &str, is_current: bool) -> WorkspaceEntry {
+    WorkspaceEntry { path: PathBuf::from(path), is_current }
+}
+
+fn drain(commands: &mut UnboundedReceiver<PromptCommand>) -> Vec<PromptCommand> {
+    let mut drained = Vec::new();
+    while let Ok(cmd) = commands.try_recv() {
+        drained.push(cmd);
+    }
+    drained
+}


### PR DESCRIPTION
This PR adds a `/move` command to `aether-cli` that moves your session to another directory. If the directory doesn't exist we attempt to create a fast copy-on-write (cow) clone. If the directory already exists, we move uncomitted git changes over. 

As a side-effect of this feature, aether-cli is now aware of workspaces and tracks them via a `workspaces.json` file in `~/.aether` so that it's able to render a menu of workspaces to select in the tui 