### PR TITLE
chore: disable incremental compilation in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,9 @@ on:
       - main
   pull_request:
 
+env:
+  CARGO_INCREMENTAL: "0"
+
 jobs:
   fmt:
     name: Formatting


### PR DESCRIPTION
## Summary
- Disable Cargo incremental compilation for the CI workflow to reduce disk usage on GitHub-hosted runners

## Testing
- Not run; workflow configuration only