### PR TITLE
feat(mcp-servers): Make edit_file and edit_plan support batched edits

### DIFF
--- a/packages/internal-evals/examples/Dockerfile
+++ b/packages/internal-evals/examples/Dockerfile
@@ -15,10 +15,10 @@ RUN pacman -Syu --noconfirm ca-certificates git dbus \
 # Install your project's toolchain here, e.g.:
 # RUN apt-get update && apt-get install -y python3 python3-pip
 
-# Provide the aether binary and an example direct eval wrapper from the repository
-# build output. Run `cargo build -p aether-agent-cli --bin aether` before this image builds.
 COPY target/debug/aether /usr/local/bin/aether
 COPY .aether /repo/.aether
+COPY AGENTS.md /repo/AGENTS.md
+COPY mcp.json /repo/mcp.json
 COPY packages/internal-evals/examples/aether-eval-agent /usr/local/bin/aether-eval-agent
 RUN chmod +x /usr/local/bin/aether-eval-agent
 

--- a/packages/internal-evals/examples/aether-eval-agent
+++ b/packages/internal-evals/examples/aether-eval-agent
@@ -1,15 +1,18 @@
 #!/bin/sh
 set -eu
 
+rm -rf /workspace/.aether
+cp -R /repo/.aether /workspace/.aether
+cp /repo/AGENTS.md /workspace/AGENTS.md
+cp /repo/mcp.json /workspace/mcp.json
+
 if [ "${AETHER_EVAL_AGENT:-}" ]; then
   exec aether headless \
     --output json \
-    --settings-file /repo/.aether/settings.json \
     --agent "$AETHER_EVAL_AGENT" \
     "$AETHER_EVAL_WRAPPED_TASK_PROMPT"
 fi
 
 exec aether headless \
   --output json \
-  --settings-file /repo/.aether/settings.json \
   "$AETHER_EVAL_WRAPPED_TASK_PROMPT"

--- a/packages/internal-evals/tests/batched_edits.rs
+++ b/packages/internal-evals/tests/batched_edits.rs
@@ -1,0 +1,71 @@
+mod common;
+use aether_evals::{Task, TaskRun, Workspace};
+use common::{EvalHarnessError, create_aether_agent};
+
+#[tokio::test]
+async fn edit_file_multi_point_revision_in_single_call_eval() -> Result<(), EvalHarnessError> {
+    let workspace =
+        Workspace::from_files([("config.txt", &file_contents(&["host = localhost", "port = 8080", "debug = false"]))])?;
+    let agent = create_aether_agent();
+    let prompt = lines(&[
+        "Use the coding MCP tools to update config.txt.",
+        "Read the file first, then call coding__edit_file EXACTLY ONCE, passing all three changes together in the edits array:",
+        "- set host to example.com",
+        "- set port to 443",
+        "- set debug to true",
+    ]);
+
+    let run = Task::new(prompt, workspace).run(&agent).await?;
+
+    assert_single_edit_call(&run, "coding__edit_file");
+    assert_eq!(
+        read_file(&run, "config.txt")?,
+        file_contents(&["host = example.com", "port = 443", "debug = true"]),
+        "{}",
+        run.failure_context()
+    );
+    Ok(())
+}
+
+#[tokio::test]
+async fn edit_plan_multi_point_revision_in_single_call_eval() -> Result<(), EvalHarnessError> {
+    let agent = create_aether_agent();
+    let prompt = lines(&[
+        "Use the plan MCP tools.",
+        "First call plan__write_plan with planName 'feature' and this exact body:",
+        "# Feature",
+        "Step one: scaffold",
+        "Step two: wire it up",
+        "Then revise it by calling plan__edit_plan EXACTLY ONCE, passing both changes together in the edits array:",
+        "- change 'Step one: scaffold' to 'Step one: design'",
+        "- change 'Step two: wire it up' to 'Step two: implement'",
+    ]);
+
+    let run = Task::new(prompt, Workspace::empty()?).run(&agent).await?;
+
+    assert_single_edit_call(&run, "plan__edit_plan");
+    assert_eq!(
+        read_file(&run, "docs/aether/plans/feature-plan.md")?,
+        lines(&["# Feature", "Step one: design", "Step two: implement"]),
+        "{}",
+        run.failure_context()
+    );
+    Ok(())
+}
+
+#[track_caller]
+fn assert_single_edit_call(run: &TaskRun, tool: &str) {
+    assert_eq!(run.transcript().tool_call_count(tool), 1, "{}", run.failure_context());
+}
+
+fn file_contents(lines: &[&str]) -> String {
+    format!("{}\n", lines.join("\n"))
+}
+
+fn lines(lines: &[&str]) -> String {
+    lines.join("\n")
+}
+
+fn read_file(run: &TaskRun, path: &str) -> Result<String, EvalHarnessError> {
+    Ok(std::fs::read_to_string(run.workspace().join(path))?)
+}

--- a/packages/internal-evals/tests/coding_edit_file.rs
+++ b/packages/internal-evals/tests/coding_edit_file.rs
@@ -1,5 +1,7 @@
 mod common;
 
+use std::fs::read_to_string;
+
 use aether_evals::{Task, TaskRun, Workspace};
 use common::{EvalHarnessError, create_aether_agent};
 
@@ -17,7 +19,7 @@ async fn edit_file_replaces_first_match_by_default_eval() -> Result<(), EvalHarn
     let run = Task::new(prompt, workspace).run(&agent).await?;
 
     assert_read_then_single_edit(&run);
-    assert_eq!(read_file(&run, "notes.txt"), file_contents(&["beta", "alpha"]), "{}", run.failure_context());
+    assert_eq!(read_file(&run, "notes.txt")?, file_contents(&["beta", "alpha"]), "{}", run.failure_context());
     Ok(())
 }
 
@@ -28,12 +30,12 @@ async fn edit_file_replace_all_updates_every_match_eval() -> Result<(), EvalHarn
     let agent = create_aether_agent();
     let prompt = lines(&[
         "Use the coding MCP tools to update tasks.md.",
-        "Read the file first, then call coding__edit_file exactly once with replaceAll enabled to change every 'todo' marker to 'done'.",
+        "Read the file first, then call coding__edit_file exactly once, using a single replace edit with replaceAll enabled, to change every 'todo' marker to 'done'.",
     ]);
 
     let run = Task::new(prompt, workspace).run(&agent).await?;
 
-    let contents = read_file(&run, "tasks.md");
+    let contents = read_file(&run, "tasks.md")?;
     assert_read_then_single_edit(&run);
     assert!(!contents.contains("todo"), "{}", run.failure_context());
     assert_eq!(contents.matches("done").count(), 3, "{}", run.failure_context());
@@ -58,7 +60,7 @@ async fn edit_file_handles_multiline_exact_replacement_eval() -> Result<(), Eval
 
     let run = Task::new(prompt, workspace).run(&agent).await?;
 
-    let contents = read_file(&run, "src/lib.rs");
+    let contents = read_file(&run, "src/lib.rs")?;
     assert_read_then_single_edit(&run);
     assert!(contents.contains("println!(\"hello from edit_file\");"), "{}", run.failure_context());
     assert!(contents.contains("pub fn keep() {}"), "{}", run.failure_context());
@@ -72,13 +74,13 @@ async fn edit_file_pattern_not_found_leaves_file_unchanged_eval() -> Result<(), 
     let agent = create_aether_agent();
     let prompt = lines(&[
         "Use the coding MCP tools on config.toml.",
-        "Read the file first, then intentionally call coding__edit_file exactly once with oldString set to 'mode = \"missing\"' and newString set to 'mode = \"unsafe\"'.",
+        "Read the file first, then intentionally call coding__edit_file exactly once with a single replace edit whose oldString is 'mode = \"missing\"' and newString is 'mode = \"unsafe\"'.",
         "This old string is not present; report the tool error and leave the file unchanged.",
     ]);
 
     let run = Task::new(prompt, workspace).run(&agent).await?;
 
-    let contents = read_file(&run, "config.toml");
+    let contents = read_file(&run, "config.toml")?;
     assert_read_then_single_edit(&run);
     assert_eq!(contents, file_contents(&["mode = \"safe\""]), "{}", run.failure_context());
     assert!(!contents.contains("unsafe"), "{}", run.failure_context());
@@ -99,6 +101,6 @@ fn lines(lines: &[&str]) -> String {
     lines.join("\n")
 }
 
-fn read_file(run: &TaskRun, path: &str) -> String {
-    std::fs::read_to_string(run.workspace().join(path)).unwrap_or_else(|error| panic!("failed to read {path}: {error}"))
+fn read_file(run: &TaskRun, path: &str) -> Result<String, EvalHarnessError> {
+    Ok(read_to_string(run.workspace().join(path))?)
 }

--- a/packages/internal-evals/tests/common/mod.rs
+++ b/packages/internal-evals/tests/common/mod.rs
@@ -11,6 +11,9 @@ pub enum EvalHarnessError {
 
     #[error("eval run failed: {0}")]
     TaskRun(Box<aether_evals::TaskRunError>),
+
+    #[error("file IO failed: {0}")]
+    Io(#[from] std::io::Error),
 }
 
 impl From<aether_evals::TaskRunError> for EvalHarnessError {

--- a/packages/mcp-servers/src/coding/tools/edit_file/description.md
+++ b/packages/mcp-servers/src/coding/tools/edit_file/description.md
@@ -1,22 +1,26 @@
-Performs exact string replacements in files.
+Use this tool to edit a file. This tool accepts an array of batched exact-string replacements. If 1 edit fails, no edits in the batch are applied.
 
 ## Usage
 
 ```json
-{"filePath": "/path/to/file.rs", "oldString": "foo", "newString": "bar"}
-{"filePath": "/path/to/file.rs", "oldString": "old_name", "newString": "new_name", "replaceAll": true}
+{"filePath": "/path/to/file.rs", "edits": [
+  {"oldString": "foo", "newString": "bar"},
+  {"oldString": "old_name", "newString": "new_name", "replaceAll": true}
+]}
 ```
 
 - `filePath` — **required**, absolute path
-- `oldString` — **required**, exact string to find (must be unique unless `replaceAll`)
-- `newString` — **required**, replacement text
-- `replaceAll` — replace all occurrences (default: false)
+- `edits` — **required**, a non-empty array. Each edit replaces `oldString` with `newString`.
+  - `oldString` — exact string to find (must be unique unless `replaceAll`).
+  - `newString` — replacement text.
+  - `replaceAll` — replace all occurrences (default: false).
 
 ## Tips
 
-- Preserve exact indentation from `read_file` output — match text AFTER the tab character, not the line number prefix
-- For renaming symbols across the codebase, use `lsp_rename` instead
-- Prefer editing existing files over creating new ones
+- Batch every edit to a file into one call; edits must target non-overlapping regions.
+- Preserve exact indentation from `read_file` output — match text AFTER the tab character, not the line-number prefix.
+- To rename symbols across the codebase, prefer `lsp_rename` instead (if available).
+- Unless your edits require overwriting an entire file, prefer this tool over `create_file`.
 
 ## Safety
 

--- a/packages/mcp-servers/src/coding/tools/edit_file/mod.rs
+++ b/packages/mcp-servers/src/coding/tools/edit_file/mod.rs
@@ -2,24 +2,16 @@ use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use std::path::Path;
 
-use crate::file_ops::{FileError, edit_text_file};
+use crate::file_ops::{ApplyEditsResult, FileEdit, FileError, apply_edits};
 use mcp_utils::display_meta::{FileDiff, ToolDisplayMeta, ToolResultMeta, basename};
 
-#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+#[derive(Debug, Clone, Deserialize, JsonSchema)]
 #[serde(rename_all = "camelCase")]
 pub struct EditFileArgs {
     /// Path to the file to edit
     #[serde(alias = "file_path")]
     pub file_path: String,
-    /// Exact string to find and replace in the file
-    #[serde(alias = "old_string")]
-    pub old_string: String,
-    /// String to replace it with
-    #[serde(alias = "new_string")]
-    pub new_string: String,
-    /// Replace all occurrences (default: false - replace only first match)
-    #[serde(default, alias = "replace_all")]
-    pub replace_all: bool,
+    pub edits: Vec<FileEdit>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
@@ -42,31 +34,28 @@ pub struct EditFileResponse {
 }
 
 pub async fn edit_file_contents(args: EditFileArgs) -> Result<EditFileResponse, FileError> {
-    let result =
-        edit_text_file(Path::new(&args.file_path), &args.old_string, &args.new_string, args.replace_all).await?;
-    let file_path = result.path.to_string_lossy().into_owned();
-    let total_lines = result.updated_content.lines().count();
+    let ApplyEditsResult { path, original_content, updated_content, replacements_made } =
+        apply_edits(Path::new(&args.file_path), &args.edits).await?;
+    let file_path = path.to_string_lossy().into_owned();
+    let total_lines = updated_content.lines().count();
     let display_meta = ToolDisplayMeta::new("Edit file", basename(&file_path));
-    let file_diff = FileDiff {
-        path: file_path.clone(),
-        old_text: Some(result.original_content),
-        new_text: result.updated_content.clone(),
-    };
+    let file_diff =
+        FileDiff { path: file_path.clone(), old_text: Some(original_content), new_text: updated_content.clone() };
 
     Ok(EditFileResponse {
         status: "success".to_string(),
         file_path,
         total_lines,
-        replacements_made: result.replacements_made,
-        content: result.updated_content,
+        replacements_made,
+        content: updated_content,
         meta: Some(ToolResultMeta::with_file_diff(display_meta, file_diff)),
     })
 }
 
-#[allow(clippy::used_underscore_binding)]
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::file_ops::EditFailureKind;
     use std::fs;
     use tempfile::TempDir;
 
@@ -77,9 +66,7 @@ mod tests {
 
         let result = edit_file_contents(EditFileArgs {
             file_path: file_path.to_string_lossy().to_string(),
-            old_string: "before".to_string(),
-            new_string: "after".to_string(),
-            replace_all: false,
+            edits: vec![FileEdit::new("before", "after")],
         })
         .await;
 
@@ -87,20 +74,22 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn edit_file_existing_file_without_match_returns_pattern_not_found() {
-        let temp_dir = TempDir::new().unwrap();
+    async fn edit_file_existing_file_without_match_returns_edits_failed() -> Result<(), Box<dyn std::error::Error>> {
+        let temp_dir = TempDir::new()?;
         let file_path = temp_dir.path().join("sample.txt");
-        fs::write(&file_path, "hello world").unwrap();
+        fs::write(&file_path, "hello world")?;
 
         let result = edit_file_contents(EditFileArgs {
             file_path: file_path.to_string_lossy().to_string(),
-            old_string: "missing".to_string(),
-            new_string: "replacement".to_string(),
-            replace_all: false,
+            edits: vec![FileEdit::new("missing", "replacement")],
         })
         .await;
 
-        assert!(matches!(result, Err(FileError::PatternNotFound { .. })));
+        let Err(FileError::EditsFailed { failures, .. }) = result else {
+            return Err("expected EditsFailed".into());
+        };
+        assert!(matches!(failures.as_slice(), [f] if matches!(f.kind, EditFailureKind::PatternNotFound { .. })));
+        Ok(())
     }
 
     #[tokio::test]
@@ -112,9 +101,7 @@ mod tests {
 
         let result = edit_file_contents(EditFileArgs {
             file_path: file_path.to_string_lossy().to_string(),
-            old_string: "line3".to_string(),
-            new_string: "replaced".to_string(),
-            replace_all: false,
+            edits: vec![FileEdit::new("line3", "replaced")],
         })
         .await
         .unwrap();
@@ -128,37 +115,35 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn edit_file_file_diff_has_correct_path() {
+    async fn edit_file_applies_batch_in_one_call() {
         let temp_dir = TempDir::new().unwrap();
-        let file_path = temp_dir.path().join("test.rs");
-        fs::write(&file_path, "hello world").unwrap();
+        let file_path = temp_dir.path().join("lines.txt");
+        fs::write(&file_path, "alpha\nbeta\ngamma\n").unwrap();
 
         let result = edit_file_contents(EditFileArgs {
             file_path: file_path.to_string_lossy().to_string(),
-            old_string: "hello".to_string(),
-            new_string: "goodbye".to_string(),
-            replace_all: false,
+            edits: vec![FileEdit::new("alpha", "ALPHA"), FileEdit::new("gamma", "GAMMA")],
         })
         .await
         .unwrap();
 
-        let diff = result.meta.unwrap().file_diff.unwrap();
-        assert_eq!(diff.path, file_path.to_string_lossy().to_string());
+        assert_eq!(result.replacements_made, 2);
+        assert_eq!(fs::read_to_string(&file_path).unwrap(), "ALPHA\nbeta\nGAMMA\n");
     }
 
     #[test]
     fn edit_file_args_accepts_snake_case_fields() {
         let args: EditFileArgs = serde_json::from_value(serde_json::json!({
             "file_path": "/tmp/test.txt",
-            "old_string": "foo",
-            "new_string": "bar",
-            "replace_all": true
+            "edits": [{ "old_string": "foo", "new_string": "bar", "replace_all": true }]
         }))
         .unwrap();
 
         assert_eq!(args.file_path, "/tmp/test.txt");
-        assert_eq!(args.old_string, "foo");
-        assert_eq!(args.new_string, "bar");
-        assert!(args.replace_all);
+        assert!(matches!(
+            args.edits.as_slice(),
+            [FileEdit { old_string, new_string, replace_all: true }]
+                if old_string == "foo" && new_string == "bar"
+        ));
     }
 }

--- a/packages/mcp-servers/src/docs/plan_mcp.md
+++ b/packages/mcp-servers/src/docs/plan_mcp.md
@@ -15,5 +15,5 @@ let server = PlanMcp::new();
 # Tools provided
 
 - **`write_plan`** -- Writes a markdown plan in the configured plans directory.
-- **`edit_plan`** -- Applies an exact string replacement to an existing plan.
+- **`edit_plan`** -- Applies a batch of exact-string replacements to an existing plan.
 - **`submit_plan`** -- Reads a named plan and returns a structured approval decision.

--- a/packages/mcp-servers/src/file_ops.rs
+++ b/packages/mcp-servers/src/file_ops.rs
@@ -1,8 +1,31 @@
 use std::io::ErrorKind;
+use std::ops::Range;
 use std::path::{Path, PathBuf};
 
+use schemars::JsonSchema;
+use serde::Deserialize;
 use thiserror::Error;
 use tokio::fs::{create_dir_all, write};
+
+#[derive(Debug, Clone, Deserialize, JsonSchema)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct FileEdit {
+    /// Exact text to find. Must match whitespace (e.g. indentation).
+    #[serde(alias = "old_string")]
+    pub old_string: String,
+    /// Text to substitute for `oldString`.
+    #[serde(alias = "new_string")]
+    pub new_string: String,
+    /// Replace every occurrence instead of just the first.
+    #[serde(default, alias = "replace_all")]
+    pub replace_all: bool,
+}
+
+impl FileEdit {
+    pub fn new(old_string: &str, new_string: &str) -> Self {
+        Self { old_string: old_string.to_string(), new_string: new_string.to_string(), replace_all: false }
+    }
+}
 
 #[derive(Debug, Error)]
 pub enum FileError {
@@ -21,11 +44,31 @@ pub enum FileError {
     #[error("Invalid offset for file {path}: offset must be 1-indexed (start from 1)")]
     InvalidOffset { path: String },
 
-    #[error("String replacement failed for file {path}: string '{pattern}' not found")]
-    PatternNotFound { path: String, pattern: String },
+    #[error("No edits supplied for file {path}: provide at least one edit")]
+    EmptyEdits { path: String },
+
+    #[error("{} edit(s) failed for file {path}; no changes were written:\n{}", .failures.len(), format_failures(.failures))]
+    EditsFailed { path: String, failures: Vec<EditFailure> },
 
     #[error("IO error: {0}")]
     Io(#[from] std::io::Error),
+}
+
+/// A single edit that could not be applied. `index` is the
+/// position of the failing edit in the supplied `edits` array,
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct EditFailure {
+    pub index: usize,
+    pub kind: EditFailureKind,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Error)]
+pub enum EditFailureKind {
+    #[error("string not found: `{pattern}`")]
+    PatternNotFound { pattern: String },
+
+    #[error("edit overlaps the edit at index {other}; use non-overlapping edits or combine them")]
+    Overlapping { other: usize },
 }
 
 pub struct WriteTextFileResult {
@@ -33,7 +76,8 @@ pub struct WriteTextFileResult {
     pub bytes_written: usize,
 }
 
-pub struct EditTextFileResult {
+#[derive(Debug)]
+pub struct ApplyEditsResult {
     pub path: PathBuf,
     pub original_content: String,
     pub updated_content: String,
@@ -61,33 +105,221 @@ pub async fn write_text_file(path: &Path, content: &str) -> Result<WriteTextFile
     Ok(WriteTextFileResult { path: path.to_path_buf(), bytes_written: content.len() })
 }
 
-pub async fn edit_text_file(
-    path: &Path,
-    old_string: &str,
-    new_string: &str,
-    replace_all: bool,
-) -> Result<EditTextFileResult, FileError> {
-    let original_content = read_text_file(path).await?;
-    let (updated_content, replacements_made) = if replace_all {
-        let count = original_content.matches(old_string).count();
-        (original_content.replace(old_string, new_string), count)
-    } else if original_content.contains(old_string) {
-        (original_content.replacen(old_string, new_string, 1), 1)
-    } else {
-        (original_content.clone(), 0)
-    };
-
-    if replacements_made == 0 {
-        return Err(FileError::PatternNotFound { path: display_path(path), pattern: old_string.to_string() });
+pub async fn apply_edits(path: &Path, edits: &[FileEdit]) -> Result<ApplyEditsResult, FileError> {
+    if edits.is_empty() {
+        return Err(FileError::EmptyEdits { path: display_path(path) });
     }
+
+    let original_content = read_text_file(path).await?;
+    let resolved = resolve_edits(&original_content, edits)
+        .map_err(|failures| FileError::EditsFailed { path: display_path(path), failures })?;
+
+    let updated_content = splice(&original_content, &resolved);
+    let replacements_made = resolved.len();
 
     if let Err(error) = write(path, &updated_content).await {
         return Err(FileError::WriteFailed { path: display_path(path), reason: error.to_string() });
     }
 
-    Ok(EditTextFileResult { path: path.to_path_buf(), original_content, updated_content, replacements_made })
+    Ok(ApplyEditsResult { path: path.to_path_buf(), original_content, updated_content, replacements_made })
+}
+
+struct ResolvedEdit {
+    range: Range<usize>,
+    replacement: String,
+    edit_index: usize,
+}
+
+fn resolve_edits(content: &str, edits: &[FileEdit]) -> Result<Vec<ResolvedEdit>, Vec<EditFailure>> {
+    let mut resolved: Vec<ResolvedEdit> = Vec::new();
+    let mut failures: Vec<EditFailure> = Vec::new();
+
+    for (index, FileEdit { old_string, new_string, replace_all }) in edits.iter().enumerate() {
+        let starts: Vec<usize> = content.match_indices(old_string).map(|(start, _)| start).collect();
+        if starts.is_empty() {
+            failures
+                .push(EditFailure { index, kind: EditFailureKind::PatternNotFound { pattern: old_string.clone() } });
+            continue;
+        }
+        let chosen = if *replace_all { starts.as_slice() } else { &starts[..1] };
+        for &start in chosen {
+            resolved.push(ResolvedEdit {
+                range: start..start + old_string.len(),
+                replacement: new_string.clone(),
+                edit_index: index,
+            });
+        }
+    }
+
+    resolved.sort_by_key(|edit| edit.range.start);
+    let mut furthest: Option<(usize, usize)> = None;
+    for edit in &resolved {
+        match furthest {
+            Some((end, other)) if edit.range.start < end => {
+                failures.push(EditFailure { index: edit.edit_index, kind: EditFailureKind::Overlapping { other } });
+                if edit.range.end > end {
+                    furthest = Some((edit.range.end, edit.edit_index));
+                }
+            }
+            _ => furthest = Some((edit.range.end, edit.edit_index)),
+        }
+    }
+
+    if failures.is_empty() {
+        Ok(resolved)
+    } else {
+        failures.sort_by_key(|failure| failure.index);
+        Err(failures)
+    }
+}
+
+fn splice(content: &str, resolved: &[ResolvedEdit]) -> String {
+    let mut result = String::with_capacity(content.len());
+    let mut last = 0;
+    for edit in resolved {
+        result.push_str(&content[last..edit.range.start]);
+        result.push_str(&edit.replacement);
+        last = edit.range.end;
+    }
+    result.push_str(&content[last..]);
+    result
+}
+
+fn format_failures(failures: &[EditFailure]) -> String {
+    failures
+        .iter()
+        .map(|failure| format!("  edits[{}]: {}", failure.index, failure.kind))
+        .collect::<Vec<_>>()
+        .join("\n")
 }
 
 fn display_path(path: &Path) -> String {
     path.to_string_lossy().into_owned()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::TempDir;
+
+    #[tokio::test]
+    async fn applies_batch_against_original_content() -> Result<(), Box<dyn std::error::Error>> {
+        let (_dir, path) = with_file("alpha\nbeta\ngamma\n").await?;
+        let result = apply_edits(&path, &[FileEdit::new("alpha", "ALPHA"), FileEdit::new("gamma", "GAMMA")]).await?;
+
+        assert_eq!(result.replacements_made, 2);
+        assert_eq!(std::fs::read_to_string(&path)?, "ALPHA\nbeta\nGAMMA\n");
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn applies_multiple_replacements_without_drift() -> Result<(), Box<dyn std::error::Error>> {
+        let (_dir, path) = with_file("one\ntwo\nthree\nfour\n").await?;
+        apply_edits(&path, &[FileEdit::new("one", "ONE"), FileEdit::new("three", "THREE")]).await?;
+        assert_eq!(std::fs::read_to_string(&path)?, "ONE\ntwo\nTHREE\nfour\n");
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn replace_all_counts_every_occurrence() -> Result<(), Box<dyn std::error::Error>> {
+        let (_dir, path) = with_file("x x x\n").await?;
+        let result = apply_edits(
+            &path,
+            &[FileEdit { old_string: "x".to_string(), new_string: "y".to_string(), replace_all: true }],
+        )
+        .await?;
+
+        assert_eq!(result.replacements_made, 3);
+        assert_eq!(std::fs::read_to_string(&path)?, "y y y\n");
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn empty_new_string_deletes_the_match() -> Result<(), Box<dyn std::error::Error>> {
+        let (_dir, path) = with_file("a\nb\nc\n").await?;
+        apply_edits(&path, &[FileEdit::new("b\n", "")]).await?;
+        assert_eq!(std::fs::read_to_string(&path)?, "a\nc\n");
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn overlapping_edits_are_rejected_and_file_unchanged() -> Result<(), Box<dyn std::error::Error>> {
+        let (_dir, path) = with_file("foobar\n").await?;
+
+        let error = apply_edits(&path, &[FileEdit::new("foob", "X"), FileEdit::new("obar", "Y")])
+            .await
+            .expect_err("overlapping edits should fail");
+
+        let failures = edits_failures(error)?;
+        assert!(failures.iter().any(|f| matches!(f.kind, EditFailureKind::Overlapping { .. })));
+        assert_eq!(std::fs::read_to_string(&path)?, "foobar\n");
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn every_overlapping_edit_is_reported() -> Result<(), Box<dyn std::error::Error>> {
+        let (_dir, path) = with_file("abcdef\n").await?;
+        let error =
+            apply_edits(&path, &[FileEdit::new("abcde", "X"), FileEdit::new("bc", "Y"), FileEdit::new("de", "Z")])
+                .await
+                .expect_err("overlapping edits should fail");
+
+        let failures = edits_failures(error)?;
+        let overlapping: Vec<usize> = failures
+            .iter()
+            .filter(|f| matches!(f.kind, EditFailureKind::Overlapping { other: 0 }))
+            .map(|f| f.index)
+            .collect();
+        assert_eq!(overlapping, vec![1, 2]);
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn pattern_not_found_is_rejected_and_file_unchanged() -> Result<(), Box<dyn std::error::Error>> {
+        let (_dir, path) = with_file("hello\n").await?;
+        let error =
+            apply_edits(&path, &[FileEdit::new("missing", "x")]).await.expect_err("missing pattern should fail");
+
+        let failures = edits_failures(error)?;
+        assert_eq!(
+            failures,
+            vec![EditFailure { index: 0, kind: EditFailureKind::PatternNotFound { pattern: "missing".to_string() } }]
+        );
+        assert_eq!(std::fs::read_to_string(&path)?, "hello\n");
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn batch_failures_aggregate_and_write_nothing() -> Result<(), Box<dyn std::error::Error>> {
+        let (_dir, path) = with_file("hello\n").await?;
+        let error = apply_edits(&path, &[FileEdit::new("missing", "z"), FileEdit::new("absent", "q")])
+            .await
+            .expect_err("batch with missing patterns should fail");
+
+        let failures = edits_failures(error)?;
+        assert_eq!(failures.len(), 2);
+        assert!(failures.iter().all(|f| matches!(f.kind, EditFailureKind::PatternNotFound { .. })));
+        assert_eq!(std::fs::read_to_string(&path)?, "hello\n");
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn empty_edits_are_rejected() {
+        let (_dir, path) = with_file("hello\n").await.unwrap();
+        assert!(matches!(apply_edits(&path, &[]).await, Err(FileError::EmptyEdits { .. })));
+    }
+
+    async fn with_file(content: &str) -> Result<(TempDir, PathBuf), Box<dyn std::error::Error>> {
+        let dir = TempDir::new()?;
+        let path = dir.path().join("file.txt");
+        write_text_file(&path, content).await?;
+        Ok((dir, path))
+    }
+
+    fn edits_failures(error: FileError) -> Result<Vec<EditFailure>, FileError> {
+        match error {
+            FileError::EditsFailed { failures, .. } => Ok(failures),
+            other => Err(other),
+        }
+    }
 }

--- a/packages/mcp-servers/src/plan/README.md
+++ b/packages/mcp-servers/src/plan/README.md
@@ -47,7 +47,7 @@ A non-zero exit code surfaces as a tool error; an exit code of `0` returns `{ "a
 | Tool | Description |
 |------|-------------|
 | `write_plan` | Write a markdown plan file for a plan name. |
-| `edit_plan` | Edit an existing plan file by exact string replacement. |
+| `edit_plan` | Edit an existing plan file by applying a batch of exact-string replacements. |
 | `submit_plan` | Submit a named markdown plan file for review and approval. |
 
 ## write_plan
@@ -74,9 +74,7 @@ A non-zero exit code surfaces as a tool error; an exit code of `0` returns `{ "a
 | Field | Type | Description |
 |-------|------|-------------|
 | `planName` | string | Stable plan identifier originally passed to `write_plan`. |
-| `oldString` | string | Exact string to replace. |
-| `newString` | string | Replacement string. |
-| `replaceAll` | bool | Whether to replace all occurrences. Defaults to false. |
+| `edits` | array | Non-empty list of exact-string replacements applied atomically. Each has `oldString`, `newString`, and optional `replaceAll`. |
 
 ### Output
 
@@ -84,7 +82,7 @@ A non-zero exit code surfaces as a tool error; an exit code of `0` returns `{ "a
 |-------|------|-------------|
 | `planName` | string | Plan identifier. |
 | `planPath` | string | Absolute path edited by the server. |
-| `replacementsMade` | number | Number of replacements made. |
+| `replacementsMade` | number | Number of replacements made (a `replaceAll` edit counts each occurrence). |
 
 ## submit_plan
 

--- a/packages/mcp-servers/src/plan/edit_plan_description.md
+++ b/packages/mcp-servers/src/plan/edit_plan_description.md
@@ -1,3 +1,12 @@
 # Edit Plan
 
-Edits an existing markdown implementation plan in Plan mode. Pass the same `planName` used with `write_plan`.
+Edits an existing markdown implementation plan in Plan mode. Pass the same `planName` used with `write_plan`, plus an `edits` array applied atomically.
+
+Each edit replaces an exact `oldString` with `newString` (optional `replaceAll`). All edits must apply or none are written, so a multi-point revision lands in a single call. Edits must target non-overlapping regions.
+
+```json
+{"planName": "auth-refactor", "edits": [
+  {"oldString": "## Old approach\n\nUse cookies.", "newString": "## Revised approach\n\nUse JWT sessions."},
+  {"oldString": "Phase 2", "newString": "Phase 3", "replaceAll": true}
+]}
+```

--- a/packages/mcp-servers/src/plan/server.rs
+++ b/packages/mcp-servers/src/plan/server.rs
@@ -1,5 +1,5 @@
 use crate::error::ServerInitError;
-use crate::file_ops::{FileError, edit_text_file, read_text_file, write_text_file};
+use crate::file_ops::{FileEdit, FileError, apply_edits, read_text_file, write_text_file};
 use crate::workspace_paths::resolve_path;
 use clap::Parser;
 use mcp_utils::display_meta::{FileDiff, ToolDisplayMeta, ToolResultMeta, basename};
@@ -305,15 +305,9 @@ pub struct EditPlanInput {
     /// Stable plan identifier originally passed to `write_plan`.
     #[serde(alias = "planName")]
     pub plan_name: String,
-    /// Exact string to find and replace in the plan file.
-    #[serde(alias = "old_string")]
-    pub old_string: String,
-    /// String to replace it with.
-    #[serde(alias = "new_string")]
-    pub new_string: String,
-    /// Replace all occurrences. Defaults to replacing the first occurrence.
-    #[serde(default, alias = "replace_all")]
-    pub replace_all: bool,
+    /// Exact-string replacements to apply, in one atomic batch. All edits must
+    /// apply or none are written.
+    pub edits: Vec<FileEdit>,
 }
 
 #[derive(Debug, Serialize, JsonSchema)]
@@ -439,7 +433,7 @@ async fn write_plan_file(plans_dir: &Path, input: WritePlanInput) -> Result<Writ
 async fn edit_plan_file(plans_dir: &Path, input: EditPlanInput) -> Result<EditPlanOutput, PlanError> {
     let plan_name = PlanName::parse(&input.plan_name)?;
     let path = plan_path(plans_dir, &plan_name);
-    let result = edit_text_file(&path, &input.old_string, &input.new_string, input.replace_all).await?;
+    let result = apply_edits(&path, &input.edits).await?;
     let plan_path = result.path.to_string_lossy().into_owned();
     let display_meta = ToolDisplayMeta::new("Edit plan", basename(&plan_path));
     let file_diff =

--- a/packages/mcp-servers/src/plan/write_plan_description.md
+++ b/packages/mcp-servers/src/plan/write_plan_description.md
@@ -1,3 +1,3 @@
 # Write Plan
 
-Writes a markdown implementation plan in Plan mode. Pass a unique `planName` such as `auth-refactor`; this tool handles persisting the plan to disk for you. Use this after drafting a new plan.
+Writes a markdown implementation plan in Plan mode. Pass a unique `planName` such as `auth-refactor`; this tool handles persisting the plan to disk for you. Use this after drafting a new plan. Revise it later with `edit_plan`.

--- a/packages/mcp-servers/tests/coding_mcp_tools.rs
+++ b/packages/mcp-servers/tests/coding_mcp_tools.rs
@@ -181,8 +181,7 @@ async fn test_edit_file_tool() {
             CallToolRequestParams::new("edit_file").with_arguments(
                 serde_json::json!({
                     "filePath": test_path,
-                    "oldString": "World",
-                    "newString": "Rust"
+                    "edits": [{ "oldString": "World", "newString": "Rust" }]
                 })
                 .as_object()
                 .unwrap()
@@ -233,9 +232,7 @@ async fn test_edit_file_tool() {
             CallToolRequestParams::new("edit_file").with_arguments(
                 serde_json::json!({
                     "filePath": test_path,
-                    "oldString": "test",
-                    "newString": "TEST",
-                    "replaceAll": true
+                    "edits": [{ "oldString": "test", "newString": "TEST", "replaceAll": true }]
                 })
                 .as_object()
                 .unwrap()
@@ -482,30 +479,27 @@ async fn test_ast_grep_uses_workspace_root_when_no_path_given() -> Result<(), Bo
 
 #[cfg(feature = "test-helpers")]
 #[tokio::test]
-async fn test_read_before_edit_safety_with_relative_path_normalization() {
+async fn test_read_before_edit_safety_with_relative_path_normalization() -> Result<(), Box<dyn std::error::Error>> {
     use mcp_servers::coding::tools::edit_file::EditFileArgs;
     use mcp_servers::coding::tools::read_file::ReadFileArgs;
+    use mcp_servers::file_ops::FileEdit;
 
-    let temp = tempfile::tempdir().unwrap();
+    let temp = tempfile::tempdir()?;
     let workspace = temp.path().to_path_buf();
     let test_file = temp.path().join("test.txt");
-    fs::write(&test_file, "hello world").unwrap();
+    fs::write(&test_file, "hello world")?;
 
     let server = CodingMcp::new().with_root_dir(workspace);
 
-    server
-        .test_read_file(ReadFileArgs { file_path: "test.txt".to_string(), offset: None, limit: None })
-        .await
-        .expect("read_file should succeed with relative path");
+    server.test_read_file(ReadFileArgs { file_path: "test.txt".to_string(), offset: None, limit: None }).await?;
 
     let result = server
         .test_edit_file(EditFileArgs {
             file_path: "test.txt".to_string(),
-            old_string: "hello".to_string(),
-            new_string: "goodbye".to_string(),
-            replace_all: false,
+            edits: vec![FileEdit::new("hello", "goodbye")],
         })
         .await;
 
     assert!(result.is_ok());
+    Ok(())
 }

--- a/packages/mcp-servers/tests/lsp_diagnostics_e2e.rs
+++ b/packages/mcp-servers/tests/lsp_diagnostics_e2e.rs
@@ -97,8 +97,7 @@ async fn test_mcp_edit_produces_diagnostics() {
         "edit_file",
         serde_json::json!({
             "filePath": main_rs,
-            "oldString": "\"not an int\"",
-            "newString": "42"
+            "edits": [{ "oldString": "\"not an int\"", "newString": "42" }]
         }),
     )
     .await;
@@ -113,8 +112,7 @@ async fn test_mcp_edit_produces_diagnostics() {
         "edit_file",
         serde_json::json!({
             "filePath": main_rs,
-            "oldString": "42",
-            "newString": "true"
+            "edits": [{ "oldString": "42", "newString": "true" }]
         }),
     )
     .await;
@@ -159,8 +157,7 @@ async fn test_diagnostics_available_after_edit_without_polling() {
         "edit_file",
         serde_json::json!({
             "filePath": main_rs,
-            "oldString": "42",
-            "newString": "\"not an int\""
+            "edits": [{ "oldString": "42", "newString": "\"not an int\"" }]
         }),
     )
     .await;
@@ -203,8 +200,7 @@ async fn test_diagnostics_all_files_after_edit() {
         "edit_file",
         serde_json::json!({
             "filePath": main_rs,
-            "oldString": "42",
-            "newString": "\"not an int\""
+            "edits": [{ "oldString": "42", "newString": "\"not an int\"" }]
         }),
     )
     .await;
@@ -244,8 +240,7 @@ async fn test_workspace_diagnostics_after_edit_without_file_check() {
         "edit_file",
         serde_json::json!({
             "filePath": main_rs,
-            "oldString": "42",
-            "newString": "\"not an int\""
+            "edits": [{ "oldString": "42", "newString": "\"not an int\"" }]
         }),
     )
     .await;
@@ -290,8 +285,7 @@ async fn test_workspace_diagnostics_clear_after_fix_without_file_check() {
         "edit_file",
         serde_json::json!({
             "filePath": main_rs,
-            "oldString": "\"not an int\"",
-            "newString": "42"
+            "edits": [{ "oldString": "\"not an int\"", "newString": "42" }]
         }),
     )
     .await;

--- a/packages/mcp-servers/tests/lsp_ts_diagnostics_e2e.rs
+++ b/packages/mcp-servers/tests/lsp_ts_diagnostics_e2e.rs
@@ -42,8 +42,7 @@ async fn test_ts_mcp_edit_produces_diagnostics() {
         "edit_file",
         serde_json::json!({
             "filePath": index_ts,
-            "oldString": "\"not a number\"",
-            "newString": "42"
+            "edits": [{ "oldString": "\"not a number\"", "newString": "42" }]
         }),
     )
     .await;
@@ -59,8 +58,7 @@ async fn test_ts_mcp_edit_produces_diagnostics() {
         "edit_file",
         serde_json::json!({
             "filePath": index_ts,
-            "oldString": "42",
-            "newString": "true"
+            "edits": [{ "oldString": "42", "newString": "true" }]
         }),
     )
     .await;
@@ -130,8 +128,7 @@ async fn test_ts_diagnostics_after_edit_without_polling() {
         "edit_file",
         serde_json::json!({
             "filePath": index_ts,
-            "oldString": "42",
-            "newString": "\"not a number\""
+            "edits": [{ "oldString": "42", "newString": "\"not a number\"" }]
         }),
     )
     .await;

--- a/packages/mcp-servers/tests/plan_mcp.rs
+++ b/packages/mcp-servers/tests/plan_mcp.rs
@@ -89,6 +89,35 @@ async fn edit_plan_updates_existing_plan_file_from_name() {
 }
 
 #[tokio::test]
+async fn edit_plan_applies_batch_in_single_call() -> Result<(), Box<dyn std::error::Error>> {
+    let temp_dir = TempDir::new()?;
+    let server = PlanMcp::new().with_plans_dir(temp_dir.path().to_path_buf());
+    let (_server_handle, client_handle) = connect(server, silent_client()).await?;
+    write_plan(&client_handle, "feature", "# Plan\nStep one\nStep two\n").await;
+
+    let request = CallToolRequestParams::new("edit_plan").with_arguments(
+        json!({
+            "planName": "feature",
+            "edits": [
+                { "oldString": "Step one", "newString": "Step ONE" },
+                { "oldString": "Step two", "newString": "Step TWO" }
+            ]
+        })
+        .as_object()
+        .ok_or("edit_plan arguments")?
+        .clone(),
+    );
+    let result = client_handle.call_tool(request).await?;
+    let text = result.content.first().and_then(|content| content.as_text()).ok_or("edit_plan text content")?;
+    let parsed: serde_json::Value = serde_json::from_str(&text.text)?;
+
+    assert_eq!(parsed["replacementsMade"], 2);
+    let plan_path = temp_dir.path().join("feature-plan.md");
+    assert_eq!(fs::read_to_string(plan_path)?, "# Plan\nStep ONE\nStep TWO\n");
+    Ok(())
+}
+
+#[tokio::test]
 async fn plan_name_rejects_path_traversal() {
     let temp_dir = TempDir::new().expect("create temp dir");
     let server = PlanMcp::new().with_plans_dir(temp_dir.path().to_path_buf());
@@ -186,9 +215,11 @@ async fn edit_plan<T: Service<RoleClient>>(
     let request = CallToolRequestParams::new("edit_plan").with_arguments(
         json!({
             "planName": plan_name,
-            "oldString": old_string,
-            "newString": new_string,
-            "replaceAll": replace_all
+            "edits": [{
+                "oldString": old_string,
+                "newString": new_string,
+                "replaceAll": replace_all
+            }]
         })
         .as_object()
         .unwrap()

--- a/packages/mcp-servers/tests/test_read_before_edit_safety.rs
+++ b/packages/mcp-servers/tests/test_read_before_edit_safety.rs
@@ -2,8 +2,13 @@ use mcp_servers::coding::CodingMcp;
 use mcp_servers::coding::tools::edit_file::EditFileArgs;
 use mcp_servers::coding::tools::read_file::ReadFileArgs;
 use mcp_servers::coding::tools::write_file::WriteFileArgs;
+use mcp_servers::file_ops::FileEdit;
 use std::fs;
 use tempfile::TempDir;
+
+fn replace(old: &str, new: &str) -> Vec<FileEdit> {
+    vec![FileEdit::new(old, new)]
+}
 
 /// Test that editing a file without reading it first fails
 #[tokio::test]
@@ -15,12 +20,8 @@ async fn test_edit_file_without_read_fails() {
     let mcp = CodingMcp::new();
 
     // Try to edit without reading first
-    let edit_args = EditFileArgs {
-        file_path: test_file.to_string_lossy().to_string(),
-        old_string: "original".to_string(),
-        new_string: "modified".to_string(),
-        replace_all: false,
-    };
+    let edit_args =
+        EditFileArgs { file_path: test_file.to_string_lossy().to_string(), edits: replace("original", "modified") };
 
     let result = mcp.test_edit_file(edit_args).await;
 
@@ -46,12 +47,8 @@ async fn test_edit_file_after_read_succeeds() {
     assert!(read_result.is_ok());
 
     // Now edit should succeed
-    let edit_args = EditFileArgs {
-        file_path: test_file.to_string_lossy().to_string(),
-        old_string: "original".to_string(),
-        new_string: "modified".to_string(),
-        replace_all: false,
-    };
+    let edit_args =
+        EditFileArgs { file_path: test_file.to_string_lossy().to_string(), edits: replace("original", "modified") };
 
     let result = mcp.test_edit_file(edit_args).await;
     assert!(result.is_ok());
@@ -146,21 +143,11 @@ async fn test_multiple_files_tracked_independently() {
     mcp.test_read_file(read_args).await.unwrap();
 
     // Edit file1 should succeed
-    let edit_args = EditFileArgs {
-        file_path: file1.to_string_lossy().to_string(),
-        old_string: "1".to_string(),
-        new_string: "one".to_string(),
-        replace_all: false,
-    };
+    let edit_args = EditFileArgs { file_path: file1.to_string_lossy().to_string(), edits: replace("1", "one") };
     assert!(mcp.test_edit_file(edit_args).await.is_ok());
 
     // Edit file2 should fail (not read yet)
-    let edit_args = EditFileArgs {
-        file_path: file2.to_string_lossy().to_string(),
-        old_string: "2".to_string(),
-        new_string: "two".to_string(),
-        replace_all: false,
-    };
+    let edit_args = EditFileArgs { file_path: file2.to_string_lossy().to_string(), edits: replace("2", "two") };
     assert!(mcp.test_edit_file(edit_args).await.is_err());
 }
 
@@ -184,9 +171,7 @@ async fn test_failed_read_doesnt_track_file() {
     // Edit should still fail because the read failed
     let edit_args = EditFileArgs {
         file_path: nonexistent_file.to_string_lossy().to_string(),
-        old_string: "content".to_string(),
-        new_string: "modified".to_string(),
-        replace_all: false,
+        edits: replace("content", "modified"),
     };
     let result = mcp.test_edit_file(edit_args).await;
     assert!(result.is_err());


### PR DESCRIPTION
This PR updates the `edit_file` and `edit_plan` tools to support batched edits in a single tool call. 