### PR TITLE
feat: Improved support for evals

### DIFF
--- a/packages/aether-cli/src/bin/aether-schemas.rs
+++ b/packages/aether-cli/src/bin/aether-schemas.rs
@@ -7,6 +7,7 @@ fn main() {
         "HeadlessOptions": schemars::schema_for!(aether_cli::headless::HeadlessOptions),
         "EvalSpec": aether_evals::EvalSpec::schema(),
         "EvalOutcome": aether_evals::EvalOutcome::schema(),
+        "EvalStreamEvent": aether_evals::EvalStreamEvent::schema(),
     });
     println!("{}", serde_json::to_string_pretty(&document).expect("schema document serializes to JSON"));
 }

--- a/packages/aether-cli/src/bin/aether-schemas.rs
+++ b/packages/aether-cli/src/bin/aether-schemas.rs
@@ -8,6 +8,7 @@ fn main() {
         "EvalSpec": aether_evals::EvalSpec::schema(),
         "EvalOutcome": aether_evals::EvalOutcome::schema(),
         "EvalStreamEvent": aether_evals::EvalStreamEvent::schema(),
+        "JudgeRubricResponse": schemars::schema_for!(aether_evals::JudgeRubricResponse),
     });
     println!("{}", serde_json::to_string_pretty(&document).expect("schema document serializes to JSON"));
 }

--- a/packages/aether-cli/src/eval/mod.rs
+++ b/packages/aether-cli/src/eval/mod.rs
@@ -2,12 +2,13 @@ mod render;
 
 use crate::output::OutputFormat;
 use aether_evals::{
-    EvalFileError, EvalFilesReport, EvalSpec, EvalSpecLoadOptions, ResolvedEvalSpec, WorkspaceRetention, run_eval_specs,
+    EvalFileError, EvalFilesReport, EvalSpec, EvalSpecLoadOptions, EvalStreamEvent, ResolvedEvalSpec,
+    WorkspaceRetention, run_eval_spec_streaming, run_eval_specs,
 };
 use render::render;
 use std::env::current_dir;
 use std::fs::read_to_string;
-use std::io::{Read, stdin};
+use std::io::{Read, Write, stdin, stdout};
 use std::num::NonZeroUsize;
 use std::path::PathBuf;
 use std::process::ExitCode;
@@ -31,7 +32,9 @@ pub struct EvalArgs {
     #[arg(long, default_value = "text")]
     pub output: OutputFormat,
 
-    /// Run a single eval from a JSON file, or from stdin with `-`. The outcome is printed to stdout as JSON.
+    /// Run a single eval from a JSON file, or from stdin with `-`. Emits newline-delimited
+    /// `EvalStreamEvent` JSON on stdout: an `agent_message` event per agent message as it streams,
+    /// terminated by one `outcome` event.
     #[arg(long, value_name = "PATH_OR_DASH")]
     pub spec_file: Option<String>,
 
@@ -53,9 +56,11 @@ pub async fn run(args: EvalArgs) -> Result<ExitCode, EvalFileError> {
         let retention = if args.retain_workspace { WorkspaceRetention::Retain } else { WorkspaceRetention::Discard };
         let spec: EvalSpec = serde_json::from_str(&json).map_err(|source| EvalFileError::ParseSpec { source })?;
         let case = ResolvedEvalSpec::resolve(spec, base_dir)?;
-        let mut evals = run_eval_specs([case], retention, NonZeroUsize::MIN).await?;
-        let outcome = evals.pop().expect("one case in, one outcome out");
-        println!("{}", serde_json::to_string(&outcome).expect("EvalOutcome serializes to JSON"));
+        let outcome = run_eval_spec_streaming(case, retention, |message| {
+            print_json_event(&EvalStreamEvent::AgentMessage { message: message.clone() });
+        })
+        .await?;
+        print_json_event(&EvalStreamEvent::Outcome { outcome });
         return Ok(ExitCode::SUCCESS);
     }
 
@@ -65,6 +70,11 @@ pub async fn run(args: EvalArgs) -> Result<ExitCode, EvalFileError> {
 
     println!("{}", render(&report, args.output));
     Ok(if report.passed() { ExitCode::SUCCESS } else { ExitCode::FAILURE })
+}
+
+fn print_json_event(event: &EvalStreamEvent) {
+    println!("{}", serde_json::to_string(event).expect("EvalStreamEvent serializes to JSON"));
+    let _ = stdout().flush();
 }
 
 fn read_eval(source: &str) -> Result<String, EvalFileError> {

--- a/packages/aether-cli/src/eval/render.rs
+++ b/packages/aether-cli/src/eval/render.rs
@@ -57,6 +57,7 @@ mod tests {
                             weight: 1.0,
                             threshold: 1.0,
                             score: 1.0,
+                            passed: true,
                             reason: "correct".to_string(),
                         }],
                     }),
@@ -79,6 +80,7 @@ mod tests {
                             weight: 1.0,
                             threshold: 1.0,
                             score: 0.5,
+                            passed: false,
                             reason: "wrong".to_string(),
                         }],
                     }),
@@ -109,6 +111,6 @@ mod tests {
         assert_eq!(parsed["evals"][1]["failures"][0], "expected tool `bash` to be called");
         assert_eq!(parsed["evals"][0]["judge"]["score"], 1.0);
         assert_eq!(parsed["evals"][1]["judge"]["criteria"][0]["id"], "behavior");
-        assert!(parsed["evals"][1]["judge"]["criteria"][0]["passed"].is_null());
+        assert_eq!(parsed["evals"][1]["judge"]["criteria"][0]["passed"], false);
     }
 }

--- a/packages/aether-cli/src/generate_command/mod.rs
+++ b/packages/aether-cli/src/generate_command/mod.rs
@@ -1,0 +1,175 @@
+use crate::output::OutputFormat;
+use futures::StreamExt;
+use llm::parser::ModelProviderParser;
+use llm::types::IsoString;
+use llm::{ChatMessage, ContentBlock, Context, LlmError, LlmResponse, StreamingModelProvider};
+use std::io::{Read, stdin};
+use std::process::ExitCode;
+use thiserror::Error;
+
+#[derive(clap::Args)]
+pub struct GenerateArgs {
+    /// Model to call, as `provider:model` (e.g. `anthropic:claude-sonnet-4-5`).
+    #[arg(long)]
+    pub model: String,
+
+    /// Prompt text to send.
+    #[arg(long, conflicts_with = "prompt_file", required_unless_present = "prompt_file")]
+    pub prompt: Option<String>,
+
+    /// Prompt to send from a file path, or `-` to read from stdin.
+    #[arg(long, value_name = "PATH_OR_DASH", conflicts_with = "prompt", required_unless_present = "prompt")]
+    pub prompt_file: Option<String>,
+
+    /// Optional system prompt.
+    #[arg(long)]
+    pub system: Option<String>,
+
+    /// Output format. `text` prints the raw response; `json`/`pretty` wrap it as
+    /// `{ "text": <response>, "model": <model> }`.
+    #[arg(long, default_value = "text")]
+    pub output: OutputFormat,
+}
+
+#[derive(Debug, Error)]
+pub enum GenerateCommandError {
+    #[error("provide exactly one of --prompt or --prompt-file")]
+    PromptSource,
+
+    #[error("failed to read prompt from {path}: {source}")]
+    ReadPrompt { path: String, source: std::io::Error },
+
+    #[error("failed to initialize model `{model}`: {source}")]
+    Model { model: String, source: LlmError },
+
+    #[error("model stream error: {0}")]
+    Stream(LlmError),
+}
+
+/// Call a model with a single prompt and print its response. The judge is a special case of this:
+/// the caller supplies a grading prompt and parses the structured verdict out of the response.
+pub async fn run(args: GenerateArgs) -> Result<ExitCode, GenerateCommandError> {
+    let prompt = resolve_prompt(args.prompt.as_deref(), args.prompt_file.as_deref())?;
+    let (provider, _) = ModelProviderParser::default()
+        .parse(&args.model)
+        .await
+        .map_err(|source| GenerateCommandError::Model { model: args.model.clone(), source })?;
+
+    let messages = {
+        let mut messages = Vec::new();
+        if let Some(system) = args.system.as_deref() {
+            messages.push(ChatMessage::System { content: system.to_string(), timestamp: IsoString::now() });
+        }
+        messages.push(ChatMessage::User { content: vec![ContentBlock::text(&prompt)], timestamp: IsoString::now() });
+        messages
+    };
+
+    let mut stream = provider.stream_response(&Context::new(messages, vec![]));
+    let mut text = String::new();
+    while let Some(result) = stream.next().await {
+        match result {
+            Ok(LlmResponse::Text { chunk }) => text.push_str(&chunk),
+            Err(error) => return Err(GenerateCommandError::Stream(error)),
+            _ => {}
+        }
+    }
+    println!("{}", format_output(&text, &args.model, args.output));
+    Ok(ExitCode::SUCCESS)
+}
+
+fn format_output(text: &str, model: &str, format: OutputFormat) -> String {
+    match format {
+        OutputFormat::Text => text.to_string(),
+        OutputFormat::Json => serde_json::json!({ "text": text, "model": model }).to_string(),
+        OutputFormat::Pretty => serde_json::to_string_pretty(&serde_json::json!({ "text": text, "model": model }))
+            .expect("generate response serializes to JSON"),
+    }
+}
+
+fn resolve_prompt(prompt: Option<&str>, prompt_file: Option<&str>) -> Result<String, GenerateCommandError> {
+    match (prompt, prompt_file) {
+        (Some(prompt), None) => Ok(prompt.to_string()),
+        (None, Some(prompt_file)) => read_prompt_file(prompt_file),
+        _ => Err(GenerateCommandError::PromptSource),
+    }
+}
+
+fn read_prompt_file(source: &str) -> Result<String, GenerateCommandError> {
+    if source == "-" {
+        let mut prompt = String::new();
+        stdin()
+            .read_to_string(&mut prompt)
+            .map_err(|error| GenerateCommandError::ReadPrompt { path: "-".to_string(), source: error })?;
+        return Ok(prompt);
+    }
+    std::fs::read_to_string(source)
+        .map_err(|error| GenerateCommandError::ReadPrompt { path: source.to_string(), source: error })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn format_output_wraps_json_and_passes_text_through() {
+        assert_eq!(format_output("hi", "anthropic:m", OutputFormat::Text), "hi");
+
+        let json: serde_json::Value =
+            serde_json::from_str(&format_output("hi", "anthropic:m", OutputFormat::Json)).unwrap();
+        assert_eq!(json["text"], "hi");
+        assert_eq!(json["model"], "anthropic:m");
+    }
+
+    #[tokio::test]
+    async fn run_errors_on_unknown_provider() {
+        let dir = tempfile::tempdir().unwrap();
+        let prompt_path = dir.path().join("prompt.txt");
+        std::fs::write(&prompt_path, "the prompt").unwrap();
+        let args = GenerateArgs {
+            model: "definitely-not-a-provider:nope".to_string(),
+            prompt: None,
+            prompt_file: Some(prompt_path.to_string_lossy().into_owned()),
+            system: None,
+            output: OutputFormat::Json,
+        };
+
+        let error = run(args).await.unwrap_err();
+
+        assert!(matches!(error, GenerateCommandError::Model { .. }), "got: {error:?}");
+    }
+
+    #[test]
+    fn resolve_prompt_uses_inline_prompt() {
+        assert_eq!(resolve_prompt(Some("say hi"), None).unwrap(), "say hi");
+    }
+
+    #[test]
+    fn resolve_prompt_reads_a_file() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("prompt.txt");
+        std::fs::write(&path, "graded prompt").unwrap();
+
+        assert_eq!(resolve_prompt(None, Some(&path.to_string_lossy())).unwrap(), "graded prompt");
+    }
+
+    #[test]
+    fn resolve_prompt_reports_missing_file() {
+        let error = resolve_prompt(None, Some("/nonexistent/prompt.txt")).unwrap_err();
+
+        assert!(matches!(error, GenerateCommandError::ReadPrompt { .. }), "got: {error:?}");
+    }
+
+    #[test]
+    fn resolve_prompt_rejects_missing_prompt_source() {
+        let error = resolve_prompt(None, None).unwrap_err();
+
+        assert!(matches!(error, GenerateCommandError::PromptSource), "got: {error:?}");
+    }
+
+    #[test]
+    fn resolve_prompt_rejects_multiple_prompt_sources() {
+        let error = resolve_prompt(Some("inline"), Some("prompt.txt")).unwrap_err();
+
+        assert!(matches!(error, GenerateCommandError::PromptSource), "got: {error:?}");
+    }
+}

--- a/packages/aether-cli/src/lib.rs
+++ b/packages/aether-cli/src/lib.rs
@@ -4,6 +4,7 @@ pub mod acp;
 pub mod credentials;
 pub mod error;
 pub mod eval;
+pub mod generate_command;
 pub mod headless;
 pub mod init;
 pub mod mcp_config_args;

--- a/packages/aether-cli/src/main.rs
+++ b/packages/aether-cli/src/main.rs
@@ -1,6 +1,7 @@
 use aether_cli::acp::{AcpArgs, AcpRunError, AcpRunOutcome, run_acp};
 use aether_cli::error::CliError;
 use aether_cli::eval::{EvalArgs, run as run_eval_command};
+use aether_cli::generate_command::{GenerateArgs, GenerateCommandError, run as run_generate_command};
 use aether_cli::headless::{HeadlessArgs, run_headless};
 use aether_cli::init::{InitError, InitOutcome, InitRequest, next_steps_message, run_init};
 use aether_cli::settings::SettingsCommand;
@@ -20,6 +21,8 @@ enum MainError {
     Cli(#[from] CliError),
     #[error("{0}")]
     Eval(#[from] EvalFileError),
+    #[error("{0}")]
+    Generate(#[from] GenerateCommandError),
     #[error("{0}")]
     Acp(#[from] AcpRunError),
     #[error("{0}")]
@@ -53,6 +56,8 @@ enum Command {
     Headless(HeadlessArgs),
     /// Run declarative JSON eval files in Docker sandboxes
     Eval(EvalArgs),
+    /// Call a model with a single prompt and print its response
+    Generate(GenerateArgs),
     /// Start the ACP server
     Acp(AcpArgs),
     /// Print the fully assembled system prompt (for debugging)
@@ -77,6 +82,8 @@ fn main() -> ExitCode {
         Some(Command::Headless(args)) => rt.block_on(run_headless(args)).map_err(Into::into),
 
         Some(Command::Eval(args)) => rt.block_on(run_eval_command(args)).map_err(Into::into),
+
+        Some(Command::Generate(args)) => rt.block_on(run_generate_command(args)).map_err(Into::into),
 
         Some(Command::Acp(args)) => rt
             .block_on(run_acp(args))

--- a/packages/aether-core/src/events/agent_message.rs
+++ b/packages/aether-core/src/events/agent_message.rs
@@ -3,10 +3,11 @@ use acp_utils::notifications::{
 };
 use llm::{ToolCallError, ToolCallRequest, ToolCallResult};
 use mcp_utils::display_meta::ToolResultMeta;
+use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
 /// Message from the agent to the user.
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, JsonSchema)]
 #[serde(tag = "type", rename_all = "snake_case")]
 pub enum AgentMessage {
     Text {

--- a/packages/aether-evals/src/evals/task.rs
+++ b/packages/aether-evals/src/evals/task.rs
@@ -3,6 +3,7 @@ use super::transcript::{Transcript, format_transcript};
 use super::workspace::Workspace;
 use crate::EvalRunError;
 use crate::agents::{Agent, AgentConfig, RunError, is_terminal};
+use aether_core::events::AgentMessage;
 use std::fmt::{Debug, Write as _};
 use thiserror::Error;
 use tokio::sync::mpsc;
@@ -39,8 +40,21 @@ impl Task {
         &self.workspace
     }
 
+    /// Run the task against `agent` and collect its transcript. Use [`Task::run_observed`] to also
+    /// observe each `AgentMessage` as it streams.
     #[tracing::instrument(skip(agent, self))]
     pub async fn run<T: Agent>(self, agent: &T) -> Result<TaskRun, TaskRunError> {
+        self.run_observed(agent, |_| {}).await
+    }
+
+    /// Run the task against `agent`, forwarding each `AgentMessage` to `on_message` before it is
+    /// added to the transcript. Terminal messages (`Done`, `Error`, `Cancelled`) are forwarded too.
+    #[tracing::instrument(skip(agent, self, on_message))]
+    pub async fn run_observed<T: Agent, U: FnMut(&AgentMessage) + Send>(
+        self,
+        agent: &T,
+        mut on_message: U,
+    ) -> Result<TaskRun, TaskRunError> {
         let Task { prompt, workspace } = self;
         let (tx, mut rx) = mpsc::channel(100);
         let agent_task = agent.run(
@@ -56,6 +70,7 @@ impl Task {
             let mut messages = Vec::new();
             while let Some(message) = rx.recv().await {
                 let is_done = is_terminal(&message);
+                on_message(&message);
                 messages.push(message);
                 if is_done {
                     break;
@@ -198,6 +213,27 @@ mod tests {
         Task::new("do the thing", Workspace::empty().unwrap()).run(&agent).await.unwrap();
 
         assert_eq!(agent.captured_task_prompt(), Some("do the thing".to_string()));
+    }
+
+    #[tokio::test]
+    async fn task_run_with_message_observer_forwards_messages_in_order() {
+        let seen = Arc::new(Mutex::new(Vec::new()));
+        let captured = seen.clone();
+        let run = Task::new("do the thing", Workspace::empty().unwrap())
+            .run_observed(&FakeAgent::with_tool_call("bash", "success"), move |message| {
+                captured.lock().unwrap().push(message.clone());
+            })
+            .await
+            .unwrap();
+
+        let agent_messages = run.transcript().messages().to_vec();
+        let observed = seen.lock().unwrap().clone();
+
+        assert_eq!(observed.len(), agent_messages.len());
+        for (observed, transcript) in observed.iter().zip(agent_messages.iter()) {
+            assert_eq!(observed, transcript);
+        }
+        assert!(matches!(observed.last(), Some(AgentMessage::Done)));
     }
 
     #[derive(Default)]

--- a/packages/aether-evals/src/lib.rs
+++ b/packages/aether-evals/src/lib.rs
@@ -18,7 +18,7 @@ pub use evals::{
 };
 pub use git_repo::GitRepoError;
 pub use spec::{
-    AgentSpec, DockerSpec, EvalFileError, EvalFilesReport, EvalOutcome, EvalSpec, EvalSpecLoadOptions, EvalToolCall,
-    Expect, JudgeCriterionSummary, JudgeRef, JudgeSpec, JudgeSummary, ResolvedEvalSpec, TaskSpec, ToolCallExpectation,
-    WorkspaceRetention, WorkspaceSpec, run_eval_specs,
+    AgentSpec, DockerSpec, EvalFileError, EvalFilesReport, EvalOutcome, EvalSpec, EvalSpecLoadOptions, EvalStreamEvent,
+    EvalToolCall, Expect, JudgeCriterionSummary, JudgeRef, JudgeSpec, JudgeSummary, ResolvedEvalSpec, TaskSpec,
+    ToolCallExpectation, WorkspaceRetention, WorkspaceSpec, run_eval_spec_streaming, run_eval_specs,
 };

--- a/packages/aether-evals/src/lib.rs
+++ b/packages/aether-evals/src/lib.rs
@@ -19,6 +19,7 @@ pub use evals::{
 pub use git_repo::GitRepoError;
 pub use spec::{
     AgentSpec, DockerSpec, EvalFileError, EvalFilesReport, EvalOutcome, EvalSpec, EvalSpecLoadOptions, EvalStreamEvent,
-    EvalToolCall, Expect, JudgeCriterionSummary, JudgeRef, JudgeSpec, JudgeSummary, ResolvedEvalSpec, TaskSpec,
-    ToolCallExpectation, WorkspaceRetention, WorkspaceSpec, run_eval_spec_streaming, run_eval_specs,
+    EvalToolCall, Expect, JudgeCriterionResponse, JudgeCriterionSummary, JudgeRef, JudgeRubricResponse, JudgeSpec,
+    JudgeSummary, ResolvedEvalSpec, TaskSpec, ToolCallExpectation, WorkspaceRetention, WorkspaceSpec,
+    run_eval_spec_streaming, run_eval_specs,
 };

--- a/packages/aether-evals/src/lib.rs
+++ b/packages/aether-evals/src/lib.rs
@@ -19,7 +19,7 @@ pub use evals::{
 pub use git_repo::GitRepoError;
 pub use spec::{
     AgentSpec, DockerSpec, EvalFileError, EvalFilesReport, EvalOutcome, EvalSpec, EvalSpecLoadOptions, EvalStreamEvent,
-    EvalToolCall, Expect, JudgeCriterionResponse, JudgeCriterionSummary, JudgeRef, JudgeRubricResponse, JudgeSpec,
-    JudgeSummary, ResolvedEvalSpec, TaskSpec, ToolCallExpectation, WorkspaceRetention, WorkspaceSpec,
-    run_eval_spec_streaming, run_eval_specs,
+    EvalToolCall, Expect, Judge, JudgeBuilder, JudgeContext, JudgeCriterionResponse, JudgeCriterionSpec,
+    JudgeCriterionSummary, JudgeError, JudgeRef, JudgeRubricResponse, JudgeSpec, JudgeSummary, ResolvedEvalSpec,
+    TaskSpec, ToolCallExpectation, WorkspaceRetention, WorkspaceSpec, judge, run_eval_spec_streaming, run_eval_specs,
 };

--- a/packages/aether-evals/src/spec/judge.rs
+++ b/packages/aether-evals/src/spec/judge.rs
@@ -1,30 +1,46 @@
 use super::report::{JudgeCriterionSummary, JudgeSummary};
-use super::types::{Expect, JudgeSpec};
+use super::types::{Expect, JudgeCriterionSpec, JudgeSpec};
 use crate::TaskRun;
 use crate::agents::truncate_chars;
 use crate::evals::format_transcript;
+use aether_core::events::AgentMessage;
 use futures::StreamExt;
 use llm::types::IsoString;
 use llm::{ChatMessage, ContentBlock, Context, LlmResponse, StreamingModelProvider};
-use schemars::JsonSchema;
+use schemars::{JsonSchema, Schema, schema_for};
 use serde::Deserialize;
+use std::borrow::Borrow;
 use std::collections::{BTreeMap, BTreeSet};
-use std::fmt::Write as _;
 use thiserror::Error;
 
 const JUDGE_CONTEXT_CHARS: usize = 4_000;
 
-/// Runs the LLM judge for an eval: builds the rubric prompt from the completed run, streams the
-/// judge model's response, and scores it against the rubric.
-pub(crate) struct Judge<'a> {
-    llm: &'a dyn StreamingModelProvider,
-    run: &'a TaskRun,
-    expect: &'a Expect,
-    spec: &'a JudgeSpec,
+#[derive(Debug, Clone)]
+pub struct Judge {
+    pub prompt: String,
+    pub criteria: Vec<JudgeCriterionSpec>,
+}
+
+#[derive(Debug, Clone, Default)]
+pub struct JudgeBuilder {
+    instructions: Option<String>,
+    task: Option<String>,
+    context: JudgeContext,
+    criteria: Vec<JudgeCriterionSpec>,
+}
+
+#[derive(Debug, Clone, Default)]
+pub struct JudgeContext {
+    pub transcript: Option<Vec<AgentMessage>>,
+    pub diff: Option<String>,
+    pub files: BTreeMap<String, String>,
 }
 
 #[derive(Debug, Error)]
 pub enum JudgeError {
+    #[error("invalid judge input: {0}")]
+    InvalidInput(String),
+
     #[error("judge LLM stream error: {0}")]
     Stream(#[from] llm::LlmError),
 
@@ -39,99 +55,37 @@ pub enum JudgeError {
     InvalidJudgment { reason: String, raw_response: String },
 }
 
-impl<'a> Judge<'a> {
-    pub(crate) fn new(
-        llm: &'a dyn StreamingModelProvider,
-        run: &'a TaskRun,
-        expect: &'a Expect,
-        spec: &'a JudgeSpec,
-    ) -> Self {
-        Self { llm, run, expect, spec }
+pub fn judge() -> JudgeBuilder {
+    JudgeBuilder::default()
+}
+
+impl Judge {
+    pub fn response_schema() -> Schema {
+        JudgeRubricResponse::schema()
     }
 
-    pub(crate) async fn run(&self) -> Result<JudgeSummary, JudgeError> {
-        tracing::info!("Running LLM judge");
-        let raw_response = self.stream_response(self.build_prompt()).await?;
-        let response: JudgeRubricResponse = serde_json::from_str(extract_json_object(&raw_response))
-            .map_err(|source| JudgeError::InvalidJson { source, raw_response: raw_response.clone() })?;
-        self.summarize_response(response, &raw_response)
-    }
-
-    async fn stream_response(&self, prompt: String) -> Result<String, JudgeError> {
-        let message = ChatMessage::User { content: vec![ContentBlock::text(prompt)], timestamp: IsoString::now() };
-        let mut response_stream = self.llm.stream_response(&Context::new(vec![message], vec![]));
-        let mut raw_response = String::new();
-        while let Some(result) = response_stream.next().await {
-            match result {
-                Ok(LlmResponse::Text { chunk }) => raw_response.push_str(&chunk),
-                Err(error) => return Err(JudgeError::Stream(error)),
-                _ => {}
-            }
-        }
-        Ok(raw_response)
-    }
-
-    fn build_prompt(&self) -> String {
-        let mut prompt = String::new();
-        let _ = writeln!(prompt, "You are grading whether an AI coding agent succeeded at a task.\n");
-        let _ = writeln!(prompt, "Task given to the agent:\n{}\n", self.run.prompt());
-        let _ = writeln!(prompt, "Agent transcript:");
-        prompt.push_str(&format_transcript(self.run.transcript().messages()));
-
-        let (agent_diff, _) = self.run.workspace().capture_git_diffs();
-        if let Some(diff) = agent_diff {
-            let _ = writeln!(prompt, "\nAgent's workspace diff:\n{}", truncate_chars(&diff.diff, JUDGE_CONTEXT_CHARS));
-        }
-        self.push_final_file_contents(&mut prompt);
-
-        if let Some(instructions) = &self.spec.instructions {
-            let _ = writeln!(prompt, "\nAdditional grading instructions:\n{instructions}\n");
-        }
-
-        let _ = writeln!(prompt, "\nRubric criteria:");
-        for criterion in &self.spec.criteria {
-            let _ = writeln!(
-                prompt,
-                "- id: {}\n  blocking: {}\n  weight: {}\n  threshold: {}\n  description: {}",
-                criterion.id, criterion.blocking, criterion.weight, criterion.threshold, criterion.description
-            );
-        }
-
-        let _ = writeln!(
-            prompt,
-            "\nReturn exactly one result for every criterion ID above and no extra criteria. Scores must be normalized numbers from 0.0 to 1.0. Do not compute weights, thresholds, blocker status, or the final score."
-        );
-        let _ = writeln!(prompt, "Respond with ONLY a JSON object matching this schema:");
-        prompt.push_str(&judge_response_schema());
-        prompt
-    }
-
-    fn summarize_response(
-        &self,
-        response: JudgeRubricResponse,
-        raw_response: &str,
-    ) -> Result<JudgeSummary, JudgeError> {
+    pub fn summarize(&self, response: JudgeRubricResponse) -> Result<JudgeSummary, JudgeError> {
         let mut responses = BTreeMap::new();
         for criterion in response.criteria {
             let id = criterion.id.clone();
             if responses.insert(id.clone(), criterion).is_some() {
-                return Err(invalid_judgment(format!("duplicate response criterion id `{id}`"), raw_response));
+                return Err(invalid_judgment(format!("duplicate response criterion id `{id}`"), ""));
             }
         }
 
-        let mut summaries = Vec::with_capacity(self.spec.criteria.len());
+        let mut summaries = Vec::with_capacity(self.criteria.len());
         let mut weighted_score = 0.0;
         let mut total_weight = 0.0;
         let mut blocking_failed = false;
 
-        for criterion in &self.spec.criteria {
+        for criterion in &self.criteria {
             let Some(response) = responses.remove(&criterion.id) else {
-                return Err(invalid_judgment(format!("missing response criterion `{}`", criterion.id), raw_response));
+                return Err(invalid_judgment(format!("missing response criterion `{}`", criterion.id), ""));
             };
             if !response.score.is_finite() || !(0.0..=1.0).contains(&response.score) {
                 return Err(invalid_judgment(
                     format!("criterion `{}` score must be between 0.0 and 1.0", criterion.id),
-                    raw_response,
+                    "",
                 ));
             }
 
@@ -152,7 +106,7 @@ impl<'a> Judge<'a> {
         }
 
         if let Some(id) = responses.keys().next() {
-            return Err(invalid_judgment(format!("unknown response criterion `{id}`"), raw_response));
+            return Err(invalid_judgment(format!("unknown response criterion `{id}`"), ""));
         }
 
         let weighted_score = weighted_score / total_weight;
@@ -165,34 +119,119 @@ impl<'a> Judge<'a> {
 
         Ok(JudgeSummary { passed: !blocking_failed, score, reason, criteria: summaries })
     }
+}
 
-    fn push_final_file_contents(&self, prompt: &mut String) {
-        let paths: BTreeSet<&String> = self
-            .expect
-            .files
-            .keys()
-            .chain(self.expect.files_contain.keys())
-            .chain(self.spec.context_files.iter())
-            .collect();
-        if paths.is_empty() {
-            return;
-        }
+impl JudgeBuilder {
+    pub fn instructions(mut self, instructions: impl Into<String>) -> Self {
+        self.instructions = Some(instructions.into());
+        self
+    }
 
-        let _ = writeln!(prompt, "\nFinal contents of files under evaluation:");
-        for path in paths {
-            match std::fs::read_to_string(self.run.workspace().join(path)) {
-                Ok(contents) => {
-                    let _ = writeln!(prompt, "--- {path} ---\n{}", truncate_chars(&contents, JUDGE_CONTEXT_CHARS));
-                }
-                Err(error) => {
-                    let _ = writeln!(prompt, "--- {path} --- (could not read: {error})");
-                }
-            }
-        }
+    pub fn task(mut self, task: impl Into<String>) -> Self {
+        self.task = Some(task.into());
+        self
+    }
+
+    pub fn transcript(mut self, transcript: impl Into<Vec<AgentMessage>>) -> Self {
+        self.context.transcript = Some(transcript.into());
+        self
+    }
+
+    pub fn diff(mut self, diff: impl Into<String>) -> Self {
+        self.context.diff = Some(diff.into());
+        self
+    }
+
+    pub fn file(mut self, path: impl Into<String>, contents: impl Into<String>) -> Self {
+        self.context.files.insert(path.into(), contents.into());
+        self
+    }
+
+    pub fn files<T, U, V>(mut self, files: T) -> Self
+    where
+        T: IntoIterator<Item = (U, V)>,
+        U: Into<String>,
+        V: Into<String>,
+    {
+        self.context.files.extend(files.into_iter().map(|(path, contents)| (path.into(), contents.into())));
+        self
+    }
+
+    pub fn criteria<T, U>(mut self, criteria: T) -> Self
+    where
+        T: IntoIterator<Item = U>,
+        U: Borrow<JudgeCriterionSpec>,
+    {
+        self.criteria = criteria.into_iter().map(|criterion| criterion.borrow().clone()).collect();
+        self
+    }
+
+    pub fn context(mut self, context: JudgeContext) -> Self {
+        self.context = context;
+        self
+    }
+
+    pub fn build(self) -> Result<Judge, JudgeError> {
+        let task = self.task.ok_or_else(|| JudgeError::InvalidInput("judge task must be provided".to_string()))?;
+        let criteria = normalize_criteria(self.criteria)?;
+        let prompt = build_prompt(self.instructions.unwrap_or_default(), task, &self.context, &criteria);
+        Ok(Judge { prompt, criteria })
     }
 }
 
-/// JSON shape the judge model is asked to respond with.
+pub(crate) struct JudgeRunner<'a> {
+    llm: &'a dyn StreamingModelProvider,
+    judge: Judge,
+}
+
+impl<'a> JudgeRunner<'a> {
+    pub(crate) fn from_eval_run(
+        llm: &'a dyn StreamingModelProvider,
+        run: &TaskRun,
+        expect: &Expect,
+        spec: &JudgeSpec,
+    ) -> Result<Self, JudgeError> {
+        let builder = judge()
+            .instructions(spec.instructions.clone().unwrap_or_default())
+            .task(run.prompt().to_string())
+            .transcript(run.transcript().messages().to_vec())
+            .criteria(&spec.criteria)
+            .files(collect_eval_context_files(run, expect, spec));
+
+        let builder = match run.workspace().capture_git_diffs().0 {
+            Some(diff) => builder.diff(truncate_chars(&diff.diff, JUDGE_CONTEXT_CHARS)),
+            None => builder,
+        };
+
+        Ok(Self { llm, judge: builder.build()? })
+    }
+
+    pub(crate) async fn run(&self) -> Result<JudgeSummary, JudgeError> {
+        tracing::info!("Running LLM judge");
+        let raw_response = self.stream_response().await?;
+        let response: JudgeRubricResponse = serde_json::from_str(extract_json_object(&raw_response))
+            .map_err(|source| JudgeError::InvalidJson { source, raw_response: raw_response.clone() })?;
+        self.judge.summarize(response)
+    }
+
+    async fn stream_response(&self) -> Result<String, JudgeError> {
+        let message = ChatMessage::User {
+            content: vec![ContentBlock::text(self.judge.prompt.clone())],
+            timestamp: IsoString::now(),
+        };
+        let mut response_stream = self.llm.stream_response(&Context::new(vec![message], vec![]));
+        let mut raw_response = String::new();
+        while let Some(result) = response_stream.next().await {
+            match result {
+                Ok(LlmResponse::Text { chunk }) => raw_response.push_str(&chunk),
+                Err(error) => return Err(JudgeError::Stream(error)),
+                _ => {}
+            }
+        }
+        Ok(raw_response)
+    }
+}
+
 #[derive(Debug, Deserialize, JsonSchema)]
 #[serde(deny_unknown_fields)]
 pub struct JudgeRubricResponse {
@@ -208,8 +247,118 @@ pub struct JudgeCriterionResponse {
     pub reason: String,
 }
 
-/// Pull the JSON object out of a judge response, tolerating prose or markdown fences the
-/// model may add around it. Falls back to the trimmed input when no braces are present.
+impl JudgeRubricResponse {
+    pub fn schema() -> Schema {
+        schema_for!(Self)
+    }
+}
+
+fn build_prompt(instructions: String, task: String, context: &JudgeContext, criteria: &[JudgeCriterionSpec]) -> String {
+    let mut sections = vec![
+        format!("## Instructions\n\n{instructions}"),
+        format!("## Task\n\nThe agent you're evaluating was given this task: <task>{task}</task>"),
+    ];
+
+    if let Some(transcript) = &context.transcript
+        && !transcript.is_empty()
+    {
+        sections.push(format!(
+            "## Agent Transcript\n\nTranscript of the agent you're evaluating: <transcript>{}</transcript>",
+            format_transcript(transcript)
+        ));
+    }
+
+    if let Some(diff) = &context.diff
+        && !diff.is_empty()
+    {
+        sections.push(format!("## Git diff\n\nGit diff produced by the agent you're evaluating: <diff>{diff}</diff>"));
+    }
+
+    if !context.files.is_empty() {
+        let blocks = context
+            .files
+            .iter()
+            .map(|(path, contents)| format!("<file><path>{path}</path><contents>{contents}</contents></file>"))
+            .collect::<Vec<_>>()
+            .join("\n");
+        sections.push(format!("## File Contents\n\nFiles under evaluation: <files>{blocks}</files>"));
+    }
+
+    let rubric = criteria
+        .iter()
+        .map(|criterion| {
+            format!(
+                "- id: {}\n  blocking: {}\n  weight: {}\n  threshold: {}\n  description: {}",
+                criterion.id, criterion.blocking, criterion.weight, criterion.threshold, criterion.description
+            )
+        })
+        .collect::<Vec<_>>()
+        .join("\n");
+    sections.push(format!("## Rubric criteria\n\n{rubric}"));
+    sections.push(format!(
+        "{}\n{}\n{}\n{}",
+        "Return exactly one result for every criterion ID above and no extra criteria.",
+        "Scores must be normalized numbers from 0.0 to 1.0.",
+        "Respond with ONLY a JSON object matching this schema:",
+        judge_response_schema()
+    ));
+
+    sections.join("\n\n")
+}
+
+fn normalize_criteria(criteria: Vec<JudgeCriterionSpec>) -> Result<Vec<JudgeCriterionSpec>, JudgeError> {
+    if criteria.is_empty() {
+        return Err(JudgeError::InvalidInput("judge criteria must not be empty".to_string()));
+    }
+
+    let mut ids = BTreeSet::new();
+    let mut normalized = Vec::with_capacity(criteria.len());
+    for mut criterion in criteria {
+        criterion.id = criterion.id.trim().to_string();
+        if criterion.id.is_empty() {
+            return Err(JudgeError::InvalidInput("judge criterion id must not be empty".to_string()));
+        }
+        if !ids.insert(criterion.id.clone()) {
+            return Err(JudgeError::InvalidInput(format!("duplicate judge criterion id `{}`", criterion.id)));
+        }
+        if criterion.description.trim().is_empty() {
+            return Err(JudgeError::InvalidInput(format!(
+                "judge criterion `{}` description must not be empty",
+                criterion.id
+            )));
+        }
+        if !criterion.weight.is_finite() || criterion.weight <= 0.0 {
+            return Err(JudgeError::InvalidInput(format!(
+                "judge criterion `{}` weight must be positive and finite",
+                criterion.id
+            )));
+        }
+        if !criterion.threshold.is_finite() || !(0.0..=1.0).contains(&criterion.threshold) {
+            return Err(JudgeError::InvalidInput(format!(
+                "judge criterion `{}` threshold must be between 0.0 and 1.0",
+                criterion.id
+            )));
+        }
+        normalized.push(criterion);
+    }
+    Ok(normalized)
+}
+
+fn collect_eval_context_files(run: &TaskRun, expect: &Expect, spec: &JudgeSpec) -> BTreeMap<String, String> {
+    expect
+        .files
+        .keys()
+        .chain(expect.files_contain.keys())
+        .chain(spec.context_files.iter())
+        .map(|path| {
+            let contents = std::fs::read_to_string(run.workspace().join(path))
+                .map(|contents| truncate_chars(&contents, JUDGE_CONTEXT_CHARS))
+                .unwrap_or_else(|error| format!("could not read: {error}"));
+            (path.clone(), contents)
+        })
+        .collect()
+}
+
 fn extract_json_object(response: &str) -> &str {
     let trimmed = response.trim();
     match (trimmed.find('{'), trimmed.rfind('}')) {
@@ -223,7 +372,7 @@ fn invalid_judgment(reason: String, raw_response: &str) -> JudgeError {
 }
 
 fn judge_response_schema() -> String {
-    serde_json::to_string_pretty(&schemars::schema_for!(JudgeRubricResponse)).unwrap()
+    serde_json::to_string_pretty(&JudgeRubricResponse::schema()).unwrap()
 }
 
 #[cfg(test)]
@@ -233,18 +382,51 @@ mod tests {
     use std::process::Command;
 
     use super::*;
-    use crate::{GitRepoSpec, TaskRun, Transcript, Workspace};
-    use aether_core::events::AgentMessage;
+    use crate::{GitRepoSpec, Transcript, Workspace};
     use llm::testing::FakeLlmProvider;
-    use llm::{ChatMessage, LlmError, LlmResponse, ToolCallRequest};
+    use llm::{ChatMessage, LlmError, ToolCallRequest};
 
     const VALID_RESPONSE: &str = r#"{"criteria":[{"id":"behavior","score":1.0,"reason":"correct"},{"id":"clarity","score":0.5,"reason":"brief"}],"overall_reason":"good"}"#;
 
-    #[tokio::test]
-    async fn judge_scores_weighted_rubric() {
-        let judge_llm = FakeLlmProvider::with_single_response(vec![LlmResponse::text(VALID_RESPONSE)]);
+    #[test]
+    fn judge_builder_builds_prompt_from_context_and_criteria() {
+        let judge = judge()
+            .instructions("be strict")
+            .task("do the thing")
+            .diff("+added line")
+            .file("notes.txt", "beta\n")
+            .criteria([criterion("works", "the task works", true, 2.0, 0.9)])
+            .build()
+            .unwrap();
 
-        let summary = Judge::new(&judge_llm, &run(), &Expect::default(), &judge_spec()).run().await.unwrap();
+        assert!(judge.prompt.contains("## Instructions\n\nbe strict"));
+        assert!(judge.prompt.contains("## Task"));
+        assert!(judge.prompt.contains("The agent you're evaluating was given this task: <task>do the thing</task>"));
+        assert!(judge.prompt.contains("## Git diff"));
+        assert!(judge.prompt.contains("Git diff produced by the agent you're evaluating: <diff>+added line</diff>"));
+        assert!(judge.prompt.contains("## File Contents"));
+        assert!(judge.prompt.contains("<path>notes.txt</path>"));
+        assert!(judge.prompt.contains("<contents>beta\n</contents>"));
+        assert!(judge.prompt.contains("## Rubric criteria"));
+        assert!(judge.prompt.contains("blocking: true"));
+        assert!(judge.prompt.contains("threshold: 0.9"));
+        assert!(judge.prompt.contains("weight: 2"));
+        assert!(judge.prompt.contains("Return exactly one result for every criterion ID above and no extra criteria."));
+        assert!(judge.prompt.contains("Respond with ONLY a JSON object matching this schema:"));
+    }
+
+    #[test]
+    fn judge_builder_accepts_slice_criteria() {
+        let criteria = vec![criterion("behavior", "does the thing", true, 1.0, 0.8)];
+        let judge = judge().task("do it").criteria(&criteria).build().unwrap();
+        assert_eq!(judge.criteria[0].id, "behavior");
+    }
+
+    #[test]
+    fn judge_summarizes_weighted_rubric() {
+        let judge = judge().task("prompt").criteria(judge_spec().criteria).build().unwrap();
+
+        let summary = judge.summarize(serde_json::from_str(VALID_RESPONSE).unwrap()).unwrap();
 
         assert!(summary.passed);
         assert!((summary.score - 0.875).abs() < f64::EPSILON);
@@ -252,13 +434,15 @@ mod tests {
         assert!(summary.reason.contains("all blockers met"));
     }
 
-    #[tokio::test]
-    async fn judge_zeroes_score_when_blocker_fails() {
-        let judge_llm = FakeLlmProvider::with_single_response(vec![LlmResponse::text(
+    #[test]
+    fn judge_zeroes_score_when_blocker_fails() {
+        let judge = judge().task("prompt").criteria(judge_spec().criteria).build().unwrap();
+        let response = serde_json::from_str(
             r#"{"criteria":[{"id":"behavior","score":0.75,"reason":"wrong behavior"},{"id":"clarity","score":1.0,"reason":"clear"}],"overall_reason":"bad"}"#,
-        )]);
+        )
+        .unwrap();
 
-        let summary = Judge::new(&judge_llm, &run(), &Expect::default(), &judge_spec()).run().await.unwrap();
+        let summary = judge.summarize(response).unwrap();
 
         assert!(!summary.passed);
         assert!(summary.score.abs() < f64::EPSILON);
@@ -266,37 +450,65 @@ mod tests {
         assert!(summary.reason.contains("one or more blockers failed"));
     }
 
-    #[tokio::test]
-    async fn judge_rejects_invalid_criterion_sets() {
-        for response in [
+    #[test]
+    fn judge_rejects_invalid_criterion_sets() {
+        let judge = judge().task("prompt").criteria(judge_spec().criteria).build().unwrap();
+        for raw_response in [
             r#"{"criteria":[],"overall_reason":"missing"}"#,
             r#"{"criteria":[{"id":"behavior","score":1.0,"reason":"ok"},{"id":"behavior","score":1.0,"reason":"ok"}],"overall_reason":"duplicate"}"#,
             r#"{"criteria":[{"id":"behavior","score":1.0,"reason":"ok"},{"id":"clarity","score":1.0,"reason":"ok"},{"id":"extra","score":1.0,"reason":"ok"}],"overall_reason":"unknown"}"#,
             r#"{"criteria":[{"id":"behavior","score":1.5,"reason":"bad"},{"id":"clarity","score":1.0,"reason":"ok"}],"overall_reason":"score"}"#,
         ] {
-            let judge_llm = FakeLlmProvider::with_single_response(vec![LlmResponse::text(response)]);
+            let response = serde_json::from_str(raw_response).unwrap();
 
-            let error = Judge::new(&judge_llm, &run(), &Expect::default(), &judge_spec()).run().await.unwrap_err();
+            let error = judge.summarize(response).unwrap_err();
 
-            assert!(matches!(error, JudgeError::InvalidJudgment { .. }), "response: {response}");
+            assert!(matches!(error, JudgeError::InvalidJudgment { .. }), "response: {raw_response}");
+        }
+    }
+
+    #[test]
+    fn judge_builder_rejects_invalid_inputs() {
+        for (builder, expected) in [
+            (judge().criteria([criterion("behavior", "ok", true, 1.0, 0.8)]), "judge task must be provided"),
+            (judge().task("prompt"), "judge criteria must not be empty"),
+            (
+                judge().task("prompt").criteria([criterion("", "ok", true, 1.0, 0.8)]),
+                "judge criterion id must not be empty",
+            ),
+            (
+                judge().task("prompt").criteria([criterion("behavior", "ok", true, 0.0, 0.8)]),
+                "weight must be positive and finite",
+            ),
+        ] {
+            let error = builder.build().unwrap_err();
+            assert!(error.to_string().contains(expected), "got: {error}");
         }
     }
 
     #[tokio::test]
-    async fn judge_extracts_json_object_from_surrounding_prose() {
+    async fn judge_runner_extracts_json_object_from_surrounding_prose() {
         let response = format!("Here is my assessment:\n{VALID_RESPONSE}");
         let judge_llm = FakeLlmProvider::with_single_response(vec![LlmResponse::text(&response)]);
 
-        let summary = Judge::new(&judge_llm, &run(), &Expect::default(), &judge_spec()).run().await.unwrap();
+        let summary = JudgeRunner::from_eval_run(&judge_llm, &run(), &Expect::default(), &judge_spec())
+            .unwrap()
+            .run()
+            .await
+            .unwrap();
 
         assert!(summary.passed);
     }
 
     #[tokio::test]
-    async fn judge_returns_invalid_json_error_with_raw_response() {
+    async fn judge_runner_returns_invalid_json_error_with_raw_response() {
         let judge_llm = FakeLlmProvider::with_single_response(vec![LlmResponse::text("not json")]);
 
-        let error = Judge::new(&judge_llm, &run(), &Expect::default(), &judge_spec()).run().await.unwrap_err();
+        let error = JudgeRunner::from_eval_run(&judge_llm, &run(), &Expect::default(), &judge_spec())
+            .unwrap()
+            .run()
+            .await
+            .unwrap_err();
 
         let JudgeError::InvalidJson { raw_response, .. } = error else {
             panic!("expected InvalidJson, got {error:?}");
@@ -305,17 +517,21 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn judge_returns_stream_error_on_llm_failure() {
+    async fn judge_runner_returns_stream_error_on_llm_failure() {
         let judge_llm = FakeLlmProvider::from_results(vec![vec![Err(LlmError::Other("boom".to_string()))]]);
 
-        let error = Judge::new(&judge_llm, &run(), &Expect::default(), &judge_spec()).run().await.unwrap_err();
+        let error = JudgeRunner::from_eval_run(&judge_llm, &run(), &Expect::default(), &judge_spec())
+            .unwrap()
+            .run()
+            .await
+            .unwrap_err();
 
         assert!(matches!(error, JudgeError::Stream(_)));
         assert!(error.to_string().contains("boom"));
     }
 
     #[tokio::test]
-    async fn judge_prompt_includes_rubric_task_transcript_and_json_schema() {
+    async fn judge_runner_prompt_includes_eval_run_context() {
         let messages = vec![
             AgentMessage::ToolCall {
                 request: ToolCallRequest {
@@ -330,7 +546,7 @@ mod tests {
         let run = TaskRun::new("edit the file".to_string(), Workspace::empty().unwrap(), Transcript::new(messages));
         let judge_llm = FakeLlmProvider::with_single_response(vec![LlmResponse::text(VALID_RESPONSE)]);
 
-        Judge::new(&judge_llm, &run, &Expect::default(), &judge_spec()).run().await.unwrap();
+        JudgeRunner::from_eval_run(&judge_llm, &run, &Expect::default(), &judge_spec()).unwrap().run().await.unwrap();
 
         let prompt = judged_prompt(&judge_llm);
         assert!(prompt.contains("Grade maintainability."));
@@ -343,20 +559,20 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn judge_prompt_includes_agent_diff_from_workspace() {
+    async fn judge_runner_prompt_includes_agent_diff_from_workspace() {
         let workspace = git_workspace_with_agent_change();
         let run = TaskRun::new("p".to_string(), workspace, Transcript::new(vec![AgentMessage::Done]));
         let judge_llm = FakeLlmProvider::with_single_response(vec![LlmResponse::text(VALID_RESPONSE)]);
 
-        Judge::new(&judge_llm, &run, &Expect::default(), &judge_spec()).run().await.unwrap();
+        JudgeRunner::from_eval_run(&judge_llm, &run, &Expect::default(), &judge_spec()).unwrap().run().await.unwrap();
 
         let prompt = judged_prompt(&judge_llm);
-        assert!(prompt.contains("Agent's workspace diff"));
+        assert!(prompt.contains("## Git diff"));
         assert!(prompt.contains("+agent change"));
     }
 
     #[tokio::test]
-    async fn judge_prompt_includes_final_contents_of_files_under_evaluation() {
+    async fn judge_runner_prompt_includes_final_contents_of_files_under_evaluation() {
         let workspace =
             Workspace::from_files([("notes.txt", "beta\nalpha\n"), ("extra.txt", "extra context")]).unwrap();
         let run = TaskRun::new("p".to_string(), workspace, Transcript::new(vec![AgentMessage::Done]));
@@ -364,17 +580,21 @@ mod tests {
             Expect { files_contain: [("notes.txt".to_string(), "beta".to_string())].into(), ..Expect::default() };
         let judge_llm = FakeLlmProvider::with_single_response(vec![LlmResponse::text(VALID_RESPONSE)]);
 
-        Judge::new(&judge_llm, &run, &expect, &judge_spec()).run().await.unwrap();
+        JudgeRunner::from_eval_run(&judge_llm, &run, &expect, &judge_spec()).unwrap().run().await.unwrap();
 
         let prompt = judged_prompt(&judge_llm);
-        assert!(prompt.contains("--- notes.txt ---"));
+        assert!(prompt.contains("<path>notes.txt</path>"));
         assert!(prompt.contains("beta\nalpha"));
-        assert!(prompt.contains("--- extra.txt ---"));
+        assert!(prompt.contains("<path>extra.txt</path>"));
         assert!(prompt.contains("extra context"));
     }
 
     fn run() -> TaskRun {
         TaskRun::new("prompt".to_string(), Workspace::empty().unwrap(), Transcript::new(vec![AgentMessage::Done]))
+    }
+
+    fn criterion(id: &str, description: &str, blocking: bool, weight: f64, threshold: f64) -> JudgeCriterionSpec {
+        JudgeCriterionSpec { id: id.to_string(), description: description.to_string(), blocking, weight, threshold }
     }
 
     fn git_workspace_with_agent_change() -> Workspace {

--- a/packages/aether-evals/src/spec/judge.rs
+++ b/packages/aether-evals/src/spec/judge.rs
@@ -146,6 +146,7 @@ impl<'a> Judge<'a> {
                 weight: criterion.weight,
                 threshold: criterion.threshold,
                 score: response.score,
+                passed,
                 reason: response.reason,
             });
         }
@@ -193,16 +194,18 @@ impl<'a> Judge<'a> {
 
 /// JSON shape the judge model is asked to respond with.
 #[derive(Debug, Deserialize, JsonSchema)]
-struct JudgeRubricResponse {
-    criteria: Vec<JudgeCriterionResponse>,
-    overall_reason: String,
+#[serde(deny_unknown_fields)]
+pub struct JudgeRubricResponse {
+    pub criteria: Vec<JudgeCriterionResponse>,
+    pub overall_reason: String,
 }
 
 #[derive(Debug, Deserialize, JsonSchema)]
-struct JudgeCriterionResponse {
-    id: String,
-    score: f64,
-    reason: String,
+#[serde(deny_unknown_fields)]
+pub struct JudgeCriterionResponse {
+    pub id: String,
+    pub score: f64,
+    pub reason: String,
 }
 
 /// Pull the JSON object out of a judge response, tolerating prose or markdown fences the
@@ -259,7 +262,7 @@ mod tests {
 
         assert!(!summary.passed);
         assert!(summary.score.abs() < f64::EPSILON);
-        assert!(!summary.criteria[0].passed());
+        assert!(!summary.criteria[0].passed);
         assert!(summary.reason.contains("one or more blockers failed"));
     }
 

--- a/packages/aether-evals/src/spec/judge.rs
+++ b/packages/aether-evals/src/spec/judge.rs
@@ -11,6 +11,7 @@ use schemars::{JsonSchema, Schema, schema_for};
 use serde::Deserialize;
 use std::borrow::Borrow;
 use std::collections::{BTreeMap, BTreeSet};
+use std::fs::read_to_string;
 use thiserror::Error;
 
 const JUDGE_CONTEXT_CHARS: usize = 4_000;
@@ -174,7 +175,7 @@ impl JudgeBuilder {
     pub fn build(self) -> Result<Judge, JudgeError> {
         let task = self.task.ok_or_else(|| JudgeError::InvalidInput("judge task must be provided".to_string()))?;
         let criteria = normalize_criteria(self.criteria)?;
-        let prompt = build_prompt(self.instructions.unwrap_or_default(), task, &self.context, &criteria);
+        let prompt = build_prompt(&self.instructions.unwrap_or_default(), &task, &self.context, &criteria);
         Ok(Judge { prompt, criteria })
     }
 }
@@ -253,7 +254,7 @@ impl JudgeRubricResponse {
     }
 }
 
-fn build_prompt(instructions: String, task: String, context: &JudgeContext, criteria: &[JudgeCriterionSpec]) -> String {
+fn build_prompt(instructions: &str, task: &str, context: &JudgeContext, criteria: &[JudgeCriterionSpec]) -> String {
     let mut sections = vec![
         format!("## Instructions\n\n{instructions}"),
         format!("## Task\n\nThe agent you're evaluating was given this task: <task>{task}</task>"),
@@ -351,9 +352,10 @@ fn collect_eval_context_files(run: &TaskRun, expect: &Expect, spec: &JudgeSpec) 
         .chain(expect.files_contain.keys())
         .chain(spec.context_files.iter())
         .map(|path| {
-            let contents = std::fs::read_to_string(run.workspace().join(path))
-                .map(|contents| truncate_chars(&contents, JUDGE_CONTEXT_CHARS))
-                .unwrap_or_else(|error| format!("could not read: {error}"));
+            let contents = read_to_string(run.workspace().join(path)).map_or_else(
+                |error| format!("could not read: {error}"),
+                |contents| truncate_chars(&contents, JUDGE_CONTEXT_CHARS),
+            );
             (path.clone(), contents)
         })
         .collect()

--- a/packages/aether-evals/src/spec/mod.rs
+++ b/packages/aether-evals/src/spec/mod.rs
@@ -5,6 +5,7 @@ mod runner;
 mod types;
 
 pub use error::EvalFileError;
+pub use judge::{JudgeCriterionResponse, JudgeRubricResponse};
 pub use report::{EvalFilesReport, EvalOutcome, EvalStreamEvent, EvalToolCall, JudgeCriterionSummary, JudgeSummary};
 pub use runner::{WorkspaceRetention, run_eval_spec_streaming, run_eval_specs};
 use serde_json::from_str;

--- a/packages/aether-evals/src/spec/mod.rs
+++ b/packages/aether-evals/src/spec/mod.rs
@@ -5,12 +5,15 @@ mod runner;
 mod types;
 
 pub use error::EvalFileError;
-pub use judge::{JudgeCriterionResponse, JudgeRubricResponse};
+pub use judge::{Judge, JudgeBuilder, JudgeContext, JudgeCriterionResponse, JudgeError, JudgeRubricResponse, judge};
 pub use report::{EvalFilesReport, EvalOutcome, EvalStreamEvent, EvalToolCall, JudgeCriterionSummary, JudgeSummary};
 pub use runner::{WorkspaceRetention, run_eval_spec_streaming, run_eval_specs};
 use serde_json::from_str;
 pub(crate) use types::ResolvedDocker;
-pub use types::{AgentSpec, DockerSpec, Expect, JudgeRef, JudgeSpec, TaskSpec, ToolCallExpectation, WorkspaceSpec};
+pub use types::{
+    AgentSpec, DockerSpec, Expect, JudgeCriterionSpec, JudgeRef, JudgeSpec, TaskSpec, ToolCallExpectation,
+    WorkspaceSpec,
+};
 
 use schemars::{JsonSchema, Schema, schema_for};
 use serde::Deserialize;

--- a/packages/aether-evals/src/spec/mod.rs
+++ b/packages/aether-evals/src/spec/mod.rs
@@ -5,8 +5,8 @@ mod runner;
 mod types;
 
 pub use error::EvalFileError;
-pub use report::{EvalFilesReport, EvalOutcome, EvalToolCall, JudgeCriterionSummary, JudgeSummary};
-pub use runner::{WorkspaceRetention, run_eval_specs};
+pub use report::{EvalFilesReport, EvalOutcome, EvalStreamEvent, EvalToolCall, JudgeCriterionSummary, JudgeSummary};
+pub use runner::{WorkspaceRetention, run_eval_spec_streaming, run_eval_specs};
 use serde_json::from_str;
 pub(crate) use types::ResolvedDocker;
 pub use types::{AgentSpec, DockerSpec, Expect, JudgeRef, JudgeSpec, TaskSpec, ToolCallExpectation, WorkspaceSpec};

--- a/packages/aether-evals/src/spec/report.rs
+++ b/packages/aether-evals/src/spec/report.rs
@@ -121,6 +121,7 @@ pub struct JudgeCriterionSummary {
     pub weight: f64,
     pub threshold: f64,
     pub score: f64,
+    pub passed: bool,
     pub reason: String,
 }
 
@@ -143,14 +144,8 @@ impl JudgeSummary {
     pub fn blocking_failures(&self) -> impl Iterator<Item = String> + '_ {
         self.criteria
             .iter()
-            .filter(|criterion| criterion.blocking && !criterion.passed())
+            .filter(|criterion| criterion.blocking && !criterion.passed)
             .map(|criterion| format!("judge criterion `{}`: {}", criterion.id, criterion.reason))
-    }
-}
-
-impl JudgeCriterionSummary {
-    pub fn passed(&self) -> bool {
-        self.score >= self.threshold
     }
 }
 
@@ -161,13 +156,14 @@ mod tests {
 
     #[test]
     fn blocking_failures_report_only_blocking_criteria_below_threshold() {
-        let criterion = |id: &str, blocking, score| JudgeCriterionSummary {
+        let criterion = |id: &str, blocking, score: f64| JudgeCriterionSummary {
             id: id.to_string(),
             description: "desc".to_string(),
             blocking,
             weight: 1.0,
             threshold: 0.8,
             score,
+            passed: score >= 0.8,
             reason: format!("{id} reason"),
         };
         let summary = JudgeSummary {

--- a/packages/aether-evals/src/spec/report.rs
+++ b/packages/aether-evals/src/spec/report.rs
@@ -1,8 +1,22 @@
 use super::runner::WorkspaceRetention;
 use crate::evals::{RetainedWorkspaceInfo, TaskRun};
+use aether_core::events::AgentMessage;
 use schemars::{JsonSchema, Schema, schema_for};
 use serde::Serialize;
 use serde_json::Value;
+
+#[derive(Debug, Clone, Serialize, JsonSchema)]
+#[serde(tag = "type", rename_all = "snake_case", deny_unknown_fields)]
+pub enum EvalStreamEvent {
+    AgentMessage { message: AgentMessage },
+    Outcome { outcome: EvalOutcome },
+}
+
+impl EvalStreamEvent {
+    pub fn schema() -> Schema {
+        schema_for!(Self)
+    }
+}
 
 /// Outcome of running a collection of eval files.
 #[derive(Debug, Clone, Serialize)]
@@ -143,6 +157,7 @@ impl JudgeCriterionSummary {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use aether_core::events::AgentMessage;
 
     #[test]
     fn blocking_failures_report_only_blocking_criteria_below_threshold() {
@@ -169,5 +184,40 @@ mod tests {
         let failures: Vec<String> = summary.blocking_failures().collect();
 
         assert_eq!(failures, vec!["judge criterion `failed`: failed reason".to_string()]);
+    }
+
+    #[test]
+    fn agent_message_event_serializes_with_snake_case_tag_and_nested_message() {
+        let event = EvalStreamEvent::AgentMessage {
+            message: AgentMessage::Text {
+                message_id: "msg_1".to_string(),
+                chunk: "hi".to_string(),
+                is_complete: false,
+                model_name: "fake".to_string(),
+            },
+        };
+        let json = serde_json::to_value(&event).unwrap();
+        assert_eq!(json["type"], "agent_message");
+        assert_eq!(json["message"]["type"], "text");
+        assert_eq!(json["message"]["message_id"], "msg_1");
+        assert_eq!(json["message"]["is_complete"], false);
+    }
+
+    #[test]
+    fn outcome_event_serializes_with_nested_outcome_fields() {
+        let outcome = EvalOutcome {
+            name: "edit-notes".to_string(),
+            passed: true,
+            failures: Vec::new(),
+            tool_calls: Vec::new(),
+            judge: None,
+            failure_context: None,
+            retained_workspace: None,
+        };
+        let event = EvalStreamEvent::Outcome { outcome };
+        let json: serde_json::Value = serde_json::to_value(&event).unwrap();
+        assert_eq!(json["type"], "outcome");
+        assert_eq!(json["outcome"]["name"], "edit-notes");
+        assert_eq!(json["outcome"]["passed"], true);
     }
 }

--- a/packages/aether-evals/src/spec/runner.rs
+++ b/packages/aether-evals/src/spec/runner.rs
@@ -4,6 +4,7 @@ use super::judge::Judge;
 use super::report::{EvalOutcome, JudgeSummary};
 use crate::agents::{DockerAgent, build_images};
 use crate::evals::TaskRun;
+use aether_core::events::AgentMessage;
 use futures::StreamExt;
 use futures::stream::iter;
 use llm::StreamingModelProvider;
@@ -27,32 +28,41 @@ pub async fn run_eval_specs(
 ) -> Result<Vec<EvalOutcome>, EvalFileError> {
     let mut prepared = Vec::new();
     for spec in specs {
-        let agent = spec.agent();
-        let judge_llm = parse_judge_llm(&spec).await?;
-        prepared.push((spec, agent, judge_llm));
+        prepared.push(prepare_spec(spec).await?);
     }
 
     build_images(prepared.iter().filter_map(|(case, _, _)| case.docker.build.clone()), max_concurrency).await?;
     let futures = prepared
         .into_iter()
-        .map(|(case, agent, judge_llm)| async move { run_eval_spec(case, agent, judge_llm, retention).await });
+        .map(|(case, agent, judge_llm)| async move { run_eval_spec(case, agent, judge_llm, retention, |_| {}).await });
 
     let evals = iter(futures).buffered(max_concurrency.get()).collect().await;
     Ok(evals)
 }
 
-async fn run_eval_spec(
+pub async fn run_eval_spec_streaming<T: FnMut(&AgentMessage) + Send>(
+    spec: ResolvedEvalSpec,
+    retention: WorkspaceRetention,
+    on_message: T,
+) -> Result<EvalOutcome, EvalFileError> {
+    let (spec, agent, judge_llm) = prepare_spec(spec).await?;
+    build_images(spec.docker.build.clone(), NonZeroUsize::MIN).await?;
+    Ok(run_eval_spec(spec, agent, judge_llm, retention, on_message).await)
+}
+
+async fn run_eval_spec<T: FnMut(&AgentMessage) + Send>(
     spec: ResolvedEvalSpec,
     agent: DockerAgent,
     judge_llm: Option<Box<dyn StreamingModelProvider>>,
     retention: WorkspaceRetention,
+    on_message: T,
 ) -> EvalOutcome {
     let task = match spec.task() {
         Ok(task) => task,
         Err(error) => return EvalOutcome::setup_failed(spec.name(), error),
     };
 
-    let run = match task.run(&agent).await {
+    let run = match task.run_observed(&agent, on_message).await {
         Ok(run) => run,
         Err(error) => {
             let (run, error) = error.into_parts();
@@ -91,6 +101,14 @@ async fn run_judge(
             None
         }
     }
+}
+
+async fn prepare_spec(
+    spec: ResolvedEvalSpec,
+) -> Result<(ResolvedEvalSpec, DockerAgent, Option<Box<dyn StreamingModelProvider>>), EvalFileError> {
+    let agent = spec.agent();
+    let judge_llm = parse_judge_llm(&spec).await?;
+    Ok((spec, agent, judge_llm))
 }
 
 async fn parse_judge_llm(spec: &ResolvedEvalSpec) -> Result<Option<Box<dyn StreamingModelProvider>>, EvalFileError> {

--- a/packages/aether-evals/src/spec/runner.rs
+++ b/packages/aether-evals/src/spec/runner.rs
@@ -1,6 +1,6 @@
 use super::ResolvedEvalSpec;
 use super::error::EvalFileError;
-use super::judge::Judge;
+use super::judge::JudgeRunner;
 use super::report::{EvalOutcome, JudgeSummary};
 use crate::agents::{DockerAgent, build_images};
 use crate::evals::TaskRun;
@@ -91,7 +91,11 @@ async fn run_judge(
         return None;
     };
     let llm = judge_llm.expect("judge model is parsed before any eval runs when a judge is configured");
-    match Judge::new(llm, run, case.expectations(), spec).run().await {
+    let result = match JudgeRunner::from_eval_run(llm, run, case.expectations(), spec) {
+        Ok(judge) => judge.run().await,
+        Err(error) => Err(error),
+    };
+    match result {
         Ok(summary) => {
             failures.extend(summary.blocking_failures());
             Some(summary)

--- a/packages/aether-evals/src/spec/types.rs
+++ b/packages/aether-evals/src/spec/types.rs
@@ -95,6 +95,32 @@ pub struct JudgeCriterionSpec {
     pub threshold: f64,
 }
 
+impl JudgeCriterionSpec {
+    pub fn new(id: impl Into<String>, description: impl Into<String>) -> Self {
+        Self {
+            id: id.into(),
+            description: description.into(),
+            blocking: default_blocking(),
+            weight: default_weight(),
+            threshold: default_threshold(),
+        }
+    }
+
+    pub fn blocking(mut self, blocking: bool) -> Self {
+        self.blocking = blocking;
+        self
+    }
+
+    pub fn weight(mut self, weight: f64) -> Self {
+        self.weight = weight;
+        self
+    }
+
+    pub fn threshold(mut self, threshold: f64) -> Self {
+        self.threshold = threshold;
+        self
+    }
+}
 #[derive(Debug, Clone, Deserialize, JsonSchema)]
 #[serde(rename_all = "camelCase")]
 pub enum ToolCallExpectation {

--- a/packages/aether-sdk/README.md
+++ b/packages/aether-sdk/README.md
@@ -284,3 +284,18 @@ await using result = await runEval({
 ```
 
 Pass `{ keepWorkspace: true }` to retain the workspace on disk for debugging.
+
+`runEval` also streams the agent's messages and the eval process's stderr while it runs. Pass
+`onMessage` and `onStderr` callbacks to observe them:
+
+```ts
+await using result = await runEval(spec, {
+  onMessage: (message) => {
+    if (message.type === "text") process.stdout.write(message.chunk);
+    if (message.type === "tool_call") console.error("tool:", message.request.name);
+  },
+  onStderr: (chunk) => process.stderr.write(chunk),
+});
+```
+
+`message` is the generated `AgentMessage` union from `@aether-agent/sdk/evals`.

--- a/packages/aether-sdk/README.md
+++ b/packages/aether-sdk/README.md
@@ -11,6 +11,7 @@
   - [External MCP servers](#external-mcp-servers)
   - [Permission and elicitation hooks](#permission-and-elicitation-hooks)
   - [Writing evals with vitest](#writing-evals-with-vitest)
+    - [Grading a run with an LLM judge](#grading-a-run-with-an-llm-judge)
 
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
 
@@ -233,7 +234,10 @@ await AetherSession.start({
 ## Writing evals with vitest
 
 `@aether-agent/sdk/evals` runs a single Dockerized eval per test via the `aether`
-CLI.
+CLI. `runEval` runs the agent and returns the outcome; you assert against it
+directly with your test runner. `result.passed` reflects whether the agent ran to
+completion — there are no built-in matchers, so check files, tool calls, and the
+workspace yourself.
 
 ```ts
 import { test, expect } from "vitest";
@@ -249,16 +253,10 @@ test("agent edits notes.txt", async () => {
       prompt: "Change the first line of notes.txt from alpha to beta",
       workspace: { files: { "notes.txt": "alpha\nalpha\n" } },
     },
-    expect: {
-      judge: {
-        model: "anthropic:claude-sonnet-4-5",
-        criteria: [{ id: "edited", description: "first line is beta" }],
-      },
-    },
   });
 
   expect(result.passed).toBe(true);
-  // Run your own assertions against the retained workspace.
+  // Assert against the retained workspace and the recorded tool calls.
   expect(await readFile(join(result.workspace.path, "notes.txt"), "utf8")).toBe(
     "beta\nalpha\n",
   );
@@ -266,20 +264,89 @@ test("agent edits notes.txt", async () => {
 });
 ```
 
+### Grading a run with an LLM judge
+
+For judgments you can't express deterministically, ask a model to score a rubric
+with `generate`, then let `judge` compute the final weighted score and
+blocker status. Collect the transcript with `runEval`'s `onMessage` callback and
+put evidence under `context` along with any diff or final file contents:
+
 ```ts
-await using result = await runEval({
-  docker: { image: "my-ts-agent:latest" },
-  name: "custom-agent-eval",
-  agent: { command: ["node", "/app/dist/agent.js"] },
-  task: { prompt: "..." },
-  expect: {
-    judge: {
-      model: "anthropic:claude-sonnet-4-5",
-      criteria: [
-        /* ... */
-      ],
+import { readFile } from "node:fs/promises";
+import { join } from "node:path";
+import { test, expect } from "vitest";
+import {
+  generate,
+  judge,
+  runEval,
+  type AgentMessage,
+} from "@aether-agent/sdk/evals";
+
+test("agent makes a maintainer-quality edit", async () => {
+  const transcript: AgentMessage[] = [];
+  await using result = await runEval(
+    {
+      docker: { image: "aether-sandbox:latest" },
+      name: "edit-notes",
+      task: { prompt: "Change the first line of notes.txt from alpha to beta", /* ... */ },
     },
-  },
+    { onMessage: (message) => transcript.push(message) },
+  );
+
+  const grader = judge({
+    instructions: "Grade strictly using only the provided transcript and files.",
+    task: "Change the first line of notes.txt from alpha to beta",
+    context: {
+      transcript,
+      files: {
+        "notes.txt": await readFile(join(result.workspace.path, "notes.txt"), "utf8"),
+      },
+    },
+    criteria: [
+      {
+        id: "correct-edit",
+        description: "The final notes.txt content is exactly 'beta\\nalpha\\n'.",
+        blocking: true,
+        threshold: 1,
+        weight: 3,
+      },
+      {
+        id: "minimal-change",
+        description: "No unrelated files or lines were changed.",
+        blocking: true,
+        threshold: 0.8,
+        weight: 2,
+      },
+    ],
+  });
+
+  const response = await generate(grader.prompt, {
+    model: "anthropic:claude-sonnet-4-5", // or set AETHER_LLM_MODEL
+    schema: grader.schema,
+  });
+  const summary = grader.summarize(response);
+
+  expect(summary.passed, summary.reason).toBe(true);
+});
+```
+
+The model returns only normalized criterion scores and reasons. `judge`
+checks that the response has exactly one result for each criterion, then computes
+criterion pass/fail, weighted score, blocker failures, and the final summary.
+
+The lower-level `generate` primitive also supports raw text responses:
+
+```ts
+import { generate } from "@aether-agent/sdk/evals";
+import { z } from "zod";
+
+const { text } = await generate("Summarize this diff in one sentence:\n" + diff, {
+  model: "anthropic:claude-sonnet-4-5", // or set AETHER_LLM_MODEL
+});
+
+const verdict = await generate("Grade this run. Respond with passed and reason.", {
+  model: "anthropic:claude-sonnet-4-5",
+  schema: z.object({ passed: z.boolean(), reason: z.string() }),
 });
 ```
 

--- a/packages/aether-sdk/package.json
+++ b/packages/aether-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aether-agent/sdk",
-  "version": "0.2.9",
+  "version": "0.3.0",
   "description": "TypeScript SDK for the Aether agent CLI",
   "repository": {
     "type": "git",

--- a/packages/aether-sdk/scripts/generate-types.mjs
+++ b/packages/aether-sdk/scripts/generate-types.mjs
@@ -37,22 +37,28 @@ async function generateEvalTypes(document) {
   writeText(
     canonicalSchemaPath,
     `${JSON.stringify(
-      { EvalSpec: document.EvalSpec, EvalOutcome: document.EvalOutcome },
+      {
+        EvalSpec: document.EvalSpec,
+        EvalOutcome: document.EvalOutcome,
+        EvalStreamEvent: document.EvalStreamEvent,
+      },
       null,
       2,
     )}\n`,
   );
 
-  const evalSpec = schemaForTypeGeneration(document.EvalSpec, "EvalSpec");
-
-  const evalOutcome = schemaForTypeGeneration(
-    document.EvalOutcome,
-    "EvalOutcome",
+  const evalStreamEvent = schemaForTypeGeneration(
+    document.EvalStreamEvent,
+    "EvalStreamEvent",
   );
 
   const parts = await Promise.all([
-    compile(evalSpec, "EvalSpec", TYPE_OPTIONS),
-    compile(evalOutcome, "EvalOutcome", TYPE_OPTIONS),
+    compile(
+      schemaForTypeGeneration(document.EvalSpec, "EvalSpec"),
+      "EvalSpec",
+      TYPE_OPTIONS,
+    ),
+    compile(evalStreamEvent, "EvalStreamEvent", TYPE_OPTIONS),
   ]);
 
   const content = [

--- a/packages/aether-sdk/scripts/generate-types.mjs
+++ b/packages/aether-sdk/scripts/generate-types.mjs
@@ -41,6 +41,7 @@ async function generateEvalTypes(document) {
         EvalSpec: document.EvalSpec,
         EvalOutcome: document.EvalOutcome,
         EvalStreamEvent: document.EvalStreamEvent,
+        JudgeRubricResponse: document.JudgeRubricResponse,
       },
       null,
       2,
@@ -59,6 +60,14 @@ async function generateEvalTypes(document) {
       TYPE_OPTIONS,
     ),
     compile(evalStreamEvent, "EvalStreamEvent", TYPE_OPTIONS),
+    compile(
+      schemaForTypeGeneration(
+        document.JudgeRubricResponse,
+        "JudgeRubricResponse",
+      ),
+      "JudgeRubricResponse",
+      TYPE_OPTIONS,
+    ),
   ]);
 
   const content = [

--- a/packages/aether-sdk/src/childProcess.ts
+++ b/packages/aether-sdk/src/childProcess.ts
@@ -27,6 +27,10 @@ export interface RunCommandOptions {
   spawnFailedMessage: string;
   exitedErrorCode: AetherSdkErrorCode;
   exitedMessage: (result: RunCommandOutput) => string;
+  /** Called with each utf8 stdout chunk as it arrives (only when `stdout` is `"pipe"`). */
+  onStdout?: (chunk: string) => void;
+  /** Called with each utf8 stderr chunk as it arrives (only when `stderr` is `"pipe"`). */
+  onStderr?: (chunk: string) => void;
 }
 
 export function runCommand(
@@ -66,11 +70,27 @@ export function runCommand(
     let stderr = "";
     if (stdoutMode === "pipe") {
       child.stdout?.setEncoding("utf8");
-      child.stdout?.on("data", (chunk: string) => (stdout += chunk));
+      child.stdout?.on("data", (chunk: string) => {
+        stdout += chunk;
+        try {
+          options.onStdout?.(chunk);
+        } catch (err) {
+          void stopChild(child);
+          reject(err);
+        }
+      });
     }
     if (stderrMode === "pipe") {
       child.stderr?.setEncoding("utf8");
-      child.stderr?.on("data", (chunk: string) => (stderr += chunk));
+      child.stderr?.on("data", (chunk: string) => {
+        stderr += chunk;
+        try {
+          options.onStderr?.(chunk);
+        } catch (err) {
+          void stopChild(child);
+          reject(err);
+        }
+      });
     }
     if (options.stdin !== undefined) {
       child.stdin?.end(options.stdin);

--- a/packages/aether-sdk/src/errors.ts
+++ b/packages/aether-sdk/src/errors.ts
@@ -7,6 +7,7 @@ export type AetherSdkErrorCode =
   | "prompt_in_progress"
   | "invalid_options"
   | "eval_command_failed"
+  | "generate_command_failed"
   | "aborted";
 
 export class AetherSdkError extends Error {

--- a/packages/aether-sdk/src/evals/generate.ts
+++ b/packages/aether-sdk/src/evals/generate.ts
@@ -1,3 +1,5 @@
+import { z } from "zod";
+
 import { resolveAetherCommand } from "../agentProcess.js";
 import { runCommand } from "../childProcess.js";
 import { AetherSdkError } from "../errors.js";
@@ -23,26 +25,45 @@ export interface GenerateOptions {
   signal?: AbortSignal;
 }
 
+export type GenerateJsonOptions<T extends z.ZodType> = GenerateOptions & {
+  /** Validate the model's response as JSON with this schema and return the parsed value. */
+  schema: T;
+};
+
 export interface GenerateResult {
   /** The model's response text. */
   text: string;
 }
 
 /**
- * Call a model with a single prompt and return its response, via the `aether generate` CLI. This is
- * the low-level primitive that {@link judge} builds on.
+ * Call a model with a single prompt and return its response, via the `aether generate` CLI.
+ * When a Zod schema is provided, the model response is parsed as JSON, validated, and returned
+ * as the inferred schema type.
  *
  * @example
  * ```ts
  * const { text } = await generate("Summarize this diff in one sentence:\n" + diff, {
  *   model: "anthropic:claude-sonnet-4-5",
  * });
+ *
+ * const verdict = await generate("Grade this run as JSON", {
+ *   model: "anthropic:claude-sonnet-4-5",
+ *   schema: z.object({ passed: z.boolean(), reason: z.string() }),
+ * });
  * ```
  */
-export async function generate(
+export function generate(
   prompt: string,
-  options: GenerateOptions = {},
-): Promise<GenerateResult> {
+  options?: GenerateOptions,
+): Promise<GenerateResult>;
+export function generate<T extends z.ZodType>(
+  prompt: string,
+  options: GenerateJsonOptions<T>,
+): Promise<z.infer<T>>;
+export async function generate<T extends z.ZodType>(
+  prompt: string,
+  options: GenerateOptions | GenerateJsonOptions<T> = {},
+): Promise<GenerateResult | z.infer<T>> {
   const model = options.model ?? process.env.AETHER_LLM_MODEL;
   if (!model) {
     throw new AetherSdkError(
@@ -64,10 +85,15 @@ export async function generate(
   ];
   if (options.system !== undefined) args.push("--system", options.system);
 
+  const promptWithInstructions =
+    "schema" in options
+      ? `${prompt}\n\nRespond with ONLY valid JSON. Do not include markdown fences or explanatory prose.`
+      : prompt;
+
   const { stdout } = await runCommand(command, args, {
     cwd: process.cwd(),
     env: resolveEnv(options.env),
-    stdin: prompt,
+    stdin: promptWithInstructions,
     abortSignal: options.signal,
     spawnFailedMessage: `Failed to run aether generate at ${command}`,
     exitedErrorCode: "generate_command_failed",
@@ -75,7 +101,9 @@ export async function generate(
       `aether generate exited with code ${exitCode}.\n${stderr}`,
   });
 
-  return { text: parseResponseText(stdout) };
+  const text = parseResponseText(stdout);
+  if ("schema" in options) return parseJsonResponse(text, options.schema);
+  return { text };
 }
 
 function parseResponseText(stdout: string): string {
@@ -100,4 +128,52 @@ function parseResponseText(stdout: string): string {
     );
   }
   return (parsed as { text: string }).text;
+}
+
+function parseJsonResponse<T extends z.ZodType>(
+  response: string,
+  schema: T,
+): z.infer<T> {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(extractJson(response));
+  } catch (err) {
+    throw new AetherSdkError(
+      "generate_command_failed",
+      `Model returned invalid JSON.\nRaw response: ${response}`,
+      err,
+    );
+  }
+
+  const result = schema.safeParse(parsed);
+  if (!result.success) {
+    throw new AetherSdkError(
+      "generate_command_failed",
+      `Model response did not match schema.\n${z.prettifyError(result.error)}\nRaw response: ${response}`,
+      result.error,
+    );
+  }
+  return result.data;
+}
+
+function extractJson(response: string): string {
+  const trimmed = response.trim();
+  try {
+    JSON.parse(trimmed);
+    return trimmed;
+  } catch {
+    const objectStart = trimmed.indexOf("{");
+    const objectEnd = trimmed.lastIndexOf("}");
+    if (objectStart !== -1 && objectEnd !== -1 && objectStart <= objectEnd) {
+      return trimmed.slice(objectStart, objectEnd + 1);
+    }
+
+    const arrayStart = trimmed.indexOf("[");
+    const arrayEnd = trimmed.lastIndexOf("]");
+    if (arrayStart !== -1 && arrayEnd !== -1 && arrayStart <= arrayEnd) {
+      return trimmed.slice(arrayStart, arrayEnd + 1);
+    }
+
+    return trimmed;
+  }
 }

--- a/packages/aether-sdk/src/evals/generate.ts
+++ b/packages/aether-sdk/src/evals/generate.ts
@@ -1,0 +1,103 @@
+import { resolveAetherCommand } from "../agentProcess.js";
+import { runCommand } from "../childProcess.js";
+import { AetherSdkError } from "../errors.js";
+import { resolveEnv } from "../processEnv.js";
+
+export interface GenerateOptions {
+  /**
+   * Model to call, as `provider:model` (e.g. `anthropic:claude-sonnet-4-5`). Defaults to the
+   * `AETHER_LLM_MODEL` environment variable.
+   */
+  model?: string;
+
+  /** Optional system prompt. */
+  system?: string;
+
+  /** Path to the `aether` binary. Defaults to the bundled `@aether-agent/cli`. */
+  binaryPath?: string;
+
+  /** Environment for the spawned process. Defaults to the current process environment. */
+  env?: Record<string, string | undefined>;
+
+  /** Abort the call. */
+  signal?: AbortSignal;
+}
+
+export interface GenerateResult {
+  /** The model's response text. */
+  text: string;
+}
+
+/**
+ * Call a model with a single prompt and return its response, via the `aether generate` CLI. This is
+ * the low-level primitive that {@link judge} builds on.
+ *
+ * @example
+ * ```ts
+ * const { text } = await generate("Summarize this diff in one sentence:\n" + diff, {
+ *   model: "anthropic:claude-sonnet-4-5",
+ * });
+ * ```
+ */
+export async function generate(
+  prompt: string,
+  options: GenerateOptions = {},
+): Promise<GenerateResult> {
+  const model = options.model ?? process.env.AETHER_LLM_MODEL;
+  if (!model) {
+    throw new AetherSdkError(
+      "invalid_options",
+      "No model provided to `generate`. Pass `options.model` or set the AETHER_LLM_MODEL environment variable.",
+    );
+  }
+
+  const { command, prefixArgs } = resolveAetherCommand(options.binaryPath);
+  const args = [
+    ...prefixArgs,
+    "generate",
+    "--model",
+    model,
+    "--prompt-file",
+    "-",
+    "--output",
+    "json",
+  ];
+  if (options.system !== undefined) args.push("--system", options.system);
+
+  const { stdout } = await runCommand(command, args, {
+    cwd: process.cwd(),
+    env: resolveEnv(options.env),
+    stdin: prompt,
+    abortSignal: options.signal,
+    spawnFailedMessage: `Failed to run aether generate at ${command}`,
+    exitedErrorCode: "generate_command_failed",
+    exitedMessage: ({ exitCode, stderr }) =>
+      `aether generate exited with code ${exitCode}.\n${stderr}`,
+  });
+
+  return { text: parseResponseText(stdout) };
+}
+
+function parseResponseText(stdout: string): string {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(stdout);
+  } catch (err) {
+    throw new AetherSdkError(
+      "generate_command_failed",
+      `Failed to parse aether generate output as JSON: ${stdout}`,
+      err,
+    );
+  }
+  if (
+    typeof parsed !== "object" ||
+    parsed === null ||
+    typeof (parsed as { text?: unknown }).text !== "string"
+  ) {
+    throw new AetherSdkError(
+      "generate_command_failed",
+      `aether generate output did not contain a string "text" field: ${stdout}`,
+    );
+  }
+  return (parsed as { text: string }).text;
+}

--- a/packages/aether-sdk/src/evals/index.ts
+++ b/packages/aether-sdk/src/evals/index.ts
@@ -1,4 +1,28 @@
 export { runEval } from "./runEval.js";
 export type { EvalRunResult, EvalRunSpec, RunEvalOptions } from "./runEval.js";
+export { generate } from "./generate.js";
+export type {
+  GenerateJsonOptions,
+  GenerateOptions,
+  GenerateResult,
+} from "./generate.js";
+export {
+  formatTranscript,
+  judge,
+  JudgeCriterionResponseSchema,
+  JudgeResponseSchema,
+  messageToString,
+} from "./judge.js";
+export type {
+  AgentMessage,
+  Judge,
+  JudgeContext,
+  JudgeCriterionResponse,
+  JudgeCriterionSpec,
+  JudgeCriterionSummary,
+  JudgeInput,
+  JudgeRubricResponse,
+  JudgeSummary,
+} from "./judge.js";
 export type { RetainedWorkspace, WorkspaceHandle } from "./workspace.js";
 export type * from "../generated/eval-types.js";

--- a/packages/aether-sdk/src/evals/judge.ts
+++ b/packages/aether-sdk/src/evals/judge.ts
@@ -1,0 +1,283 @@
+import { z } from "zod";
+
+import { AetherSdkError } from "../errors.js";
+import type {
+  AgentMessage,
+  JudgeCriterionResponse,
+  JudgeCriterionSpec,
+  JudgeCriterionSummary,
+  JudgeRubricResponse,
+  JudgeSummary,
+} from "../generated/eval-types.js";
+
+export type {
+  AgentMessage,
+  JudgeCriterionResponse,
+  JudgeCriterionSpec,
+  JudgeCriterionSummary,
+  JudgeRubricResponse,
+  JudgeSummary,
+};
+
+export interface JudgeInput {
+  /** High-level grading instructions. */
+  instructions: string;
+  /** The task the agent was given. */
+  task: string;
+  /** Evidence the judge should use when grading the run. */
+  context?: JudgeContext;
+  /** Ordered rubric criteria to score on a normalized 0.0..=1.0 scale. */
+  criteria: JudgeCriterionSpec[];
+}
+
+export interface JudgeContext {
+  /** The agent transcript, e.g. messages collected via `runEval`'s `onMessage` callback. */
+  transcript?: AgentMessage[];
+  /** A workspace diff to grade against. */
+  diff?: string;
+  /** Final file contents to include, keyed by path. */
+  files?: Record<string, string>;
+}
+
+type NormalizedJudgeCriterion = Required<JudgeCriterionSpec>;
+
+export interface Judge {
+  prompt: string;
+  schema: typeof JudgeResponseSchema;
+  criteria: Required<JudgeCriterionSpec>[];
+  summarize(response: JudgeRubricResponse): JudgeSummary;
+}
+
+export const JudgeCriterionResponseSchema = z.object({
+  id: z.string(),
+  score: z.number().min(0).max(1),
+  reason: z.string(),
+});
+
+export const JudgeResponseSchema = z.object({
+  criteria: z.array(JudgeCriterionResponseSchema),
+  overall_reason: z.string(),
+});
+
+/** Compose a judge prompt and deterministic rubric summarizer from structured context. */
+export function judge(input: JudgeInput): Judge {
+  const criteria = normalizeCriteria(input.criteria);
+  const sections: string[] = [
+    `## Instructions`,
+    `${input.instructions}`,
+
+    `## Task`,
+    `The agent you're evaluating was given this task: <task>${input.task}</task>`,
+  ];
+
+  if (input.context?.transcript?.length) {
+    sections.push(
+      `## Agent Transcript`,
+      `Transcript of the agent you're evaluating: <transcript>${formatTranscript(input.context.transcript)}</transcript>`,
+    );
+  }
+
+  if (input.context?.diff) {
+    sections.push(
+      `## Git diff`,
+      `Git diff produced by the agent you're evaluating: <diff>${input.context.diff}</diff>`,
+    );
+  }
+
+  if (input.context?.files && Object.keys(input.context.files).length > 0) {
+    const blocks = Object.entries(input.context.files).map(([path, content]) =>
+      [
+        `<file>`,
+        `<path>${path}</path>`,
+        `<contents>${content}</contents>`,
+        `</file>`,
+      ].join(""),
+    );
+
+    sections.push(
+      `## File Contents`,
+      `Files under evaluation: <files>${blocks.join("\n")}</files>`,
+    );
+  }
+
+  const rubric = criteria.map(
+    (criterion) =>
+      `- id: ${criterion.id}\n  blocking: ${criterion.blocking}\n  weight: ${criterion.weight}\n  threshold: ${criterion.threshold}\n  description: ${criterion.description}`,
+  );
+  sections.push([`## Rubric criteria`, `${rubric.join("\n")}`].join("\n"));
+  sections.push(
+    [
+      "Return exactly one result for every criterion ID above and no extra criteria.",
+      "Scores must be normalized numbers from 0.0 to 1.0.",
+      "Respond with ONLY a JSON object matching this schema:",
+      JSON.stringify(z.toJSONSchema(JudgeResponseSchema), null, 2),
+    ].join("\n"),
+  );
+
+  return {
+    prompt: sections.join("\n\n"),
+    schema: JudgeResponseSchema,
+    criteria,
+    summarize: (response) => summarizeJudgeResponse(criteria, response),
+  };
+}
+
+/** Render a transcript of streamed `AgentMessage`s as readable lines for a judge prompt. */
+export function formatTranscript(messages: AgentMessage[]): string {
+  const lines: string[] = [];
+  const buffers = new Map<
+    string,
+    { kind: "agent" | "thinking"; text: string }
+  >();
+
+  const flush = (id: string): void => {
+    const buffer = buffers.get(id);
+    if (buffer && buffer.text.trim())
+      lines.push(`[${buffer.kind}] ${buffer.text}`);
+    buffers.delete(id);
+  };
+
+  for (const message of messages) {
+    if (message.type === "text" || message.type === "thought") {
+      const kind = message.type === "text" ? "agent" : "thinking";
+      const buffer = buffers.get(message.message_id) ?? { kind, text: "" };
+      buffer.text += message.chunk;
+      buffers.set(message.message_id, buffer);
+      if (message.is_complete) flush(message.message_id);
+    } else {
+      const formatted = messageToString(message);
+      if (formatted) lines.push(formatted);
+    }
+  }
+
+  for (const id of [...buffers.keys()]) flush(id);
+  return lines.join("\n");
+}
+
+/** Format a single agent message into a readable line for a judge prompt. */
+export function messageToString(message: AgentMessage): string {
+  switch (message.type) {
+    case "tool_call":
+      return `[tool-call] ${message.request.name} ${message.request.arguments}`.trimEnd();
+    case "tool_result":
+      return `[tool-result] ${message.result.name}: ${message.result.result}`;
+    case "tool_error":
+      return `[tool-error] ${message.error.name}: ${message.error.error}`;
+    case "error":
+      return `[error] ${message.message}`;
+    default:
+      return "";
+  }
+}
+
+function normalizeCriteria(
+  criteria: JudgeCriterionSpec[],
+): NormalizedJudgeCriterion[] {
+  if (criteria.length === 0) {
+    throw invalidJudgeInput("judge criteria must not be empty");
+  }
+
+  const ids = new Set<string>();
+  return criteria.map((criterion) => {
+    const id = criterion.id.trim();
+    if (!id) throw invalidJudgeInput("judge criterion id must not be empty");
+    if (ids.has(id))
+      throw invalidJudgeInput(`duplicate judge criterion id \`${id}\``);
+    ids.add(id);
+
+    const normalized = {
+      id,
+      description: criterion.description,
+      blocking: criterion.blocking ?? true,
+      weight: criterion.weight ?? 1,
+      threshold: criterion.threshold ?? 1,
+    };
+
+    if (!normalized.description.trim()) {
+      throw invalidJudgeInput(
+        `judge criterion \`${id}\` description must not be empty`,
+      );
+    }
+
+    if (!Number.isFinite(normalized.weight) || normalized.weight <= 0) {
+      throw invalidJudgeInput(
+        `judge criterion \`${id}\` weight must be greater than 0`,
+      );
+    }
+
+    if (
+      !Number.isFinite(normalized.threshold) ||
+      normalized.threshold < 0 ||
+      normalized.threshold > 1
+    ) {
+      throw invalidJudgeInput(
+        `judge criterion \`${id}\` threshold must be between 0.0 and 1.0`,
+      );
+    }
+
+    return normalized;
+  });
+}
+
+function summarizeJudgeResponse(
+  criteria: NormalizedJudgeCriterion[],
+  response: JudgeRubricResponse,
+): JudgeSummary {
+  const responses = new Map<string, JudgeCriterionResponse>();
+  for (const criterion of response.criteria) {
+    if (responses.has(criterion.id)) {
+      throw invalidJudgment(
+        `duplicate response criterion id \`${criterion.id}\``,
+      );
+    }
+    responses.set(criterion.id, criterion);
+  }
+
+  const summaries: JudgeCriterionSummary[] = [];
+  let weightedScore = 0;
+  let totalWeight = 0;
+  let blockingFailed = false;
+
+  for (const criterion of criteria) {
+    const responseCriterion = responses.get(criterion.id);
+    if (!responseCriterion) {
+      throw invalidJudgment(`missing response criterion \`${criterion.id}\``);
+    }
+    responses.delete(criterion.id);
+
+    const passed = responseCriterion.score >= criterion.threshold;
+    blockingFailed ||= criterion.blocking && !passed;
+    weightedScore += responseCriterion.score * criterion.weight;
+    totalWeight += criterion.weight;
+    summaries.push({
+      id: criterion.id,
+      description: criterion.description,
+      blocking: criterion.blocking,
+      weight: criterion.weight,
+      threshold: criterion.threshold,
+      score: responseCriterion.score,
+      passed,
+      reason: responseCriterion.reason,
+    });
+  }
+
+  const unknownId = responses.keys().next().value as string | undefined;
+  if (unknownId)
+    throw invalidJudgment(`unknown response criterion \`${unknownId}\``);
+
+  weightedScore /= totalWeight;
+  const score = blockingFailed ? 0 : weightedScore;
+  const reason = blockingFailed
+    ? `weighted score ${weightedScore.toFixed(2)}; one or more blockers failed; ${response.overall_reason}`
+    : `weighted score ${weightedScore.toFixed(2)}; all blockers met; ${response.overall_reason}`;
+
+  return { passed: !blockingFailed, score, reason, criteria: summaries };
+}
+
+function invalidJudgeInput(message: string): AetherSdkError {
+  return new AetherSdkError("invalid_options", message);
+}
+
+function invalidJudgment(message: string): AetherSdkError {
+  return new AetherSdkError("generate_command_failed", message);
+}

--- a/packages/aether-sdk/src/evals/runEval.ts
+++ b/packages/aether-sdk/src/evals/runEval.ts
@@ -4,14 +4,22 @@ import { runCommand } from "../childProcess.js";
 import { AetherSdkError } from "../errors.js";
 import { resolveEnv } from "../processEnv.js";
 import type {
+  AgentMessage,
   EvalOutcome,
   EvalSpec,
+  EvalStreamEvent,
   JudgeCriterionSummary,
   JudgeSummary,
 } from "../generated/eval-types.js";
 import { createWorkspaceHandle, type WorkspaceHandle } from "./workspace.js";
 
-export type { EvalSpec, EvalOutcome, JudgeSummary, JudgeCriterionSummary };
+export type {
+  AgentMessage,
+  EvalSpec,
+  EvalOutcome,
+  JudgeSummary,
+  JudgeCriterionSummary,
+};
 export type EvalRunSpec = Omit<EvalSpec, "expect">;
 
 export interface RunEvalOptions {
@@ -32,6 +40,12 @@ export interface RunEvalOptions {
 
   /** Abort the eval run. */
   signal?: AbortSignal;
+
+  /** Called for each `AgentMessage` the eval emits, as soon as it arrives. */
+  onMessage?: (message: AgentMessage) => void;
+
+  /** Called with each raw stderr chunk produced by the eval process. */
+  onStderr?: (chunk: string) => void;
 }
 
 export interface EvalRunResult
@@ -42,7 +56,8 @@ export interface EvalRunResult
 
 /**
  * Run a single Dockerized eval via the `aether` CLI and return its outcome plus a disposable handle
- * to the retained workspace.
+ * to the retained workspace. Agent messages and stderr are streamed to the optional `onMessage`
+ * and `onStderr` callbacks while the eval runs.
  *
  * @example
  * ```ts
@@ -71,7 +86,8 @@ export async function runEval(
   const baseDir = options.baseDir ?? processCwd();
   const { command, prefixArgs } = resolveAetherCommand(options.binaryPath);
   const childEnv = resolveEnv(options.env);
-  const { stdout, stderr } = await runCommand(
+  const consumer = createEvalEventConsumer(options);
+  const { stderr } = await runCommand(
     command,
     [
       ...prefixArgs,
@@ -81,14 +97,14 @@ export async function runEval(
       "--retain-workspace",
       "--base-dir",
       baseDir,
-      "--output",
-      "json",
     ],
     {
       cwd: baseDir,
       env: childEnv,
       stdin: JSON.stringify(spec),
       abortSignal: options.signal,
+      onStdout: (chunk) => consumer.push(chunk),
+      onStderr: options.onStderr,
       spawnFailedMessage: `Failed to run aether eval at ${command}`,
       exitedErrorCode: "eval_command_failed",
       exitedMessage: ({ exitCode, stderr }) =>
@@ -96,22 +112,14 @@ export async function runEval(
     },
   );
 
-  const { retainedWorkspace, ...outcome } = (() => {
-    try {
-      return JSON.parse(stdout.trim()) as EvalOutcome;
-    } catch (err) {
-      throw new AetherSdkError(
-        "eval_command_failed",
-        `Failed to parse aether eval output as JSON.\nstdout:\n${stdout}\nstderr:\n${stderr}`,
-        err,
-      );
-    }
-  })();
+  const outcome = consumer.finish(stderr);
+
+  const { retainedWorkspace, ...result } = outcome;
 
   if (!retainedWorkspace) {
     throw new AetherSdkError(
       "eval_command_failed",
-      `aether eval did not report a workspace path.\nstdout:\n${stdout}\nstderr:\n${stderr}`,
+      `aether eval did not report a workspace path.\nstderr:\n${stderr}`,
     );
   }
 
@@ -121,8 +129,70 @@ export async function runEval(
   );
 
   return {
-    ...outcome,
+    ...result,
     workspace,
     [Symbol.asyncDispose]: () => workspace[Symbol.asyncDispose](),
   };
+}
+
+function createEvalEventConsumer(options: RunEvalOptions) {
+  let buffered = "";
+  let outcome: EvalOutcome | undefined;
+
+  function push(chunk: string): void {
+    buffered += chunk;
+    const lines = buffered.split(/\r?\n/);
+    buffered = lines.pop() ?? "";
+    for (const line of lines) processLine(line);
+  }
+
+  function finish(stderr: string): EvalOutcome {
+    if (buffered.trim()) {
+      const pending = buffered;
+      buffered = "";
+      processLine(pending);
+    }
+    if (!outcome) {
+      throw new AetherSdkError(
+        "eval_command_failed",
+        `aether eval did not emit an outcome event.\nstderr:\n${stderr}`,
+      );
+    }
+    return outcome;
+  }
+
+  function processLine(line: string): void {
+    if (!line.trim()) return;
+    let parsed: EvalStreamEvent;
+    try {
+      parsed = JSON.parse(line) as EvalStreamEvent;
+    } catch (err) {
+      throw new AetherSdkError(
+        "eval_command_failed",
+        `Failed to parse aether eval event line as JSON: ${line}`,
+        err,
+      );
+    }
+    switch (parsed.type) {
+      case "agent_message":
+        options.onMessage?.(parsed.message);
+        return;
+      case "outcome":
+        if (outcome) {
+          throw new AetherSdkError(
+            "eval_command_failed",
+            "aether eval emitted multiple outcome events",
+          );
+        }
+        outcome = parsed.outcome;
+        return;
+      default:
+        throw new AetherSdkError(
+          "eval_command_failed",
+          `unknown aether eval event type: ${(parsed as { type?: unknown }).type}`,
+        );
+    }
+  }
+
+  return { push, finish };
 }

--- a/packages/aether-sdk/test/evals/generate.test.ts
+++ b/packages/aether-sdk/test/evals/generate.test.ts
@@ -1,0 +1,153 @@
+import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { z } from "zod";
+
+import { generate } from "../../src/evals/index.js";
+
+/**
+ * A stand-in for the real `aether generate` binary. It validates argv, reads the prompt from stdin,
+ * captures `{ argv, prompt, model, system }` to `FAKE_GENERATE_CAPTURE` when set, and prints a JSON
+ * response. Behavior is steered by env vars so a single fake covers every case.
+ */
+const FAKE_GENERATE = `#!/usr/bin/env node
+import { writeFileSync } from "node:fs";
+
+const argv = process.argv.slice(2);
+if (argv[0] !== "generate" || !argv.includes("--model") || !argv.includes("--prompt-file") || !argv.includes("-") || !argv.includes("--output")) {
+  process.stderr.write("unexpected argv: " + JSON.stringify(argv) + "\\n");
+  process.exit(1);
+}
+
+const chunks = [];
+for await (const chunk of process.stdin) chunks.push(chunk);
+const prompt = Buffer.concat(chunks).toString("utf8");
+
+const model = argv[argv.indexOf("--model") + 1];
+const systemIdx = argv.indexOf("--system");
+const system = systemIdx === -1 ? null : argv[systemIdx + 1];
+
+if (process.env.FAKE_GENERATE_CAPTURE) {
+  writeFileSync(process.env.FAKE_GENERATE_CAPTURE, JSON.stringify({ argv, prompt, model, system }));
+}
+
+if (process.env.FAKE_GENERATE_EXIT) {
+  process.stderr.write(process.env.FAKE_GENERATE_STDERR ?? "boom");
+  process.exit(Number(process.env.FAKE_GENERATE_EXIT));
+}
+
+const stdout = process.env.FAKE_GENERATE_RAW_STDOUT ?? JSON.stringify({ text: process.env.FAKE_GENERATE_RESPONSE ?? "default response", model });
+process.stdout.write(stdout + "\\n", () => process.exit(0));
+`;
+
+describe("generate", () => {
+  let scratch: string;
+  let fakeBinary: string;
+
+  beforeEach(async () => {
+    scratch = await mkdtemp(join(tmpdir(), "generate-test-"));
+    fakeBinary = join(scratch, "fake-aether.mjs");
+    await writeFile(fakeBinary, FAKE_GENERATE, { mode: 0o755 });
+  });
+
+  afterEach(async () => {
+    await rm(scratch, { recursive: true, force: true });
+  });
+
+  const baseEnv = (extra: Record<string, string>) => ({
+    ...process.env,
+    ...extra,
+  });
+
+  it("returns the model's response text", async () => {
+    const result = await generate("say hi", {
+      binaryPath: fakeBinary,
+      model: "anthropic:claude-sonnet-4-5",
+      env: baseEnv({ FAKE_GENERATE_RESPONSE: "hello world" }),
+    });
+
+    expect(result.text).toBe("hello world");
+  });
+
+  it("sends the model, prompt on stdin, and json output flag", async () => {
+    const capture = join(scratch, "capture.json");
+    await generate("the prompt body", {
+      binaryPath: fakeBinary,
+      model: "anthropic:claude-sonnet-4-5",
+      system: "be terse",
+      env: baseEnv({ FAKE_GENERATE_CAPTURE: capture }),
+    });
+
+    const captured = JSON.parse(await readFile(capture, "utf8"));
+    expect(captured.model).toBe("anthropic:claude-sonnet-4-5");
+    expect(captured.prompt).toBe("the prompt body");
+    expect(captured.system).toBe("be terse");
+    expect(captured.argv).toContain("--output");
+    expect(captured.argv).toContain("json");
+  });
+
+  it("returns typed JSON when a schema is provided", async () => {
+    const capture = join(scratch, "capture.json");
+    const verdict = await generate("grade the run", {
+      binaryPath: fakeBinary,
+      model: "anthropic:claude-sonnet-4-5",
+      schema: z.object({ passed: z.boolean(), reason: z.string() }),
+      env: baseEnv({
+        FAKE_GENERATE_CAPTURE: capture,
+        FAKE_GENERATE_RESPONSE: '{"passed":true,"reason":"ok"}',
+      }),
+    });
+
+    expect(verdict).toEqual({ passed: true, reason: "ok" });
+    const captured = JSON.parse(await readFile(capture, "utf8"));
+    expect(captured.prompt).toContain("grade the run");
+    expect(captured.prompt).toContain("Respond with ONLY valid JSON");
+  });
+
+  it("rejects JSON responses that do not match the schema", async () => {
+    await expect(
+      generate("grade the run", {
+        binaryPath: fakeBinary,
+        model: "anthropic:claude-sonnet-4-5",
+        schema: z.object({ passed: z.boolean(), reason: z.string() }),
+        env: baseEnv({ FAKE_GENERATE_RESPONSE: '{"passed":"yes"}' }),
+      }),
+    ).rejects.toThrow(/did not match schema/);
+  });
+
+  it("throws invalid_options when no model is given", async () => {
+    const saved = process.env.AETHER_LLM_MODEL;
+    delete process.env.AETHER_LLM_MODEL;
+    try {
+      await expect(generate("p", { binaryPath: fakeBinary })).rejects.toThrow(
+        /No model provided/,
+      );
+    } finally {
+      if (saved !== undefined) process.env.AETHER_LLM_MODEL = saved;
+    }
+  });
+
+  it("rejects with generate_command_failed on a non-zero exit", async () => {
+    await expect(
+      generate("p", {
+        binaryPath: fakeBinary,
+        model: "anthropic:claude-sonnet-4-5",
+        env: baseEnv({
+          FAKE_GENERATE_EXIT: "1",
+          FAKE_GENERATE_STDERR: "model unavailable",
+        }),
+      }),
+    ).rejects.toThrow(/aether generate exited with code 1|model unavailable/);
+  });
+
+  it("rejects when stdout is not JSON", async () => {
+    await expect(
+      generate("p", {
+        binaryPath: fakeBinary,
+        model: "anthropic:claude-sonnet-4-5",
+        env: baseEnv({ FAKE_GENERATE_RAW_STDOUT: "this is not json" }),
+      }),
+    ).rejects.toThrow(/Failed to parse aether generate output as JSON/);
+  });
+});

--- a/packages/aether-sdk/test/evals/judge.test.ts
+++ b/packages/aether-sdk/test/evals/judge.test.ts
@@ -1,0 +1,200 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  formatTranscript,
+  judge,
+  JudgeResponseSchema,
+} from "../../src/evals/index.js";
+
+const baseJudgeInput = {
+  task: "do the thing",
+  instructions: "be strict",
+};
+
+describe("judge", () => {
+  it("builds a judge prompt from task, context, instructions, and criteria", () => {
+    const result = judge({
+      ...baseJudgeInput,
+      context: {
+        diff: "+added line",
+        files: { "notes.txt": "beta\n" },
+      },
+      criteria: [
+        {
+          id: "works",
+          description: "the task works",
+          blocking: true,
+          threshold: 0.9,
+          weight: 2,
+        },
+      ],
+    });
+
+    expect(result.prompt).toContain("## Instructions\n\nbe strict");
+    expect(result.prompt).toContain("## Task");
+    expect(result.prompt).toContain(
+      "The agent you're evaluating was given this task: <task>do the thing</task>",
+    );
+    expect(result.prompt).toContain("## Git diff");
+    expect(result.prompt).toContain(
+      "Git diff produced by the agent you're evaluating: <diff>+added line</diff>",
+    );
+    expect(result.prompt).toContain("## File Contents");
+    expect(result.prompt).toContain("<path>notes.txt</path>");
+    expect(result.prompt).toContain("<contents>beta\n</contents>");
+    expect(result.prompt).toContain("## Rubric criteria");
+    expect(result.prompt).toContain("blocking: true");
+    expect(result.prompt).toContain("threshold: 0.9");
+    expect(result.prompt).toContain("weight: 2");
+    expect(result.prompt).toContain(
+      "Return exactly one result for every criterion ID above and no extra criteria.",
+    );
+    expect(result.prompt).toContain(
+      "Respond with ONLY a JSON object matching this schema:",
+    );
+    expect(result.schema).toBe(JudgeResponseSchema);
+  });
+
+  it("normalizes criteria defaults", () => {
+    const result = judge({
+      ...baseJudgeInput,
+      criteria: [{ id: "behavior", description: "does the thing" }],
+    });
+
+    expect(result.criteria).toEqual([
+      {
+        id: "behavior",
+        description: "does the thing",
+        blocking: true,
+        threshold: 1,
+        weight: 1,
+      },
+    ]);
+  });
+
+  it("summarizes normalized criterion scores with weights and blockers", () => {
+    const result = judge({
+      ...baseJudgeInput,
+      criteria: [
+        {
+          id: "behavior",
+          description: "does the thing",
+          blocking: true,
+          threshold: 0.8,
+          weight: 3,
+        },
+        {
+          id: "style",
+          description: "is maintainable",
+          blocking: false,
+          threshold: 0.8,
+          weight: 1,
+        },
+      ],
+    });
+
+    const summary = result.summarize({
+      criteria: [
+        { id: "behavior", score: 1, reason: "correct" },
+        { id: "style", score: 0.5, reason: "rough" },
+      ],
+      overall_reason: "mostly good",
+    });
+
+    expect(summary.passed).toBe(true);
+    expect(summary.score).toBe(0.875);
+    expect(summary.reason).toBe(
+      "weighted score 0.88; all blockers met; mostly good",
+    );
+    expect(summary.criteria[0]).toMatchObject({
+      id: "behavior",
+      score: 1,
+    });
+    expect(summary.criteria[1]).toMatchObject({
+      id: "style",
+      score: 0.5,
+    });
+  });
+
+  it("zeroes the final score when a blocking criterion fails", () => {
+    const result = judge({
+      ...baseJudgeInput,
+      criteria: [
+        {
+          id: "behavior",
+          description: "does the thing",
+          blocking: true,
+          threshold: 0.8,
+          weight: 1,
+        },
+      ],
+    });
+
+    const summary = result.summarize({
+      criteria: [{ id: "behavior", score: 0.75, reason: "not quite" }],
+      overall_reason: "failed behavior",
+    });
+
+    expect(summary.passed).toBe(false);
+    expect(summary.score).toBe(0);
+    expect(summary.reason).toBe(
+      "weighted score 0.75; one or more blockers failed; failed behavior",
+    );
+  });
+
+  it("rejects invalid judge response criterion sets", () => {
+    const result = judge({
+      ...baseJudgeInput,
+      criteria: [{ id: "behavior", description: "does the thing" }],
+    });
+
+    expect(() =>
+      result.summarize({ criteria: [], overall_reason: "missing" }),
+    ).toThrow(/missing response criterion `behavior`/);
+    expect(() =>
+      result.summarize({
+        criteria: [
+          { id: "behavior", score: 1, reason: "ok" },
+          { id: "behavior", score: 1, reason: "dupe" },
+        ],
+        overall_reason: "duplicate",
+      }),
+    ).toThrow(/duplicate response criterion id `behavior`/);
+    expect(() =>
+      result.summarize({
+        criteria: [
+          { id: "behavior", score: 1, reason: "ok" },
+          { id: "extra", score: 1, reason: "extra" },
+        ],
+        overall_reason: "unknown",
+      }),
+    ).toThrow(/unknown response criterion `extra`/);
+  });
+
+  it("formatTranscript joins streamed text chunks and renders tool calls", () => {
+    const text = formatTranscript([
+      {
+        type: "text",
+        message_id: "m1",
+        chunk: "Hello ",
+        is_complete: false,
+        model_name: "fake",
+      },
+      {
+        type: "text",
+        message_id: "m1",
+        chunk: "world",
+        is_complete: true,
+        model_name: "fake",
+      },
+      {
+        type: "tool_call",
+        model_name: "fake",
+        request: { id: "c1", name: "bash", arguments: '{"cmd":"ls"}' },
+      },
+    ]);
+
+    expect(text).toContain("[agent] Hello world");
+    expect(text).toContain('[tool-call] bash {"cmd":"ls"}');
+  });
+});

--- a/packages/aether-sdk/test/evals/runEval.test.ts
+++ b/packages/aether-sdk/test/evals/runEval.test.ts
@@ -7,10 +7,10 @@ import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { runEval } from "../../src/evals/index.js";
 
 /**
- * A stand-in for the real `aether eval --spec-file -` binary: it parses the spec from
- * stdin, writes the inline workspace files to a fresh temp dir, and prints a passing
- * `EvalOutcome` whose `retainedWorkspace` points at that dir. Lets us exercise the `runEval` helper
- * without Docker.
+ * A stand-in for the real `aether eval --spec-file -` binary: it parses the spec
+ * from stdin, writes the inline workspace files to a fresh temp dir, streams an `agent_message`
+ * event, writes a stderr chunk, then prints a passing `outcome` event whose `retainedWorkspace`
+ * points at that dir. Lets us exercise the `runEval` helper without Docker.
  */
 const FAKE_AETHER = `#!/usr/bin/env node
 import { mkdirSync, writeFileSync, mkdtempSync } from "node:fs";
@@ -31,6 +31,20 @@ for (const [rel, content] of Object.entries(spec.task?.workspace?.files ?? {})) 
   mkdirSync(dirname(path), { recursive: true });
   writeFileSync(path, content);
 }
+
+process.stdout.write(JSON.stringify({
+  type: "agent_message",
+  message: {
+    type: "text",
+    message_id: "msg_1",
+    chunk: "starting eval",
+    is_complete: false,
+    model_name: "fake",
+  },
+}) + "\\n");
+
+process.stderr.write("debug from fake eval\\n");
+
 const outcome = {
   name: spec.name,
   passed: true,
@@ -44,7 +58,7 @@ const outcome = {
   ],
   retainedWorkspace: { rootPath: workspace, path: workspace },
 };
-process.stdout.write(JSON.stringify(outcome) + "\\n", () => process.exit(0));
+process.stdout.write(JSON.stringify({ type: "outcome", outcome }) + "\\n", () => process.exit(0));
 `;
 
 const SPEC = {
@@ -124,5 +138,61 @@ describe("runEval", () => {
         { binaryPath: fakeBinary },
       ),
     ).rejects.toThrow(/`expect` is not allowed/);
+  });
+
+  it("invokes onMessage for each agent_message event before resolving", async () => {
+    const messages: unknown[] = [];
+    const result = await runEval(SPEC, {
+      binaryPath: fakeBinary,
+      onMessage: (message) => messages.push(message),
+    });
+
+    expect(result.passed).toBe(true);
+    expect(messages).toHaveLength(1);
+    expect(messages[0]).toMatchObject({
+      type: "text",
+      message_id: "msg_1",
+      chunk: "starting eval",
+    });
+    await result.workspace.cleanup();
+  });
+
+  it("invokes onStderr for each stderr chunk", async () => {
+    const stderrChunks: string[] = [];
+    const result = await runEval(SPEC, {
+      binaryPath: fakeBinary,
+      onStderr: (chunk) => stderrChunks.push(chunk),
+    });
+
+    expect(stderrChunks.join("")).toContain("debug from fake eval");
+    await result.workspace.cleanup();
+  });
+
+  it("rejects with eval_command_failed when a JSON event line is malformed", async () => {
+    const malformed = `#!/usr/bin/env node
+process.stdout.write("this is not json\\n");
+process.exit(0);
+`;
+    await writeFile(join(scratch, "malformed.mjs"), malformed, {
+      mode: 0o755,
+    });
+    await expect(
+      runEval(SPEC, { binaryPath: join(scratch, "malformed.mjs") }),
+    ).rejects.toThrow(
+      /eval_command_failed|Failed to parse aether eval event line/,
+    );
+  });
+
+  it("rejects with eval_command_failed when no outcome event is emitted", async () => {
+    const noOutcome = `#!/usr/bin/env node
+process.stdout.write(JSON.stringify({ type: "agent_message", message: { type: "done" } }) + "\\n");
+process.exit(0);
+`;
+    await writeFile(join(scratch, "no-outcome.mjs"), noOutcome, {
+      mode: 0o755,
+    });
+    await expect(
+      runEval(SPEC, { binaryPath: join(scratch, "no-outcome.mjs") }),
+    ).rejects.toThrow(/did not emit an outcome event/);
   });
 });

--- a/packages/llm/src/tools.rs
+++ b/packages/llm/src/tools.rs
@@ -1,7 +1,8 @@
+use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
 #[doc = include_str!("docs/tools.md")]
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
 pub struct ToolDefinition {
     pub name: String,
     pub description: String,
@@ -11,7 +12,7 @@ pub struct ToolDefinition {
     pub annotations: Option<ToolAnnotations>,
 }
 
-#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
 #[serde(rename_all = "camelCase")]
 pub struct ToolAnnotations {
     pub title: Option<String>,
@@ -50,7 +51,7 @@ impl ToolAnnotations {
 }
 
 /// Tool call request from the LLM
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
 pub struct ToolCallRequest {
     pub id: String,
     pub name: String,
@@ -58,7 +59,7 @@ pub struct ToolCallRequest {
 }
 
 /// Successful result of a tool call
-#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
 pub struct ToolCallResult {
     pub id: String,
     pub name: String,
@@ -67,7 +68,7 @@ pub struct ToolCallResult {
 }
 
 /// Error result of a tool call
-#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
 pub struct ToolCallError {
     pub id: String,
     pub name: String,

--- a/packages/mcp-utils/Cargo.toml
+++ b/packages/mcp-utils/Cargo.toml
@@ -31,7 +31,6 @@ client = [
     "dep:llm",
     "dep:reqwest",
     "dep:thiserror",
-    "dep:schemars",
     "rmcp/transport-streamable-http-client-reqwest",
     "rmcp/transport-child-process",
 ]
@@ -43,6 +42,7 @@ tokio = { workspace = true }
 rmcp = { workspace = true }
 tracing = { workspace = true }
 utils = { package = "aether-utils", path = "../utils", version = "0.2.8" }
+schemars = { workspace = true }
 
 # client-only deps
 aether-auth = { path = "../aether-auth", version = "0.1.6", optional = true }
@@ -51,7 +51,6 @@ serde_json = { workspace = true }
 regex = { workspace = true }
 reqwest = { workspace = true, optional = true }
 thiserror = { workspace = true, optional = true }
-schemars = { workspace = true, optional = true }
 
 [dev-dependencies]
 aether-doctest = { path = "../doctest" }

--- a/packages/mcp-utils/src/display_meta.rs
+++ b/packages/mcp-utils/src/display_meta.rs
@@ -5,13 +5,14 @@
 
 use std::path::Path;
 
+use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
 /// Human-readable display metadata for a tool operation.
 ///
 /// Contains a pre-computed `title` (e.g., "Read file") and `value`
 /// (e.g., "Cargo.toml, 156 lines") that consumers render directly.
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, JsonSchema)]
 pub struct ToolDisplayMeta {
     pub title: String,
     pub value: String,
@@ -25,7 +26,7 @@ impl ToolDisplayMeta {
 
 /// Full file contents for a diff, sent as metadata so the ACP layer
 /// can emit a first-class `ToolCallContent::Diff`.
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, JsonSchema)]
 pub struct FileDiff {
     pub path: String,
     /// Original file content (`None` for new files).
@@ -36,20 +37,20 @@ pub struct FileDiff {
 }
 
 /// A snapshot of the agent's current task plan.
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, JsonSchema)]
 pub struct PlanMeta {
     pub entries: Vec<PlanMetaEntry>,
 }
 
 /// A single entry in a plan.
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, JsonSchema)]
 pub struct PlanMetaEntry {
     pub content: String,
     pub status: PlanMetaStatus,
 }
 
 /// Execution status of a plan entry.
-#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq)]
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, JsonSchema)]
 #[serde(rename_all = "snake_case")]
 pub enum PlanMetaStatus {
     Pending,
@@ -61,7 +62,7 @@ pub enum PlanMetaStatus {
 ///
 /// Wraps a [`ToolDisplayMeta`] so that tool output structs can use
 /// `Option<ToolResultMeta>` instead of `Option<serde_json::Value>`.
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, JsonSchema)]
 pub struct ToolResultMeta {
     pub display: ToolDisplayMeta,
     #[serde(skip_serializing_if = "Option::is_none")]

--- a/website/src/content/docs/aether/running/evals.mdx
+++ b/website/src/content/docs/aether/running/evals.mdx
@@ -339,3 +339,16 @@ Setup failures include invalid JSON, a missing Dockerfile, or a failed Docker bu
 Per-eval failures include container errors, unmet expectations, and judge failures. Those are reported for the failing eval while other eval files continue to run.
 
 The CLI eval format is the recommended path for Aether users. The underlying Rust harness lives in the `aether-evals` crate and is useful when you need custom setup or assertions that JSON cannot express, but most agent regression tests should start as `*.eval.json` files run by `aether eval`.
+
+### Machine-readable output
+
+`aether eval --output json` prints an aggregate `EvalFilesReport` (one JSON object describing every eval) and exits non-zero if any eval failed. This is the format to use when scripting over a directory of eval files.
+
+For a single eval, `aether eval --spec-file <path-or-->` (the path used by `@aether-agent/sdk`'s `runEval`) always streams newline-delimited `EvalStreamEvent` JSON on stdout, regardless of `--output`. Each line is one of:
+
+```jsonl
+{"type":"agent_message","message":{"type":"text","message_id":"msg_1","chunk":"...","is_complete":false,"model_name":"..."}}
+{"type":"outcome","outcome":{"name":"edit-notes","passed":true,"failures":[],"toolCalls":[],"retainedWorkspace":{"rootPath":"/tmp/...","path":"/tmp/..."}}}
+```
+
+`agent_message` events are emitted and flushed as the eval runs, so callers can observe agent progress before the run completes. The stream terminates with exactly one `outcome` event carrying the `EvalOutcome`. Multi-file `aether eval --output json` is unaffected and still returns the aggregate report.


### PR DESCRIPTION
This PR makes a number of improvements to Aether's evals feature, including: 

1. Evals output streaming messages for observability / debugging 
2. Consumers of the TS SDK can now hook into this via a `onmessage` callback 
3. `aether-cli` gets a new `generate` command for a single call and response (llm as a judge uses this)
4. llm as a judge gets better support via a `judge` method for building prompts with criteria and context built in. 