### PR TITLE
feat(mcp-servers): Add ast-grep tool

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -255,6 +255,8 @@ dependencies = [
  "aether-mcp-utils",
  "aether-project",
  "aether-utils",
+ "ast-grep-core",
+ "ast-grep-language",
  "chrono",
  "clap",
  "dom_smoothie",
@@ -569,6 +571,57 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a3a1fd6f75306b68087b831f025c712524bcb19aad54e557b1129cfa0a2b207"
 dependencies = [
  "rustversion",
+]
+
+[[package]]
+name = "ast-grep-core"
+version = "0.43.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce81c07a23ebe5012b2053ba72af27e36699bf5f8ae6c204cdc2906aa277e5a6"
+dependencies = [
+ "bit-set 0.10.0",
+ "regex",
+ "thiserror 2.0.18",
+ "tree-sitter",
+]
+
+[[package]]
+name = "ast-grep-language"
+version = "0.43.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07b41f5cc1c89eaef8330a873ba26030dbb5b917076de5890d0446e549e4187c"
+dependencies = [
+ "ast-grep-core",
+ "ignore",
+ "serde",
+ "tree-sitter",
+ "tree-sitter-bash",
+ "tree-sitter-c",
+ "tree-sitter-c-sharp",
+ "tree-sitter-cpp",
+ "tree-sitter-css",
+ "tree-sitter-dart",
+ "tree-sitter-elixir",
+ "tree-sitter-go",
+ "tree-sitter-haskell",
+ "tree-sitter-hcl",
+ "tree-sitter-html",
+ "tree-sitter-java",
+ "tree-sitter-javascript",
+ "tree-sitter-json",
+ "tree-sitter-kotlin-sg",
+ "tree-sitter-lua",
+ "tree-sitter-md",
+ "tree-sitter-nix",
+ "tree-sitter-php",
+ "tree-sitter-python",
+ "tree-sitter-ruby",
+ "tree-sitter-rust",
+ "tree-sitter-scala",
+ "tree-sitter-solidity",
+ "tree-sitter-swift",
+ "tree-sitter-typescript",
+ "tree-sitter-yaml",
 ]
 
 [[package]]
@@ -1296,7 +1349,16 @@ version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "08807e080ed7f9d5433fa9b275196cfc35414f66a0c79d864dc51a0d825231a3"
 dependencies = [
- "bit-vec",
+ "bit-vec 0.8.0",
+]
+
+[[package]]
+name = "bit-set"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09ec2f926cc3060f09db9ebc5b52823d85268d24bb917e472c0c4bea35780a7d"
+dependencies = [
+ "bit-vec 0.9.1",
 ]
 
 [[package]]
@@ -1304,6 +1366,15 @@ name = "bit-vec"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e764a1d40d510daf35e07be9eb06e75770908c27d411ee6c92109c9840eaaf7"
+
+[[package]]
+name = "bit-vec"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b71798fca2c1fe1086445a7258a4bc81e6e49dcd24c8d0dd9a1e57395b603f51"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "bitflags"
@@ -2110,7 +2181,7 @@ version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fac5fca71e65e94cc718a6e2af65d6e0f9c6027751c2aa562fbb5087fda639bc"
 dependencies = [
- "bit-set",
+ "bit-set 0.8.0",
  "cssparser",
  "foldhash",
  "html5ever 0.39.0",
@@ -2253,7 +2324,7 @@ version = "0.16.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "998b056554fbe42e03ae0e152895cd1a7e1002aec800fdc6635d20270260c46f"
 dependencies = [
- "bit-set",
+ "bit-set 0.8.0",
  "regex-automata",
  "regex-syntax",
 ]
@@ -5081,6 +5152,7 @@ version = "1.0.150"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e8014e44b4736ed0538adeecded0fce2a272f22dc9578a7eb6b2d9993c74cfb9"
 dependencies = [
+ "indexmap 2.14.0",
  "itoa",
  "memchr",
  "serde",
@@ -5345,6 +5417,12 @@ name = "stable_deref_trait"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
+
+[[package]]
+name = "streaming-iterator"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b2231b7c3057d5e4ad0156fb3dc807d900806020c5ffa3ee6ff2c8c76fb8520"
 
 [[package]]
 name = "string_cache"
@@ -5910,6 +5988,296 @@ dependencies = [
  "tracing-core",
  "tracing-log",
  "tracing-serde",
+]
+
+[[package]]
+name = "tree-sitter"
+version = "0.26.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4dab76d0b724ba557954125188cf0633a1ca43199ced82d95c7b9c32cc3de1f3"
+dependencies = [
+ "cc",
+ "regex",
+ "regex-syntax",
+ "serde_json",
+ "streaming-iterator",
+ "tree-sitter-language",
+]
+
+[[package]]
+name = "tree-sitter-bash"
+version = "0.25.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e5ec769279cc91b561d3df0d8a5deb26b0ad40d183127f409494d6d8fc53062"
+dependencies = [
+ "cc",
+ "tree-sitter-language",
+]
+
+[[package]]
+name = "tree-sitter-c"
+version = "0.24.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a9b2eb57a55fed6b00812912e730b7a275cf4fe98bfd6a5d76263d4438371728"
+dependencies = [
+ "cc",
+ "tree-sitter-language",
+]
+
+[[package]]
+name = "tree-sitter-c-sharp"
+version = "0.23.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1aac67f1ad71de1d6d39708d34811081c26dfa495658de6c14c34200849357c"
+dependencies = [
+ "cc",
+ "tree-sitter-language",
+]
+
+[[package]]
+name = "tree-sitter-cpp"
+version = "0.23.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df2196ea9d47b4ab4a31b9297eaa5a5d19a0b121dceb9f118f6790ad0ab94743"
+dependencies = [
+ "cc",
+ "tree-sitter-language",
+]
+
+[[package]]
+name = "tree-sitter-css"
+version = "0.25.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5cbc5e18f29a2c6d6435891f42569525cf95435a3e01c2f1947abcde178686f"
+dependencies = [
+ "cc",
+ "tree-sitter-language",
+]
+
+[[package]]
+name = "tree-sitter-dart"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "325dd1e24ee9ee21111e9c43680ae7d6010aaa9f282b048a99b9c7163c1cf553"
+dependencies = [
+ "cc",
+ "tree-sitter-language",
+]
+
+[[package]]
+name = "tree-sitter-elixir"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "66dd064a762ed95bfc29857fa3cb7403bb1e5cb88112de0f6341b7e47284ba40"
+dependencies = [
+ "cc",
+ "tree-sitter-language",
+]
+
+[[package]]
+name = "tree-sitter-go"
+version = "0.25.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8560a4d2f835cc0d4d2c2e03cbd0dde2f6114b43bc491164238d333e28b16ea"
+dependencies = [
+ "cc",
+ "tree-sitter-language",
+]
+
+[[package]]
+name = "tree-sitter-haskell"
+version = "0.23.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "977c51e504548cba13fc27cb5a2edab2124cf6716a1934915d07ab99523b05a4"
+dependencies = [
+ "cc",
+ "tree-sitter-language",
+]
+
+[[package]]
+name = "tree-sitter-hcl"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a7b2cc3d7121553b84309fab9d11b3ff3d420403eef9ae50f9fd1cd9d9cf012"
+dependencies = [
+ "cc",
+ "tree-sitter-language",
+]
+
+[[package]]
+name = "tree-sitter-html"
+version = "0.23.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "261b708e5d92061ede329babaaa427b819329a9d427a1d710abb0f67bbef63ee"
+dependencies = [
+ "cc",
+ "tree-sitter-language",
+]
+
+[[package]]
+name = "tree-sitter-java"
+version = "0.23.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0aa6cbcdc8c679b214e616fd3300da67da0e492e066df01bcf5a5921a71e90d6"
+dependencies = [
+ "cc",
+ "tree-sitter-language",
+]
+
+[[package]]
+name = "tree-sitter-javascript"
+version = "0.25.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68204f2abc0627a90bdf06e605f5c470aa26fdcb2081ea553a04bdad756693f5"
+dependencies = [
+ "cc",
+ "tree-sitter-language",
+]
+
+[[package]]
+name = "tree-sitter-json"
+version = "0.24.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4d727acca406c0020cffc6cf35516764f36c8e3dc4408e5ebe2cb35a947ec471"
+dependencies = [
+ "cc",
+ "tree-sitter-language",
+]
+
+[[package]]
+name = "tree-sitter-kotlin-sg"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c06ec43ae3c12165d4ac08afe4e1f5fc6757ffe274fa7bd5af9007ef11ba4319"
+dependencies = [
+ "cc",
+ "tree-sitter-language",
+]
+
+[[package]]
+name = "tree-sitter-language"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "009994f150cc0cd50ff54917d5bc8bffe8cad10ca10d81c34da2ec421ae61782"
+
+[[package]]
+name = "tree-sitter-lua"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8daaf5f4235188a58603c39760d5fa5d4b920d36a299c934adddae757f32a10c"
+dependencies = [
+ "cc",
+ "tree-sitter-language",
+]
+
+[[package]]
+name = "tree-sitter-md"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2efd398be546456c814598ee56c0f51769a77241511b4a58077815d120afa882"
+dependencies = [
+ "cc",
+ "tree-sitter-language",
+]
+
+[[package]]
+name = "tree-sitter-nix"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4952a9733f3a98f6683a0ccd1035d84ab7a52f7e84eeed58548d86765ad92de3"
+dependencies = [
+ "cc",
+ "tree-sitter-language",
+]
+
+[[package]]
+name = "tree-sitter-php"
+version = "0.24.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d8c17c3ab69052c5eeaa7ff5cd972dd1bc25d1b97ee779fec391ad3b5df5592"
+dependencies = [
+ "cc",
+ "tree-sitter-language",
+]
+
+[[package]]
+name = "tree-sitter-python"
+version = "0.25.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6bf85fd39652e740bf60f46f4cda9492c3a9ad75880575bf14960f775cb74a1c"
+dependencies = [
+ "cc",
+ "tree-sitter-language",
+]
+
+[[package]]
+name = "tree-sitter-ruby"
+version = "0.23.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be0484ea4ef6bb9c575b4fdabde7e31340a8d2dbc7d52b321ac83da703249f95"
+dependencies = [
+ "cc",
+ "tree-sitter-language",
+]
+
+[[package]]
+name = "tree-sitter-rust"
+version = "0.24.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "439e577dbe07423ec2582ac62c7531120dbfccfa6e5f92406f93dd271a120e45"
+dependencies = [
+ "cc",
+ "tree-sitter-language",
+]
+
+[[package]]
+name = "tree-sitter-scala"
+version = "0.26.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "de5a4a7ff23a55474ce6a741d52aaeca7a82fe9421bb982b86e98c6ac8629397"
+dependencies = [
+ "cc",
+ "tree-sitter-language",
+]
+
+[[package]]
+name = "tree-sitter-solidity"
+version = "1.2.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4eacf8875b70879f0cb670c60b233ad0b68752d9e1474e6c3ef168eea8a90b25"
+dependencies = [
+ "cc",
+ "tree-sitter-language",
+]
+
+[[package]]
+name = "tree-sitter-swift"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fe36052155b9dd69ca82b3b8f1b4ccfb2d867125ac1a4db1dd7331829242668c"
+dependencies = [
+ "cc",
+ "tree-sitter-language",
+]
+
+[[package]]
+name = "tree-sitter-typescript"
+version = "0.23.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c5f76ed8d947a75cc446d5fccd8b602ebf0cde64ccf2ffa434d873d7a575eff"
+dependencies = [
+ "cc",
+ "tree-sitter-language",
+]
+
+[[package]]
+name = "tree-sitter-yaml"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53c223db85f05e34794f065454843b0668ebc15d240ada63e2b5939f43ce7c97"
+dependencies = [
+ "cc",
+ "tree-sitter-language",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -110,6 +110,8 @@ glob = "0.3"
 globset = "0.4"
 grep = "0.4.1"
 ignore = "0.4"
+ast-grep-core = "0.43"
+ast-grep-language = "0.43"
 
 # Terminal UI
 crossterm = { version = "0.29", features = ["event-stream"] }

--- a/ast-grep-tool-plan.md
+++ b/ast-grep-tool-plan.md
@@ -1,0 +1,694 @@
+# Add `ast_grep` Tool to the Coding MCP Server
+
+## Overview
+
+### Problem statement
+
+The built-in `coding` MCP server currently has:
+
+- `grep` for regex/text search.
+- `find` for file discovery.
+- LSP tools for symbol-aware navigation.
+
+It does not have a structural search tool for finding syntax patterns like `fn $NAME(...) { $$$BODY }`, `console.log($$$ARGS)`, or `useEffect($$$ARGS)` without relying on brittle regexes or requiring a live LSP server.
+
+Add a read-only `ast_grep` MCP tool to the existing `coding` MCP server. The tool should use ast-grep's Rust library crates in-process rather than shelling out to the `sg` / `ast-grep` CLI.
+
+### Success criteria and acceptance conditions
+
+- A new `ast_grep` MCP tool is available from the existing `coding` server.
+- The tool performs read-only AST structural search over a file or directory.
+- The implementation uses Rust crates (`ast-grep-core` and `ast-grep-language`) and does **not** require an external `ast-grep` binary to be installed.
+- The tool supports:
+  - Required ast-grep `pattern` string.
+  - Required `language` string using `ast_grep_language::SupportLang` aliases such as `rs`, `rust`, `ts`, `tsx`, `py`, `js`.
+  - Optional `path`, defaulting to the coding server workspace root.
+  - Optional `glob` file filter.
+  - Optional context line controls.
+  - Optional `headLimit` result limit.
+- Results include deterministic structured output with file path, 1-based line/column range, byte range, matched text, and metavariable captures.
+- Directory searches respect `.gitignore`, skip hidden files by default, do not follow symlinks, and search only files matching the selected language unless the path is an explicit file.
+- Tool annotations mark the tool as read-only and closed-world:
+  - `read_only_hint = true`
+  - `open_world_hint = false`
+- Existing coding tools continue to compile and pass tests.
+- Unit and integration tests cover the public tool behavior.
+
+## Technical Approach
+
+### Architectural decision
+
+Add the tool to the existing `coding` MCP server, not a new MCP server.
+
+Rationale:
+
+- `coding` already owns code search, file traversal, workspace root resolution, and MCP tool registration.
+- `ast_grep` sits naturally between `grep` and LSP: structural source search that is more precise than regex but does not require an LSP server.
+- A new MCP server would add configuration and discovery overhead without a strong boundary benefit.
+
+### Library vs shell-out decision
+
+Use ast-grep's Rust libraries in-process:
+
+- `ast-grep-core` for `Pattern::try_new` and matching APIs.
+- `ast-grep-language` for `SupportLang`, language aliases, parser integration, and language-aware extension filtering.
+
+Do not shell out to the CLI.
+
+Rationale:
+
+- No external binary install requirement.
+- Avoids shell escaping and command injection risk.
+- Produces typed structured MCP output directly.
+- Fits the current `grep` / `find` pattern of in-process Rust implementations.
+- Avoids version drift between the packaged MCP server and a user's installed `ast-grep` CLI.
+
+### MVP scope
+
+Implement read-only structural search only. Do **not** implement rewriting in this change.
+
+A future rewrite tool should be separate, e.g. `ast_rewrite` or `ast_grep_rewrite`, with non-read-only MCP annotations and explicit file safety semantics.
+
+### Input schema
+
+Create `AstGrepInput` in `packages/mcp-servers/src/coding/tools/ast_grep/mod.rs`:
+
+```rust
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct AstGrepInput {
+    /// ast-grep pattern code, e.g. "fn $NAME() { $$$BODY }"
+    pub pattern: String,
+
+    /// Language alias understood by ast-grep, e.g. "rs", "rust", "ts", "tsx", "py", "js".
+    pub language: String,
+
+    /// File or directory to search. Defaults to the coding server workspace root.
+    pub path: Option<String>,
+
+    /// Optional glob filter, e.g. "**/*.rs" or "*.{ts,tsx}".
+    pub glob: Option<String>,
+
+    /// Lines before each match.
+    pub context_before: Option<u32>,
+
+    /// Lines after each match.
+    pub context_after: Option<u32>,
+
+    /// Lines before and after each match. Overrides contextBefore/contextAfter.
+    pub context_around: Option<u32>,
+
+    /// Maximum number of matches to return.
+    pub head_limit: Option<usize>,
+}
+```
+
+Use `language` rather than `type` to make it clear this is an AST parser selection, not a ripgrep file type filter.
+
+### Output schema
+
+Create output structs:
+
+```rust
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct AstGrepOutput {
+    pub matches: Vec<AstGrepMatch>,
+    pub count: usize,
+    pub truncated: bool,
+    pub language: String,
+    pub search_path: String,
+    #[serde(rename = "_meta", skip_serializing_if = "Option::is_none")]
+    #[schemars(skip)]
+    pub meta: Option<ToolResultMeta>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct AstGrepMatch {
+    pub file: String,
+    pub range: AstGrepRange,
+    pub text: String,
+    pub captures: Vec<AstGrepCapture>,
+    pub before_context: Option<Vec<String>>,
+    pub after_context: Option<Vec<String>>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct AstGrepRange {
+    /// 1-based line number.
+    pub start_line: usize,
+    /// 1-based character column.
+    pub start_column: usize,
+    /// 1-based line number.
+    pub end_line: usize,
+    /// 1-based character column.
+    pub end_column: usize,
+    /// 0-based byte offset.
+    pub start_byte: usize,
+    /// 0-based exclusive byte offset.
+    pub end_byte: usize,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct AstGrepCapture {
+    pub name: String,
+    pub text: String,
+}
+```
+
+Use 1-based line/column values for user-facing consistency with `read_file` and `grep`. Keep byte offsets 0-based because they are source offsets.
+
+### Matching behavior
+
+- Parse `language` once:
+
+```rust
+let lang: SupportLang = args.language.parse()
+    .map_err(|_| AstGrepError::UnsupportedLanguage(args.language.clone()))?;
+```
+
+- Compile the pattern once with non-panicking API:
+
+```rust
+use ast_grep_core::Pattern;
+
+let pattern = Pattern::try_new(&args.pattern, lang)
+    .map_err(|e| AstGrepError::InvalidPattern(e.to_string()))?;
+```
+
+Do not use `Pattern::new`, because it unwraps and can panic on invalid user input.
+
+- For each source file:
+
+```rust
+use ast_grep_language::LanguageExt;
+
+let source = std::fs::read_to_string(path)?;
+let root = lang.ast_grep(&source);
+for node_match in root.root().find_all(pattern.clone()) {
+    // build AstGrepMatch
+}
+```
+
+- Convert positions:
+
+```rust
+let start = node_match.start_pos();
+let end = node_match.end_pos();
+let range = node_match.range();
+
+AstGrepRange {
+    start_line: start.line() + 1,
+    start_column: start.column(&*node_match) + 1,
+    end_line: end.line() + 1,
+    end_column: end.column(&*node_match) + 1,
+    start_byte: range.start,
+    end_byte: range.end,
+}
+```
+
+- Convert captures deterministically:
+
+```rust
+let mut captures: Vec<AstGrepCapture> =
+    std::collections::HashMap::<String, String>::from(node_match.get_env().clone())
+        .into_iter()
+        .map(|(name, text)| AstGrepCapture { name, text })
+        .collect();
+captures.sort_by(|a, b| a.name.cmp(&b.name));
+```
+
+### File traversal behavior
+
+For explicit file paths:
+
+- Validate the path exists.
+- Apply `glob` if provided.
+- Parse the file using the provided `language`, even if the file extension does not match that language. This lets advanced users search extensionless files or generated fixtures.
+
+For directory paths:
+
+- Use `ignore::WalkBuilder` sequentially for deterministic ordering and simplicity.
+- Configure it like `find` / `grep`:
+
+```rust
+WalkBuilder::new(search_path)
+    .hidden(false)
+    .git_ignore(true)
+    .follow_links(false)
+```
+
+- Collect matching files into `Vec<PathBuf>`, sort by path, then parse in order.
+- Include only regular files where:
+  - Optional `glob` matches, and
+  - The file extension maps to the selected `SupportLang`.
+
+Use the `Language` trait implementation for extension inference:
+
+```rust
+use ast_grep_language::{Language, SupportLang};
+
+fn file_matches_language(path: &Path, lang: SupportLang) -> bool {
+    <SupportLang as Language>::from_path(path) == Some(lang)
+}
+```
+
+### Error handling
+
+Add `AstGrepError` to `packages/mcp-servers/src/coding/error.rs` and wrap it in `CodingError`:
+
+```rust
+#[derive(Debug, Error)]
+pub enum AstGrepError {
+    #[error("Search path does not exist: {0}")]
+    PathNotFound(String),
+
+    #[error("Invalid glob pattern '{pattern}': {reason}")]
+    InvalidGlobPattern { pattern: String, reason: String },
+
+    #[error("Failed to build glob set: {0}")]
+    GlobSetBuildFailed(String),
+
+    #[error("Unsupported ast-grep language: {0}")]
+    UnsupportedLanguage(String),
+
+    #[error("Invalid ast-grep pattern: {0}")]
+    InvalidPattern(String),
+
+    #[error("Failed to read file '{path}': {reason}")]
+    ReadFailed { path: String, reason: String },
+}
+```
+
+For directory walks, skip individual unreadable/non-UTF-8 files to behave like search tools that tolerate noisy trees. For an explicit file path, return `ReadFailed`.
+
+### Trade-offs
+
+- Sequential directory processing is simpler and deterministic. If performance becomes an issue, a later change can parallelize after preserving stable ordering and limit semantics.
+- `language` is required. Inference is attractive, but the pattern itself is language-specific, so requiring a parser makes the tool less surprising.
+- Rule-file support via `ast-grep-config` is intentionally excluded from the MVP. Add it later as a separate tool or mode if needed.
+- Rewriting is excluded from the MVP to avoid mixing read-only search with mutation safety design.
+
+## Implementation Steps
+
+1. **Add dependencies**
+
+   Update workspace dependencies in `/Users/josh/code/aether-2/Cargo.toml`:
+
+   ```toml
+   ast-grep-core = "0.43"
+   ast-grep-language = "0.43"
+   ```
+
+   Update `/Users/josh/code/aether-2/packages/mcp-servers/Cargo.toml`:
+
+   - Add optional dependencies:
+
+     ```toml
+     ast-grep-core = { workspace = true, optional = true }
+     ast-grep-language = { workspace = true, optional = true }
+     ```
+
+   - Add both to the `coding` feature:
+
+     ```toml
+     "dep:ast-grep-core",
+     "dep:ast-grep-language",
+     ```
+
+2. **Create the `ast_grep` tool module**
+
+   Add directory:
+
+   ```text
+   /Users/josh/code/aether-2/packages/mcp-servers/src/coding/tools/ast_grep/
+   ```
+
+   Add files:
+
+   ```text
+   mod.rs
+   description.md
+   ```
+
+   In `mod.rs`:
+
+   - Define `AstGrepInput`.
+   - Define `AstGrepOutput`, `AstGrepMatch`, `AstGrepRange`, and `AstGrepCapture`.
+   - Implement:
+
+     ```rust
+     pub async fn perform_ast_grep(args: AstGrepInput) -> Result<AstGrepOutput, AstGrepError>
+     ```
+
+   - Keep private helpers below public structs/functions:
+
+     ```rust
+     fn build_glob_set(glob: Option<&str>) -> Result<Option<globset::GlobSet>, AstGrepError>
+     fn collect_files(search_path: &Path, lang: SupportLang, glob: Option<&globset::GlobSet>) -> Vec<PathBuf>
+     fn file_matches_filters(path: &Path, lang: SupportLang, glob: Option<&globset::GlobSet>) -> bool
+     fn search_file(path: &Path, lang: SupportLang, pattern: &Pattern, args: &AstGrepInput) -> Result<Vec<AstGrepMatch>, AstGrepError>
+     fn build_match(path: &Path, source: &str, node_match: NodeMatchLike, context_before: usize, context_after: usize) -> AstGrepMatch
+     fn context_for_match(source: &str, start_line: usize, end_line: usize, before: usize, after: usize) -> (Option<Vec<String>>, Option<Vec<String>>)
+     ```
+
+   The concrete `NodeMatchLike` should be the real ast-grep node match type inferred by the helper signature. If Rust lifetime/generic syntax becomes cumbersome, inline match construction inside `search_file` and keep only simple helpers for context/captures.
+
+3. **Implement `perform_ast_grep` control flow**
+
+   Pseudo-code:
+
+   ```rust
+   pub async fn perform_ast_grep(mut args: AstGrepInput) -> Result<AstGrepOutput, AstGrepError> {
+       if args.path.as_deref().is_some_and(|p| p.trim().is_empty()) {
+           args.path = None;
+       }
+
+       let lang: SupportLang = args.language.parse()
+           .map_err(|_| AstGrepError::UnsupportedLanguage(args.language.clone()))?;
+       let pattern = Pattern::try_new(&args.pattern, lang)
+           .map_err(|e| AstGrepError::InvalidPattern(e.to_string()))?;
+       let glob_set = build_glob_set(args.glob.as_deref())?;
+
+       let search_path = args.path.as_deref().unwrap_or(".");
+       let path = Path::new(search_path);
+       if !path.exists() {
+           return Err(AstGrepError::PathNotFound(search_path.to_string()));
+       }
+
+       let (context_before, context_after) = context_counts(&args);
+       let limit = args.head_limit.unwrap_or(usize::MAX);
+       let mut matches = Vec::new();
+       let mut truncated = false;
+
+       let files = if path.is_file() {
+           if glob_set.as_ref().is_some_and(|glob| !glob.is_match(path)) {
+               Vec::new()
+           } else {
+               vec![path.to_path_buf()]
+           }
+       } else {
+           collect_files(path, lang, glob_set.as_ref())
+       };
+
+       for file in files {
+           let file_matches = search_file(&file, lang, &pattern, context_before, context_after, limit - matches.len())?;
+           matches.extend(file_matches);
+           if matches.len() >= limit {
+               matches.truncate(limit);
+               truncated = true;
+               break;
+           }
+       }
+
+       let count = matches.len();
+       let meta = ToolDisplayMeta::new(
+           "AST grep",
+           format!("'{}' in {} ({count} matches)", args.pattern, basename(search_path)),
+       );
+
+       Ok(AstGrepOutput {
+           matches,
+           count,
+           truncated,
+           language: lang.to_string(),
+           search_path: search_path.to_string(),
+           meta: Some(meta.into()),
+       })
+   }
+   ```
+
+   Avoid comments in code unless explaining a non-obvious why.
+
+4. **Register the module**
+
+   Update `/Users/josh/code/aether-2/packages/mcp-servers/src/coding/tools/mod.rs`:
+
+   ```rust
+   pub mod ast_grep;
+   ```
+
+5. **Add error integration**
+
+   Update `/Users/josh/code/aether-2/packages/mcp-servers/src/coding/error.rs`:
+
+   - Add `AstGrep(#[from] AstGrepError)` variant to `CodingError` near `Grep` and `Find`.
+   - Add the `AstGrepError` enum near `GrepError`.
+
+6. **Expose tool types through `CodingTools`**
+
+   Update `/Users/josh/code/aether-2/packages/mcp-servers/src/coding/tools_trait.rs`:
+
+   - Import:
+
+     ```rust
+     use super::tools::ast_grep::{AstGrepInput, AstGrepOutput, perform_ast_grep};
+     ```
+
+   - Add a default trait method near `grep` and `find`:
+
+     ```rust
+     /// Search code using ast-grep structural patterns.
+     fn ast_grep(&self, args: AstGrepInput) -> impl Future<Output = Result<AstGrepOutput, CodingError>> + Send {
+         async move { perform_ast_grep(args).await.map_err(CodingError::from) }
+     }
+     ```
+
+   Update `/Users/josh/code/aether-2/packages/mcp-servers/src/docs/coding_tools.md` to list `ast_grep` under provided methods.
+
+7. **Add default implementation**
+
+   Update `/Users/josh/code/aether-2/packages/mcp-servers/src/coding/default_tools.rs`:
+
+   - Import `AstGrepInput`, `AstGrepOutput`, and `perform_ast_grep`.
+   - Add:
+
+     ```rust
+     async fn ast_grep(&self, args: AstGrepInput) -> Result<AstGrepOutput, CodingError> {
+         perform_ast_grep(args).await.map_err(CodingError::from)
+     }
+     ```
+
+8. **Add the MCP tool method**
+
+   Update `/Users/josh/code/aether-2/packages/mcp-servers/src/coding/mod.rs`:
+
+   - Import:
+
+     ```rust
+     use tools::ast_grep::{AstGrepInput, AstGrepOutput, perform_ast_grep};
+     ```
+
+     If `perform_ast_grep` is not used directly in `mod.rs`, do not import it there.
+
+   - Add quick reference line in `build_instructions()`:
+
+     ```text
+     - **Structural code patterns** (AST search): `ast_grep`
+     ```
+
+   - Add tool method next to `grep` / `find`:
+
+     ```rust
+     #[doc = include_str!("tools/ast_grep/description.md")]
+     #[tool(annotations(read_only_hint = true, open_world_hint = false))]
+     pub async fn ast_grep(
+         &self,
+         request: Parameters<AstGrepInput>,
+         context: RequestContext<RoleServer>,
+     ) -> Result<Json<AstGrepOutput>, String> {
+         let Parameters(mut args) = request;
+         let root = self.primary_workspace_root().await;
+         let normalized_path = resolve_dir(&root, args.path.as_deref());
+         args.path = Some(normalized_path.to_string_lossy().to_string());
+         notify_preview(&context, ToolDisplayMeta::new("AST grep", format!("'{}'", args.pattern))).await;
+         self.tools.ast_grep(args).await.into_mcp()
+     }
+     ```
+
+9. **Write tool description**
+
+   Add `/Users/josh/code/aether-2/packages/mcp-servers/src/coding/tools/ast_grep/description.md`:
+
+   Include:
+
+   - Short description: structural AST search using ast-grep patterns.
+   - Guidance: use `ast_grep` for syntax shapes, `grep` for raw text/log/TODO searches, LSP for definitions/references/types.
+   - Usage examples:
+
+     ```json
+     {"language": "rs", "pattern": "fn $NAME($$$ARGS) { $$$BODY }", "glob": "**/*.rs"}
+     {"language": "ts", "pattern": "console.log($$$ARGS)", "path": "src", "headLimit": 20}
+     {"language": "tsx", "pattern": "useEffect($$$ARGS)", "contextAround": 2}
+     {"language": "py", "pattern": "def $NAME($$$ARGS): $$$BODY"}
+     ```
+
+   - Parameter explanations.
+   - Mention line/column ranges are 1-based and byte ranges are 0-based.
+
+10. **Update user-facing docs**
+
+   Update:
+
+   - `/Users/josh/code/aether-2/packages/mcp-servers/src/coding/README.md`
+     - Add `ast_grep` to the Search table.
+     - Add it to the table of contents only if the section structure changes.
+   - `/Users/josh/code/aether-2/packages/mcp-servers/src/docs/coding_mcp.md`
+     - Add `ast_grep` under Shell & search.
+   - `/Users/josh/code/aether-2/packages/mcp-servers/README.md`
+     - Update the `coding` feature/server description from `grep, find` to include `ast_grep` or “structural search”.
+
+11. **Add unit tests for the tool module**
+
+   In `packages/mcp-servers/src/coding/tools/ast_grep/mod.rs`, add tests similar to `grep` and `find` module tests:
+
+   - `finds_rust_function_pattern`
+     - Create temp dir with `lib.rs` containing multiple functions.
+     - Search `language: "rs"`, pattern `fn $NAME() {}` or `fn $NAME($$$ARGS) { $$$BODY }`.
+     - Assert matches include expected function text.
+   - `returns_metavariable_captures`
+     - Pattern `fn $NAME() {}`.
+     - Assert capture `NAME` is `foo` for `fn foo() {}`.
+   - `filters_directory_by_language`
+     - Include `.rs` and `.py` files with text that would otherwise match.
+     - Search `language: "rs"`.
+     - Assert only `.rs` files are returned.
+   - `applies_glob_filter`
+     - Include `src/lib.rs` and `tests/lib.rs`.
+     - Use `glob: "src/**/*.rs"` or equivalent.
+     - Assert only `src` file is searched.
+   - `invalid_language_returns_error`
+     - Use `language: "not-a-language"`.
+     - Assert `AstGrepError::UnsupportedLanguage`.
+   - `invalid_pattern_returns_error`
+     - Use empty pattern or a known multiple-root pattern such as `"12  3344"` for a language where it errors.
+     - Assert `AstGrepError::InvalidPattern`.
+   - `head_limit_truncates_results`
+     - Produce several matches.
+     - Use `headLimit: 1`.
+     - Assert `count == 1` and `truncated == true`.
+   - `range_is_one_based_and_byte_offsets_are_zero_based`
+     - Use a small source where expected range is obvious.
+     - Assert start line/column are 1-based.
+
+12. **Add MCP integration test**
+
+   Update `/Users/josh/code/aether-2/packages/mcp-servers/tests/coding_mcp_tools.rs` or add a new integration test file if the existing file is getting too broad.
+
+   Add test:
+
+   ```rust
+   #[tokio::test]
+   async fn test_ast_grep_uses_workspace_root_when_no_path_given() -> Result<(), Box<dyn std::error::Error>> {
+       let temp = tempfile::tempdir()?;
+       let workspace = temp.path().to_path_buf();
+       std::fs::write(workspace.join("lib.rs"), "fn target() {}\nfn other() {}\n")?;
+
+       let server_service = CodingMcp::new().with_root_dir(workspace.clone());
+       let client_info = ClientInfo::new(ClientCapabilities::default(), Implementation::new("test-client", "0.1.0"));
+       let (_server_handle, client) = connect(server_service, client_info).await?;
+
+       let result = client.call_tool(
+           CallToolRequestParams::new("ast_grep").with_arguments(
+               serde_json::json!({
+                   "language": "rs",
+                   "pattern": "fn $NAME() {}"
+               }).as_object().unwrap().clone(),
+           ),
+       ).await?;
+
+       let text_content = result.content.first().and_then(|c| c.as_text()).ok_or("Expected text content")?;
+       let parsed: serde_json::Value = serde_json::from_str(&text_content.text)?;
+       assert_eq!(parsed["searchPath"].as_str().unwrap(), workspace.to_str().unwrap());
+       assert!(parsed["matches"].as_array().unwrap().iter().any(|m| {
+           m["file"].as_str().unwrap().ends_with("lib.rs") &&
+           m["captures"].as_array().unwrap().iter().any(|c| c["name"] == "NAME" && c["text"] == "target")
+       }));
+
+       Ok(())
+   }
+   ```
+
+   Also consider a small integration assertion that the tool appears in `list_tools` if there is an existing pattern for that in tests.
+
+13. **Run validation**
+
+   Preferred quick checks:
+
+   - Use LSP diagnostics for workspace or affected files first.
+   - Then run targeted tests if needed:
+
+     ```bash
+     just test -p aether-mcp-servers ast_grep
+     ```
+
+   If the project’s `just test` does not accept package/test filters, use the repository’s standard `just test`.
+
+## Testing Plan
+
+### Unit tests required
+
+Add unit tests in `packages/mcp-servers/src/coding/tools/ast_grep/mod.rs` for:
+
+- Basic Rust structural match.
+- TypeScript or TSX structural match if compilation time remains acceptable.
+- Capture extraction and deterministic capture sorting.
+- Glob filtering.
+- Language-based extension filtering for directory walks.
+- Direct file path behavior.
+- Invalid language errors.
+- Invalid pattern errors.
+- Missing path errors.
+- Context line extraction.
+- `headLimit` truncation.
+- Deterministic path ordering.
+
+### Integration tests needed
+
+Add MCP-level tests for public API behavior:
+
+- `ast_grep` defaults to `CodingMcp::with_root_dir(...)` workspace root when `path` is omitted.
+- JSON response shape includes `matches`, `count`, `truncated`, `language`, and `searchPath`.
+- At least one match contains expected `file`, `text`, `range`, and `captures`.
+
+### Edge cases to verify
+
+- Empty `path` or whitespace `path` defaults to workspace root.
+- `glob` that matches no files returns `matches: []`, `count: 0`, `truncated: false`.
+- Unsupported language aliases return a clean tool error, not a panic.
+- Invalid ast-grep patterns return a clean tool error, not a panic.
+- Non-UTF-8 files in directory searches do not crash the search.
+- Explicit non-UTF-8 file path returns a readable error.
+- Multi-line matches have correct start/end line values and context after the end line.
+- `headLimit: 0` returns no matches and `truncated: true` if there would have been at least one match. If implementing that exactly is awkward, reject `headLimit: 0` with a validation error and document it.
+
+## Files to Modify/Create
+
+| Path | Change | Status |
+|---|---|---|
+| `/Users/josh/code/aether-2/Cargo.toml` | Add workspace dependencies `ast-grep-core` and `ast-grep-language`. | Modify |
+| `/Users/josh/code/aether-2/packages/mcp-servers/Cargo.toml` | Add optional deps and include them in the `coding` feature. | Modify |
+| `/Users/josh/code/aether-2/packages/mcp-servers/src/coding/tools/ast_grep/mod.rs` | Implement input/output structs, `perform_ast_grep`, helpers, and unit tests. | Add |
+| `/Users/josh/code/aether-2/packages/mcp-servers/src/coding/tools/ast_grep/description.md` | Add MCP tool documentation and examples. | Add |
+| `/Users/josh/code/aether-2/packages/mcp-servers/src/coding/tools/mod.rs` | Export `pub mod ast_grep;`. | Modify |
+| `/Users/josh/code/aether-2/packages/mcp-servers/src/coding/error.rs` | Add `AstGrepError` and `CodingError::AstGrep`. | Modify |
+| `/Users/josh/code/aether-2/packages/mcp-servers/src/coding/tools_trait.rs` | Add imports and default `ast_grep` method. | Modify |
+| `/Users/josh/code/aether-2/packages/mcp-servers/src/coding/default_tools.rs` | Implement `CodingTools::ast_grep` for `DefaultCodingTools`. | Modify |
+| `/Users/josh/code/aether-2/packages/mcp-servers/src/coding/mod.rs` | Import tool types, add quick-reference instruction, and register `ast_grep` MCP method. | Modify |
+| `/Users/josh/code/aether-2/packages/mcp-servers/src/docs/coding_tools.md` | Document `ast_grep` as a provided backend method. | Modify |
+| `/Users/josh/code/aether-2/packages/mcp-servers/src/docs/coding_mcp.md` | Add `ast_grep` to coding server tool docs. | Modify |
+| `/Users/josh/code/aether-2/packages/mcp-servers/src/coding/README.md` | Add `ast_grep` to Search tools. | Modify |
+| `/Users/josh/code/aether-2/packages/mcp-servers/README.md` | Update high-level coding server description to mention structural search. | Modify |
+| `/Users/josh/code/aether-2/packages/mcp-servers/tests/coding_mcp_tools.rs` | Add MCP integration test for `ast_grep` workspace-root behavior and response shape. | Modify |
+
+## Additional Notes
+
+- The tool should be named `ast_grep` to match existing snake_case MCP tool naming.
+- Do not add `ast-grep-config` in the MVP. Use it later only if adding YAML rule-file scanning.
+- Do not add rewrite support in this change. Rewriting needs separate permissions, read-before-edit/write safety, and likely diagnostic refresh behavior.
+- Keep implementation comments sparse and only explain non-obvious “why” decisions.
+- If dependency compilation cost is a concern after implementation, measure it before attempting optimization; correctness and tool stability matter more for the first version.
+- If directory search performance becomes a problem, add parallel traversal in a follow-up while preserving deterministic output ordering and `headLimit` semantics.

--- a/packages/mcp-servers/Cargo.toml
+++ b/packages/mcp-servers/Cargo.toml
@@ -37,6 +37,8 @@ coding = [
     "dep:globset",
     "dep:grep",
     "dep:ignore",
+    "dep:ast-grep-core",
+    "dep:ast-grep-language",
     "dep:regex",
     "dep:tracing",
     "dep:thiserror",
@@ -94,6 +96,8 @@ glob = { workspace = true, optional = true }
 globset = { workspace = true, optional = true }
 grep = { workspace = true, optional = true }
 ignore = { workspace = true, optional = true }
+ast-grep-core = { workspace = true, optional = true }
+ast-grep-language = { workspace = true, optional = true }
 regex = { workspace = true, optional = true }
 tracing = { workspace = true, optional = true }
 thiserror = { workspace = true, optional = true }

--- a/packages/mcp-servers/README.md
+++ b/packages/mcp-servers/README.md
@@ -4,7 +4,7 @@ Pre-built [MCP](https://modelcontextprotocol.io/) tool servers for Aether agents
 
 | Feature | Server | What it provides |
 |---------|--------|-----------------|
-| `coding` | [`CodingMcp`](src/coding/README.md) | File read/write/edit, bash, grep, find, LSP integration, web fetch/search |
+| `coding` | [`CodingMcp`](src/coding/README.md) | File read/write/edit, bash, grep, `ast_grep` structural search, find, LSP integration, web fetch/search |
 | `skills` | [`SkillsMcp`](src/skills/README.md) | Slash commands and reusable skill prompts |
 | `tasks` | [`TasksMcp`](src/tasks/README.md) | Hierarchical task management with dependencies |
 | `subagents` | [`SubAgentsMcp`](src/subagents/README.md) | Spawn and orchestrate sub-agents |

--- a/packages/mcp-servers/src/coding/README.md
+++ b/packages/mcp-servers/src/coding/README.md
@@ -35,6 +35,7 @@ File operations, code search, bash execution, LSP integration, and web tools. Th
 | Tool | Description |
 |------|-------------|
 | `grep` | Search file contents with regex. Supports glob filters, file type filters, context lines, case-insensitive mode, and multiline matching. Output modes: `Content`, `FilesWithMatches`, `Count`. |
+| `ast_grep` | Search code with ast-grep structural AST patterns. Supports language aliases, glob filters, context lines, captures, and result limits. |
 | `find` | Find files by glob pattern. Recursive directory walk. |
 
 ### Bash

--- a/packages/mcp-servers/src/coding/default_tools.rs
+++ b/packages/mcp-servers/src/coding/default_tools.rs
@@ -1,9 +1,10 @@
 use super::error::CodingError;
 use super::{
-    BackgroundProcessHandle, BashInput, BashResult, EditFileArgs, EditFileResponse, FindInput, FindOutput, GrepInput,
-    GrepOutput, ListFilesArgs, ListFilesResult, ReadBackgroundBashOutput, ReadFileArgs, ReadFileResult, WriteFileArgs,
-    WriteFileResponse, edit_file_contents, execute_command_in_dir, find_files_by_name, list_files, perform_grep,
-    read_background_bash, read_file_contents, tools_trait::CodingTools, write_file_contents,
+    AstGrepInput, AstGrepOutput, BackgroundProcessHandle, BashInput, BashResult, EditFileArgs, EditFileResponse,
+    FindInput, FindOutput, GrepInput, GrepOutput, ListFilesArgs, ListFilesResult, ReadBackgroundBashOutput,
+    ReadFileArgs, ReadFileResult, WriteFileArgs, WriteFileResponse, edit_file_contents, execute_command_in_dir,
+    find_files_by_name, list_files, perform_ast_grep, perform_grep, read_background_bash, read_file_contents,
+    tools_trait::CodingTools, write_file_contents,
 };
 use std::path::PathBuf;
 
@@ -52,6 +53,10 @@ impl CodingTools for DefaultCodingTools {
 
     async fn grep(&self, args: GrepInput) -> Result<GrepOutput, CodingError> {
         perform_grep(args).await.map_err(CodingError::from)
+    }
+
+    async fn ast_grep(&self, args: AstGrepInput) -> Result<AstGrepOutput, CodingError> {
+        perform_ast_grep(args).await.map_err(CodingError::from)
     }
 
     async fn find(&self, args: FindInput) -> Result<FindOutput, CodingError> {

--- a/packages/mcp-servers/src/coding/error.rs
+++ b/packages/mcp-servers/src/coding/error.rs
@@ -22,6 +22,10 @@ pub enum CodingError {
     #[error(transparent)]
     Grep(#[from] GrepError),
 
+    /// ast-grep structural search errors
+    #[error(transparent)]
+    AstGrep(#[from] AstGrepError),
+
     /// Find file errors
     #[error(transparent)]
     Find(#[from] FindError),
@@ -75,16 +79,24 @@ pub enum BashError {
     WaitFailed(String),
 }
 
-/// Errors related to grep search operations
+/// Errors related to building glob filters, shared across search tools
 #[derive(Debug, Error)]
-pub enum GrepError {
+pub enum GlobError {
     /// Invalid glob pattern
     #[error("Invalid glob pattern '{pattern}': {reason}")]
-    InvalidGlobPattern { pattern: String, reason: String },
+    InvalidPattern { pattern: String, reason: String },
 
     /// Failed to build glob set
     #[error("Failed to build glob set: {0}")]
-    GlobSetBuildFailed(String),
+    BuildFailed(String),
+}
+
+/// Errors related to grep search operations
+#[derive(Debug, Error)]
+pub enum GrepError {
+    /// Glob filter errors
+    #[error(transparent)]
+    Glob(#[from] GlobError),
 
     /// Invalid regex pattern
     #[error("Invalid regex pattern: {0}")]
@@ -97,6 +109,38 @@ pub enum GrepError {
     /// Search path does not exist
     #[error("Search path does not exist: {0}")]
     PathNotFound(String),
+}
+
+/// Errors related to ast-grep structural search operations
+#[derive(Debug, Error)]
+pub enum AstGrepError {
+    /// Search path does not exist
+    #[error("Search path does not exist: {0}")]
+    PathNotFound(String),
+
+    /// Glob filter errors
+    #[error(transparent)]
+    Glob(#[from] GlobError),
+
+    /// Unsupported ast-grep language
+    #[error("Unsupported ast-grep language: {0}")]
+    UnsupportedLanguage(String),
+
+    /// Invalid ast-grep pattern
+    #[error("Invalid ast-grep pattern: {0}")]
+    InvalidPattern(String),
+
+    /// Invalid regex in a capture constraint
+    #[error("Invalid regex for constraint '{name}': {reason}")]
+    InvalidConstraintRegex { name: String, reason: String },
+
+    /// Failed to read file
+    #[error("Failed to read file '{path}': {reason}")]
+    ReadFailed { path: String, reason: String },
+
+    /// Search failed during ast-grep processing
+    #[error("Search error: {0}")]
+    SearchFailed(String),
 }
 
 /// Errors related to find file operations

--- a/packages/mcp-servers/src/coding/mod.rs
+++ b/packages/mcp-servers/src/coding/mod.rs
@@ -56,6 +56,7 @@ use crate::{
 };
 
 use mcp_utils::display_meta::{ToolDisplayMeta, ToolResultMeta, basename, truncate};
+use tools::ast_grep::{AstGrepInput, AstGrepOutput, perform_ast_grep};
 use tools::bash::{
     BackgroundProcessHandle, BashInput, BashOutput, BashResult, ReadBackgroundBashInput, ReadBackgroundBashOutput,
     execute_command_in_dir, read_background_bash,
@@ -319,6 +320,7 @@ File I/O, search, shell, and optional LSP code intelligence tools for coding wor
 ## Quick Reference
 
 - **Text patterns** (TODOs, logs, strings): `grep`
+- **Structural code patterns** (AST search): `ast_grep`
 - **File names** (find *.test.ts): `find`
 - **Read/write/edit** files: `read_file`, `write_file`, `edit_file`
 - **Shell commands**: `bash`
@@ -494,6 +496,21 @@ When using tools that take file paths, always use absolute paths from:
         args.path = Some(normalized_path.to_string_lossy().to_string());
         notify_preview(&context, ToolDisplayMeta::new("Grep", format!("'{}'", args.pattern))).await;
         self.tools.grep(args).await.into_mcp()
+    }
+
+    #[doc = include_str!("tools/ast_grep/description.md")]
+    #[tool(annotations(read_only_hint = true, open_world_hint = false))]
+    pub async fn ast_grep(
+        &self,
+        request: Parameters<AstGrepInput>,
+        context: RequestContext<RoleServer>,
+    ) -> Result<Json<AstGrepOutput>, String> {
+        let Parameters(mut args) = request;
+        let root = self.primary_workspace_root().await;
+        let normalized_path = resolve_dir(&root, args.path.as_deref());
+        args.path = Some(normalized_path.to_string_lossy().to_string());
+        notify_preview(&context, ToolDisplayMeta::new("AST grep", format!("'{}'", args.pattern))).await;
+        self.tools.ast_grep(args).await.into_mcp()
     }
 
     #[doc = include_str!("tools/find/description.md")]

--- a/packages/mcp-servers/src/coding/tools/ast_grep/description.md
+++ b/packages/mcp-servers/src/coding/tools/ast_grep/description.md
@@ -1,0 +1,43 @@
+Structural AST search using ast-grep patterns.
+
+Use `ast_grep` when you need to find syntax shapes such as functions, calls, hooks, imports, or language constructs. Use `grep` for raw text, logs, TODOs, and regex searches. Use LSP tools for definitions, references, types, and symbol navigation when a language server is available.
+
+## Usage
+
+```json
+{"language": "rs", "pattern": "fn $NAME($$$ARGS) { $$$BODY }", "glob": "**/*.rs"}
+{"language": "rs", "pattern": "use $PATH;", "glob": "**/*.rs"}
+{"language": "rs", "pattern": "use $CRATE;", "constraints": {"CRATE": "^crossterm"}, "glob": "**/*.rs"}
+{"language": "ts", "pattern": "console.log($$$ARGS)", "path": "src", "headLimit": 20}
+{"language": "tsx", "pattern": "useEffect($$$ARGS)", "contextAround": 2}
+{"language": "py", "pattern": "def $NAME($$$ARGS): $$$BODY"}
+```
+
+## Filtering by capture value
+
+Use `constraints` to keep only matches whose captured text matches a regex. For example, this finds every file that imports `crossterm` in 1-toolcall:
+
+```json
+{
+  "language": "rs",
+  "pattern": "use $CRATE;",
+  "constraints": {"CRATE": "^crossterm"},
+  "glob": "**/*.rs"
+}
+```
+
+## Parameters
+
+- `pattern` — required ast-grep pattern code.
+- `language` — required ast-grep language alias such as `rs`, `rust`, `ts`, `tsx`, `py`, or `js`.
+- `path` — file or directory to search. Defaults to the workspace root.
+- `glob` — optional file filter such as `**/*.rs` or `*.{ts,tsx}`.
+- `constraints` — optional map from metavariable name (without `$`) to a regex the captured text must match. Only matches where every constraint is satisfied are returned. Example: `{"CRATE": "^crossterm"}` with pattern `use $CRATE;`.
+- `contextBefore` — lines before each match.
+- `contextAfter` — lines after each match.
+- `contextAround` — lines before and after each match; overrides `contextBefore` and `contextAfter`.
+- `headLimit` — maximum number of matches to return.
+
+Directory searches respect `.gitignore`, skip hidden files, do not follow symlinks, and search only files matching the selected language. Explicit file searches parse the provided file with the selected language even if the extension does not match.
+
+Result line and column ranges are 1-based. Byte ranges are 0-based and end-exclusive.

--- a/packages/mcp-servers/src/coding/tools/ast_grep/mod.rs
+++ b/packages/mcp-servers/src/coding/tools/ast_grep/mod.rs
@@ -1,0 +1,572 @@
+use crate::coding::error::AstGrepError;
+use crate::coding::tools::glob_filter::build_glob_set;
+use ast_grep_core::Doc;
+use ast_grep_core::matcher::{NodeMatch, Pattern};
+use ast_grep_language::{Language, LanguageExt, SupportLang};
+use globset::GlobSet;
+use ignore::{WalkBuilder, WalkState};
+use mcp_utils::display_meta::{ToolDisplayMeta, ToolResultMeta, basename};
+use regex::Regex;
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
+use std::fs::read_to_string;
+use std::path::Path;
+use std::sync::{Arc, Mutex};
+use tokio::task::spawn_blocking;
+
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct AstGrepInput {
+    /// ast-grep pattern code.
+    pub pattern: String,
+    /// Language alias understood by ast-grep, e.g. "rs", "rust", "ts", "tsx", "py", "js".
+    pub language: String,
+    /// File or directory to search. Defaults to the coding server workspace root.
+    pub path: Option<String>,
+    /// Optional glob filter, e.g. "**/*.rs" or "*.{ts,tsx}".
+    pub glob: Option<String>,
+    /// Lines before each match.
+    pub context_before: Option<u32>,
+    /// Lines after each match.
+    pub context_after: Option<u32>,
+    /// Lines before and after each match. Overrides contextBefore/contextAfter.
+    pub context_around: Option<u32>,
+    /// Maximum number of matches to return.
+    pub head_limit: Option<usize>,
+    /// Optional regex constraints on metavariable captures.
+    /// Key is the metavariable name without `$`; value is a regex the captured text must match.
+    /// Example: `{"CRATE": "^crossterm"}` with pattern `use $CRATE;`.
+    pub constraints: Option<HashMap<String, String>>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct AstGrepOutput {
+    pub matches: Vec<AstGrepMatch>,
+    pub count: usize,
+    pub truncated: bool,
+    pub language: String,
+    pub search_path: String,
+    #[serde(rename = "_meta", skip_serializing_if = "Option::is_none")]
+    #[schemars(skip)]
+    pub meta: Option<ToolResultMeta>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct AstGrepMatch {
+    pub file: String,
+    pub range: AstGrepRange,
+    pub text: String,
+    pub captures: Vec<AstGrepCapture>,
+    pub before_context: Option<Vec<String>>,
+    pub after_context: Option<Vec<String>>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct AstGrepRange {
+    /// 1-based line number.
+    pub start_line: usize,
+    /// 1-based character column.
+    pub start_column: usize,
+    /// 1-based line number.
+    pub end_line: usize,
+    /// 1-based character column.
+    pub end_column: usize,
+    /// 0-based byte offset.
+    pub start_byte: usize,
+    /// 0-based exclusive byte offset.
+    pub end_byte: usize,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct AstGrepCapture {
+    pub name: String,
+    pub text: String,
+}
+
+pub async fn perform_ast_grep(mut args: AstGrepInput) -> Result<AstGrepOutput, AstGrepError> {
+    spawn_blocking(move || {
+        if args.path.as_deref().is_some_and(|p| p.trim().is_empty()) {
+            args.path = None;
+        }
+
+        let lang: SupportLang =
+            args.language.parse().map_err(|_| AstGrepError::UnsupportedLanguage(args.language.clone()))?;
+
+        let pattern = Pattern::try_new(&args.pattern, lang).map_err(|e| AstGrepError::InvalidPattern(e.to_string()))?;
+
+        let constraint_regexes = compile_constraints(args.constraints.as_ref())?;
+        let glob_set = build_glob_set(args.glob.as_deref())?;
+        let search_path = args.path.as_deref().unwrap_or(".");
+        let path = Path::new(search_path);
+        if !path.exists() {
+            return Err(AstGrepError::PathNotFound(search_path.to_string()));
+        }
+
+        let (context_before, context_after) = context_counts(&args);
+        let limit = args.head_limit.unwrap_or(usize::MAX);
+        let mut matches = if path.is_file() {
+            if glob_matches(path, path, glob_set.as_ref()) {
+                search_file(path, lang, &pattern, &constraint_regexes, context_before, context_after)?
+            } else {
+                Vec::new()
+            }
+        } else {
+            search_directory(path, lang, pattern, glob_set, &constraint_regexes, context_before, context_after)
+        };
+
+        matches.sort_by(|a, b| {
+            a.file
+                .cmp(&b.file)
+                .then(a.range.start_byte.cmp(&b.range.start_byte))
+                .then(a.range.end_byte.cmp(&b.range.end_byte))
+        });
+        let truncated = matches.len() > limit;
+        matches.truncate(limit);
+
+        let count = matches.len();
+        let meta = ToolDisplayMeta::new(
+            "AST grep",
+            format!("'{}' in {} ({count} matches)", args.pattern, basename(search_path)),
+        );
+
+        Ok(AstGrepOutput {
+            matches,
+            count,
+            truncated,
+            language: lang.to_string(),
+            search_path: search_path.to_string(),
+            meta: Some(meta.into()),
+        })
+    })
+    .await
+    .map_err(|error| AstGrepError::SearchFailed(error.to_string()))?
+}
+
+fn search_directory(
+    search_path: &Path,
+    lang: SupportLang,
+    pattern: Pattern,
+    glob: Option<GlobSet>,
+    constraints: &HashMap<String, Regex>,
+    context_before: usize,
+    context_after: usize,
+) -> Vec<AstGrepMatch> {
+    let matches = Arc::new(Mutex::new(Vec::new()));
+    let pattern = Arc::new(pattern);
+    let glob = Arc::new(glob);
+    let constraints = Arc::new(constraints.clone());
+    let search_root = Arc::new(search_path.to_path_buf());
+    let mut walker = WalkBuilder::new(search_path);
+    walker.follow_links(false);
+
+    walker.build_parallel().run(|| {
+        let matches = matches.clone();
+        let pattern = pattern.clone();
+        let glob = glob.clone();
+        let constraints = constraints.clone();
+        let search_root = search_root.clone();
+
+        Box::new(move |result| {
+            let Ok(entry) = result else {
+                return WalkState::Continue;
+            };
+
+            if !entry.file_type().is_some_and(|file_type| file_type.is_file()) {
+                return WalkState::Continue;
+            }
+
+            if !file_matches_filters(entry.path(), search_root.as_ref().as_path(), lang, glob.as_ref().as_ref()) {
+                return WalkState::Continue;
+            }
+
+            let Ok(file_matches) =
+                search_file(entry.path(), lang, &pattern, &constraints, context_before, context_after)
+            else {
+                return WalkState::Continue;
+            };
+
+            if !file_matches.is_empty()
+                && let Ok(mut matches) = matches.lock()
+            {
+                matches.extend(file_matches);
+            }
+
+            WalkState::Continue
+        })
+    });
+
+    matches.lock().map(|matches| matches.clone()).unwrap_or_default()
+}
+
+fn file_matches_filters(path: &Path, search_root: &Path, lang: SupportLang, glob: Option<&GlobSet>) -> bool {
+    <SupportLang as Language>::from_path(path) == Some(lang) && glob_matches(path, search_root, glob)
+}
+
+fn glob_matches(path: &Path, search_root: &Path, glob: Option<&GlobSet>) -> bool {
+    let Some(glob) = glob else {
+        return true;
+    };
+
+    glob.is_match(path) || path.strip_prefix(search_root).is_ok_and(|relative| glob.is_match(relative))
+}
+
+fn search_file(
+    path: &Path,
+    lang: SupportLang,
+    pattern: &Pattern,
+    constraints: &HashMap<String, Regex>,
+    context_before: usize,
+    context_after: usize,
+) -> Result<Vec<AstGrepMatch>, AstGrepError> {
+    let source = read_to_string(path)
+        .map_err(|error| AstGrepError::ReadFailed { path: path.display().to_string(), reason: error.to_string() })?;
+
+    let lines: Vec<&str> = source.lines().collect();
+    let root = lang.ast_grep(&source);
+    let mut matches = Vec::new();
+    for node_match in root.root().find_all(pattern.clone()) {
+        if !constraints_match(&node_match, constraints) {
+            continue;
+        }
+        matches.push(build_match(path, &lines, &node_match, context_before, context_after));
+    }
+    Ok(matches)
+}
+
+fn build_match<T: Doc>(
+    path: &Path,
+    lines: &[&str],
+    node_match: &NodeMatch<'_, T>,
+    context_before: usize,
+    context_after: usize,
+) -> AstGrepMatch {
+    let start = node_match.start_pos();
+    let end = node_match.end_pos();
+    let range = node_match.range();
+    let start_line = start.line() + 1;
+    let end_line = end.line() + 1;
+    let (before_context, after_context) = context_for_match(lines, start_line, end_line, context_before, context_after);
+
+    AstGrepMatch {
+        file: path.to_string_lossy().to_string(),
+        range: AstGrepRange {
+            start_line,
+            start_column: start.column(node_match.get_node()) + 1,
+            end_line,
+            end_column: end.column(node_match.get_node()) + 1,
+            start_byte: range.start,
+            end_byte: range.end,
+        },
+        text: node_match.text().to_string(),
+        captures: captures(node_match),
+        before_context,
+        after_context,
+    }
+}
+
+fn captures<T: Doc>(node_match: &NodeMatch<'_, T>) -> Vec<AstGrepCapture> {
+    let env: HashMap<String, String> = HashMap::from(node_match.get_env().clone());
+    let mut captures: Vec<AstGrepCapture> = env.into_iter().map(|(name, text)| AstGrepCapture { name, text }).collect();
+    captures.sort_by(|a, b| a.name.cmp(&b.name));
+    captures
+}
+
+fn context_for_match(
+    lines: &[&str],
+    start_line: usize,
+    end_line: usize,
+    before: usize,
+    after: usize,
+) -> (Option<Vec<String>>, Option<Vec<String>>) {
+    let before_context = if before == 0 {
+        None
+    } else {
+        let start = start_line.saturating_sub(before).max(1);
+        let context: Vec<String> =
+            lines[start - 1..start_line.saturating_sub(1)].iter().map(|line| (*line).to_string()).collect();
+        Some(context)
+    };
+    let after_context = if after == 0 {
+        None
+    } else if end_line >= lines.len() {
+        Some(Vec::new())
+    } else {
+        let end = (end_line + after).min(lines.len());
+        let context: Vec<String> = lines[end_line..end].iter().map(|line| (*line).to_string()).collect();
+        Some(context)
+    };
+    (before_context, after_context)
+}
+
+fn compile_constraints(constraints: Option<&HashMap<String, String>>) -> Result<HashMap<String, Regex>, AstGrepError> {
+    let Some(constraints) = constraints else { return Ok(HashMap::new()) };
+    constraints
+        .iter()
+        .map(|(name, pattern)| {
+            Regex::new(pattern)
+                .map(|regex| (name.clone(), regex))
+                .map_err(|error| AstGrepError::InvalidConstraintRegex { name: name.clone(), reason: error.to_string() })
+        })
+        .collect()
+}
+
+fn constraints_match<T: Doc>(node_match: &NodeMatch<'_, T>, constraints: &HashMap<String, Regex>) -> bool {
+    let env = node_match.get_env();
+    constraints.iter().all(|(name, regex)| env.get_match(name).is_some_and(|node| regex.is_match(&node.text())))
+}
+
+fn context_counts(args: &AstGrepInput) -> (usize, usize) {
+    if let Some(around) = args.context_around {
+        (around as usize, around as usize)
+    } else {
+        (args.context_before.unwrap_or(0) as usize, args.context_after.unwrap_or(0) as usize)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+    use tempfile::TempDir;
+
+    fn input(pattern: &str, path: &Path) -> AstGrepInput {
+        AstGrepInput {
+            pattern: pattern.to_string(),
+            language: "rs".to_string(),
+            path: Some(path.to_string_lossy().to_string()),
+            glob: None,
+            context_before: None,
+            context_after: None,
+            context_around: None,
+            head_limit: None,
+            constraints: None,
+        }
+    }
+
+    #[tokio::test]
+    async fn finds_rust_function_pattern() {
+        let temp = TempDir::new().unwrap();
+        fs::write(temp.path().join("lib.rs"), "fn foo() {}\nfn bar() { let x = 1; }\n").unwrap();
+
+        let result = perform_ast_grep(input("fn $NAME() { $$$BODY }", temp.path())).await.unwrap();
+
+        assert_eq!(result.count, 2);
+        assert!(result.matches.iter().any(|m| m.text == "fn foo() {}"));
+        assert!(result.matches.iter().any(|m| m.text == "fn bar() { let x = 1; }"));
+    }
+
+    #[tokio::test]
+    async fn returns_metavariable_captures() {
+        let temp = TempDir::new().unwrap();
+        fs::write(temp.path().join("lib.rs"), "fn foo() {}\n").unwrap();
+
+        let result = perform_ast_grep(input("fn $NAME() {}", temp.path())).await.unwrap();
+
+        assert_eq!(result.matches[0].captures[0].name, "NAME");
+        assert_eq!(result.matches[0].captures[0].text, "foo");
+    }
+
+    #[tokio::test]
+    async fn filters_directory_by_language() {
+        let temp = TempDir::new().unwrap();
+        fs::write(temp.path().join("lib.rs"), "fn foo() {}\n").unwrap();
+        fs::write(temp.path().join("test.py"), "fn fake() {}\n").unwrap();
+
+        let result = perform_ast_grep(input("fn $NAME() {}", temp.path())).await.unwrap();
+
+        assert_eq!(result.count, 1);
+        assert!(result.matches[0].file.ends_with("lib.rs"));
+    }
+
+    #[tokio::test]
+    async fn applies_glob_filter() {
+        let temp = TempDir::new().unwrap();
+        fs::create_dir(temp.path().join("src")).unwrap();
+        fs::create_dir(temp.path().join("tests")).unwrap();
+        fs::write(temp.path().join("src/lib.rs"), "fn src_fn() {}\n").unwrap();
+        fs::write(temp.path().join("tests/lib.rs"), "fn test_fn() {}\n").unwrap();
+        let mut args = input("fn $NAME() {}", temp.path());
+        args.glob = Some("src/**/*.rs".to_string());
+        let result = perform_ast_grep(args).await.unwrap();
+        assert_eq!(result.count, 1);
+        assert!(result.matches[0].file.ends_with("src/lib.rs"));
+    }
+
+    #[tokio::test]
+    async fn invalid_language_returns_error() {
+        let temp = TempDir::new().unwrap();
+        let mut args = input("fn $NAME() {}", temp.path());
+        args.language = "not-a-language".to_string();
+        let result = perform_ast_grep(args).await;
+        assert!(matches!(result, Err(AstGrepError::UnsupportedLanguage(_))));
+    }
+
+    #[tokio::test]
+    async fn invalid_pattern_returns_error() {
+        let temp = TempDir::new().unwrap();
+        let result = perform_ast_grep(input("", temp.path())).await;
+
+        assert!(matches!(result, Err(AstGrepError::InvalidPattern(_))));
+    }
+
+    #[tokio::test]
+    async fn head_limit_truncates_results() {
+        let temp = TempDir::new().unwrap();
+        fs::write(temp.path().join("lib.rs"), "fn a() {}\nfn b() {}\n").unwrap();
+        let mut args = input("fn $NAME() {}", temp.path());
+        args.head_limit = Some(1);
+        let result = perform_ast_grep(args).await.unwrap();
+        assert_eq!(result.count, 1);
+        assert!(result.truncated);
+    }
+
+    #[tokio::test]
+    async fn head_limit_zero_returns_no_matches_but_truncated() {
+        let temp = TempDir::new().unwrap();
+        fs::write(temp.path().join("lib.rs"), "fn a() {}\n").unwrap();
+        let mut args = input("fn $NAME() {}", temp.path());
+        args.head_limit = Some(0);
+        let result = perform_ast_grep(args).await.unwrap();
+        assert_eq!(result.count, 0);
+        assert!(result.truncated);
+    }
+
+    #[tokio::test]
+    async fn nonexistent_path_returns_error() {
+        let result = perform_ast_grep(input("fn $NAME() {}", Path::new("/no/such/path/exists"))).await;
+
+        assert!(matches!(result, Err(AstGrepError::PathNotFound(_))));
+    }
+
+    #[tokio::test]
+    async fn explicit_unreadable_file_returns_error() {
+        let temp = TempDir::new().unwrap();
+        let file = temp.path().join("invalid.rs");
+        fs::write(&file, [0xff, 0xfe, 0x00, 0x01]).unwrap();
+        let result = perform_ast_grep(input("fn $NAME() {}", &file)).await;
+        assert!(matches!(result, Err(AstGrepError::ReadFailed { .. })));
+    }
+
+    #[tokio::test]
+    async fn range_is_one_based_and_byte_offsets_are_zero_based() {
+        let temp = TempDir::new().unwrap();
+        fs::write(temp.path().join("lib.rs"), "\nfn foo() {}\n").unwrap();
+        let result = perform_ast_grep(input("fn $NAME() {}", temp.path())).await.unwrap();
+        let range = &result.matches[0].range;
+
+        assert_eq!(range.start_line, 2);
+        assert_eq!(range.start_column, 1);
+        assert_eq!(range.start_byte, 1);
+    }
+
+    #[tokio::test]
+    async fn directory_search_skips_hidden_files() {
+        let temp = TempDir::new().unwrap();
+        fs::write(temp.path().join("visible.rs"), "fn visible() {}\n").unwrap();
+        fs::write(temp.path().join(".hidden.rs"), "fn hidden() {}\n").unwrap();
+        let result = perform_ast_grep(input("fn $NAME() {}", temp.path())).await.unwrap();
+
+        assert_eq!(result.count, 1);
+        assert_eq!(result.matches[0].text, "fn visible() {}");
+    }
+
+    #[tokio::test]
+    async fn directory_search_respects_gitignore() {
+        let temp = TempDir::new().unwrap();
+        fs::create_dir(temp.path().join(".git")).unwrap();
+        fs::write(temp.path().join(".gitignore"), "ignored.rs\n").unwrap();
+        fs::write(temp.path().join("included.rs"), "fn included() {}\n").unwrap();
+        fs::write(temp.path().join("ignored.rs"), "fn ignored() {}\n").unwrap();
+
+        let result = perform_ast_grep(input("fn $NAME() {}", temp.path())).await.unwrap();
+
+        assert_eq!(result.count, 1);
+        assert_eq!(result.matches[0].text, "fn included() {}");
+    }
+
+    #[tokio::test]
+    async fn includes_context_lines() {
+        let temp = TempDir::new().unwrap();
+        fs::write(temp.path().join("lib.rs"), "before\nfn foo() {}\nafter\n").unwrap();
+        let mut args = input("fn $NAME() {}", temp.path());
+        args.context_around = Some(1);
+
+        let result = perform_ast_grep(args).await.unwrap();
+
+        assert_eq!(result.matches[0].before_context.as_ref().unwrap(), &vec!["before".to_string()]);
+        assert_eq!(result.matches[0].after_context.as_ref().unwrap(), &vec!["after".to_string()]);
+    }
+
+    #[tokio::test]
+    async fn filters_matches_by_constraint() {
+        let temp = TempDir::new().unwrap();
+        fs::write(temp.path().join("lib.rs"), "use crossterm::execute;\nuse serde::Serialize;\n").unwrap();
+
+        let mut args = input("use $CRATE;", temp.path());
+        args.constraints = Some(HashMap::from([("CRATE".to_string(), "^crossterm".to_string())]));
+
+        let result = perform_ast_grep(args).await.unwrap();
+
+        assert_eq!(result.count, 1);
+        assert_eq!(result.matches[0].text, "use crossterm::execute;");
+    }
+
+    #[tokio::test]
+    async fn constraint_with_no_matches_returns_empty() {
+        let temp = TempDir::new().unwrap();
+        fs::write(temp.path().join("lib.rs"), "fn foo() {}\n").unwrap();
+
+        let mut args = input("fn $NAME() {}", temp.path());
+        args.constraints = Some(HashMap::from([("NAME".to_string(), "^bar".to_string())]));
+
+        let result = perform_ast_grep(args).await.unwrap();
+
+        assert_eq!(result.count, 0);
+    }
+
+    #[tokio::test]
+    async fn constraint_on_missing_capture_returns_empty() {
+        let temp = TempDir::new().unwrap();
+        fs::write(temp.path().join("lib.rs"), "fn foo() {}\n").unwrap();
+
+        let mut args = input("fn $NAME() {}", temp.path());
+        args.constraints = Some(HashMap::from([("MISSING".to_string(), ".*".to_string())]));
+
+        let result = perform_ast_grep(args).await.unwrap();
+
+        assert_eq!(result.count, 0);
+    }
+
+    #[tokio::test]
+    async fn invalid_constraint_regex_returns_error() {
+        let temp = TempDir::new().unwrap();
+        fs::write(temp.path().join("lib.rs"), "fn foo() {}\n").unwrap();
+
+        let mut args = input("fn $NAME() {}", temp.path());
+        args.constraints = Some(HashMap::from([("NAME".to_string(), "(".to_string())]));
+
+        let result = perform_ast_grep(args).await;
+
+        assert!(matches!(result, Err(AstGrepError::InvalidConstraintRegex { .. })));
+    }
+
+    #[tokio::test]
+    async fn multiple_constraints_all_must_match() {
+        let temp = TempDir::new().unwrap();
+        fs::write(temp.path().join("lib.rs"), "fn alpha() {}\nfn beta() {}\n").unwrap();
+
+        let mut args = input("fn $NAME() {}", temp.path());
+        args.constraints =
+            Some(HashMap::from([("NAME".to_string(), "^a".to_string()), ("NAME".to_string(), "lpha".to_string())]));
+
+        let result = perform_ast_grep(args).await.unwrap();
+
+        assert_eq!(result.count, 1);
+        assert!(result.matches[0].text.contains("alpha"));
+    }
+}

--- a/packages/mcp-servers/src/coding/tools/glob_filter.rs
+++ b/packages/mcp-servers/src/coding/tools/glob_filter.rs
@@ -1,0 +1,14 @@
+use crate::coding::error::GlobError;
+use globset::{Glob, GlobSet, GlobSetBuilder};
+
+pub fn build_glob_set(glob: Option<&str>) -> Result<Option<GlobSet>, GlobError> {
+    let Some(glob) = glob else {
+        return Ok(None);
+    };
+
+    let mut builder = GlobSetBuilder::new();
+    builder.add(
+        Glob::new(glob).map_err(|e| GlobError::InvalidPattern { pattern: glob.to_owned(), reason: e.to_string() })?,
+    );
+    builder.build().map(Some).map_err(|e| GlobError::BuildFailed(e.to_string()))
+}

--- a/packages/mcp-servers/src/coding/tools/grep/mod.rs
+++ b/packages/mcp-servers/src/coding/tools/grep/mod.rs
@@ -1,9 +1,9 @@
 pub mod common;
 
 use crate::coding::error::GrepError;
+use crate::coding::tools::glob_filter::build_glob_set;
 use aether_lspd::extensions_for_alias as extensions_for_type;
 use common::{CountSink, HasMatchSink, MatchCollectorSink, MatchData, OutputMode};
-use globset::{Glob, GlobSetBuilder};
 use grep::{
     regex::{RegexMatcher, RegexMatcherBuilder},
     searcher::{BinaryDetection, Searcher, SearcherBuilder},
@@ -199,18 +199,6 @@ impl SearchResults {
     fn empty() -> Self {
         Self { matches: Vec::new(), files_with_matches: Vec::new(), file_counts: Vec::new() }
     }
-}
-
-fn build_glob_set(glob_pattern: Option<&str>) -> Result<Option<globset::GlobSet>, GrepError> {
-    let Some(glob_pattern) = glob_pattern else {
-        return Ok(None);
-    };
-    let mut builder = GlobSetBuilder::new();
-    builder.add(
-        Glob::new(glob_pattern)
-            .map_err(|e| GrepError::InvalidGlobPattern { pattern: glob_pattern.to_owned(), reason: e.to_string() })?,
-    );
-    builder.build().map(Some).map_err(|e| GrepError::GlobSetBuildFailed(e.to_string()))
 }
 
 fn build_matcher(

--- a/packages/mcp-servers/src/coding/tools/mod.rs
+++ b/packages/mcp-servers/src/coding/tools/mod.rs
@@ -1,7 +1,9 @@
+pub mod ast_grep;
 pub mod bash;
 pub mod edit_file;
 pub mod file_io;
 pub mod find;
+pub mod glob_filter;
 pub mod grep;
 pub mod list_files;
 pub mod read_file;

--- a/packages/mcp-servers/src/coding/tools_trait.rs
+++ b/packages/mcp-servers/src/coding/tools_trait.rs
@@ -3,6 +3,7 @@ use std::future::Future;
 use std::path::PathBuf;
 
 use super::error::CodingError;
+use super::tools::ast_grep::{AstGrepInput, AstGrepOutput, perform_ast_grep};
 use super::tools::bash::{BackgroundProcessHandle, BashInput, BashResult, ReadBackgroundBashOutput};
 use super::tools::edit_file::{EditFileArgs, EditFileResponse};
 use super::tools::find::{FindInput, FindOutput, find_files_by_name};
@@ -42,6 +43,10 @@ pub trait CodingTools: Send + Sync + Debug {
     /// Search file contents using regex patterns.
     fn grep(&self, args: GrepInput) -> impl Future<Output = Result<GrepOutput, CodingError>> + Send {
         async move { perform_grep(args).await.map_err(CodingError::from) }
+    }
+
+    fn ast_grep(&self, args: AstGrepInput) -> impl Future<Output = Result<AstGrepOutput, CodingError>> + Send {
+        async move { perform_ast_grep(args).await.map_err(CodingError::from) }
     }
 
     /// Find files by name using glob patterns.

--- a/packages/mcp-servers/src/docs/coding_error.md
+++ b/packages/mcp-servers/src/docs/coding_error.md
@@ -7,6 +7,7 @@ Error types for all coding tool operations.
 - **`File`** -- File read, write, or edit failures ([`FileError`]).
 - **`Bash`** -- Shell command execution failures ([`BashError`]).
 - **`Grep`** -- Regex search failures ([`GrepError`]).
+- **`AstGrep`** -- Structural AST search failures ([`AstGrepError`]).
 - **`Find`** -- Glob-based file discovery failures ([`FindError`]).
 - **`ListFiles`** -- Directory listing failures ([`ListFilesError`]).
 - **`WebFetch`** -- URL fetch failures ([`WebFetchError`]).
@@ -17,7 +18,9 @@ Error types for all coding tool operations.
 
 - [`FileError`] -- `NotFound`, `ReadFailed`, `WriteFailed`, `CreateDirFailed`, `InvalidOffset`, `PatternNotFound`, `Io`.
 - [`BashError`] -- `Forbidden`, `TimeoutTooLarge`, `SpawnFailed`, `InvalidRegex`, `JoinFailed`, `ShellNotFound`, `WaitFailed`.
-- [`GrepError`] -- `InvalidGlobPattern`, `GlobSetBuildFailed`, `InvalidRegex`, `SearchFailed`, `PathNotFound`.
+- [`GlobError`] -- `InvalidPattern`, `BuildFailed` (shared by the search tools).
+- [`GrepError`] -- `Glob`, `InvalidRegex`, `SearchFailed`, `PathNotFound`.
+- [`AstGrepError`] -- `PathNotFound`, `Glob`, `UnsupportedLanguage`, `InvalidPattern`, `ReadFailed`, `SearchFailed`.
 - [`FindError`] -- `PathNotFound`, `InvalidGlobPattern`, `LockFailed`.
 - [`ListFilesError`] -- `ReadDirFailed`, `ReadEntryFailed`, `MetadataFailed`.
 - [`WebFetchError`] -- `InvalidUrl`, `RequestFailed`, `Timeout`, `ResponseTooLarge`, `ParseFailed`.

--- a/packages/mcp-servers/src/docs/coding_mcp.md
+++ b/packages/mcp-servers/src/docs/coding_mcp.md
@@ -1,4 +1,4 @@
-The primary MCP tool server for coding workflows. Provides file I/O, shell execution, regex search, glob-based file discovery, LSP code intelligence, and web fetch/search -- all exposed as MCP tools that an agent can invoke.
+The primary MCP tool server for coding workflows. Provides file I/O, shell execution, regex search, structural AST search, glob-based file discovery, LSP code intelligence, and web fetch/search -- all exposed as MCP tools that an agent can invoke.
 
 # Construction
 

--- a/packages/mcp-servers/src/docs/coding_tools.md
+++ b/packages/mcp-servers/src/docs/coding_tools.md
@@ -16,6 +16,7 @@ Implement this trait to provide a custom backend -- for example, a sandboxed fil
 **Provided** (default implementations using standalone functions):
 
 - **`grep`** -- Regex search across files. Delegates to [`perform_grep`](crate::coding::tools::grep::perform_grep).
+- **`ast_grep`** -- Structural AST search across files. Delegates to [`perform_ast_grep`](crate::coding::tools::ast_grep::perform_ast_grep).
 - **`find`** -- Glob-based file discovery. Delegates to [`find_files_by_name`](crate::coding::tools::find::find_files_by_name).
 
 # See also

--- a/packages/mcp-servers/tests/coding_mcp_tools.rs
+++ b/packages/mcp-servers/tests/coding_mcp_tools.rs
@@ -443,6 +443,43 @@ async fn test_grep_and_find_use_workspace_root_when_no_path_given() -> Result<()
     Ok(())
 }
 
+#[tokio::test]
+async fn test_ast_grep_uses_workspace_root_when_no_path_given() -> Result<(), Box<dyn std::error::Error>> {
+    let temp = tempfile::tempdir()?;
+    let workspace = temp.path().to_path_buf();
+    fs::write(workspace.join("lib.rs"), "fn target() {}\nfn other() {}\n")?;
+
+    let server_service = CodingMcp::new().with_root_dir(workspace.clone());
+    let client_info = ClientInfo::new(ClientCapabilities::default(), Implementation::new("test-client", "0.1.0"));
+    let (_server_handle, client) = connect(server_service, client_info).await?;
+    let result = client
+        .call_tool(
+            CallToolRequestParams::new("ast_grep").with_arguments(
+                serde_json::json!({
+                    "language": "rs",
+                    "pattern": "fn $NAME() {}"
+                })
+                .as_object()
+                .unwrap()
+                .clone(),
+            ),
+        )
+        .await?;
+
+    let text_content = result.content.first().and_then(|c| c.as_text()).ok_or("Expected text content")?;
+    let parsed: serde_json::Value = serde_json::from_str(&text_content.text)?;
+    let matches = parsed["matches"].as_array().ok_or("matches should be an array")?;
+    assert_eq!(parsed["searchPath"].as_str().unwrap(), workspace.to_str().unwrap());
+    assert!(matches.iter().any(|m| {
+        m["file"].as_str().unwrap().ends_with("lib.rs")
+            && m["text"].as_str().unwrap() == "fn target() {}"
+            && m["range"]["startLine"].as_u64().unwrap() == 1
+            && m["captures"].as_array().unwrap().iter().any(|c| c["name"] == "NAME" && c["text"] == "target")
+    }));
+
+    Ok(())
+}
+
 #[cfg(feature = "test-helpers")]
 #[tokio::test]
 async fn test_read_before_edit_safety_with_relative_path_normalization() {


### PR DESCRIPTION
This PR give the `coding` MCP server an ast grep tool, which uses https://github.com/ast-grep/ast-grep  as a library (it's written in Rust so it's easy to use as a lib). 

This tool is useful in many applications, e.g. it can do "find all files that import crossterm" in a single token-efficient tool call.  