### PR TITLE
feat(aether-evals): Drive dockerized agents under eval via ACP

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -2,4 +2,5 @@ target/*
 !target/debug/
 target/debug/*
 !target/debug/aether
+!target/debug/aether-evals-acp-client
 .git/

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -153,9 +153,12 @@ dependencies = [
 name = "aether-evals"
 version = "0.2.3"
 dependencies = [
+ "aether-acp-utils",
  "aether-agent-core",
  "aether-llm",
  "aether-project",
+ "agent-client-protocol",
+ "clap",
  "futures",
  "schemars 1.2.1",
  "serde",
@@ -3352,10 +3355,12 @@ dependencies = [
 name = "internal-evals"
 version = "0.1.0"
 dependencies = [
+ "aether-agent-core",
  "aether-evals",
  "aether-project",
  "serde_json",
  "tempfile",
+ "testcontainers",
  "thiserror 2.0.18",
  "tokio",
 ]

--- a/justfile
+++ b/justfile
@@ -107,9 +107,9 @@ sweep DAYS="7":
 sweep-installed:
     cargo sweep --time 1
 
-# Build the sandbox image from the eval example Dockerfile (copies the aether debug binary)
+# Build the sandbox image from the eval example Dockerfile (copies eval runtime debug binaries)
 build-sandbox TAG="aether-sandbox:latest":
-    cargo build -p aether-agent-cli --bin aether
+    cargo build -p aether-agent-cli --bin aether -p aether-evals --bin aether-evals-acp-client
     docker build -t {{TAG}} -f packages/internal-evals/examples/Dockerfile .
 
 # Run wisp + aether agent inside the sandbox

--- a/packages/acp-utils/src/client/session.rs
+++ b/packages/acp-utils/src/client/session.rs
@@ -14,7 +14,6 @@ use agent_client_protocol::schema::{
     SessionConfigOption, SessionId, SessionNotification, SessionUpdate, SetSessionConfigOptionRequest, TextContent,
 };
 use agent_client_protocol::{self as acp, Client, ConnectionTo, JsonRpcRequest};
-use std::str::FromStr;
 use tokio::sync::mpsc;
 use tracing::info;
 
@@ -38,11 +37,10 @@ pub struct AcpSession {
 /// [`AcpEvent`]s, and tunnels elicitation requests through the `_aether/elicitation`
 /// extension method.
 pub async fn spawn_acp_session(
-    agent_command: &str,
+    agent: TokioAcpAgent,
     init_request: InitializeRequest,
     new_session_request: NewSessionRequest,
 ) -> Result<AcpSession, AcpClientError> {
-    let agent = TokioAcpAgent::from_str(agent_command).map_err(AcpClientError::InvalidAgentCommand)?;
     let (event_tx, event_rx) = mpsc::unbounded_channel::<AcpEvent>();
     let (cmd_tx, cmd_rx) = mpsc::unbounded_channel::<PromptCommand>();
     let (init_tx, mut init_rx) = mpsc::unbounded_channel::<InitializeResult>();

--- a/packages/acp-utils/src/client/tokio_agent.rs
+++ b/packages/acp-utils/src/client/tokio_agent.rs
@@ -7,6 +7,7 @@
 use agent_client_protocol::schema::{McpServer, McpServerStdio};
 use agent_client_protocol::util::internal_error;
 use agent_client_protocol::{AcpAgent, ByteStreams, ConnectTo, Error, Role, util};
+use std::path::PathBuf;
 use std::process::Stdio;
 use std::str::FromStr;
 use tokio::io::{AsyncBufReadExt, BufReader};
@@ -19,6 +20,14 @@ pub struct TokioAcpAgent {
 }
 
 impl TokioAcpAgent {
+    pub fn from_command(command: impl Into<PathBuf>, args: Vec<String>) -> Self {
+        let command = command.into();
+        let name = command.file_name().and_then(|name| name.to_str()).unwrap_or("acp-agent").to_string();
+        let mut stdio = McpServerStdio::new(name, command);
+        stdio.args = args;
+        Self { stdio }
+    }
+
     pub fn stdio(&self) -> &McpServerStdio {
         &self.stdio
     }

--- a/packages/acp-utils/src/lib.rs
+++ b/packages/acp-utils/src/lib.rs
@@ -1,5 +1,9 @@
 #![doc = include_str!("../README.md")]
 
+/// Meta key under which Aether agents publish the machine-readable tool name on an ACP
+/// `ToolCall._meta`, so consumers can recover the original tool name from the humanized title.
+pub const AETHER_TOOL_NAME_META_KEY: &str = "aetherToolName";
+
 pub mod config_meta;
 pub mod config_option_id;
 pub mod content;

--- a/packages/aether-cli/src/acp/protocol/events.rs
+++ b/packages/aether-cli/src/acp/protocol/events.rs
@@ -1,5 +1,7 @@
 use acp_utils::notifications::{ContextClearedParams, ContextUsageParams, SubAgentProgressParams};
-use aether_core::events::{AgentMessage, SubAgentProgressPayload};
+use aether_core::events::{
+    AgentMessage, SubAgentProgressPayload, aether_tool_name_meta, humanize_tool_name, parse_tool_call_chunk,
+};
 use agent_client_protocol::schema::{
     self as acp, Content, ContentBlock, ContentChunk, Diff, MessageId, PlanEntry, PlanEntryPriority, PlanEntryStatus,
     SessionId, SessionNotification, SessionUpdate, StopReason, TextContent, ToolCall, ToolCallContent, ToolCallId,
@@ -191,13 +193,10 @@ fn map_tool_call_to_notification(session_id: SessionId, request: &ToolCallReques
         SessionUpdate::ToolCall(
             ToolCall::new(ToolCallId::new(request.id.clone()), humanize_tool_name(&request.name))
                 .status(acp::ToolCallStatus::InProgress)
-                .raw_input(raw_input),
+                .raw_input(raw_input)
+                .meta(aether_tool_name_meta(&request.name)),
         ),
     )
-}
-
-fn parse_tool_call_chunk(chunk: &str) -> serde_json::Value {
-    serde_json::from_str(chunk).unwrap_or_else(|_| serde_json::Value::String(chunk.to_string()))
 }
 
 fn map_tool_call_update_to_notification(session_id: SessionId, tool_call_id: &str, chunk: &str) -> SessionNotification {
@@ -207,17 +206,6 @@ fn map_tool_call_update_to_notification(session_id: SessionId, tool_call_id: &st
         session_id,
         SessionUpdate::ToolCallUpdate(ToolCallUpdate::new(ToolCallId::new(tool_call_id.to_string()), fields)),
     )
-}
-
-/// Produces the initial human-readable title for a tool call (e.g., "Read file").
-/// This is sent when the tool call starts.
-fn humanize_tool_name(name: &str) -> String {
-    let base = name.split("__").last().unwrap_or(name);
-    let mut result = base.replace('_', " ");
-    if let Some(first) = result.get_mut(0..1) {
-        first.make_ascii_uppercase();
-    }
-    result
 }
 
 fn map_tool_result_to_notification(
@@ -612,6 +600,25 @@ mod tests {
         assert_eq!(humanize_tool_name("read_file"), "Read file");
         assert_eq!(humanize_tool_name("bash"), "Bash");
         assert_eq!(humanize_tool_name("plugins__coding__read_file"), "Read file");
+    }
+
+    #[test]
+    fn test_tool_call_notification_includes_original_tool_name_meta() -> Result<(), String> {
+        let session_id = acp::SessionId::new("test-session");
+        let request = ToolCallRequest {
+            id: "call_1".to_string(),
+            name: "coding__read_file".to_string(),
+            arguments: "{}".to_string(),
+        };
+
+        let notification = map_tool_call_to_notification(session_id, &request);
+        let SessionUpdate::ToolCall(tool_call) = notification.update else {
+            return Err("Expected ToolCall".to_string());
+        };
+        let meta = tool_call.meta.ok_or("meta should be present")?;
+        assert_eq!(meta.get("aetherToolName").and_then(|value| value.as_str()), Some("coding__read_file"));
+        assert_eq!(tool_call.title, "Read file");
+        Ok(())
     }
 
     #[test]

--- a/packages/aether-core/src/events/acp.rs
+++ b/packages/aether-core/src/events/acp.rs
@@ -1,0 +1,452 @@
+use super::AgentMessage;
+use acp_utils::AETHER_TOOL_NAME_META_KEY;
+use agent_client_protocol::schema::{
+    ContentBlock, ContentChunk, Meta, SessionUpdate, StopReason, ToolCall, ToolCallContent, ToolCallStatus,
+    ToolCallUpdate, ToolCallUpdateFields,
+};
+use llm::{ToolCallError, ToolCallRequest, ToolCallResult};
+use std::collections::HashMap;
+
+pub struct AcpAgentMessageMapper {
+    model_name: String,
+    active_message: Option<BufferedMessage>,
+    tool_calls: HashMap<String, ToolCallState>,
+    message_counter: usize,
+}
+
+impl AcpAgentMessageMapper {
+    pub fn new(model_name: impl Into<String>) -> Self {
+        Self { model_name: model_name.into(), active_message: None, tool_calls: HashMap::new(), message_counter: 1 }
+    }
+
+    pub fn map_update(&mut self, update: SessionUpdate) -> Vec<AgentMessage> {
+        match update {
+            SessionUpdate::AgentMessageChunk(chunk) => self.buffer_chunk(&chunk, MessageKind::Text),
+            SessionUpdate::AgentThoughtChunk(chunk) => self.buffer_chunk(&chunk, MessageKind::Thought),
+            SessionUpdate::ToolCall(tool_call) => self.map_tool_call(tool_call),
+            SessionUpdate::ToolCallUpdate(update) => self.map_tool_call_update(update),
+            _ => Vec::new(),
+        }
+    }
+
+    pub fn finish(&mut self, stop_reason: StopReason) -> Vec<AgentMessage> {
+        let mut messages = self.flush_buffered();
+        messages.push(map_stop_reason(stop_reason));
+        messages
+    }
+
+    pub fn flush_buffered(&mut self) -> Vec<AgentMessage> {
+        self.active_message.take().map_or_else(Vec::new, |buffered| vec![buffered.into_agent_message(&self.model_name)])
+    }
+
+    fn buffer_chunk(&mut self, chunk: &ContentChunk, kind: MessageKind) -> Vec<AgentMessage> {
+        let Some(text) = content_block_text(&chunk.content) else { return Vec::new() };
+        let message_id = self.message_id_for(chunk, kind);
+        self.buffer_message(BufferedMessage { kind, message_id, text })
+    }
+
+    fn buffer_message(&mut self, incoming: BufferedMessage) -> Vec<AgentMessage> {
+        if let Some(buffered) = &mut self.active_message
+            && buffered.kind == incoming.kind
+            && buffered.message_id == incoming.message_id
+        {
+            buffered.text.push_str(&incoming.text);
+            return Vec::new();
+        }
+
+        let previous = self.active_message.replace(incoming);
+        previous.map_or_else(Vec::new, |buffered| vec![buffered.into_agent_message(&self.model_name)])
+    }
+
+    fn message_id_for(&mut self, chunk: &ContentChunk, kind: MessageKind) -> String {
+        if let Some(message_id) = &chunk.message_id {
+            return message_id.0.to_string();
+        }
+
+        if let Some(buffered) = &self.active_message
+            && buffered.kind == kind
+        {
+            return buffered.message_id.clone();
+        }
+
+        self.next_message_id()
+    }
+
+    fn next_message_id(&mut self) -> String {
+        let message_id = format!("acp_msg_{}", self.message_counter);
+        self.message_counter += 1;
+        message_id
+    }
+
+    fn map_tool_call(&mut self, tool_call: ToolCall) -> Vec<AgentMessage> {
+        let mut messages = self.flush_buffered();
+        let id = tool_call.tool_call_id.0.to_string();
+        let name = tool_name_from_meta(tool_call.meta.as_ref()).unwrap_or_else(|| tool_call.title.clone());
+        let state = self.tool_calls.entry(id.clone()).or_default();
+        state.apply_tool_call(name, tool_call.raw_input.as_ref(), tool_call.content, tool_call.raw_output);
+
+        messages.push(AgentMessage::ToolCall {
+            request: ToolCallRequest { id, name: state.name(), arguments: state.arguments.clone() },
+            model_name: self.model_name.clone(),
+        });
+        messages
+    }
+
+    fn map_tool_call_update(&mut self, update: ToolCallUpdate) -> Vec<AgentMessage> {
+        let mut messages = self.flush_buffered();
+        let id = update.tool_call_id.0.to_string();
+        let update_result = self.tool_calls.entry(id.clone()).or_default().apply_update(update.fields);
+
+        if update_result.arguments_changed
+            && !update_result.is_terminal()
+            && let Some(state) = self.tool_calls.get(&id)
+        {
+            messages.push(AgentMessage::ToolCallUpdate {
+                tool_call_id: id.clone(),
+                chunk: state.arguments.clone(),
+                model_name: self.model_name.clone(),
+            });
+        }
+
+        match update_result.status {
+            Some(ToolCallStatus::Completed) => {
+                if let Some(state) = self.tool_calls.remove(&id) {
+                    messages.push(state.into_tool_result(id, &self.model_name));
+                }
+            }
+            Some(ToolCallStatus::Failed) => {
+                if let Some(state) = self.tool_calls.remove(&id) {
+                    messages.push(state.into_tool_error(id, &self.model_name));
+                }
+            }
+            _ => {}
+        }
+
+        messages
+    }
+}
+
+pub fn aether_tool_name_meta(name: &str) -> serde_json::Map<String, serde_json::Value> {
+    let mut meta = serde_json::Map::new();
+    meta.insert(AETHER_TOOL_NAME_META_KEY.to_string(), name.to_string().into());
+    meta
+}
+
+pub fn tool_name_from_meta(meta: Option<&Meta>) -> Option<String> {
+    meta?.get(AETHER_TOOL_NAME_META_KEY).and_then(serde_json::Value::as_str).map(ToString::to_string)
+}
+
+pub fn parse_tool_call_chunk(chunk: &str) -> serde_json::Value {
+    serde_json::from_str(chunk).unwrap_or_else(|_| serde_json::Value::String(chunk.to_string()))
+}
+
+pub fn humanize_tool_name(name: &str) -> String {
+    let base = name.split("__").last().unwrap_or(name);
+    let mut result = base.replace('_', " ");
+    if let Some(first) = result.get_mut(0..1) {
+        first.make_ascii_uppercase();
+    }
+    result
+}
+
+struct BufferedMessage {
+    kind: MessageKind,
+    message_id: String,
+    text: String,
+}
+
+impl BufferedMessage {
+    fn into_agent_message(self, model_name: &str) -> AgentMessage {
+        self.kind.into_agent_message(&self.message_id, &self.text, model_name)
+    }
+}
+
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum MessageKind {
+    Text,
+    Thought,
+}
+
+impl MessageKind {
+    fn into_agent_message(self, message_id: &str, text: &str, model_name: &str) -> AgentMessage {
+        match self {
+            MessageKind::Text => AgentMessage::text(message_id, text, true, model_name),
+            MessageKind::Thought => AgentMessage::thought(message_id, text, true, model_name),
+        }
+    }
+}
+
+struct ToolCallState {
+    name: Option<String>,
+    arguments: String,
+    content: Vec<ToolCallContent>,
+    raw_output: Option<serde_json::Value>,
+}
+
+impl Default for ToolCallState {
+    fn default() -> Self {
+        Self { name: None, arguments: value_to_arguments(None), content: Vec::new(), raw_output: None }
+    }
+}
+
+impl ToolCallState {
+    fn apply_tool_call(
+        &mut self,
+        name: String,
+        raw_input: Option<&serde_json::Value>,
+        content: Vec<ToolCallContent>,
+        raw_output: Option<serde_json::Value>,
+    ) {
+        self.name = Some(name);
+        if let Some(raw_input) = raw_input {
+            self.arguments = value_to_arguments(Some(raw_input));
+        }
+        if !content.is_empty() {
+            self.content = content;
+        }
+        if let Some(raw_output) = raw_output {
+            self.raw_output = Some(raw_output);
+        }
+    }
+
+    fn apply_update(&mut self, fields: ToolCallUpdateFields) -> ToolCallUpdateResult {
+        if self.name.is_none() {
+            self.name = fields.title;
+        }
+
+        let arguments_changed = if let Some(raw_input) = &fields.raw_input {
+            self.arguments = value_to_arguments(Some(raw_input));
+            true
+        } else {
+            false
+        };
+
+        if let Some(content) = fields.content {
+            self.content = content;
+        }
+        if let Some(raw_output) = fields.raw_output {
+            self.raw_output = Some(raw_output);
+        }
+
+        ToolCallUpdateResult { status: fields.status, arguments_changed }
+    }
+
+    fn name(&self) -> String {
+        self.name.clone().unwrap_or_else(|| "tool".to_string())
+    }
+
+    fn into_tool_result(self, id: String, model_name: &str) -> AgentMessage {
+        AgentMessage::ToolResult {
+            result: ToolCallResult {
+                id,
+                name: self.name(),
+                arguments: self.arguments,
+                result: tool_result_text(&self.content, self.raw_output.as_ref()),
+            },
+            result_meta: None,
+            model_name: model_name.to_string(),
+        }
+    }
+
+    fn into_tool_error(self, id: String, model_name: &str) -> AgentMessage {
+        AgentMessage::ToolError {
+            error: ToolCallError {
+                id,
+                name: self.name(),
+                arguments: Some(self.arguments),
+                error: tool_result_text(&self.content, self.raw_output.as_ref()),
+            },
+            model_name: model_name.to_string(),
+        }
+    }
+}
+
+struct ToolCallUpdateResult {
+    status: Option<ToolCallStatus>,
+    arguments_changed: bool,
+}
+
+impl ToolCallUpdateResult {
+    fn is_terminal(&self) -> bool {
+        matches!(self.status, Some(ToolCallStatus::Completed | ToolCallStatus::Failed))
+    }
+}
+
+fn map_stop_reason(stop_reason: StopReason) -> AgentMessage {
+    match stop_reason {
+        StopReason::EndTurn => AgentMessage::Done,
+        StopReason::Cancelled => AgentMessage::Cancelled { message: "ACP prompt cancelled".to_string() },
+        StopReason::MaxTokens => AgentMessage::Error { message: "ACP prompt stopped: max_tokens".to_string() },
+        StopReason::MaxTurnRequests => {
+            AgentMessage::Error { message: "ACP prompt stopped: max_turn_requests".to_string() }
+        }
+        StopReason::Refusal => AgentMessage::Error { message: "ACP prompt stopped: refusal".to_string() },
+        _ => AgentMessage::Error { message: format!("ACP prompt stopped: {stop_reason:?}") },
+    }
+}
+
+fn content_block_text(content: &ContentBlock) -> Option<String> {
+    match content {
+        ContentBlock::Text(text) => Some(text.text.clone()),
+        _ => None,
+    }
+}
+
+fn value_to_arguments(value: Option<&serde_json::Value>) -> String {
+    value.map_or_else(|| "{}".to_string(), ToString::to_string)
+}
+
+fn tool_result_text(content: &[ToolCallContent], raw_output: Option<&serde_json::Value>) -> String {
+    let mut parts = content.iter().filter_map(tool_content_text).collect::<Vec<_>>();
+    if let Some(raw_output) = raw_output {
+        parts.push(match raw_output {
+            serde_json::Value::String(s) => s.clone(),
+            value => value.to_string(),
+        });
+    }
+    parts.join("\n")
+}
+
+fn tool_content_text(content: &ToolCallContent) -> Option<String> {
+    match content {
+        ToolCallContent::Content(content) => content_block_text(&content.content),
+        ToolCallContent::Diff(diff) => Some(format!("diff {}\n{}", diff.path.display(), diff.new_text)),
+        _ => None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use agent_client_protocol::schema::{
+        ContentBlock, ContentChunk, MessageId, TextContent, ToolCallId, ToolCallUpdateFields,
+    };
+
+    #[test]
+    fn buffers_text_until_finish() {
+        let mut mapper = AcpAgentMessageMapper::new("model");
+        assert!(mapper.map_update(SessionUpdate::AgentMessageChunk(text_chunk("hello "))).is_empty());
+        assert!(mapper.map_update(SessionUpdate::AgentMessageChunk(text_chunk("world"))).is_empty());
+
+        let messages = mapper.finish(StopReason::EndTurn);
+        assert_eq!(messages, vec![AgentMessage::text("acp_msg_1", "hello world", true, "model"), AgentMessage::Done]);
+    }
+
+    #[test]
+    fn preserves_acp_message_id_when_present() {
+        let mut mapper = AcpAgentMessageMapper::new("model");
+        let chunk = text_chunk("hello").message_id(MessageId::new("msg_42"));
+
+        let messages = mapper.finish_after_update(SessionUpdate::AgentMessageChunk(chunk), StopReason::EndTurn);
+
+        assert_eq!(messages[0], AgentMessage::text("msg_42", "hello", true, "model"));
+    }
+
+    #[test]
+    fn flushes_text_before_tool_call_and_uses_meta_name() {
+        let mut mapper = AcpAgentMessageMapper::new("model");
+        assert!(mapper.map_update(SessionUpdate::AgentMessageChunk(text_chunk("hello"))).is_empty());
+        let tool_call = ToolCall::new(ToolCallId::new("call_1"), "Read file")
+            .raw_input(serde_json::json!({"filePath":"a.txt"}))
+            .meta(aether_tool_name_meta("coding__read_file"));
+
+        let messages = mapper.map_update(SessionUpdate::ToolCall(tool_call));
+        assert_eq!(messages[0], AgentMessage::text("acp_msg_1", "hello", true, "model"));
+        assert!(matches!(&messages[1], AgentMessage::ToolCall { request, .. } if request.name == "coding__read_file"));
+    }
+
+    #[test]
+    fn maps_completed_tool_update_to_result() {
+        let mut mapper = AcpAgentMessageMapper::new("model");
+        mapper.map_update(SessionUpdate::ToolCall(ToolCall::new(ToolCallId::new("call_1"), "tool")));
+        let fields = ToolCallUpdateFields::new()
+            .status(ToolCallStatus::Completed)
+            .content(vec![ToolCallContent::from(ContentBlock::Text(TextContent::new("ok")))]);
+
+        let messages =
+            mapper.map_update(SessionUpdate::ToolCallUpdate(ToolCallUpdate::new(ToolCallId::new("call_1"), fields)));
+        assert!(matches!(&messages[0], AgentMessage::ToolResult { result, .. } if result.result == "ok"));
+    }
+
+    #[test]
+    fn preserves_interleaved_text_and_thought_order() {
+        let mut mapper = AcpAgentMessageMapper::new("model");
+        assert!(mapper.map_update(SessionUpdate::AgentThoughtChunk(text_chunk("thinking"))).is_empty());
+
+        let mut messages = mapper.map_update(SessionUpdate::AgentMessageChunk(text_chunk("answer")));
+        messages.extend(mapper.finish(StopReason::EndTurn));
+
+        assert_eq!(
+            messages,
+            vec![
+                AgentMessage::thought("acp_msg_1", "thinking", true, "model"),
+                AgentMessage::text("acp_msg_2", "answer", true, "model"),
+                AgentMessage::Done,
+            ]
+        );
+    }
+
+    #[test]
+    fn tool_call_merges_with_prior_update_state() {
+        let mut mapper = AcpAgentMessageMapper::new("model");
+        let fields = ToolCallUpdateFields::new()
+            .raw_input(serde_json::json!({"filePath":"a.txt"}))
+            .content(vec![ToolCallContent::from(ContentBlock::Text(TextContent::new("ok")))]);
+        mapper.map_update(SessionUpdate::ToolCallUpdate(ToolCallUpdate::new(ToolCallId::new("call_1"), fields)));
+
+        mapper.map_update(SessionUpdate::ToolCall(ToolCall::new(ToolCallId::new("call_1"), "tool")));
+        let messages = mapper.map_update(SessionUpdate::ToolCallUpdate(ToolCallUpdate::new(
+            ToolCallId::new("call_1"),
+            ToolCallUpdateFields::new().status(ToolCallStatus::Completed),
+        )));
+
+        assert!(
+            matches!(&messages[0], AgentMessage::ToolResult { result, .. } if result.arguments == r#"{"filePath":"a.txt"}"# && result.result == "ok")
+        );
+    }
+
+    #[test]
+    fn terminal_tool_update_removes_state() {
+        let mut mapper = AcpAgentMessageMapper::new("model");
+        mapper.map_update(SessionUpdate::ToolCall(
+            ToolCall::new(ToolCallId::new("call_1"), "tool").raw_input(serde_json::json!({"first":true})),
+        ));
+        mapper.map_update(SessionUpdate::ToolCallUpdate(ToolCallUpdate::new(
+            ToolCallId::new("call_1"),
+            ToolCallUpdateFields::new().status(ToolCallStatus::Completed),
+        )));
+
+        let messages = mapper.map_update(SessionUpdate::ToolCallUpdate(ToolCallUpdate::new(
+            ToolCallId::new("call_1"),
+            ToolCallUpdateFields::new().status(ToolCallStatus::Completed),
+        )));
+
+        assert!(
+            matches!(&messages[0], AgentMessage::ToolResult { result, .. } if result.name == "tool" && result.arguments == "{}")
+        );
+    }
+
+    #[test]
+    fn humanizes_tool_names() {
+        assert_eq!(humanize_tool_name("coding__read_file"), "Read file");
+        assert_eq!(humanize_tool_name("read_file"), "Read file");
+        assert_eq!(humanize_tool_name("bash"), "Bash");
+        assert_eq!(humanize_tool_name("plugins__coding__read_file"), "Read file");
+    }
+
+    trait MapperTestExt {
+        fn finish_after_update(&mut self, update: SessionUpdate, stop_reason: StopReason) -> Vec<AgentMessage>;
+    }
+
+    impl MapperTestExt for AcpAgentMessageMapper {
+        fn finish_after_update(&mut self, update: SessionUpdate, stop_reason: StopReason) -> Vec<AgentMessage> {
+            let mut messages = self.map_update(update);
+            messages.extend(self.finish(stop_reason));
+            messages
+        }
+    }
+
+    fn text_chunk(text: &str) -> ContentChunk {
+        ContentChunk::new(ContentBlock::Text(TextContent::new(text)))
+    }
+}

--- a/packages/aether-core/src/events/mod.rs
+++ b/packages/aether-core/src/events/mod.rs
@@ -4,10 +4,14 @@
 //! - Agent message types (`AgentMessage`, `Command`)
 //! - ACP protocol extension payloads (`SubAgentProgressPayload`)
 
+mod acp;
 mod agent_message;
 mod sub_agent_progress;
 mod user_message;
 
+pub use acp::{
+    AcpAgentMessageMapper, aether_tool_name_meta, humanize_tool_name, parse_tool_call_chunk, tool_name_from_meta,
+};
 pub use agent_message::AgentMessage;
 pub use sub_agent_progress::SubAgentProgressPayload;
 pub use user_message::{AgentCommand, Command, UserCommand};

--- a/packages/aether-evals/Cargo.toml
+++ b/packages/aether-evals/Cargo.toml
@@ -24,6 +24,9 @@ schemars = { workspace = true }
 thiserror = { workspace = true }
 tracing = { workspace = true }
 tempfile = { workspace = true }
+clap = { workspace = true }
+agent-client-protocol = { workspace = true }
+acp_utils = { package = "aether-acp-utils", path = "../acp-utils", version = "0.3.22", features = ["client"] }
 aether-core = { package = "aether-agent-core", path = "../aether-core", version = "0.6.12" }
 aether-project = { path = "../aether-project", version = "0.5.12" }
 llm = { package = "aether-llm", path = "../llm", version = "0.7.11" }

--- a/packages/aether-evals/README.md
+++ b/packages/aether-evals/README.md
@@ -53,7 +53,10 @@ Aether Evals' fake-agent coverage should use normal test names. Reserve `_eval` 
 ## Core API
 
 - `run_eval(&agent, prompt, workspace)` runs one eval and returns an `EvalReport`.
-- `DockerAetherAgent::new(image)` runs `aether headless --output json` in a fresh Testcontainers container for each eval run.
+- `DockerAetherAgent::new(image)` drives the real Aether CLI (`aether acp`) through `aether-evals-acp-client` with an isolated container `AETHER_HOME`.
+- `DockerAgent::new(image, command)` runs a static in-container command that emits `AgentMessage` NDJSON.
+- `DockerAgent::with_command_builder(image, builder)` builds argv per run when the command needs the container cwd or wrapped prompt.
+- `AcpClientCommand::aether(settings, agent)` builds the lower-level ACP client command used by `DockerAetherAgent`.
 - `Workspace::empty()` creates an isolated temp directory.
 - `Workspace::from_dir(path)` copies fixture directory contents into a temp directory.
 - `Workspace::from_git_repo(GitRepoSpec { url, start_commit, gold_commit, subdir })` clones and checks out a git repository.
@@ -61,7 +64,7 @@ Aether Evals' fake-agent coverage should use normal test names. Reserve `_eval` 
 
 ## Dockerized Aether evals
 
-Use `DockerAetherAgent` when an eval should exercise the real Aether CLI in an isolated container. Aether Evals mounts the workspace root at `/workspace`; git-backed workspaces with `GitRepoSpec::subdir` mount the repository root so `.git` remains available while headless runs from the matching relative cwd under `/workspace`.
+Use `DockerAetherAgent` when an eval should exercise the real Aether CLI in an isolated container. Aether Evals mounts the workspace root at `/workspace`; git-backed workspaces with `GitRepoSpec::subdir` mount the repository root so `.git` remains available while Aether runs from the matching relative cwd under `/workspace`. Aether evals drive the CLI through ACP with `aether-evals-acp-client`, while the standalone `aether headless` command remains available for direct CLI use.
 
 ```rust
 use aether_evals::{DockerAetherAgent, DockerImage, GitRepoSpec, Workspace, run_eval};
@@ -70,8 +73,7 @@ use std::path::Path;
 
 let settings = AetherSettings::load_file_for_export(Path::new(".aether/settings.json"))?;
 let agent = DockerAetherAgent::new(DockerImage::new("aether-sandbox", "latest"))
-    .with_settings(settings)
-    .with_agent("Fast");
+    .with_settings(settings);
 
 let report = run_eval(
     &agent,
@@ -85,8 +87,6 @@ let report = run_eval(
 )
 .await?;
 ```
-
-By default the Docker agent forwards provider API key env vars, `OLLAMA_HOST`, and `AETHER_*` except host `AETHER_HOME`. Each run gets a fresh temporary container `AETHER_HOME`; configured settings are passed with `--settings-json`, and `.with_agent(...)` passes `--agent`.
 
 ## Assertions
 

--- a/packages/aether-evals/src/agents/acp_client.rs
+++ b/packages/aether-evals/src/agents/acp_client.rs
@@ -1,0 +1,155 @@
+use super::docker_agent::{AETHER_EVAL_WRAPPED_TASK_PROMPT_ENV, AgentCommandBuilder, DockerCommandConfig};
+use aether_project::AetherSettings;
+use llm::LlmModel;
+use std::{collections::HashMap, env::vars};
+
+pub const CONTAINER_AETHER_HOME: &str = "/root/.aether";
+
+/// Builds the argv that drives an ACP stdio agent through `aether-evals-acp-client`. The agent
+/// argv is passed verbatim after `--`, so no shell quoting is involved.
+pub struct AcpClientCommand {
+    client_command: Vec<String>,
+    model_name: Option<String>,
+    agent_argv: Vec<String>,
+}
+
+impl AcpClientCommand {
+    /// Wrap an arbitrary ACP stdio agent argv (e.g. `["node", "/opt/agent/dist/eval-agent.js"]`).
+    pub fn new(agent_argv: Vec<String>) -> Self {
+        Self { client_command: default_client_command(), model_name: None, agent_argv }
+    }
+
+    /// Wrap the real Aether CLI (`aether acp`) with optional settings and named agent.
+    pub fn aether(settings: Option<AetherSettings>, agent: Option<String>) -> Self {
+        Self::new(aether_acp_agent_argv(settings, agent))
+    }
+
+    /// Override the client invocation. An empty command keeps the `aether-evals-acp-client` default.
+    pub fn with_client_command(mut self, client_command: Option<Vec<String>>) -> Self {
+        if let Some(command) = client_command.filter(|command| !command.is_empty()) {
+            self.client_command = command;
+        }
+        self
+    }
+
+    pub fn with_model_name(mut self, model_name: Option<String>) -> Self {
+        self.model_name = model_name;
+        self
+    }
+}
+
+impl AgentCommandBuilder for AcpClientCommand {
+    fn build(&self, config: DockerCommandConfig<'_>) -> Vec<String> {
+        let mut command = self.client_command.clone();
+        command.extend([
+            "--cwd".to_string(),
+            config.container_cwd.display().to_string(),
+            "--prompt-env".to_string(),
+            AETHER_EVAL_WRAPPED_TASK_PROMPT_ENV.to_string(),
+        ]);
+        if let Some(model_name) = &self.model_name {
+            command.push("--model-name".to_string());
+            command.push(model_name.clone());
+        }
+        command.push("--".to_string());
+        command.extend(self.agent_argv.iter().cloned());
+        command
+    }
+}
+
+pub fn aether_eval_env_vars() -> HashMap<String, String> {
+    let mut env_vars: HashMap<String, String> = vars()
+        .filter(|(key, _)| {
+            key != "AETHER_HOME"
+                && (LlmModel::ALL_REQUIRED_ENV_VARS.contains(&key.as_str())
+                    || key == "OLLAMA_HOST"
+                    || key.starts_with("AETHER_"))
+        })
+        .collect();
+    env_vars.insert("AETHER_HOME".to_string(), CONTAINER_AETHER_HOME.to_string());
+    env_vars
+}
+
+fn aether_acp_agent_argv(settings: Option<AetherSettings>, agent: Option<String>) -> Vec<String> {
+    let mut argv = vec!["aether".to_string(), "acp".to_string()];
+    if let Some(agent) = agent {
+        argv.push("--agent".to_string());
+        argv.push(agent);
+    }
+    if let Some(settings) = settings {
+        argv.push("--settings-json".to_string());
+        argv.push(serde_json::to_string(&settings).expect("AetherSettings should serialize to JSON"));
+    }
+    argv
+}
+
+fn default_client_command() -> Vec<String> {
+    vec!["aether-evals-acp-client".to_string()]
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::path::Path;
+
+    fn build(command: &AcpClientCommand) -> Vec<String> {
+        command.build(DockerCommandConfig { container_cwd: Path::new("/workspace") })
+    }
+
+    #[test]
+    fn aether_eval_env_vars_sets_container_aether_home() {
+        let env_vars = aether_eval_env_vars();
+
+        assert_eq!(env_vars.get("AETHER_HOME").map(String::as_str), Some(CONTAINER_AETHER_HOME));
+    }
+
+    #[test]
+    fn aether_wraps_acp_with_agent_and_settings() {
+        let command = build(&AcpClientCommand::aether(Some(AetherSettings::default()), Some("Fast Agent".to_string())));
+
+        assert_eq!(command[0], "aether-evals-acp-client");
+        assert_eq!(command[1], "--cwd");
+        assert_eq!(command[2], "/workspace");
+
+        let separator = command.iter().position(|arg| arg == "--").expect("agent argv is passed after `--`");
+        let agent_argv = &command[separator + 1..];
+        assert_eq!(agent_argv[0], "aether");
+        assert_eq!(agent_argv[1], "acp");
+        assert_eq!(agent_argv[2], "--agent");
+        assert_eq!(agent_argv[3], "Fast Agent");
+        assert_eq!(agent_argv[4], "--settings-json");
+        assert!(!command.iter().any(|arg| arg.contains("headless")));
+    }
+
+    #[test]
+    fn aether_omits_agent_and_settings_flags_when_absent() {
+        let command = AcpClientCommand::aether(None, None)
+            .build(DockerCommandConfig { container_cwd: Path::new("/workspace/subdir") });
+
+        let separator = command.iter().position(|arg| arg == "--").unwrap();
+        assert_eq!(&command[separator + 1..], &["aether".to_string(), "acp".to_string()]);
+        assert!(command.contains(&"/workspace/subdir".to_string()));
+        assert!(!command.iter().any(|arg| arg == "--model-name"));
+    }
+
+    #[test]
+    fn wraps_arbitrary_agent_with_client_override_and_model_name() {
+        let command = build(
+            &AcpClientCommand::new(vec!["node".to_string(), "/opt/agent/dist/eval-agent.js".to_string()])
+                .with_client_command(Some(vec!["/bin/acp-client".to_string()]))
+                .with_model_name(Some("typescript-acp-agent".to_string())),
+        );
+
+        assert_eq!(command[0], "/bin/acp-client");
+        assert!(command.windows(2).any(|w| w == ["--model-name", "typescript-acp-agent"]));
+        let separator = command.iter().position(|arg| arg == "--").expect("agent argv is passed after `--`");
+        assert_eq!(&command[separator + 1..], &["node".to_string(), "/opt/agent/dist/eval-agent.js".to_string()]);
+    }
+
+    #[test]
+    fn empty_client_command_override_keeps_default() {
+        let command = build(&AcpClientCommand::new(vec!["agent".to_string()]).with_client_command(Some(Vec::new())));
+
+        assert_eq!(command[0], "aether-evals-acp-client");
+    }
+}

--- a/packages/aether-evals/src/agents/docker.rs
+++ b/packages/aether-evals/src/agents/docker.rs
@@ -100,11 +100,11 @@ pub enum DockerError {
         source: std::io::Error,
     },
 
-    #[error("Aether headless exited without completing: {stderr}")]
-    HeadlessExit { stderr: String },
+    #[error("Docker command exited without emitting a terminal AgentMessage: {stderr}")]
+    CommandExitWithoutTerminal { stderr: String },
 
-    #[error("Aether headless emitted invalid JSON line: {line}")]
-    HeadlessJsonLine {
+    #[error("Docker command emitted invalid AgentMessage JSON line: {line}")]
+    AgentMessageJsonLine {
         line: String,
         #[source]
         source: serde_json::Error,

--- a/packages/aether-evals/src/agents/docker_aether_agent.rs
+++ b/packages/aether-evals/src/agents/docker_aether_agent.rs
@@ -1,12 +1,10 @@
-use super::docker::{Docker, DockerExecConfig};
-use super::transcript::is_terminal;
-use super::{Agent, AgentConfig, DockerError, DockerImage, RunError, build_task_prompt};
+use super::{
+    AcpClientCommand, Agent, AgentConfig, CONTAINER_AETHER_HOME, DockerAgent, DockerError, DockerImage, RunError,
+    aether_eval_env_vars,
+};
 use aether_core::events::AgentMessage;
 use aether_project::AetherSettings;
-use llm::LlmModel;
-use std::path::{Path, PathBuf};
 use testcontainers::core::Mount;
-use tokio::io::{AsyncBufRead, AsyncBufReadExt};
 use tokio::sync::mpsc::Sender;
 
 pub struct DockerAetherAgent {
@@ -29,89 +27,18 @@ impl DockerAetherAgent {
         self.agent = Some(agent.into());
         self
     }
-
-    fn build_command(&self, task_prompt: &str, container_cwd: &Path) -> Vec<String> {
-        let mut command = vec![
-            "aether".to_string(),
-            "headless".to_string(),
-            "--cwd".to_string(),
-            container_cwd.display().to_string(),
-        ];
-
-        if let Some(agent) = &self.agent {
-            command.push("--agent".to_string());
-            command.push(agent.clone());
-        }
-
-        command.extend(["--output".to_string(), "json".to_string()]);
-
-        if let Some(settings) = &self.settings {
-            command.push("--settings-json".to_string());
-            command.push(serde_json::to_string(settings).expect("AetherSettings should serialize to JSON"));
-        }
-        command.push(build_task_prompt(task_prompt, container_cwd));
-        command
-    }
 }
 
 impl Agent for DockerAetherAgent {
     async fn run(&self, config: AgentConfig<'_>, tx: Sender<AgentMessage>) -> Result<(), RunError> {
         let aether_home = tempfile::tempdir().map_err(|source| DockerError::AetherHomeTempDir { source })?;
-        let docker = {
-            let mut docker = Docker::new(self.image.clone())
-                .with_env_var("AETHER_HOME", "/root/.aether")
-                .with_mount(Mount::bind_mount(aether_home.path().display().to_string(), "/root/.aether"));
+        let agent = DockerAgent::with_command_builder(
+            self.image.clone(),
+            AcpClientCommand::aether(self.settings.clone(), self.agent.clone()),
+        )
+        .with_env_vars(aether_eval_env_vars())
+        .with_mount(Mount::bind_mount(aether_home.path().display().to_string(), CONTAINER_AETHER_HOME));
 
-            for (key, value) in std::env::vars().filter(|(key, _)| {
-                key != "AETHER_HOME"
-                    && (LlmModel::ALL_REQUIRED_ENV_VARS.contains(&key.as_str())
-                        || key == "OLLAMA_HOST"
-                        || key.starts_with("AETHER_"))
-            }) {
-                docker = docker.with_env_var(key, value);
-            }
-
-            docker
-        };
-
-        let container_cwd = config
-            .relative_cwd
-            .map_or_else(|| PathBuf::from("/workspace"), |relative_cwd| Path::new("/workspace").join(relative_cwd));
-
-        let command = self.build_command(config.task_prompt, &container_cwd);
-        let (sent_terminal, stderr) = {
-            let mut session = docker.exec(DockerExecConfig { workspace_root: config.workspace_root, command }).await?;
-            let sent_terminal = forward_stdout_messages(session.stdout(), &tx).await?;
-
-            (sent_terminal, session.stderr_to_string().await?)
-        };
-
-        if !stderr.trim().is_empty() {
-            tracing::debug!("aether headless stderr: {}", stderr.trim());
-        }
-
-        if sent_terminal { Ok(()) } else { Err(DockerError::HeadlessExit { stderr }.into()) }
+        agent.run(config, tx).await
     }
-}
-
-async fn forward_stdout_messages<T: AsyncBufRead + Unpin>(
-    reader: T,
-    tx: &Sender<AgentMessage>,
-) -> Result<bool, RunError> {
-    let mut lines = reader.lines();
-    while let Some(line) = lines.next_line().await.map_err(|source| DockerError::StdoutRead { source })? {
-        if line.trim().is_empty() {
-            continue;
-        }
-        tracing::debug!("aether headless: {line}");
-        let message: AgentMessage =
-            serde_json::from_str(&line).map_err(|source| DockerError::HeadlessJsonLine { line, source })?;
-        let terminal = is_terminal(&message);
-        tx.send(message).await.map_err(|error| RunError::ChannelSendFailed(error.to_string()))?;
-        if terminal {
-            return Ok(true);
-        }
-    }
-
-    Ok(false)
 }

--- a/packages/aether-evals/src/agents/docker_agent.rs
+++ b/packages/aether-evals/src/agents/docker_agent.rs
@@ -1,0 +1,157 @@
+use super::docker::{Docker, DockerExecConfig};
+use super::transcript::is_terminal;
+use super::{Agent, AgentConfig, DockerError, DockerImage, RunError, build_task_prompt};
+use aether_core::events::AgentMessage;
+use std::collections::HashMap;
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+use testcontainers::core::Mount;
+use tokio::io::{AsyncBufRead, AsyncBufReadExt};
+use tokio::sync::mpsc::Sender;
+
+/// Environment variable through which `DockerAgent` hands the wrapped task prompt to the
+/// in-container command. Shared with `aether-evals-acp-client`, which reads it back.
+pub const AETHER_EVAL_WRAPPED_TASK_PROMPT_ENV: &str = "AETHER_EVAL_WRAPPED_TASK_PROMPT";
+
+pub struct DockerAgent {
+    image: DockerImage,
+    command: Arc<dyn AgentCommandBuilder>,
+    env_vars: HashMap<String, String>,
+    mounts: Vec<Mount>,
+}
+
+pub struct DockerCommandConfig<'a> {
+    pub container_cwd: &'a Path,
+}
+
+pub trait AgentCommandBuilder: Send + Sync {
+    fn build(&self, config: DockerCommandConfig<'_>) -> Vec<String>;
+}
+
+impl DockerAgent {
+    pub fn new(image: DockerImage, command: Vec<String>) -> Self {
+        Self::with_command_builder(image, command)
+    }
+
+    pub fn with_command_builder(image: DockerImage, builder: impl AgentCommandBuilder + 'static) -> Self {
+        Self { image, command: Arc::new(builder), env_vars: HashMap::new(), mounts: Vec::new() }
+    }
+
+    pub fn with_env_var(mut self, key: impl Into<String>, value: impl Into<String>) -> Self {
+        self.env_vars.insert(key.into(), value.into());
+        self
+    }
+
+    pub fn with_env_vars(mut self, env_vars: HashMap<String, String>) -> Self {
+        self.env_vars.extend(env_vars);
+        self
+    }
+
+    pub fn with_mount(mut self, mount: Mount) -> Self {
+        self.mounts.push(mount);
+        self
+    }
+}
+
+impl AgentCommandBuilder for Vec<String> {
+    fn build(&self, _config: DockerCommandConfig<'_>) -> Vec<String> {
+        self.clone()
+    }
+}
+
+impl Agent for DockerAgent {
+    async fn run(&self, config: AgentConfig<'_>, tx: Sender<AgentMessage>) -> Result<(), RunError> {
+        let container_workspace_root = Path::new("/workspace");
+        let container_cwd = container_cwd(container_workspace_root, config.relative_cwd);
+        let wrapped_task_prompt = build_task_prompt(config.task_prompt, &container_cwd);
+        let command = self.command.build(DockerCommandConfig { container_cwd: &container_cwd });
+
+        let mut docker = Docker::new(self.image.clone())
+            .with_env_var("AETHER_EVAL_WORKSPACE_ROOT", container_workspace_root.display().to_string())
+            .with_env_var("AETHER_EVAL_CWD", container_cwd.display().to_string())
+            .with_env_var("AETHER_EVAL_TASK_PROMPT", config.task_prompt)
+            .with_env_var(AETHER_EVAL_WRAPPED_TASK_PROMPT_ENV, wrapped_task_prompt);
+
+        for mount in &self.mounts {
+            docker = docker.with_mount(mount.clone());
+        }
+
+        for (key, value) in &self.env_vars {
+            docker = docker.with_env_var(key.clone(), value.clone());
+        }
+
+        let (sent_terminal, stderr) = {
+            let mut session = docker.exec(DockerExecConfig { workspace_root: config.workspace_root, command }).await?;
+            let sent_terminal = forward_stdout_messages(session.stdout(), &tx).await?;
+            (sent_terminal, session.stderr_to_string().await?)
+        };
+
+        if !stderr.trim().is_empty() {
+            tracing::debug!("docker agent stderr: {}", stderr.trim());
+        }
+
+        if sent_terminal { Ok(()) } else { Err(DockerError::CommandExitWithoutTerminal { stderr }.into()) }
+    }
+}
+
+async fn forward_stdout_messages<T: AsyncBufRead + Unpin>(
+    reader: T,
+    tx: &Sender<AgentMessage>,
+) -> Result<bool, RunError> {
+    let mut lines = reader.lines();
+    while let Some(line) = lines.next_line().await.map_err(|source| DockerError::StdoutRead { source })? {
+        if line.trim().is_empty() {
+            continue;
+        }
+        tracing::debug!("docker agent stdout: {line}");
+        let message: AgentMessage =
+            serde_json::from_str(&line).map_err(|source| DockerError::AgentMessageJsonLine { line, source })?;
+        let terminal = is_terminal(&message);
+        tx.send(message).await.map_err(|error| RunError::ChannelSendFailed(error.to_string()))?;
+        if terminal {
+            return Ok(true);
+        }
+    }
+
+    Ok(false)
+}
+
+fn container_cwd(container_workspace_root: &Path, relative_cwd: Option<&Path>) -> PathBuf {
+    relative_cwd.map_or_else(
+        || container_workspace_root.to_path_buf(),
+        |relative_cwd| container_workspace_root.join(relative_cwd),
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn with_env_vars_merges_explicit_container_env() {
+        let agent = DockerAgent::new(DockerImage::new("sandbox", "latest"), vec!["agent".to_string()])
+            .with_env_var("ONE", "1")
+            .with_env_vars(HashMap::from([("TWO".to_string(), "2".to_string())]));
+
+        assert_eq!(agent.env_vars.get("ONE"), Some(&"1".to_string()));
+        assert_eq!(agent.env_vars.get("TWO"), Some(&"2".to_string()));
+    }
+
+    #[test]
+    fn static_vec_command_is_returned_as_argv() {
+        let command = vec!["print-agent-messages".to_string()]
+            .build(DockerCommandConfig { container_cwd: Path::new("/workspace") });
+
+        assert_eq!(command, vec!["print-agent-messages".to_string()]);
+    }
+
+    #[test]
+    fn container_cwd_uses_workspace_root_when_no_relative_cwd() {
+        assert_eq!(container_cwd(Path::new("/workspace"), None), Path::new("/workspace"));
+    }
+
+    #[test]
+    fn container_cwd_joins_relative_cwd() {
+        assert_eq!(container_cwd(Path::new("/workspace"), Some(Path::new("subdir"))), Path::new("/workspace/subdir"));
+    }
+}

--- a/packages/aether-evals/src/agents/mod.rs
+++ b/packages/aether-evals/src/agents/mod.rs
@@ -1,13 +1,17 @@
+mod acp_client;
 mod agent;
 mod docker;
 mod docker_aether_agent;
+mod docker_agent;
 mod fake_agent;
 mod image_builder;
 mod transcript;
 
+pub use acp_client::{AcpClientCommand, CONTAINER_AETHER_HOME, aether_eval_env_vars};
 pub use agent::{Agent, AgentConfig, RunError};
 pub use docker::{DockerError, DockerImage, DockerImageParseError};
 pub use docker_aether_agent::DockerAetherAgent;
+pub use docker_agent::{AETHER_EVAL_WRAPPED_TASK_PROMPT_ENV, AgentCommandBuilder, DockerAgent, DockerCommandConfig};
 pub use fake_agent::FakeAgent;
 pub use image_builder::{ImageBuildError, ImageBuildRequest, build_images};
 

--- a/packages/aether-evals/src/bin/aether-evals-acp-client.rs
+++ b/packages/aether-evals/src/bin/aether-evals-acp-client.rs
@@ -1,0 +1,107 @@
+use acp_utils::client::{AcpEvent, TokioAcpAgent, spawn_acp_session};
+use aether_core::events::AcpAgentMessageMapper;
+use aether_evals::AETHER_EVAL_WRAPPED_TASK_PROMPT_ENV;
+use agent_client_protocol::schema::{Implementation, InitializeRequest, NewSessionRequest, ProtocolVersion};
+use clap::Parser;
+use std::path::PathBuf;
+
+#[derive(Debug, Parser)]
+struct Args {
+    #[arg(long)]
+    cwd: PathBuf,
+    #[arg(long, default_value_t = AETHER_EVAL_WRAPPED_TASK_PROMPT_ENV.to_string())]
+    prompt_env: String,
+    #[arg(long)]
+    model_name: Option<String>,
+    /// The ACP agent argv, provided after `--` (e.g. `-- aether acp --agent Fast`). Passed to the
+    /// agent process verbatim, with no shell parsing.
+    #[arg(last = true, required = true)]
+    agent_command: Vec<String>,
+}
+
+#[tokio::main]
+async fn main() {
+    if let Err(error) = run().await {
+        eprintln!("{error}");
+        std::process::exit(1);
+    }
+}
+
+async fn run() -> Result<(), ClientError> {
+    let args = Args::parse();
+    let prompt = std::env::var(&args.prompt_env).map_err(|_| ClientError::MissingPromptEnv(args.prompt_env.clone()))?;
+    let (command, agent_args) = args.agent_command.split_first().ok_or(ClientError::EmptyAgentCommand)?;
+    let init_request = InitializeRequest::new(ProtocolVersion::LATEST)
+        .client_info(Implementation::new("aether-evals-acp-client", env!("CARGO_PKG_VERSION")));
+    let new_session_request = NewSessionRequest::new(args.cwd);
+    let agent = TokioAcpAgent::from_command(command.clone(), agent_args.to_vec());
+    let mut session = spawn_acp_session(agent, init_request, new_session_request).await?;
+    let model_name = args.model_name.unwrap_or_else(|| session.agent_name.clone());
+    let mut mapper = AcpAgentMessageMapper::new(model_name);
+
+    session.prompt_handle.prompt(&session.session_id, &prompt, None)?;
+
+    while let Some(event) = session.event_rx.recv().await {
+        match event {
+            AcpEvent::SessionUpdate { update, .. } => print_messages(mapper.map_update(*update))?,
+            AcpEvent::PromptDone(stop_reason) => {
+                print_messages(mapper.finish(stop_reason))?;
+                return Ok(());
+            }
+            AcpEvent::PromptError(error) => {
+                let mut messages = mapper.flush_buffered();
+                messages.push(aether_core::events::AgentMessage::Error { message: error.to_string() });
+                print_messages(messages)?;
+                return Ok(());
+            }
+            AcpEvent::ContextCleared(_) => print_message(&aether_core::events::AgentMessage::ContextCleared)?,
+            AcpEvent::ConnectionClosed => return Err(ClientError::ConnectionClosed),
+            AcpEvent::ContextUsage(_)
+            | AcpEvent::SubAgentProgress(_)
+            | AcpEvent::AuthMethodsUpdated(_)
+            | AcpEvent::McpNotification(_)
+            | AcpEvent::ElicitationRequest { .. }
+            | AcpEvent::AuthenticateComplete { .. }
+            | AcpEvent::AuthenticateFailed { .. }
+            | AcpEvent::SessionsListed { .. }
+            | AcpEvent::SessionLoaded { .. }
+            | AcpEvent::NewSessionCreated { .. }
+            | AcpEvent::PromptSearchResults(_)
+            | AcpEvent::PromptSearchFailed { .. }
+            | AcpEvent::SessionPreviewLoaded(_)
+            | AcpEvent::SessionPreviewFailed { .. }
+            | AcpEvent::WorkspacesListed(_)
+            | AcpEvent::WorkspaceListFailed { .. }
+            | AcpEvent::WorkspaceMoved(_)
+            | AcpEvent::WorkspaceMoveFailed { .. } => {}
+        }
+    }
+
+    Err(ClientError::ConnectionClosed)
+}
+
+fn print_messages(messages: Vec<aether_core::events::AgentMessage>) -> Result<(), ClientError> {
+    for message in messages {
+        print_message(&message)?;
+    }
+    Ok(())
+}
+
+fn print_message(message: &aether_core::events::AgentMessage) -> Result<(), ClientError> {
+    println!("{}", serde_json::to_string(message)?);
+    Ok(())
+}
+
+#[derive(Debug, thiserror::Error)]
+enum ClientError {
+    #[error("prompt environment variable `{0}` is not set")]
+    MissingPromptEnv(String),
+    #[error("no agent command provided after `--`")]
+    EmptyAgentCommand,
+    #[error("ACP connection closed before prompt completed")]
+    ConnectionClosed,
+    #[error(transparent)]
+    Acp(#[from] acp_utils::client::AcpClientError),
+    #[error(transparent)]
+    Json(#[from] serde_json::Error),
+}

--- a/packages/aether-evals/src/lib.rs
+++ b/packages/aether-evals/src/lib.rs
@@ -6,7 +6,9 @@ mod git_repo;
 mod spec;
 
 pub use agents::{
-    Agent, AgentConfig, DockerAetherAgent, DockerImage, DockerImageParseError, FakeAgent, ImageBuildError, RunError,
+    AETHER_EVAL_WRAPPED_TASK_PROMPT_ENV, AcpClientCommand, Agent, AgentCommandBuilder, AgentConfig,
+    CONTAINER_AETHER_HOME, DockerAetherAgent, DockerAgent, DockerCommandConfig, DockerImage, DockerImageParseError,
+    FakeAgent, ImageBuildError, RunError, aether_eval_env_vars,
 };
 pub use assertions::{assert_tool_call_count, assert_tool_call_with_args, assert_tool_called};
 pub use error::{EvalRunError, WorkspaceError};

--- a/packages/aether-evals/src/spec/mod.rs
+++ b/packages/aether-evals/src/spec/mod.rs
@@ -33,7 +33,7 @@ pub(crate) struct EvalCase {
 }
 
 /// A declarative eval file, authored as JSON, that describes one scenario to run against a
-/// Dockerized `aether headless` agent.
+/// Dockerized agent.
 #[derive(Debug, Clone, Deserialize)]
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
 pub(crate) struct EvalSpec {
@@ -41,7 +41,7 @@ pub(crate) struct EvalSpec {
     #[serde(default)]
     pub docker: Option<DockerSpec>,
 
-    /// Named agent from settings to pass through to `aether headless --agent`.
+    /// Named agent from settings to pass through to `aether acp --agent`.
     #[serde(default)]
     pub agent: Option<String>,
 
@@ -107,11 +107,9 @@ impl EvalCase {
         if let Some(settings) = &self.settings {
             agent = agent.with_settings(settings.clone());
         }
-
-        if let Some(agent_name) = self.eval.agent.as_deref() {
-            agent = agent.with_agent(agent_name);
+        if let Some(agent_name) = &self.eval.agent {
+            agent = agent.with_agent(agent_name.clone());
         }
-
         Ok(agent)
     }
 
@@ -328,9 +326,13 @@ mod tests {
 
     #[test]
     fn rejects_unknown_fields() {
-        let result: Result<EvalSpec, _> =
-            serde_json::from_str(r#"{"docker":{"image":"sandbox:latest"},"name":"c","prompt":"p","bogus":true}"#);
-        assert!(result.is_err());
+        for json in [
+            r#"{"docker":{"image":"sandbox:latest"},"name":"c","prompt":"p","bogus":true}"#,
+            r#"{"docker":{"image":"sandbox:latest"},"name":"c","prompt":"p","runtime":{"type":"acp","command":["a"]}}"#,
+        ] {
+            let result: Result<EvalSpec, _> = serde_json::from_str(json);
+            assert!(result.is_err());
+        }
     }
 
     #[test]

--- a/packages/aether-evals/tests/docker_agent_tests.rs
+++ b/packages/aether-evals/tests/docker_agent_tests.rs
@@ -5,7 +5,7 @@ use aether_evals::{DockerAetherAgent, DockerImage, Workspace, run_eval};
 use aether_project::{AetherSettings, AgentConfig as AetherAgentConfig, PromptSource};
 
 #[tokio::test]
-async fn docker_aether_agent_eval() -> Result<(), aether_evals::EvalRunError> {
+async fn docker_agent_aether_acp_eval() -> Result<(), aether_evals::EvalRunError> {
     if var("AETHER_RUN_DOCKER_TESTS").ok().as_deref() != Some("1") {
         eprintln!("skipping Docker eval test; set AETHER_RUN_DOCKER_TESTS=1 to run");
         return Ok(());

--- a/packages/internal-evals/Cargo.toml
+++ b/packages/internal-evals/Cargo.toml
@@ -11,9 +11,11 @@ dist = false
 workspace = true
 
 [dev-dependencies]
+aether-core = { package = "aether-agent-core", path = "../aether-core" }
 aether-evals = { path = "../aether-evals" }
 aether-project = { path = "../aether-project" }
 serde_json = { workspace = true }
 tempfile = { workspace = true }
+testcontainers = { workspace = true }
 thiserror = { workspace = true }
 tokio = { workspace = true }

--- a/packages/internal-evals/README.md
+++ b/packages/internal-evals/README.md
@@ -39,9 +39,9 @@ just evals-list
 
 ## Docker and agent configuration
 
-All evals in this repo run in the `aether-sandbox:latest` image, built from [`examples/Dockerfile`](examples/Dockerfile). `just evals` builds it (via `just build-sandbox`) before running anything, so a fresh checkout works without manual setup. The example eval also points `docker.file` at the same Dockerfile, so running it standalone with `aether eval` builds the identical image. The evals crate loads repo `.aether/settings.json` and passes it to Dockerized headless with `--settings-json`.
+All evals in this repo run in the `aether-sandbox:latest` image, built from [`examples/Dockerfile`](examples/Dockerfile). `just evals` builds it (via `just build-sandbox`) before running anything, so a fresh checkout works without manual setup. The example eval also points `docker.file` at the same Dockerfile, so running it standalone with `aether eval` builds the identical image. The evals crate loads repo `.aether/settings.json` and passes it to Dockerized Aether ACP with `--settings-json`.
 
-Set `AETHER_EVAL_AGENT` to pass `--agent` through to `aether headless`:
+Set `AETHER_EVAL_AGENT` to pass `--agent` through to `aether acp`:
 
 ```bash
 AETHER_EVAL_AGENT="Fast" just evals
@@ -51,7 +51,7 @@ AETHER_EVAL_AGENT="Fast" just evals
 
 - Put real LLM scenarios in `packages/internal-evals/tests` or add declarative `*.eval.json` files under `packages/internal-evals/examples`; shared Rust setup code lives in `tests/common`.
 - `just evals` runs tests ending in `_eval` with nextest's default filter disabled and the `evals` group selected; keep that suffix for real provider-backed eval tests.
-- Prefer `aether_evals::DockerAetherAgent` and settings-driven MCP wiring over fake agents.
+- Prefer `aether_evals::DockerAetherAgent` with settings-driven MCP wiring over fake agents.
 - Run the agent with `aether_evals::run_eval(&agent, prompt, workspace).await?`.
 - Assert Aether namespaced MCP tool names, such as `coding__read_file` and `coding__edit_file`, with `EvalReport` helpers.
 - Prefer direct filesystem assertions over shell commands for file outcomes.

--- a/packages/internal-evals/examples/Dockerfile
+++ b/packages/internal-evals/examples/Dockerfile
@@ -1,8 +1,9 @@
 # The repository sandbox image, also serving as the example for `aether eval`.
 #
-# The only hard requirement is that the `aether` binary is on the container's PATH —
-# `aether eval` runs `aether headless` inside this image for every case. Install whatever
-# toolchain your repo's evals need (python, node, a JDK, build tools, ...).
+# The only hard requirement is that the `aether` binary and `aether-evals-acp-client`
+# are on the container's PATH — `aether eval` drives `aether acp` inside this image
+# for every case. Install whatever toolchain your repo's evals need (python, node,
+# a JDK, build tools, ...).
 #
 # Build it with `just build-sandbox`, or point an eval file at this file with
 # `"docker": { "file": "Dockerfile", "context": "../../.." }` (paths relative to the eval file).
@@ -16,9 +17,11 @@ RUN pacman -Syu --noconfirm ca-certificates git dbus \
 # Install your project's toolchain here, e.g.:
 # RUN apt-get update && apt-get install -y python3 python3-pip
 
-# Provide the aether binary from the repository build output. Run
-# `cargo build -p aether-agent-cli --bin aether` before this image builds.
+# Provide the aether and eval ACP client binaries from the repository build output. Run
+# `cargo build -p aether-agent-cli --bin aether -p aether-evals --bin aether-evals-acp-client`
+# before this image builds.
 COPY target/debug/aether /usr/local/bin/aether
+COPY target/debug/aether-evals-acp-client /usr/local/bin/aether-evals-acp-client
 
 WORKDIR /workspace
 

--- a/packages/internal-evals/tests/common/mod.rs
+++ b/packages/internal-evals/tests/common/mod.rs
@@ -20,7 +20,6 @@ pub fn create_aether_agent() -> Result<DockerAetherAgent, EvalHarnessError> {
     let image = DockerImage::new("aether-sandbox", "latest");
     let settings = load_repo_eval_settings()?;
     let agent = DockerAetherAgent::new(image).with_settings(settings);
-
     Ok(match eval_agent_name() {
         Some(agent_name) => agent.with_agent(agent_name),
         None => agent,

--- a/packages/wisp/src/runtime_state.rs
+++ b/packages/wisp/src/runtime_state.rs
@@ -2,12 +2,13 @@ use crate::cli::Cli;
 use crate::error::AppError;
 use crate::settings::{StatusLineSettings, WispSettings};
 use crate::workspace_status::WorkspaceStatus;
-use acp_utils::client::{AcpEvent, AcpPromptHandle, spawn_acp_session};
+use acp_utils::client::{AcpClientError, AcpEvent, AcpPromptHandle, TokioAcpAgent, spawn_acp_session};
 use agent_client_protocol::schema::{
     AuthMethod, Implementation, InitializeRequest, NewSessionRequest, PromptCapabilities, ProtocolVersion,
     SessionCapabilities, SessionConfigOption, SessionId,
 };
 use std::env::current_dir;
+use std::str::FromStr;
 use tokio::sync::mpsc;
 use tui::Theme;
 
@@ -35,8 +36,8 @@ impl RuntimeState {
         let init_request = InitializeRequest::new(ProtocolVersion::LATEST)
             .client_info(Implementation::new("wisp", env!("CARGO_PKG_VERSION")));
 
-        let session =
-            spawn_acp_session(agent_command, init_request, new_session_request).await.map_err(AppError::Acp)?;
+        let agent = TokioAcpAgent::from_str(agent_command).map_err(AcpClientError::InvalidAgentCommand)?;
+        let session = spawn_acp_session(agent, init_request, new_session_request).await.map_err(AppError::Acp)?;
 
         let theme = crate::settings::load_theme(&settings);
 

--- a/website/src/content/docs/aether/running/evals.mdx
+++ b/website/src/content/docs/aether/running/evals.mdx
@@ -3,7 +3,7 @@ title: Evals
 description: Build and run CLI evals for Aether agents in Docker sandboxes.
 ---
 
-`aether eval` runs regression tests for Aether agents. Each eval creates a workspace, runs `aether headless --output json` in a fresh Docker container, then checks the agent's tool calls and file changes.
+`aether eval` evals for Aether agents. Each eval creates a workspace, drives `aether acp` through `aether-evals-acp-client` in a fresh Docker container, then checks the agent's tool calls and file changes.
 
 ## Overview
 
@@ -30,7 +30,7 @@ Each `*.eval.json` file defines one scenario: the sandbox image to run in, the p
 
 ## Dockerfiles
 
-Each eval runs inside Docker. The image must contain the `aether` binary because the eval runner starts the agent by executing `aether headless` inside the container.
+Each eval runs inside Docker. The image must contain the `aether` and `aether-evals-acp-client` binaries because the eval runner starts the agent by executing `aether-evals-acp-client`, which drives `aether acp` inside the container.
 
 Create `evals/Dockerfile`:
 
@@ -45,7 +45,8 @@ RUN apt-get update \
     libssl-dev \
   && rm -rf /var/lib/apt/lists/*
 
-RUN cargo install aether-agent-cli
+RUN cargo install aether-agent-cli \
+  && cargo install aether-evals --bin aether-evals-acp-client
 
 WORKDIR /workspace
 ```

--- a/website/src/content/docs/aether/running/headless.mdx
+++ b/website/src/content/docs/aether/running/headless.mdx
@@ -178,7 +178,7 @@ aether show-prompt --agent Researcher
 
 ### `eval`
 
-Run declarative eval files in Docker sandboxes. Evals execute `aether headless --output json` under the hood and aggregate pass/fail results.
+Run declarative eval files in Docker sandboxes. Evals drive `aether acp` through `aether-evals-acp-client` under the hood and aggregate pass/fail results.
 
 ```bash
 aether eval evals/ --output json


### PR DESCRIPTION
This PR adds a feature to aether's evals to drive Docker-ized agents being eval'ed via ACP. This opens the door for two things: 

1. Aether's TypeScript SDK uses runs via ACP, so this makes it easier to eval agents created via the TypeScript SDK
2. It also makes it possible to eval _any_ ACP agent in the future. 