### PR TITLE
fix: Small fixes

### DIFF
--- a/packages/aether-cli/src/init/mod.rs
+++ b/packages/aether-cli/src/init/mod.rs
@@ -147,12 +147,11 @@ pub async fn run_init(request: InitRequest) -> Result<InitOutcome, InitError> {
 
 pub fn next_steps_message(outcome: &InitOutcome) -> Option<String> {
     match outcome {
-        InitOutcome::Applied { settings_path, missing_env_var: Some(var) } => Some(format!(
-            "Wrote {}. Set ${var} in your shell, then run `wisp` or `aether` to start chatting.",
-            settings_path.display()
-        )),
+        InitOutcome::Applied { settings_path, missing_env_var: Some(var) } => {
+            Some(format!("Wrote {}. Set ${var} in your shell.", settings_path.display()))
+        }
         InitOutcome::Applied { settings_path, missing_env_var: None } => {
-            Some(format!("Wrote {}. Run `wisp` or `aether` to start chatting.", settings_path.display()))
+            Some(format!("Wrote {}", settings_path.display()))
         }
         InitOutcome::AlreadyInitialized { settings_path } => {
             Some(format!("Already initialized at {}; pass --force to overwrite.", settings_path.display()))

--- a/packages/wisp/src/components/prompt_composer.rs
+++ b/packages/wisp/src/components/prompt_composer.rs
@@ -4,7 +4,7 @@ use crate::components::dropped_files::parse_dropped_file_paths;
 use crate::components::file_picker::{FilePicker, FilePickerMessage};
 use crate::components::input_prompt::{InputPrompt, prompt_content_width};
 use crate::components::prompt_search_picker::{PromptSearchPicker, PromptSearchPickerMessage, cursor_at_match_end};
-use crate::components::text_input::{SelectedFileMention, TextInput, TextInputMessage, is_newline_modifier};
+use crate::components::text_input::{SelectedFileMention, TextInput, TextInputMessage, is_newline_key};
 use crate::keybindings::Keybindings;
 use acp_utils::notifications::{AetherCapabilities, PromptSearchParams, PromptSearchResponse};
 use std::collections::HashSet;
@@ -400,7 +400,7 @@ impl Component for PromptComposer {
                     return Some(vec![]);
                 }
 
-                if key_event.code == KeyCode::Enter && is_newline_modifier(key_event.modifiers) {
+                if is_newline_key(key_event) {
                     self.close_all();
                     let outcome = self.text_input.on_event(event).await;
                     return self.handle_text_input_outcome(outcome);
@@ -647,6 +647,18 @@ mod tests {
         assert!(composer.has_command_picker());
 
         let msgs = composer.on_event(&key_with_modifiers(KeyCode::Enter, KeyModifiers::SHIFT)).await.unwrap();
+        assert!(msgs.is_empty());
+        assert!(!composer.has_command_picker());
+        assert_eq!(composer.buffer(), "/\n");
+    }
+
+    #[tokio::test]
+    async fn ctrl_j_closes_command_picker_and_inserts_newline() {
+        let mut composer = PromptComposer::default();
+        type_chars(&mut composer, "/").await;
+        assert!(composer.has_command_picker());
+
+        let msgs = composer.on_event(&key_with_modifiers(KeyCode::Char('j'), KeyModifiers::CONTROL)).await.unwrap();
         assert!(msgs.is_empty());
         assert!(!composer.has_command_picker());
         assert_eq!(composer.buffer(), "/\n");

--- a/packages/wisp/src/components/text_input.rs
+++ b/packages/wisp/src/components/text_input.rs
@@ -221,7 +221,7 @@ impl Component for TextInput {
 
 impl TextInput {
     async fn handle_key(&mut self, key_event: &KeyEvent) -> Option<Vec<TextInputMessage>> {
-        if key_event.code == KeyCode::Enter && is_newline_modifier(key_event.modifiers) {
+        if is_newline_key(key_event) {
             self.history.reset();
             self.field.insert_at_cursor('\n');
             return Some(vec![]);
@@ -266,7 +266,12 @@ impl TextInput {
     }
 }
 
-pub(crate) fn is_newline_modifier(modifiers: KeyModifiers) -> bool {
+pub(crate) fn is_newline_key(key_event: &KeyEvent) -> bool {
+    (key_event.code == KeyCode::Enter && is_newline_modifier(key_event.modifiers))
+        || (key_event.code == KeyCode::Char('j') && key_event.modifiers.contains(KeyModifiers::CONTROL))
+}
+
+fn is_newline_modifier(modifiers: KeyModifiers) -> bool {
     modifiers.contains(KeyModifiers::SHIFT) || modifiers.contains(KeyModifiers::ALT)
 }
 
@@ -420,6 +425,16 @@ mod tests {
 
         assert!(matches!(outcome.as_deref(), Some([])));
         assert_eq!(input.buffer(), "hello\nworld");
+        assert_eq!(cursor(&input), 6);
+    }
+
+    #[tokio::test]
+    async fn ctrl_j_inserts_newline() {
+        let mut input = input_with("hello", None);
+        let outcome = input.on_event(&key_with_modifiers(KeyCode::Char('j'), KeyModifiers::CONTROL)).await;
+
+        assert!(matches!(outcome.as_deref(), Some([])));
+        assert_eq!(input.buffer(), "hello\n");
         assert_eq!(cursor(&input), 6);
     }
 


### PR DESCRIPTION
This PR

- fixes #38 , there was an edge case where if a user remapped shift+enter in their terminal to output a newline, wisp wouldn't detect the shift+enter key to create a newline
- fixes #154 , small change to copy after users create user level settings.