### PR TITLE
feat(aether-cli): Allow filtering mcp tools by annotation

### DIFF
--- a/packages/aether-cli/README.md
+++ b/packages/aether-cli/README.md
@@ -214,7 +214,7 @@ Define agents with specific model, prompts, and tool configurations:
       "prompts": [".aether/prompts/researcher.md"],
       "mcps": [".aether/researcher-mcp.json"],
       "tools": {
-        "allow": ["coding__grep", "coding__read_file", "coding__glob"],
+        "allow": [{ "readOnly": true }],
         "deny": []
       }
     },
@@ -237,7 +237,7 @@ Define agents with specific model, prompts, and tool configurations:
 - **Agent `mcps`** — Optional ordered MCP config sources that override top-level `mcps` for that agent. Supports the same string shorthand and typed objects as top-level `mcps`.
 - **`userInvocable: true`** — Agent appears as a mode option in ACP clients (e.g., Wisp's Shift+Tab)
 - **`agentInvocable: true`** — Agent can be spawned as a sub-agent
-- **`tools`** — Filter which MCP tools the agent can use (optional). Supports `allow` (allowlist) and `deny` (blocklist) with trailing `*` wildcards. If both are set, `allow` is applied first, then `deny` removes from the result. Omit or leave empty to allow all tools.
+- **`tools`** — Filter which MCP tools the agent can use (optional). Supports `allow` (allowlist) and `deny` (blocklist) entries. Entries can be exact/trailing-`*` name patterns such as `coding__read_file` or annotation matchers such as `{ "readOnly": true }`, `{ "destructive": false }`, `{ "idempotent": true }`, and `{ "openWorld": false }`. If both are set, `allow` is applied first, then `deny` removes from the result. Omit or leave empty to allow all tools.
 
 You can scaffold settings interactively via `aether settings init --user` or `aether settings init --project`. Edit the generated settings JSON directly to customize agents.
 

--- a/packages/aether-cli/src/init/build_settings.rs
+++ b/packages/aether-cli/src/init/build_settings.rs
@@ -1,7 +1,7 @@
 use super::InitScope;
 use super::harness::HarnessIntegration;
 use super::recommendations::{ProviderRecommendations, recommended_for_provider};
-use aether_core::agent_spec::ToolFilter;
+use aether_core::agent_spec::{ToolFilter, ToolMatcher};
 use aether_project::{AetherSettings, AgentConfig, McpSourceSpec, PromptSource};
 use llm::catalog::Provider;
 use mcp_utils::client::{InMemoryServerConfig, InMemoryType, McpServerConfig};
@@ -14,9 +14,6 @@ const EXPLORER_AGENTS_PATH: &str = "agents/codebase-explorer/AGENTS.md";
 
 const AETHER_SKILL_MD: &str = include_str!("templates/skills/aether/SKILL.md");
 const AETHER_SKILL_PATH: &str = "skills/aether/SKILL.md";
-
-const READ_ONLY_DENIED_CODING_TOOLS: &[&str] =
-    &["coding__bash", "coding__edit_file", "coding__lsp_rename", "coding__write_file"];
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, clap::ValueEnum)]
 #[clap(rename_all = "kebab-case")]
@@ -63,7 +60,10 @@ fn minimal_preset(provider: Provider, recs: &ProviderRecommendations, scope: Ini
         reasoning_effort: recs.plan.reasoning_effort,
         user_invocable: true,
         mcps: vec![mcps(vec![("coding", vec![]), ("skills", skills_args(&[]))])],
-        tools: ToolFilter { allow: vec!["coding__bash".to_string(), "skills__*".to_string()], deny: vec![] },
+        tools: ToolFilter {
+            allow: vec![ToolMatcher::name("coding__bash"), ToolMatcher::name("skills__*")],
+            deny: vec![],
+        },
         ..AgentConfig::default()
     };
 
@@ -207,5 +207,15 @@ fn mcps(servers: Vec<(&str, Vec<String>)>) -> McpSourceSpec {
 }
 
 fn read_only_coding_tools() -> ToolFilter {
-    ToolFilter { allow: vec![], deny: READ_ONLY_DENIED_CODING_TOOLS.iter().map(|tool| (*tool).to_string()).collect() }
+    ToolFilter {
+        allow: vec![
+            ToolMatcher::read_only(),
+            ToolMatcher::name("plan__*"),
+            ToolMatcher::name("skills__*"),
+            ToolMatcher::name("subagents__*"),
+            ToolMatcher::name("tasks__*"),
+            ToolMatcher::name("survey__*"),
+        ],
+        deny: vec![],
+    }
 }

--- a/packages/aether-cli/src/show_prompt/run.rs
+++ b/packages/aether-cli/src/show_prompt/run.rs
@@ -86,12 +86,9 @@ mod tests {
     use super::*;
 
     fn tool(name: &str, desc: &str, params: &str, server: Option<&str>) -> ToolDefinition {
-        ToolDefinition {
-            name: name.to_string(),
-            description: desc.to_string(),
-            parameters: params.to_string(),
-            server: server.map(String::from),
-        }
+        let mut tool = ToolDefinition::new(name, desc, params);
+        tool.server = server.map(String::from);
+        tool
     }
 
     #[test]

--- a/packages/aether-cli/tests/run_init.rs
+++ b/packages/aether-cli/tests/run_init.rs
@@ -1,4 +1,5 @@
 use aether_cli::init::{HarnessIntegration, InitError, InitOutcome, InitTarget, Preset, apply_init};
+use aether_core::agent_spec::ToolMatcher;
 use aether_core::core::Prompt;
 use aether_project::{AetherSettings, AgentCatalog, McpSourceSpec, PromptSource};
 use llm::catalog::Provider;
@@ -116,7 +117,7 @@ fn writes_project_batteries_preset_for_anthropic() {
     let plan_servers = inline_servers(&plan.mcps[0]);
     let plan_server_names: Vec<&str> = plan_servers.keys().map(String::as_str).collect();
     assert_eq!(plan_server_names, vec!["coding", "plan", "skills", "subagents", "survey", "tasks"]);
-    assert!(!plan.tools.deny.iter().any(|tool| tool.starts_with("plan__")));
+    assert!(!plan.tools.deny.iter().any(|tool| matches!(tool, ToolMatcher::Name(name) if name.starts_with("plan__"))));
 
     let explore = &settings.agents[2];
     assert!(explore.agent_invocable);
@@ -293,15 +294,25 @@ fn unsupported_provider_returns_error_without_writing_files() {
 }
 
 fn assert_read_only_coding_tools(agent: &aether_project::AgentConfig) {
-    assert_eq!(agent.tools.allow, Vec::<String>::new());
-    assert_eq!(agent.tools.deny, vec!["coding__bash", "coding__edit_file", "coding__lsp_rename", "coding__write_file"]);
+    assert_eq!(
+        agent.tools.allow,
+        vec![
+            ToolMatcher::read_only(),
+            ToolMatcher::name("plan__*"),
+            ToolMatcher::name("skills__*"),
+            ToolMatcher::name("subagents__*"),
+            ToolMatcher::name("tasks__*"),
+            ToolMatcher::name("survey__*"),
+        ]
+    );
+    assert!(agent.tools.deny.is_empty());
 }
 
 fn assert_minimal_mcp_and_tools(agent: &aether_project::AgentConfig) {
     let McpSourceSpec::Inline { servers } = &agent.mcps[0] else { panic!("minimal MCPs should be inline") };
     let names: Vec<&str> = servers.keys().map(String::as_str).collect();
     assert_eq!(names, vec!["coding", "skills"]);
-    assert_eq!(agent.tools.allow, vec!["coding__bash", "skills__*"]);
+    assert_eq!(agent.tools.allow, vec![ToolMatcher::name("coding__bash"), ToolMatcher::name("skills__*")]);
     assert!(agent.tools.deny.is_empty());
 }
 

--- a/packages/aether-core/examples/anthropic_test.rs
+++ b/packages/aether-core/examples/anthropic_test.rs
@@ -62,10 +62,10 @@ async fn main() -> Result<(), Box<dyn Error>> {
     ];
 
     let tools = vec![
-        ToolDefinition {
-            name: "search_web".to_string(),
-            description: "Search the web for current information".to_string(),
-            parameters: json!({
+        ToolDefinition::new(
+            "search_web",
+            "Search the web for current information",
+            json!({
                 "type": "object",
                 "properties": {
                     "query": {
@@ -76,12 +76,11 @@ async fn main() -> Result<(), Box<dyn Error>> {
                 "required": ["query"]
             })
             .to_string(),
-            server: None,
-        },
-        ToolDefinition {
-            name: "calculate".to_string(),
-            description: "Perform mathematical calculations".to_string(),
-            parameters: json!({
+        ),
+        ToolDefinition::new(
+            "calculate",
+            "Perform mathematical calculations",
+            json!({
                 "type": "object",
                 "properties": {
                     "expression": {
@@ -92,8 +91,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
                 "required": ["expression"]
             })
             .to_string(),
-            server: None,
-        },
+        ),
     ];
     let context = Context::new(messages, tools);
 

--- a/packages/aether-core/src/agent_spec.rs
+++ b/packages/aether-core/src/agent_spec.rs
@@ -82,21 +82,80 @@ impl AgentSpec {
     }
 }
 
+#[derive(Debug, Clone, PartialEq, Eq, serde::Deserialize, serde::Serialize, schemars::JsonSchema)]
+#[serde(untagged)]
+pub enum ToolMatcher {
+    Name(String),
+    Annotations(ToolAnnotationMatcher),
+}
+
+impl ToolMatcher {
+    pub fn name(pattern: impl Into<String>) -> Self {
+        Self::Name(pattern.into())
+    }
+
+    pub fn read_only() -> Self {
+        Self::Annotations(ToolAnnotationMatcher { read_only: Some(true), ..ToolAnnotationMatcher::default() })
+    }
+
+    pub fn annotations(matcher: ToolAnnotationMatcher) -> Self {
+        Self::Annotations(matcher)
+    }
+
+    pub fn matches(&self, tool: &ToolDefinition) -> bool {
+        match self {
+            Self::Name(pattern) => matches_pattern(pattern, &tool.name),
+            Self::Annotations(matcher) => matcher.matches(tool),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Eq, serde::Deserialize, serde::Serialize, schemars::JsonSchema)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct ToolAnnotationMatcher {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub read_only: Option<bool>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub destructive: Option<bool>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub idempotent: Option<bool>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub open_world: Option<bool>,
+}
+
+impl ToolAnnotationMatcher {
+    pub fn matches(&self, tool: &ToolDefinition) -> bool {
+        let Some(annotations) = tool.annotations.as_ref() else {
+            return false;
+        };
+        let pairs = [
+            (self.read_only, annotations.read_only_hint),
+            (self.destructive, annotations.destructive_hint),
+            (self.idempotent, annotations.idempotent_hint),
+            (self.open_world, annotations.open_world_hint),
+        ];
+        if pairs.iter().all(|(field, _)| field.is_none()) {
+            return false;
+        }
+        pairs.iter().all(|(field, hint)| field.is_none_or(|value| *hint == Some(value)))
+    }
+}
+
 /// Filter for restricting which tools an agent can use.
 ///
-/// Supports `allow` (allowlist) and `deny` (blocklist) with trailing `*` wildcards.
+/// Supports `allow` (allowlist) and `deny` (blocklist) with name patterns and MCP annotation matchers.
 /// If both are set, allow is applied first, then deny removes from the result.
 /// An empty filter (the default) allows all tools.
 #[doc = ""]
 #[doc = include_str!("docs/tool_filter.md")]
 #[derive(Debug, Clone, Default, PartialEq, Eq, serde::Deserialize, serde::Serialize, schemars::JsonSchema)]
 pub struct ToolFilter {
-    /// If non-empty, only tools matching these patterns are allowed.
+    /// If non-empty, only tools matching these patterns or annotations are allowed.
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
-    pub allow: Vec<String>,
-    /// Tools matching these patterns are removed.
+    pub allow: Vec<ToolMatcher>,
+    /// Tools matching these patterns or annotations are removed.
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
-    pub deny: Vec<String>,
+    pub deny: Vec<ToolMatcher>,
 }
 
 impl ToolFilter {
@@ -106,13 +165,13 @@ impl ToolFilter {
 
     /// Apply this filter to a list of tool definitions.
     pub fn apply(&self, tools: Vec<ToolDefinition>) -> Vec<ToolDefinition> {
-        tools.into_iter().filter(|t| self.is_allowed(&t.name)).collect()
+        tools.into_iter().filter(|tool| self.is_tool_allowed(tool)).collect()
     }
 
-    /// Check whether a tool name passes this filter.
-    pub fn is_allowed(&self, tool_name: &str) -> bool {
-        let allowed = self.allow.is_empty() || self.allow.iter().any(|p| matches_pattern(p, tool_name));
-        allowed && !self.deny.iter().any(|p| matches_pattern(p, tool_name))
+    pub fn is_tool_allowed(&self, tool: &ToolDefinition) -> bool {
+        let allowed = self.allow.is_empty() || self.allow.iter().any(|matcher| matcher.matches(tool));
+        let denied = self.deny.iter().any(|matcher| matcher.matches(tool));
+        allowed && !denied
     }
 }
 
@@ -159,6 +218,7 @@ impl AgentSpecExposure {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use llm::ToolAnnotations;
 
     #[test]
     fn default_spec_has_expected_fields() {
@@ -176,7 +236,11 @@ mod tests {
     }
 
     fn make_tool(name: &str) -> ToolDefinition {
-        ToolDefinition { name: name.to_string(), description: String::new(), parameters: String::new(), server: None }
+        ToolDefinition::new(name, "", "")
+    }
+
+    fn make_annotated_tool(name: &str, annotations: ToolAnnotations) -> ToolDefinition {
+        ToolDefinition::new(name, "", "").with_annotations(annotations)
     }
 
     #[test]
@@ -189,7 +253,8 @@ mod tests {
 
     #[test]
     fn allow_keeps_only_matching_tools() {
-        let filter = ToolFilter { allow: vec!["read_file".to_string(), "grep".to_string()], deny: vec![] };
+        let filter =
+            ToolFilter { allow: vec![ToolMatcher::name("read_file"), ToolMatcher::name("grep")], deny: vec![] };
         let tools = vec![make_tool("bash"), make_tool("read_file"), make_tool("grep")];
         let result = filter.apply(tools);
         let names: Vec<_> = result.iter().map(|t| t.name.as_str()).collect();
@@ -198,7 +263,7 @@ mod tests {
 
     #[test]
     fn deny_removes_matching_tools() {
-        let filter = ToolFilter { allow: vec![], deny: vec!["bash".to_string()] };
+        let filter = ToolFilter { allow: vec![], deny: vec![ToolMatcher::name("bash")] };
         let tools = vec![make_tool("bash"), make_tool("read_file")];
         let result = filter.apply(tools);
         let names: Vec<_> = result.iter().map(|t| t.name.as_str()).collect();
@@ -207,7 +272,7 @@ mod tests {
 
     #[test]
     fn wildcard_matching() {
-        let filter = ToolFilter { allow: vec!["coding__*".to_string()], deny: vec![] };
+        let filter = ToolFilter { allow: vec![ToolMatcher::name("coding__*")], deny: vec![] };
         let tools = vec![make_tool("coding__grep"), make_tool("coding__read_file"), make_tool("plugins__bash")];
         let result = filter.apply(tools);
         let names: Vec<_> = result.iter().map(|t| t.name.as_str()).collect();
@@ -216,8 +281,10 @@ mod tests {
 
     #[test]
     fn combined_allow_and_deny() {
-        let filter =
-            { ToolFilter { allow: vec!["coding__*".to_string()], deny: vec!["coding__write_file".to_string()] } };
+        let filter = ToolFilter {
+            allow: vec![ToolMatcher::name("coding__*")],
+            deny: vec![ToolMatcher::name("coding__write_file")],
+        };
         let tools = vec![
             make_tool("coding__grep"),
             make_tool("coding__write_file"),
@@ -230,10 +297,125 @@ mod tests {
     }
 
     #[test]
-    fn is_allowed_exact_match() {
-        let filter = ToolFilter { allow: vec!["bash".to_string()], deny: vec![] };
-        assert!(filter.is_allowed("bash"));
-        assert!(!filter.is_allowed("bash_extended"));
+    fn annotation_allow_matches_present_values() {
+        let filter = ToolFilter { allow: vec![ToolMatcher::read_only()], deny: vec![] };
+        let tools = vec![
+            make_tool("unknown"),
+            make_annotated_tool("read", ToolAnnotations { read_only_hint: Some(true), ..ToolAnnotations::default() }),
+            make_annotated_tool("write", ToolAnnotations { read_only_hint: Some(false), ..ToolAnnotations::default() }),
+        ];
+        let names: Vec<_> = filter.apply(tools).into_iter().map(|tool| tool.name).collect();
+        assert_eq!(names, vec!["read"]);
+    }
+
+    #[test]
+    fn deny_annotation_removes_destructive_tools() {
+        let filter = ToolFilter {
+            allow: vec![],
+            deny: vec![ToolMatcher::annotations(ToolAnnotationMatcher {
+                destructive: Some(true),
+                ..ToolAnnotationMatcher::default()
+            })],
+        };
+        let tools = vec![
+            make_tool("unknown"),
+            make_annotated_tool(
+                "safe_update",
+                ToolAnnotations {
+                    read_only_hint: Some(false),
+                    destructive_hint: Some(false),
+                    ..ToolAnnotations::default()
+                },
+            ),
+        ];
+        let names: Vec<_> = filter.apply(tools).into_iter().map(|tool| tool.name).collect();
+        assert_eq!(names, vec!["unknown", "safe_update"]);
+    }
+
+    #[test]
+    fn annotation_matchers_do_not_match_missing_fields() {
+        let filter = ToolFilter {
+            allow: vec![],
+            deny: vec![
+                ToolMatcher::annotations(ToolAnnotationMatcher {
+                    destructive: Some(true),
+                    ..ToolAnnotationMatcher::default()
+                }),
+                ToolMatcher::annotations(ToolAnnotationMatcher {
+                    open_world: Some(true),
+                    ..ToolAnnotationMatcher::default()
+                }),
+                ToolMatcher::annotations(ToolAnnotationMatcher {
+                    idempotent: Some(false),
+                    ..ToolAnnotationMatcher::default()
+                }),
+                ToolMatcher::annotations(ToolAnnotationMatcher {
+                    read_only: Some(false),
+                    ..ToolAnnotationMatcher::default()
+                }),
+            ],
+        };
+        let tools = vec![make_tool("unknown")];
+        let names: Vec<_> = filter.apply(tools).into_iter().map(|tool| tool.name).collect();
+        assert_eq!(names, vec!["unknown"]);
+    }
+
+    #[test]
+    fn annotation_matchers_do_not_infer_fields_from_read_only_hint() {
+        let filter = ToolFilter {
+            allow: vec![ToolMatcher::annotations(ToolAnnotationMatcher {
+                destructive: Some(false),
+                ..ToolAnnotationMatcher::default()
+            })],
+            deny: vec![],
+        };
+        let tools = vec![make_annotated_tool("read", ToolAnnotations::read_only())];
+        assert!(filter.apply(tools).is_empty());
+    }
+
+    #[test]
+    fn deny_wins_over_allow() {
+        let filter =
+            ToolFilter { allow: vec![ToolMatcher::read_only()], deny: vec![ToolMatcher::name("coding__read_file")] };
+        let tools = vec![make_annotated_tool(
+            "coding__read_file",
+            ToolAnnotations { read_only_hint: Some(true), ..ToolAnnotations::default() },
+        )];
+        assert!(filter.apply(tools).is_empty());
+    }
+
+    #[test]
+    fn mixed_allow_entries_are_ored() {
+        let filter = ToolFilter { allow: vec![ToolMatcher::read_only(), ToolMatcher::name("plan__*")], deny: vec![] };
+        let tools = vec![
+            make_annotated_tool(
+                "coding__grep",
+                ToolAnnotations { read_only_hint: Some(true), ..ToolAnnotations::default() },
+            ),
+            make_tool("plan__write_plan"),
+            make_tool("coding__bash"),
+        ];
+        let names: Vec<_> = filter.apply(tools).into_iter().map(|tool| tool.name).collect();
+        assert_eq!(names, vec!["coding__grep", "plan__write_plan"]);
+    }
+
+    #[test]
+    fn empty_annotation_matcher_matches_nothing() {
+        let filter =
+            ToolFilter { allow: vec![ToolMatcher::annotations(ToolAnnotationMatcher::default())], deny: vec![] };
+        let tools = vec![make_annotated_tool(
+            "coding__grep",
+            ToolAnnotations { read_only_hint: Some(true), ..ToolAnnotations::default() },
+        )];
+        assert!(filter.apply(tools).is_empty());
+    }
+
+    #[test]
+    fn exact_name_match_is_not_a_prefix_match() {
+        let filter = ToolFilter { allow: vec![ToolMatcher::name("bash")], deny: vec![] };
+        let names: Vec<_> =
+            filter.apply(vec![make_tool("bash"), make_tool("bash_extended")]).into_iter().map(|t| t.name).collect();
+        assert_eq!(names, vec!["bash"]);
     }
 
     #[test]

--- a/packages/aether-core/src/docs/tool_filter.md
+++ b/packages/aether-core/src/docs/tool_filter.md
@@ -1,11 +1,25 @@
-Allow only a few read-only tools:
+Allow specific tools by name:
 
 ```json
 { "allow": ["read_file", "grep", "find"] }
 ```
 
-Allow everything except the shell, using a trailing `*` wildcard:
+Allow tools annotated as read-only by their MCP server:
 
 ```json
-{ "deny": ["bash*"] }
+{ "allow": [{ "readOnly": true }] }
 ```
+
+Combine tool matchers with exact or trailing-`*` name patterns:
+
+```json
+{ "allow": [{ "readOnly": true }, "plan__*"], "deny": ["coding__web_*"] }
+```
+
+Deny always wins over allow:
+
+```json
+{ "allow": [{ "readOnly": true }], "deny": [{ "openWorld": true }] }
+```
+
+Annotation matcher fields are `readOnly`, `destructive`, `idempotent`, and `openWorld`. Missing tool annotations or missing annotation fields do not receive default boolean values and do not match.

--- a/packages/aether-project/src/docs/agent_config.md
+++ b/packages/aether-project/src/docs/agent_config.md
@@ -1,7 +1,7 @@
 A single agent definition. Every agent must be invocable on at least one
 surface — set `userInvocable`, `agentInvocable`, or both.
 
-A user-invocable agent with its own prompt and a tool allowlist:
+A user-invocable agent with its own prompt and a read-only tool allowlist:
 
 ```json
 {
@@ -10,7 +10,7 @@ A user-invocable agent with its own prompt and a tool allowlist:
   "model": "anthropic:claude-sonnet-4-5-20250929",
   "userInvocable": true,
   "prompts": [".aether/REVIEW.md"],
-  "tools": { "allow": ["read_file", "grep", "find"] }
+  "tools": { "allow": [{ "readOnly": true }, "plan__*"] }
 }
 ```
 

--- a/packages/llm/README.md
+++ b/packages/llm/README.md
@@ -87,12 +87,11 @@ use llm::{
     AssistantReasoning, ChatMessage, ContentBlock, Context, ToolCallResult, ToolDefinition,
 };
 
-let tools = vec![ToolDefinition {
-    name: "get_weather".into(),
-    description: "Get current weather for a city".into(),
-    parameters: r#"{"type":"object","properties":{"city":{"type":"string"}},"required":["city"]}"#.into(),
-    server: None,
-}];
+let tools = vec![ToolDefinition::new(
+    "get_weather",
+    "Get current weather for a city",
+    r#"{"type":"object","properties":{"city":{"type":"string"}},"required":["city"]}"#,
+)];
 
 let mut context = Context::new(
     vec![ChatMessage::User {

--- a/packages/llm/src/context.rs
+++ b/packages/llm/src/context.rs
@@ -275,12 +275,7 @@ mod tests {
 
     #[test]
     fn replace_conversation_does_not_change_tools() {
-        let tool = ToolDefinition {
-            name: "read_file".to_string(),
-            description: "Reads a file".to_string(),
-            parameters: "{}".to_string(),
-            server: None,
-        };
+        let tool = ToolDefinition::new("read_file", "Reads a file", "{}");
         let mut ctx = Context::new(
             vec![ChatMessage::System { content: "system".to_string(), timestamp: IsoString::now() }],
             vec![tool.clone()],
@@ -404,13 +399,7 @@ mod tests {
         // With no tools, estimate = message_bytes / 4
         assert_eq!(base_estimate, 87 / 4);
 
-        // Now add a tool definition and verify it increases
-        let tool = ToolDefinition {
-            name: "read_file".to_string(),           // 9
-            description: "Reads a file".to_string(), // 12
-            parameters: "{}".to_string(),            // 2
-            server: None,
-        };
+        let tool = ToolDefinition::new("read_file", "Reads a file", "{}");
         let ctx_with_tools = Context::new(ctx.messages().clone(), vec![tool]);
         let with_tools_estimate = ctx_with_tools.estimated_token_count();
         assert_eq!(with_tools_estimate, (87 + 9 + 12 + 2) / 4);

--- a/packages/llm/src/docs/tools.md
+++ b/packages/llm/src/docs/tools.md
@@ -14,3 +14,5 @@ Tools follow a request-response lifecycle:
 - [`ToolCallError`] -- Failed execution: includes the `error` string. Construct from a request with [`ToolCallError::from_request`].
 
 The optional `server` field on `ToolDefinition` tracks which MCP server originally provided the tool, if any.
+
+The optional `annotations` field preserves MCP tool hints such as `readOnlyHint`, `destructiveHint`, `idempotentHint`, and `openWorldHint`. These values are hints supplied by the server and are used by higher-level filtering policy; they are not a security boundary.

--- a/packages/llm/src/providers/anthropic/mappers.rs
+++ b/packages/llm/src/providers/anthropic/mappers.rs
@@ -249,12 +249,11 @@ mod tests {
 
     #[test]
     fn test_map_tools() {
-        let tools = vec![ToolDefinition {
-            name: "search".to_string(),
-            description: "Search for information".to_string(),
-            parameters: r#"{"type": "object", "properties": {"query": {"type": "string"}}}"#.to_string(),
-            server: None,
-        }];
+        let tools = vec![ToolDefinition::new(
+            "search",
+            "Search for information",
+            r#"{"type": "object", "properties": {"query": {"type": "string"}}}"#,
+        )];
 
         let mapped = map_tools(&tools).unwrap();
         assert_eq!(mapped.len(), 1);
@@ -264,12 +263,11 @@ mod tests {
 
     #[test]
     fn test_map_tools_no_cache_control() {
-        let tools = vec![ToolDefinition {
-            name: "search".to_string(),
-            description: "Search for information".to_string(),
-            parameters: r#"{"type": "object", "properties": {"query": {"type": "string"}}}"#.to_string(),
-            server: None,
-        }];
+        let tools = vec![ToolDefinition::new(
+            "search",
+            "Search for information",
+            r#"{"type": "object", "properties": {"query": {"type": "string"}}}"#,
+        )];
 
         let mapped = map_tools(&tools).unwrap();
         assert_eq!(mapped.len(), 1);

--- a/packages/llm/src/providers/anthropic/provider.rs
+++ b/packages/llm/src/providers/anthropic/provider.rs
@@ -334,12 +334,11 @@ mod tests {
                 ChatMessage::System { content: "You are helpful".to_string(), timestamp: IsoString::now() },
                 ChatMessage::User { content: vec![ContentBlock::text("Hello")], timestamp: IsoString::now() },
             ],
-            vec![ToolDefinition {
-                name: "search".to_string(),
-                description: "Search for information".to_string(),
-                parameters: r#"{"type": "object", "properties": {"query": {"type": "string"}}}"#.to_string(),
-                server: None,
-            }],
+            vec![ToolDefinition::new(
+                "search",
+                "Search for information",
+                r#"{"type": "object", "properties": {"query": {"type": "string"}}}"#,
+            )],
         );
 
         let request = provider.build_request(&context).unwrap();
@@ -369,12 +368,11 @@ mod tests {
                 ChatMessage::System { content: "Hello".to_string(), timestamp: IsoString::now() },
                 ChatMessage::User { content: vec![ContentBlock::text("Hello")], timestamp: IsoString::now() },
             ],
-            vec![ToolDefinition {
-                name: "search".to_string(),
-                description: "Search for information".to_string(),
-                parameters: r#"{"type": "object", "properties": {"query": {"type": "string"}}}"#.to_string(),
-                server: None,
-            }],
+            vec![ToolDefinition::new(
+                "search",
+                "Search for information",
+                r#"{"type": "object", "properties": {"query": {"type": "string"}}}"#,
+            )],
         );
 
         let request = provider.build_request(&context).unwrap();

--- a/packages/llm/src/providers/bedrock/mappers.rs
+++ b/packages/llm/src/providers/bedrock/mappers.rs
@@ -438,12 +438,11 @@ mod tests {
 
     #[test]
     fn test_map_tools() {
-        let tools = vec![ToolDefinition {
-            name: "search".to_string(),
-            description: "Search for information".to_string(),
-            parameters: r#"{"type": "object", "properties": {"query": {"type": "string"}}}"#.to_string(),
-            server: None,
-        }];
+        let tools = vec![ToolDefinition::new(
+            "search",
+            "Search for information",
+            r#"{"type": "object", "properties": {"query": {"type": "string"}}}"#,
+        )];
 
         let config = map_tools(&tools, None).unwrap();
         assert_eq!(config.tools().len(), 1);
@@ -535,12 +534,11 @@ mod tests {
 
     #[test]
     fn tool_cache_point_is_added_when_cache_point_provided() {
-        let tools = vec![ToolDefinition {
-            name: "search".to_string(),
-            description: "Search for information".to_string(),
-            parameters: r#"{"type": "object", "properties": {"query": {"type": "string"}}}"#.to_string(),
-            server: None,
-        }];
+        let tools = vec![ToolDefinition::new(
+            "search",
+            "Search for information",
+            r#"{"type": "object", "properties": {"query": {"type": "string"}}}"#,
+        )];
         let cache_point = default_cache_point().unwrap();
 
         let config = map_tools(&tools, Some(&cache_point)).unwrap();
@@ -552,12 +550,7 @@ mod tests {
 
     #[test]
     fn test_map_tools_invalid_json() {
-        let tools = vec![ToolDefinition {
-            name: "broken".to_string(),
-            description: "A broken tool".to_string(),
-            parameters: "not valid json".to_string(),
-            server: None,
-        }];
+        let tools = vec![ToolDefinition::new("broken", "A broken tool", "not valid json")];
 
         let result = map_tools(&tools, None);
         assert!(result.is_err());

--- a/packages/llm/src/providers/codex/mappers.rs
+++ b/packages/llm/src/providers/codex/mappers.rs
@@ -255,12 +255,11 @@ mod tests {
 
     #[test]
     fn map_tools_produces_function_type() {
-        let tools = vec![ToolDefinition {
-            name: "read_file".to_string(),
-            description: "Read a file from disk".to_string(),
-            parameters: r#"{"type": "object", "properties": {"path": {"type": "string"}}}"#.to_string(),
-            server: None,
-        }];
+        let tools = vec![ToolDefinition::new(
+            "read_file",
+            "Read a file from disk",
+            r#"{"type": "object", "properties": {"path": {"type": "string"}}}"#,
+        )];
 
         let mapped = map_tools(&tools).unwrap();
         assert_eq!(mapped.len(), 1);
@@ -275,12 +274,7 @@ mod tests {
 
     #[test]
     fn map_tools_returns_error_on_invalid_json_parameters() {
-        let tools = vec![ToolDefinition {
-            name: "broken".to_string(),
-            description: "A tool with invalid params".to_string(),
-            parameters: "not valid json".to_string(),
-            server: None,
-        }];
+        let tools = vec![ToolDefinition::new("broken", "A tool with invalid params", "not valid json")];
 
         let result = map_tools(&tools);
         assert!(result.is_err());

--- a/packages/llm/src/providers/codex/provider.rs
+++ b/packages/llm/src/providers/codex/provider.rs
@@ -231,12 +231,11 @@ mod tests {
                 ChatMessage::System { content: "You are helpful".to_string(), timestamp: IsoString::now() },
                 ChatMessage::User { content: vec![ContentBlock::text("Hello")], timestamp: IsoString::now() },
             ],
-            vec![ToolDefinition {
-                name: "bash".to_string(),
-                description: "Run a command".to_string(),
-                parameters: r#"{"type": "object", "properties": {"cmd": {"type": "string"}}}"#.to_string(),
-                server: None,
-            }],
+            vec![ToolDefinition::new(
+                "bash",
+                "Run a command",
+                r#"{"type": "object", "properties": {"cmd": {"type": "string"}}}"#,
+            )],
         );
 
         let request = provider.build_request(&context).unwrap();

--- a/packages/llm/src/providers/openai/mappers.rs
+++ b/packages/llm/src/providers/openai/mappers.rs
@@ -279,12 +279,11 @@ mod tests {
 
     #[test]
     fn map_tools_with_valid_json() {
-        let tools = vec![ToolDefinition {
-            name: "search".to_string(),
-            description: "Search for things".to_string(),
-            parameters: r#"{"type": "object", "properties": {"q": {"type": "string"}}}"#.to_string(),
-            server: None,
-        }];
+        let tools = vec![ToolDefinition::new(
+            "search",
+            "Search for things",
+            r#"{"type": "object", "properties": {"q": {"type": "string"}}}"#,
+        )];
         let result = map_tools(&tools, None);
         assert!(result.is_ok());
         assert_eq!(result.unwrap().len(), 1);
@@ -292,12 +291,7 @@ mod tests {
 
     #[test]
     fn map_tools_with_invalid_json_returns_error() {
-        let tools = vec![ToolDefinition {
-            name: "broken_tool".to_string(),
-            description: "A tool with bad params".to_string(),
-            parameters: "not valid json{{{".to_string(),
-            server: None,
-        }];
+        let tools = vec![ToolDefinition::new("broken_tool", "A tool with bad params", "not valid json{{{")];
         let result = map_tools(&tools, None);
         assert!(result.is_err());
         match result.unwrap_err() {
@@ -311,12 +305,7 @@ mod tests {
     #[test]
     fn map_tools_applies_transform_when_provided() {
         let raw_params = r#"{"$schema": "https://json-schema.org/draft/2020-12/schema", "title": "MySchema", "type": "object", "properties": {"q": {"type": "string", "format": "uri"}}}"#;
-        let tools = vec![ToolDefinition {
-            name: "search".to_string(),
-            description: "Search".to_string(),
-            parameters: raw_params.to_string(),
-            server: None,
-        }];
+        let tools = vec![ToolDefinition::new("search", "Search", raw_params)];
         let result = map_tools(&tools, Some(normalize_for_moonshot)).unwrap();
         let ChatCompletionTools::Function(f) = &result[0] else {
             panic!("Expected function tool");

--- a/packages/llm/src/providers/openai/responses_provider.rs
+++ b/packages/llm/src/providers/openai/responses_provider.rs
@@ -399,12 +399,7 @@ mod tests {
                     result: "Found results".to_string(),
                 })),
             ],
-            vec![ToolDefinition {
-                name: "search".to_string(),
-                description: "Search".to_string(),
-                parameters: r#"{"type":"object"}"#.to_string(),
-                server: None,
-            }],
+            vec![ToolDefinition::new("search", "Search", r#"{"type":"object"}"#)],
         );
 
         let req = build_response_request("gpt-4.1", &context).unwrap();
@@ -453,12 +448,11 @@ mod tests {
 
     #[test]
     fn test_map_tools_valid() {
-        let tools = vec![ToolDefinition {
-            name: "read_file".to_string(),
-            description: "Read a file".to_string(),
-            parameters: r#"{"type":"object","properties":{"path":{"type":"string"}}}"#.to_string(),
-            server: None,
-        }];
+        let tools = vec![ToolDefinition::new(
+            "read_file",
+            "Read a file",
+            r#"{"type":"object","properties":{"path":{"type":"string"}}}"#,
+        )];
 
         let result = map_tools(&tools).unwrap();
         assert_eq!(result.len(), 1);
@@ -470,12 +464,7 @@ mod tests {
 
     #[test]
     fn test_map_tools_invalid_json() {
-        let tools = vec![ToolDefinition {
-            name: "broken".to_string(),
-            description: "Broken".to_string(),
-            parameters: "not json{".to_string(),
-            server: None,
-        }];
+        let tools = vec![ToolDefinition::new("broken", "Broken", "not json{")];
 
         let result = map_tools(&tools);
         assert!(result.is_err());

--- a/packages/llm/src/providers/openai_compatible/types.rs
+++ b/packages/llm/src/providers/openai_compatible/types.rs
@@ -299,12 +299,7 @@ mod tests {
                 ChatMessage::User { content: vec![ContentBlock::text("run a tool")], timestamp: IsoString::now() },
                 message,
             ],
-            vec![ToolDefinition {
-                name: "test__tool".to_string(),
-                description: "test".to_string(),
-                parameters: "{\"type\":\"object\"}".to_string(),
-                server: None,
-            }],
+            vec![ToolDefinition::new("test__tool", "test", "{\"type\":\"object\"}")],
         )
     }
 

--- a/packages/llm/src/tools.rs
+++ b/packages/llm/src/tools.rs
@@ -7,6 +7,46 @@ pub struct ToolDefinition {
     pub description: String,
     pub parameters: String,
     pub server: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub annotations: Option<ToolAnnotations>,
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ToolAnnotations {
+    pub title: Option<String>,
+    pub read_only_hint: Option<bool>,
+    pub destructive_hint: Option<bool>,
+    pub idempotent_hint: Option<bool>,
+    pub open_world_hint: Option<bool>,
+}
+
+impl ToolDefinition {
+    pub fn new(name: impl Into<String>, description: impl Into<String>, parameters: impl Into<String>) -> Self {
+        Self {
+            name: name.into(),
+            description: description.into(),
+            parameters: parameters.into(),
+            server: None,
+            annotations: None,
+        }
+    }
+
+    pub fn with_server(mut self, server: impl Into<String>) -> Self {
+        self.server = Some(server.into());
+        self
+    }
+
+    pub fn with_annotations(mut self, annotations: impl Into<Option<ToolAnnotations>>) -> Self {
+        self.annotations = annotations.into();
+        self
+    }
+}
+
+impl ToolAnnotations {
+    pub fn read_only() -> Self {
+        Self { read_only_hint: Some(true), ..Self::default() }
+    }
 }
 
 /// Tool call request from the LLM

--- a/packages/mcp-servers/src/coding/mod.rs
+++ b/packages/mcp-servers/src/coding/mod.rs
@@ -480,7 +480,7 @@ When using tools that take file paths, always use absolute paths from:
     }
 
     #[doc = include_str!("tools/grep/description.md")]
-    #[tool]
+    #[tool(annotations(read_only_hint = true, open_world_hint = false))]
     pub async fn grep(
         &self,
         request: Parameters<GrepInput>,
@@ -495,7 +495,7 @@ When using tools that take file paths, always use absolute paths from:
     }
 
     #[doc = include_str!("tools/find/description.md")]
-    #[tool]
+    #[tool(annotations(read_only_hint = true, open_world_hint = false))]
     pub async fn find(
         &self,
         request: Parameters<FindInput>,
@@ -510,7 +510,7 @@ When using tools that take file paths, always use absolute paths from:
     }
 
     #[doc = include_str!("tools/read_file/description.md")]
-    #[tool]
+    #[tool(annotations(read_only_hint = true, open_world_hint = false))]
     pub async fn read_file(
         &self,
         request: Parameters<ReadFileArgs>,
@@ -523,7 +523,12 @@ When using tools that take file paths, always use absolute paths from:
     }
 
     #[doc = include_str!("tools/write_file/description.md")]
-    #[tool]
+    #[tool(annotations(
+        read_only_hint = false,
+        destructive_hint = true,
+        idempotent_hint = false,
+        open_world_hint = false
+    ))]
     pub async fn write_file(
         &self,
         request: Parameters<WriteFileArgs>,
@@ -544,7 +549,12 @@ When using tools that take file paths, always use absolute paths from:
     }
 
     #[doc = include_str!("tools/edit_file/description.md")]
-    #[tool]
+    #[tool(annotations(
+        read_only_hint = false,
+        destructive_hint = true,
+        idempotent_hint = false,
+        open_world_hint = false
+    ))]
     pub async fn edit_file(
         &self,
         request: Parameters<EditFileArgs>,
@@ -565,7 +575,7 @@ When using tools that take file paths, always use absolute paths from:
     }
 
     #[doc = include_str!("tools/list_files/description.md")]
-    #[tool]
+    #[tool(annotations(read_only_hint = true, open_world_hint = false))]
     pub async fn list_files(
         &self,
         request: Parameters<ListFilesArgs>,
@@ -581,7 +591,12 @@ When using tools that take file paths, always use absolute paths from:
     }
 
     #[doc = include_str!("tools/bash/description.md")]
-    #[tool]
+    #[tool(annotations(
+        read_only_hint = false,
+        destructive_hint = true,
+        idempotent_hint = false,
+        open_world_hint = true
+    ))]
     pub async fn bash(
         &self,
         request: Parameters<BashInput>,
@@ -620,7 +635,7 @@ When using tools that take file paths, always use absolute paths from:
     }
 
     #[doc = include_str!("tools/bash/read_background_description.md")]
-    #[tool]
+    #[tool(annotations(read_only_hint = true, open_world_hint = false))]
     pub async fn read_background_bash(
         &self,
         request: Parameters<ReadBackgroundBashInput>,
@@ -646,7 +661,7 @@ When using tools that take file paths, always use absolute paths from:
     }
 
     #[doc = include_str!("tools/web_fetch/description.md")]
-    #[tool]
+    #[tool(annotations(read_only_hint = true, open_world_hint = true))]
     pub async fn web_fetch(
         &self,
         request: Parameters<WebFetchInput>,
@@ -658,7 +673,7 @@ When using tools that take file paths, always use absolute paths from:
     }
 
     #[doc = include_str!("tools/web_search/description.md")]
-    #[tool]
+    #[tool(annotations(read_only_hint = true, open_world_hint = true))]
     pub async fn web_search(
         &self,
         request: Parameters<WebSearchInput>,
@@ -677,7 +692,7 @@ When using tools that take file paths, always use absolute paths from:
     }
 
     #[doc = include_str!("../lsp/tools/symbol_lookup/description.md")]
-    #[tool]
+    #[tool(annotations(read_only_hint = true, open_world_hint = false))]
     pub async fn lsp_symbol(
         &self,
         request: Parameters<LspSymbolInput>,
@@ -690,7 +705,7 @@ When using tools that take file paths, always use absolute paths from:
     }
 
     #[doc = include_str!("../lsp/tools/workspace_search/description.md")]
-    #[tool]
+    #[tool(annotations(read_only_hint = true, open_world_hint = false))]
     pub async fn lsp_workspace_search(
         &self,
         request: Parameters<LspWorkspaceSearchInput>,
@@ -703,7 +718,7 @@ When using tools that take file paths, always use absolute paths from:
     }
 
     #[doc = include_str!("../lsp/tools/document_info/description.md")]
-    #[tool]
+    #[tool(annotations(read_only_hint = true, open_world_hint = false))]
     pub async fn lsp_document(
         &self,
         request: Parameters<LspDocumentInput>,
@@ -716,7 +731,7 @@ When using tools that take file paths, always use absolute paths from:
     }
 
     #[doc = include_str!("../lsp/tools/check_errors/description.md")]
-    #[tool]
+    #[tool(annotations(read_only_hint = true, open_world_hint = false))]
     pub async fn lsp_check_errors(
         &self,
         request: Parameters<LspDiagnosticsRequest>,
@@ -733,7 +748,12 @@ When using tools that take file paths, always use absolute paths from:
     }
 
     #[doc = include_str!("../lsp/tools/rename/description.md")]
-    #[tool]
+    #[tool(annotations(
+        read_only_hint = false,
+        destructive_hint = true,
+        idempotent_hint = false,
+        open_world_hint = false
+    ))]
     pub async fn lsp_rename(
         &self,
         request: Parameters<LspRenameInput>,

--- a/packages/mcp-servers/src/plan/server.rs
+++ b/packages/mcp-servers/src/plan/server.rs
@@ -130,21 +130,36 @@ impl PlanMcp {
     }
 
     #[doc = include_str!("./write_plan_description.md")]
-    #[tool]
+    #[tool(annotations(
+        read_only_hint = false,
+        destructive_hint = true,
+        idempotent_hint = false,
+        open_world_hint = false
+    ))]
     pub async fn write_plan(&self, request: Parameters<WritePlanInput>) -> Result<Json<WritePlanOutput>, String> {
         let Parameters(input) = request;
         write_plan_file(&self.plans_dir, input).await.map(Json).map_err(|e| e.to_string())
     }
 
     #[doc = include_str!("./edit_plan_description.md")]
-    #[tool]
+    #[tool(annotations(
+        read_only_hint = false,
+        destructive_hint = true,
+        idempotent_hint = false,
+        open_world_hint = false
+    ))]
     pub async fn edit_plan(&self, request: Parameters<EditPlanInput>) -> Result<Json<EditPlanOutput>, String> {
         let Parameters(input) = request;
         edit_plan_file(&self.plans_dir, input).await.map(Json).map_err(|e| e.to_string())
     }
 
     #[doc = include_str!("./submit_plan_description.md")]
-    #[tool]
+    #[tool(annotations(
+        read_only_hint = false,
+        destructive_hint = false,
+        idempotent_hint = false,
+        open_world_hint = true
+    ))]
     pub async fn submit_plan(
         &self,
         request: Parameters<SubmitPlanInput>,

--- a/packages/mcp-servers/src/skills/server.rs
+++ b/packages/mcp-servers/src/skills/server.rs
@@ -335,7 +335,7 @@ impl ServerHandler for SkillsMcp {
 #[tool_router]
 impl SkillsMcp {
     #[doc = include_str!("tools/list_skills/description.md")]
-    #[tool]
+    #[tool(annotations(read_only_hint = true, open_world_hint = false))]
     pub async fn list_skills(&self, request: Parameters<ListSkillsInput>) -> Result<Json<ListSkillsOutput>, String> {
         let Parameters(_input) = request;
         let catalog = self.catalog.read().await;
@@ -360,7 +360,7 @@ impl SkillsMcp {
     }
 
     #[doc = include_str!("tools/get_skills/description.md")]
-    #[tool]
+    #[tool(annotations(read_only_hint = true, open_world_hint = false))]
     pub async fn get_skills(&self, request: Parameters<LoadSkillsInput>) -> Result<Json<LoadSkillsOutput>, String> {
         let Parameters(args) = request;
         let expander = ShellExpander::new();
@@ -373,7 +373,12 @@ impl SkillsMcp {
     }
 
     #[doc = include_str!("tools/save_note/description.md")]
-    #[tool]
+    #[tool(annotations(
+        read_only_hint = false,
+        destructive_hint = false,
+        idempotent_hint = false,
+        open_world_hint = false
+    ))]
     pub async fn save_note(&self, request: Parameters<SaveNoteInput>) -> Result<Json<SaveNoteOutput>, String> {
         let Parameters(input) = request;
         let today = today_string();
@@ -382,7 +387,7 @@ impl SkillsMcp {
     }
 
     #[doc = include_str!("tools/search_notes/description.md")]
-    #[tool]
+    #[tool(annotations(read_only_hint = true, open_world_hint = false))]
     pub async fn search_notes(&self, request: Parameters<SearchNotesInput>) -> Result<Json<SearchNotesOutput>, String> {
         let Parameters(input) = request;
         let result = search_notes(&input, &self.notes_dir).map_err(|e| e.to_string())?;

--- a/packages/mcp-servers/src/subagents/server.rs
+++ b/packages/mcp-servers/src/subagents/server.rs
@@ -128,7 +128,12 @@ impl ServerHandler for SubAgentsMcp {
 #[tool_router]
 impl SubAgentsMcp {
     #[doc = include_str!("tools/spawn_subagent/description.md")]
-    #[tool]
+    #[tool(annotations(
+        read_only_hint = false,
+        destructive_hint = true,
+        idempotent_hint = false,
+        open_world_hint = true
+    ))]
     pub async fn spawn_subagent(
         &self,
         request: Parameters<SpawnSubAgentsInput>,

--- a/packages/mcp-servers/src/survey/server.rs
+++ b/packages/mcp-servers/src/survey/server.rs
@@ -73,7 +73,12 @@ impl SurveyMcp {
     /// Use this to gather information from the user when you need specific inputs
     /// (text, numbers, booleans, selections). The schema parameter defines the form
     /// fields using JSON Schema format.
-    #[tool]
+    #[tool(annotations(
+        read_only_hint = false,
+        destructive_hint = false,
+        idempotent_hint = false,
+        open_world_hint = true
+    ))]
     pub async fn ask_user(
         &self,
         request: Parameters<AskUserInput>,

--- a/packages/mcp-servers/src/tasks/server.rs
+++ b/packages/mcp-servers/src/tasks/server.rs
@@ -142,7 +142,12 @@ impl ServerHandler for TasksMcp {
 #[tool_router]
 impl TasksMcp {
     #[doc = include_str!("./tools/create/description.md")]
-    #[tool]
+    #[tool(annotations(
+        read_only_hint = false,
+        destructive_hint = false,
+        idempotent_hint = false,
+        open_world_hint = false
+    ))]
     pub async fn task_create(&self, request: Parameters<TaskCreateInput>) -> Result<Json<TaskCreateOutput>, String> {
         let Parameters(input) = request;
         let mut store = self.task_store.lock().await;
@@ -151,7 +156,12 @@ impl TasksMcp {
     }
 
     #[doc = include_str!("./tools/update/description.md")]
-    #[tool]
+    #[tool(annotations(
+        read_only_hint = false,
+        destructive_hint = true,
+        idempotent_hint = false,
+        open_world_hint = false
+    ))]
     pub async fn task_update(&self, request: Parameters<TaskUpdateInput>) -> Result<Json<TaskUpdateOutput>, String> {
         let Parameters(input) = request;
         let mut store = self.task_store.lock().await;
@@ -160,7 +170,7 @@ impl TasksMcp {
     }
 
     #[doc = include_str!("./tools/list/description.md")]
-    #[tool]
+    #[tool(annotations(read_only_hint = true, open_world_hint = false))]
     pub async fn task_list(&self, request: Parameters<TaskListInput>) -> Result<Json<TaskListOutput>, String> {
         let Parameters(input) = request;
         let mut store = self.task_store.lock().await;
@@ -169,7 +179,7 @@ impl TasksMcp {
     }
 
     #[doc = include_str!("./tools/get/description.md")]
-    #[tool]
+    #[tool(annotations(read_only_hint = true, open_world_hint = false))]
     pub async fn task_get(&self, request: Parameters<TaskGetInput>) -> Result<Json<TaskGetOutput>, String> {
         let Parameters(input) = request;
         let mut store = self.task_store.lock().await;

--- a/packages/mcp-utils/src/client/connection.rs
+++ b/packages/mcp-utils/src/client/connection.rs
@@ -6,6 +6,7 @@ use super::{
 };
 use crate::{client::OAuthHandlerContext, transport::create_in_memory_transport};
 use aether_auth::{OAuthCredentialStorage, create_auth_manager_from_store, perform_oauth_flow};
+use llm::ToolAnnotations;
 use rmcp::{
     RoleClient, RoleServer, ServiceExt,
     model::{ClientInfo, Root, Tool as RmcpTool},
@@ -33,6 +34,17 @@ pub struct Tool {
     pub name: String,
     pub description: String,
     pub parameters: Value,
+    pub annotations: Option<ToolAnnotations>,
+}
+
+pub(crate) fn convert_tool_annotations(annotations: &rmcp::model::ToolAnnotations) -> ToolAnnotations {
+    ToolAnnotations {
+        title: annotations.title.clone(),
+        read_only_hint: annotations.read_only_hint,
+        destructive_hint: annotations.destructive_hint,
+        idempotent_hint: annotations.idempotent_hint,
+        open_world_hint: annotations.open_world_hint,
+    }
 }
 
 impl From<RmcpTool> for Tool {
@@ -47,6 +59,7 @@ impl From<&RmcpTool> for Tool {
             name: tool.name.to_string(),
             description: tool.description.clone().unwrap_or_default().to_string(),
             parameters: serde_json::Value::Object((*tool.input_schema).clone()),
+            annotations: tool.annotations.as_ref().map(convert_tool_annotations),
         }
     }
 }

--- a/packages/mcp-utils/src/client/manager.rs
+++ b/packages/mcp-utils/src/client/manager.rs
@@ -216,11 +216,14 @@ impl McpManager {
             if record.proxied {
                 continue;
             }
-            definitions.extend(record.tools().iter().map(|tool| ToolDefinition {
-                name: create_namespaced_tool_name(name, &tool.name),
-                description: tool.description.clone(),
-                parameters: tool.parameters.to_string(),
-                server: Some(name.clone()),
+            definitions.extend(record.tools().iter().map(|tool| {
+                ToolDefinition::new(
+                    create_namespaced_tool_name(name, &tool.name),
+                    tool.description.clone(),
+                    tool.parameters.to_string(),
+                )
+                .with_server(name.clone())
+                .with_annotations(tool.annotations.clone())
             }));
         }
         definitions
@@ -791,7 +794,7 @@ mod tests {
             Box::new(self)
         }
 
-        #[tool(description = "Returns the provided value")]
+        #[tool(description = "Returns the provided value", annotations(read_only_hint = true, open_world_hint = false))]
         async fn echo(&self, request: Parameters<EchoRequest>) -> Json<EchoResult> {
             let Parameters(EchoRequest { value }) = request;
             Json(EchoResult { value })
@@ -1020,6 +1023,26 @@ mod tests {
 
         assert!(!names(&manager).iter().any(|name| name.starts_with("git__")));
         assert!(names(&manager).contains(&"github__echo".to_string()));
+    }
+
+    #[tokio::test]
+    async fn tool_definitions_preserve_annotations() {
+        let (event_sender, _event_receiver) = mpsc::channel(32);
+        let mut manager = McpManager::new(event_sender, None);
+        manager
+            .add_mcps(vec![McpServer::new(
+                "test",
+                McpTransport::InMemory { server: TestServer::default().into_dyn() },
+                false,
+            )])
+            .await
+            .unwrap();
+
+        let tools = manager.tool_definitions();
+        let echo = tools.iter().find(|tool| tool.name == "test__echo").expect("echo tool");
+        let annotations = echo.annotations.as_ref().expect("annotations should be preserved");
+        assert_eq!(annotations.read_only_hint, Some(true));
+        assert_eq!(annotations.open_world_hint, Some(false));
     }
 
     #[tokio::test]

--- a/packages/mcp-utils/src/client/tool_proxy.rs
+++ b/packages/mcp-utils/src/client/tool_proxy.rs
@@ -1,6 +1,7 @@
 use super::McpError;
+use super::connection::convert_tool_annotations;
 use super::mcp_client::McpClient;
-use llm::ToolDefinition;
+use llm::{ToolAnnotations, ToolDefinition};
 use rmcp::{RoleClient, service::RunningService};
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
@@ -113,12 +114,12 @@ impl ToolProxy {
     pub fn call_tool_definition(proxy_name: &str) -> ToolDefinition {
         let schema = Self::call_tool_schema();
         let namespaced_name = format!("{proxy_name}__call_tool");
-        ToolDefinition {
-            name: namespaced_name,
-            description: "Execute a tool on a nested MCP server. Browse the tool-proxy directory to discover available tools first.".to_string(),
-            parameters: Value::Object((*schema).clone()).to_string(),
-            server: Some(proxy_name.to_string()),
-        }
+        ToolDefinition::new(
+            namespaced_name,
+            "Execute a tool on a nested MCP server. Browse the tool-proxy directory to discover available tools first.",
+            Value::Object((*schema).clone()).to_string(),
+        )
+        .with_server(proxy_name.to_string())
     }
 
     /// Write tool entries to `tool_dir/<server_name>/`, removing any stale files first.
@@ -139,6 +140,7 @@ impl ToolProxy {
                 description: tool.description.clone().unwrap_or_default().to_string(),
                 server: server_name.to_string(),
                 parameters: Value::Object((*tool.input_schema).clone()),
+                annotations: tool.annotations.as_ref().map(convert_tool_annotations),
             };
 
             let file_path = server_dir.join(format!("{}.json", tool.name));
@@ -188,6 +190,8 @@ pub struct ToolFileEntry {
     pub description: String,
     pub server: String,
     pub parameters: Value,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub annotations: Option<ToolAnnotations>,
 }
 
 #[cfg(test)]
@@ -209,6 +213,7 @@ mod tests {
                 },
                 "required": ["repo", "title"]
             }),
+            annotations: None,
         };
 
         let json_str = serde_json::to_string_pretty(&entry).unwrap();
@@ -258,6 +263,7 @@ mod tests {
             description: "Does stuff".to_string(),
             server: "test-server".to_string(),
             parameters: json!({"type": "object", "properties": {}}),
+            annotations: None,
         };
 
         let file_path = server_dir.join("my_tool.json");
@@ -303,6 +309,7 @@ mod tests {
             description: "Old tool".to_string(),
             server: "my-server".to_string(),
             parameters: json!({"type": "object", "properties": {}}),
+            annotations: None,
         };
         std::fs::write(server_dir.join("old_tool.json"), serde_json::to_string_pretty(&old_entry).unwrap()).unwrap();
         assert!(server_dir.join("old_tool.json").exists());
@@ -313,6 +320,24 @@ mod tests {
 
         assert!(!server_dir.join("old_tool.json").exists(), "stale file should be removed");
         assert!(server_dir.join("new_tool.json").exists(), "new file should be written");
+    }
+
+    #[tokio::test]
+    async fn write_tool_entries_to_dir_preserves_annotations() {
+        let tmp = tempfile::tempdir().unwrap();
+        let tool_dir = tmp.path().to_path_buf();
+        let tools = vec![
+            rmcp::model::Tool::new("read", "Read", Arc::new(serde_json::Map::new()))
+                .with_annotations(rmcp::model::ToolAnnotations::new().read_only(true).open_world(false)),
+        ];
+
+        ToolProxy::write_tool_entries_to_dir("my-server", &tools, &tool_dir).await.unwrap();
+
+        let contents = std::fs::read_to_string(tool_dir.join("my-server/read.json")).unwrap();
+        let parsed: ToolFileEntry = serde_json::from_str(&contents).unwrap();
+        let annotations = parsed.annotations.expect("annotations should be written");
+        assert_eq!(annotations.read_only_hint, Some(true));
+        assert_eq!(annotations.open_world_hint, Some(false));
     }
 
     fn make_proxy(members: &[&str]) -> ToolProxy {

--- a/website/src/content/docs/aether/settings/mcp-servers.mdx
+++ b/website/src/content/docs/aether/settings/mcp-servers.mdx
@@ -4,10 +4,10 @@ description: Configure the MCP servers that give agents their tools.
 ---
 
 import {
-  Tabs,
-  TabItem,
-  CardGrid,
-  LinkCard,
+    Tabs,
+    TabItem,
+    CardGrid,
+    LinkCard,
 } from "@astrojs/starlight/components";
 
 Agents get tools from MCP (Model Context Protocol) servers. Settings can reference MCP sources from either user settings (`$HOME/.aether/settings.json`) or project settings (`.aether/settings.json`) via `mcps`, and the default project source is usually `.aether/mcp.json`.
@@ -336,6 +336,10 @@ Missing variables are errors; they are not replaced with an empty string. For MC
 
 The `tools` field in an [agent entry](/aether/settings/overview/#agents) restricts which discovered MCP tools the model can use.
 
+Filters can be tool name patterns or (MCP) annotation matchers. `allow` is applied first; `deny` then removes matching tools, so deny wins.
+
+### Name patterns
+
 Tool names use `server__tool` with a double underscore. Patterns support exact names or a trailing `*` prefix wildcard only.
 
 | Pattern             | Matches                              |
@@ -349,7 +353,18 @@ Tool names use `server__tool` with a double underscore. Patterns support exact n
 
 Wildcards are only valid at the end of a pattern.
 
-**Read-only agent:**
+### Annotation matchers
+
+MCP servers can attach tool annotations and you can filter tools based on those:
+
+| Matcher field  | MCP annotation       | Meaning |
+| -------------- | -------------------- | ------- |
+| `readOnly`     | `readOnlyHint`       | The tool should not modify its environment. |
+| `destructive`  | `destructiveHint`    | The tool may perform destructive updates. |
+| `idempotent`   | `idempotentHint`     | Repeated calls with the same arguments should not add effects. |
+| `openWorld`    | `openWorldHint`      | The tool may interact with external systems or the network. |
+
+**Annotation-first read-only agent:**
 
 ```json title=".aether/settings.json"
 {
@@ -362,14 +377,27 @@ Wildcards are only valid at the end of a pattern.
       "prompts": [".aether/READONLY.md"],
       "mcps": [".aether/mcp.json"],
       "tools": {
-        "allow": [
-          "coding__read_file",
-          "coding__list_files",
-          "coding__grep",
-          "coding__find",
-          "coding__lsp_*",
-          "coding__web_*"
-        ]
+        "allow": [{ "readOnly": true }]
+      }
+    }
+  ]
+}
+```
+
+**Read-only tools plus explicit plan tools:**
+
+```json title=".aether/settings.json"
+{
+  "agents": [
+    {
+      "name": "Planner",
+      "description": "Can inspect code and write plan files",
+      "model": "anthropic:claude-sonnet-4-5-20250929",
+      "userInvocable": true,
+      "mcps": [".aether/mcp.json"],
+      "tools": {
+        "allow": [{ "readOnly": true }, "plan__*", "skills__*"],
+        "deny": ["coding__web_*"]
       }
     }
   ]
@@ -391,6 +419,25 @@ Wildcards are only valid at the end of a pattern.
       "tools": {
         "allow": ["coding__*"],
         "deny": ["coding__bash", "coding__read_background_bash"]
+      }
+    }
+  ]
+}
+```
+
+**Deny destructive tools from mixed servers:**
+
+```json title=".aether/settings.json"
+{
+  "agents": [
+    {
+      "name": "SafeOps",
+      "description": "Allows everything except tools annotated as destructive",
+      "model": "anthropic:claude-sonnet-4-5-20250929",
+      "userInvocable": true,
+      "mcps": [".aether/mcp.json"],
+      "tools": {
+        "deny": [{ "destructive": true }]
       }
     }
   ]


### PR DESCRIPTION
This PR adds a feature to `aether-cli` to filter the tools an agent has access to using MCP annotations on the tools, e.g. you can now allow / deny tools with `readOnly`, `destructive` etc. annotations 