### PR TITLE
refactor: Dry up tests in mcp-servers and wisp with test builders

### DIFF
--- a/crates/mcp-servers/src/coding/tools/ast_grep/mod.rs
+++ b/crates/mcp-servers/src/coding/tools/ast_grep/mod.rs
@@ -15,7 +15,7 @@ use std::path::Path;
 use std::sync::{Arc, Mutex};
 use tokio::task::spawn_blocking;
 
-#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+#[derive(Debug, Clone, Default, Serialize, Deserialize, JsonSchema)]
 #[serde(rename_all = "camelCase")]
 pub struct AstGrepInput {
     /// ast-grep pattern code.

--- a/crates/mcp-servers/src/coding/tools/bash/mod.rs
+++ b/crates/mcp-servers/src/coding/tools/bash/mod.rs
@@ -11,7 +11,7 @@ use uuid::Uuid;
 use crate::coding::error::BashError;
 use mcp_utils::display_meta::{ToolDisplayMeta, ToolResultMeta, truncate};
 
-#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+#[derive(Debug, Clone, Default, Serialize, Deserialize, JsonSchema)]
 #[serde(rename_all = "camelCase")]
 pub struct BashInput {
     /// The command to execute

--- a/crates/mcp-servers/src/coding/tools/edit_file/mod.rs
+++ b/crates/mcp-servers/src/coding/tools/edit_file/mod.rs
@@ -5,7 +5,7 @@ use std::path::Path;
 use crate::file_ops::{ApplyEditsResult, FileEdit, FileError, apply_edits};
 use mcp_utils::display_meta::{FileDiff, ToolDisplayMeta, ToolResultMeta, basename};
 
-#[derive(Debug, Clone, Deserialize, JsonSchema)]
+#[derive(Debug, Clone, Deserialize, Serialize, JsonSchema)]
 #[serde(rename_all = "camelCase")]
 pub struct EditFileArgs {
     /// Path to the file to edit

--- a/crates/mcp-servers/src/coding/tools/find/mod.rs
+++ b/crates/mcp-servers/src/coding/tools/find/mod.rs
@@ -7,7 +7,7 @@ use std::path::Path;
 use crate::coding::error::FindError;
 use mcp_utils::display_meta::{ToolDisplayMeta, ToolResultMeta};
 
-#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+#[derive(Debug, Clone, Default, Serialize, Deserialize, JsonSchema)]
 pub struct FindInput {
     /// The glob pattern to match files against
     pub pattern: String,

--- a/crates/mcp-servers/src/coding/tools/grep/mod.rs
+++ b/crates/mcp-servers/src/coding/tools/grep/mod.rs
@@ -71,7 +71,7 @@ pub enum GrepOutput {
     Count(GrepCountOutput),
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+#[derive(Debug, Clone, Default, Serialize, Deserialize, JsonSchema)]
 #[serde(rename_all = "camelCase")]
 pub struct GrepInput {
     /// The regular expression pattern to search for in file contents

--- a/crates/mcp-servers/src/coding/tools/list_files/mod.rs
+++ b/crates/mcp-servers/src/coding/tools/list_files/mod.rs
@@ -5,7 +5,7 @@ use std::time::SystemTime;
 use crate::coding::error::ListFilesError;
 use mcp_utils::display_meta::{ToolDisplayMeta, ToolResultMeta, basename};
 
-#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+#[derive(Debug, Clone, Default, Serialize, Deserialize, JsonSchema)]
 #[serde(rename_all = "camelCase")]
 pub struct ListFilesArgs {
     /// Directory path to list (defaults to current directory if not provided)

--- a/crates/mcp-servers/src/coding/tools/read_file/mod.rs
+++ b/crates/mcp-servers/src/coding/tools/read_file/mod.rs
@@ -7,7 +7,7 @@ use std::path::Path;
 const MAX_LINE_LENGTH: usize = 2000;
 const DEFAULT_LINE_LIMIT: usize = 2000;
 
-#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+#[derive(Debug, Clone, Default, Serialize, Deserialize, JsonSchema)]
 #[serde(rename_all = "camelCase")]
 pub struct ReadFileArgs {
     /// Path to the file to read (must be an existing file)

--- a/crates/mcp-servers/src/file_ops.rs
+++ b/crates/mcp-servers/src/file_ops.rs
@@ -3,11 +3,11 @@ use std::ops::Range;
 use std::path::{Path, PathBuf};
 
 use schemars::JsonSchema;
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 use thiserror::Error;
 use tokio::fs::{create_dir_all, write};
 
-#[derive(Debug, Clone, Deserialize, JsonSchema)]
+#[derive(Debug, Clone, Deserialize, Serialize, JsonSchema)]
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
 pub struct FileEdit {
     /// Exact text to find. Must match whitespace (e.g. indentation).

--- a/crates/mcp-servers/src/plan/mod.rs
+++ b/crates/mcp-servers/src/plan/mod.rs
@@ -1,3 +1,6 @@
 mod server;
 
-pub use server::{DEFAULT_PLAN_PROMPT, DEFAULT_PLANS_DIR, PlanMcp, PlanMcpArgs, default_plans_dir};
+pub use server::{
+    DEFAULT_PLAN_PROMPT, DEFAULT_PLANS_DIR, EditPlanInput, PlanMcp, PlanMcpArgs, SubmitPlanInput, WritePlanInput,
+    default_plans_dir,
+};

--- a/crates/mcp-servers/src/plan/server.rs
+++ b/crates/mcp-servers/src/plan/server.rs
@@ -278,7 +278,7 @@ impl ServerHandler for PlanMcp {
     }
 }
 
-#[derive(Debug, Deserialize, JsonSchema)]
+#[derive(Debug, Serialize, Deserialize, JsonSchema)]
 #[serde(rename_all = "camelCase")]
 pub struct WritePlanInput {
     /// Stable plan identifier chosen by the agent, e.g. `auth-refactor`.
@@ -299,7 +299,7 @@ pub struct WritePlanOutput {
     pub meta: Option<ToolResultMeta>,
 }
 
-#[derive(Debug, Deserialize, JsonSchema)]
+#[derive(Debug, Serialize, Deserialize, JsonSchema)]
 #[serde(rename_all = "camelCase")]
 pub struct EditPlanInput {
     /// Stable plan identifier originally passed to `write_plan`.
@@ -321,7 +321,7 @@ pub struct EditPlanOutput {
     pub meta: Option<ToolResultMeta>,
 }
 
-#[derive(Debug, Deserialize, JsonSchema)]
+#[derive(Debug, Serialize, Deserialize, JsonSchema)]
 #[serde(rename_all = "camelCase")]
 pub struct SubmitPlanInput {
     /// Stable plan identifier originally passed to `write_plan`.

--- a/crates/mcp-servers/tests/coding_mcp_tools.rs
+++ b/crates/mcp-servers/tests/coding_mcp_tools.rs
@@ -1,361 +1,156 @@
+mod common;
+
+use common::{TestClient, TestResult, test_error};
 use mcp_servers::coding::CodingMcp;
-use mcp_utils::testing::connect;
-use rmcp::model::{CallToolRequestParams, ClientCapabilities, ClientInfo, Implementation};
+use mcp_servers::coding::tools::ast_grep::AstGrepInput;
+use mcp_servers::coding::tools::bash::BashInput;
+use mcp_servers::coding::tools::edit_file::EditFileArgs;
+use mcp_servers::coding::tools::find::FindInput;
+use mcp_servers::coding::tools::grep::GrepInput;
+use mcp_servers::coding::tools::list_files::ListFilesArgs;
+use mcp_servers::coding::tools::read_file::ReadFileArgs;
+use mcp_servers::coding::tools::write_file::WriteFileArgs;
+use mcp_servers::file_ops::FileEdit;
 use std::fs::{self, canonicalize};
 
 #[tokio::test]
-async fn test_read_file_tool() {
-    // Create server and client
-    let server_service = CodingMcp::new();
-    let client_info = ClientInfo::new(ClientCapabilities::default(), Implementation::new("test-client", "0.1.0"));
-
-    let (_server_handle, client) =
-        connect(server_service, client_info).await.expect("Failed to connect MCP server and client");
-
-    // Create test file
+async fn test_read_file_tool() -> TestResult {
+    let mcp = TestClient::start(CodingMcp::new).await?;
     let test_content = "Hello, World!\nThis is a test file.";
-    tokio::fs::write("/tmp/test_read_file.txt", test_content).await.expect("Failed to create test file");
+    tokio::fs::write("/tmp/test_read_file.txt", test_content).await?;
 
-    // Test read_file tool
-    let result = client
-        .call_tool(
-            CallToolRequestParams::new("read_file").with_arguments(
-                serde_json::json!({
-                    "filePath": "/tmp/test_read_file.txt"
-                })
-                .as_object()
-                .unwrap()
-                .clone(),
-            ),
-        )
-        .await
-        .expect("Failed to call read_file tool");
+    let parsed = mcp
+        .call("read_file", ReadFileArgs { file_path: "/tmp/test_read_file.txt".to_string(), ..Default::default() })
+        .await?;
 
-    // Verify result
-    assert!(result.content.len() == 1);
-    if let Some(content) = result.content.first() {
-        if let Some(text_content) = content.as_text() {
-            let parsed: serde_json::Value = serde_json::from_str(&text_content.text).expect("Invalid JSON response");
-            assert_eq!(parsed["status"], "success");
+    assert_eq!(parsed["status"], "success");
+    assert_eq!(parsed["content"], "    1\tHello, World!\n    2\tThis is a test file.");
+    assert_eq!(parsed["totalLines"], 2);
+    assert_eq!(parsed["linesShown"], 2);
 
-            // Verify line-numbered content format (should read full file by default)
-            let expected_formatted = "    1\tHello, World!\n    2\tThis is a test file.";
-            assert_eq!(parsed["content"], expected_formatted);
-            assert_eq!(parsed["totalLines"], 2);
-            assert_eq!(parsed["linesShown"], 2);
-        } else {
-            panic!("Expected text content");
-        }
-    } else {
-        panic!("Expected content in result");
-    }
-
-    // Clean up
     let _ = tokio::fs::remove_file("/tmp/test_read_file.txt").await;
+    Ok(())
 }
 
 #[tokio::test]
-async fn test_write_file_tool() {
-    // Create server and client
-    let server_service = CodingMcp::new();
-    let client_info = ClientInfo::new(ClientCapabilities::default(), Implementation::new("test-client", "0.1.0"));
-
-    let (_server_handle, client) =
-        connect(server_service, client_info).await.expect("Failed to connect MCP server and client");
-
+async fn test_write_file_tool() -> TestResult {
+    let mcp = TestClient::start(CodingMcp::new).await?;
     let test_content = "This is test content written by the tool.";
     let test_path = "/tmp/test_write_file.txt";
 
-    // Test write_file tool with new simplified API
-    let result = client
-        .call_tool(
-            CallToolRequestParams::new("write_file").with_arguments(
-                serde_json::json!({
-                    "filePath": test_path,
-                    "content": test_content
-                })
-                .as_object()
-                .unwrap()
-                .clone(),
-            ),
-        )
-        .await
-        .expect("Failed to call write_file tool");
+    let parsed = mcp
+        .call("write_file", WriteFileArgs { file_path: test_path.to_string(), content: test_content.to_string() })
+        .await?;
 
-    // Verify result
-    assert!(result.content.len() == 1);
-    if let Some(content) = result.content.first() {
-        if let Some(text_content) = content.as_text() {
-            let parsed: serde_json::Value = serde_json::from_str(&text_content.text).expect("Invalid JSON response");
-            assert!(parsed["message"].as_str().unwrap().contains("Successfully wrote"));
-            assert_eq!(parsed["bytesWritten"], test_content.len());
-            assert_eq!(parsed["filePath"], test_path);
-        } else {
-            panic!("Expected text content");
-        }
-    } else {
-        panic!("Expected content in result");
-    }
+    assert!(parsed["message"].as_str().unwrap().contains("Successfully wrote"));
+    assert_eq!(parsed["bytesWritten"], test_content.len());
+    assert_eq!(parsed["filePath"], test_path);
 
-    // Verify file was actually written
-    let file_content = tokio::fs::read_to_string(test_path).await.expect("Failed to read written file");
+    let file_content = tokio::fs::read_to_string(test_path).await?;
     assert_eq!(file_content, test_content);
 
-    // Clean up
     let _ = tokio::fs::remove_file(test_path).await;
+    Ok(())
 }
 
 #[tokio::test]
-async fn test_bash_tool() {
-    // Create server and client
-    let server_service = CodingMcp::new();
-    let client_info = ClientInfo::new(ClientCapabilities::default(), Implementation::new("test-client", "0.1.0"));
+async fn test_bash_tool() -> TestResult {
+    let mcp = TestClient::start(CodingMcp::new).await?;
 
-    let (_server_handle, client) =
-        connect(server_service, client_info).await.expect("Failed to connect MCP server and client");
+    let parsed =
+        mcp.call("bash", BashInput { command: "echo 'Hello from bash'".to_string(), ..Default::default() }).await?;
 
-    // Test bash tool with a simple command
-    let result = client
-        .call_tool(
-            CallToolRequestParams::new("bash").with_arguments(
-                serde_json::json!({
-                    "command": "echo 'Hello from bash'"
-                })
-                .as_object()
-                .unwrap()
-                .clone(),
-            ),
-        )
-        .await
-        .expect("Failed to call bash tool");
-
-    // Verify result
-    assert!(result.content.len() == 1);
-    if let Some(content) = result.content.first() {
-        if let Some(text_content) = content.as_text() {
-            let parsed: serde_json::Value = serde_json::from_str(&text_content.text).expect("Invalid JSON response");
-            assert_eq!(parsed["exitCode"], 0);
-            assert!(parsed["output"].as_str().unwrap().contains("Hello from bash"));
-            assert_eq!(parsed["killed"], false);
-        } else {
-            panic!("Expected text content");
-        }
-    } else {
-        panic!("Expected content in result");
-    }
+    assert_eq!(parsed["exitCode"], 0);
+    assert!(parsed["output"].as_str().unwrap().contains("Hello from bash"));
+    assert_eq!(parsed["killed"], false);
+    Ok(())
 }
 
 #[tokio::test]
-async fn test_edit_file_tool() {
-    // Create server and client
-    let server_service = CodingMcp::new();
-    let client_info = ClientInfo::new(ClientCapabilities::default(), Implementation::new("test-client", "0.1.0"));
-
-    let (_server_handle, client) =
-        connect(server_service, client_info).await.expect("Failed to connect MCP server and client");
-
+async fn test_edit_file_tool() -> TestResult {
+    let mcp = TestClient::start(CodingMcp::new).await?;
     let test_path = "/tmp/test_edit_file.txt";
     let initial_content = "Hello, World!\nThis is a test.";
+    tokio::fs::write(test_path, initial_content).await?;
 
-    // Create initial file
-    tokio::fs::write(test_path, initial_content).await.expect("Failed to create test file");
-
-    // First, read the file (required by safety check)
-    client
-        .call_tool(
-            CallToolRequestParams::new("read_file").with_arguments(
-                serde_json::json!({
-                    "filePath": test_path
-                })
-                .as_object()
-                .unwrap()
-                .clone(),
-            ),
-        )
-        .await
-        .expect("Failed to read file before edit");
-
-    // Test edit_file tool - replace single occurrence
-    let result = client
-        .call_tool(
-            CallToolRequestParams::new("edit_file").with_arguments(
-                serde_json::json!({
-                    "filePath": test_path,
-                    "edits": [{ "oldString": "World", "newString": "Rust" }]
-                })
-                .as_object()
-                .unwrap()
-                .clone(),
-            ),
-        )
-        .await
-        .expect("Failed to call edit_file tool");
-
-    // Verify result
-    assert!(result.content.len() == 1);
-    if let Some(content) = result.content.first() {
-        if let Some(text_content) = content.as_text() {
-            let parsed: serde_json::Value = serde_json::from_str(&text_content.text).expect("Invalid JSON response");
-            assert_eq!(parsed["status"], "success");
-            assert_eq!(parsed["replacementsMade"], 1);
-        } else {
-            panic!("Expected text content");
-        }
-    } else {
-        panic!("Expected content in result");
-    }
-
-    // Verify file was actually edited
-    let file_content = tokio::fs::read_to_string(test_path).await.expect("Failed to read edited file");
-    assert_eq!(file_content, "Hello, Rust!\nThis is a test.");
-
-    // Test replace_all flag
-    tokio::fs::write(test_path, "test test test").await.expect("Failed to write test file");
-
-    // Read the file again before editing
-    client
-        .call_tool(
-            CallToolRequestParams::new("read_file").with_arguments(
-                serde_json::json!({
-                    "filePath": test_path
-                })
-                .as_object()
-                .unwrap()
-                .clone(),
-            ),
-        )
-        .await
-        .expect("Failed to read file before second edit");
-
-    let result = client
-        .call_tool(
-            CallToolRequestParams::new("edit_file").with_arguments(
-                serde_json::json!({
-                    "filePath": test_path,
-                    "edits": [{ "oldString": "test", "newString": "TEST", "replaceAll": true }]
-                })
-                .as_object()
-                .unwrap()
-                .clone(),
-            ),
-        )
-        .await
-        .expect("Failed to call edit_file tool with replace_all");
-
-    if let Some(text_content) = result.content.first().and_then(|c| c.as_text()) {
-        let parsed: serde_json::Value = serde_json::from_str(&text_content.text).expect("Invalid JSON response");
-        assert_eq!(parsed["replacementsMade"], 3);
-    }
-
-    let file_content = tokio::fs::read_to_string(test_path).await.expect("Failed to read edited file");
-    assert_eq!(file_content, "TEST TEST TEST");
-
-    // Clean up
-    let _ = tokio::fs::remove_file(test_path).await;
-}
-
-#[tokio::test]
-async fn test_list_files_tool() {
-    // Create server and client
-    let server_service = CodingMcp::new();
-    let client_info = ClientInfo::new(ClientCapabilities::default(), Implementation::new("test-client", "0.1.0"));
-
-    let (_server_handle, client) =
-        connect(server_service, client_info).await.expect("Failed to connect MCP server and client");
-
-    // Create test directory and files
-    let test_dir = "/tmp/test_list_files";
-    let _ = fs::remove_dir_all(test_dir); // Clean up any existing directory
-    fs::create_dir_all(test_dir).expect("Failed to create test directory");
-
-    // Create some test files
-    fs::write(format!("{test_dir}/file1.txt"), "content1").expect("Failed to create test file 1");
-    fs::write(format!("{test_dir}/file2.rs"), "fn main() {}").expect("Failed to create test file 2");
-    fs::create_dir(format!("{test_dir}/subdir")).expect("Failed to create subdirectory");
-    fs::write(format!("{test_dir}/.hidden_file"), "hidden content").expect("Failed to create hidden file");
-
-    // Test list_files tool
-    let result = client
-        .call_tool(
-            CallToolRequestParams::new("list_files").with_arguments(
-                serde_json::json!({
-                    "path": test_dir
-                })
-                .as_object()
-                .unwrap()
-                .clone(),
-            ),
-        )
-        .await
-        .expect("Failed to call list_files tool");
-
-    // Verify result
-    assert!(result.content.len() == 1);
-    if let Some(content) = result.content.first() {
-        if let Some(text_content) = content.as_text() {
-            let parsed: serde_json::Value = serde_json::from_str(&text_content.text).expect("Invalid JSON response");
-            assert_eq!(parsed["status"], "success");
-            assert_eq!(parsed["totalCount"], 3); // Should not include hidden file by default
-
-            let files = parsed["files"].as_array().expect("Files should be an array");
-            let file_names: Vec<String> = files.iter().map(|f| f["name"].as_str().unwrap().to_string()).collect();
-
-            assert!(file_names.contains(&"file1.txt".to_string()));
-            assert!(file_names.contains(&"file2.rs".to_string()));
-            assert!(file_names.contains(&"subdir".to_string()));
-            assert!(!file_names.contains(&".hidden_file".to_string())); // Hidden file should not be included
-        } else {
-            panic!("Expected text content");
-        }
-    } else {
-        panic!("Expected content in result");
-    }
-
-    // Test including hidden files
-    let result_with_hidden = client
-        .call_tool(
-            CallToolRequestParams::new("list_files").with_arguments(
-                serde_json::json!({
-                    "path": test_dir,
-                    "includeHidden": true
-                })
-                .as_object()
-                .unwrap()
-                .clone(),
-            ),
-        )
-        .await
-        .expect("Failed to call list_files tool with hidden files");
-
-    if let Some(text_content) = result_with_hidden.content.first().and_then(|c| c.as_text()) {
-        let parsed: serde_json::Value = serde_json::from_str(&text_content.text).expect("Invalid JSON response");
-        assert_eq!(parsed["totalCount"], 4); // Should include hidden file now
-    }
-
-    // Clean up
-    let _ = fs::remove_dir_all(test_dir);
-}
-
-#[tokio::test]
-async fn test_list_files_uses_workspace_root_when_no_path_given() -> Result<(), Box<dyn std::error::Error>> {
-    let temp = tempfile::tempdir()?;
-    let workspace = temp.path().to_path_buf();
-
-    fs::write(temp.path().join("alpha.txt"), "a")?;
-    fs::write(temp.path().join("beta.rs"), "b")?;
-
-    let server_service = CodingMcp::new().with_root_dir(workspace.clone());
-    let client_info = ClientInfo::new(ClientCapabilities::default(), Implementation::new("test-client", "0.1.0"));
-    let (_server_handle, client) = connect(server_service, client_info).await?;
-    let result = client
-        .call_tool(
-            CallToolRequestParams::new("list_files").with_arguments(serde_json::json!({}).as_object().unwrap().clone()),
+    mcp.call("read_file", ReadFileArgs { file_path: test_path.to_string(), ..Default::default() }).await?;
+    let parsed = mcp
+        .call(
+            "edit_file",
+            EditFileArgs { file_path: test_path.to_string(), edits: vec![FileEdit::new("World", "Rust")] },
         )
         .await?;
 
-    let text_content = result.content.first().and_then(|c| c.as_text()).ok_or("Expected text content")?;
-    let parsed: serde_json::Value = serde_json::from_str(&text_content.text)?;
-    let files = parsed["files"].as_array().ok_or("Files should be an array")?;
+    assert_eq!(parsed["status"], "success");
+    assert_eq!(parsed["replacementsMade"], 1);
+    let file_content = tokio::fs::read_to_string(test_path).await?;
+    assert_eq!(file_content, "Hello, Rust!\nThis is a test.");
+
+    tokio::fs::write(test_path, "test test test").await?;
+    mcp.call("read_file", ReadFileArgs { file_path: test_path.to_string(), ..Default::default() }).await?;
+    let parsed = mcp
+        .call(
+            "edit_file",
+            EditFileArgs {
+                file_path: test_path.to_string(),
+                edits: vec![FileEdit {
+                    old_string: "test".to_string(),
+                    new_string: "TEST".to_string(),
+                    replace_all: true,
+                }],
+            },
+        )
+        .await?;
+
+    assert_eq!(parsed["replacementsMade"], 3);
+    let file_content = tokio::fs::read_to_string(test_path).await?;
+    assert_eq!(file_content, "TEST TEST TEST");
+
+    let _ = tokio::fs::remove_file(test_path).await;
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_list_files_tool() -> TestResult {
+    let mcp = TestClient::start(CodingMcp::new).await?;
+    let test_dir = "/tmp/test_list_files";
+    let _ = fs::remove_dir_all(test_dir);
+    fs::create_dir_all(test_dir)?;
+    fs::write(format!("{test_dir}/file1.txt"), "content1")?;
+    fs::write(format!("{test_dir}/file2.rs"), "fn main() {}")?;
+    fs::create_dir(format!("{test_dir}/subdir"))?;
+    fs::write(format!("{test_dir}/.hidden_file"), "hidden content")?;
+
+    let parsed =
+        mcp.call("list_files", ListFilesArgs { path: Some(test_dir.to_string()), ..Default::default() }).await?;
+
+    assert_eq!(parsed["status"], "success");
+    assert_eq!(parsed["totalCount"], 3);
+    let files = parsed["files"].as_array().ok_or_else(|| test_error("Files should be an array"))?;
+    let file_names: Vec<String> = files.iter().map(|f| f["name"].as_str().unwrap().to_string()).collect();
+    assert!(file_names.contains(&"file1.txt".to_string()));
+    assert!(file_names.contains(&"file2.rs".to_string()));
+    assert!(file_names.contains(&"subdir".to_string()));
+    assert!(!file_names.contains(&".hidden_file".to_string()));
+
+    let parsed =
+        mcp.call("list_files", ListFilesArgs { path: Some(test_dir.to_string()), include_hidden: Some(true) }).await?;
+    assert_eq!(parsed["totalCount"], 4);
+
+    let _ = fs::remove_dir_all(test_dir);
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_list_files_uses_workspace_root_when_no_path_given() -> TestResult {
+    let temp = tempfile::tempdir()?;
+    let workspace = temp.path().to_path_buf();
+    fs::write(temp.path().join("alpha.txt"), "a")?;
+    fs::write(temp.path().join("beta.rs"), "b")?;
+
+    let mcp = TestClient::start(|| CodingMcp::new().with_root_dir(workspace)).await?;
+    let parsed = mcp.call("list_files", ListFilesArgs::default()).await?;
+    let files = parsed["files"].as_array().ok_or_else(|| test_error("Files should be an array"))?;
     let file_names: Vec<String> = files.iter().map(|f| f["name"].as_str().unwrap().to_string()).collect();
 
     assert!(file_names.contains(&"alpha.txt".to_string()));
@@ -364,108 +159,50 @@ async fn test_list_files_uses_workspace_root_when_no_path_given() -> Result<(), 
 }
 
 #[tokio::test]
-async fn test_bash_pwd_uses_workspace_root() -> Result<(), Box<dyn std::error::Error>> {
+async fn test_bash_pwd_uses_workspace_root() -> TestResult {
     let temp = tempfile::tempdir()?;
     let workspace = temp.path().to_path_buf();
-    let server_service = CodingMcp::new().with_root_dir(workspace.clone());
-    let client_info = ClientInfo::new(ClientCapabilities::default(), Implementation::new("test-client", "0.1.0"));
-    let (_server_handle, client) = connect(server_service, client_info).await?;
-    let result = client
-        .call_tool(
-            CallToolRequestParams::new("bash").with_arguments(
-                serde_json::json!({
-                    "command": "pwd"
-                })
-                .as_object()
-                .unwrap()
-                .clone(),
-            ),
-        )
-        .await?;
+    let mcp = TestClient::start(|| CodingMcp::new().with_root_dir(workspace.clone())).await?;
 
-    let text_content = result.content.first().and_then(|c| c.as_text()).ok_or("Expected text content")?;
-    let parsed: serde_json::Value = serde_json::from_str(&text_content.text)?;
-    let pwd = parsed["output"].as_str().ok_or("Expected output string")?.trim();
+    let parsed = mcp.call("bash", BashInput { command: "pwd".to_string(), ..Default::default() }).await?;
+    let pwd = parsed["output"].as_str().ok_or_else(|| test_error("Expected output string"))?.trim();
     assert_eq!(canonicalize(pwd)?, canonicalize(&workspace)?);
     Ok(())
 }
 
 #[tokio::test]
-async fn test_grep_and_find_use_workspace_root_when_no_path_given() -> Result<(), Box<dyn std::error::Error>> {
+async fn test_grep_and_find_use_workspace_root_when_no_path_given() -> TestResult {
     let temp = tempfile::tempdir()?;
     let workspace = temp.path().to_path_buf();
     fs::write(temp.path().join("root_only.txt"), "needle\n")?;
     fs::write(temp.path().join("other.rs"), "fn main() {}\n")?;
 
-    let server_service = CodingMcp::new().with_root_dir(workspace.clone());
-    let client_info = ClientInfo::new(ClientCapabilities::default(), Implementation::new("test-client", "0.1.0"));
-    let (_server_handle, client) = connect(server_service, client_info).await?;
-    let grep_result = client
-        .call_tool(
-            CallToolRequestParams::new("grep").with_arguments(
-                serde_json::json!({
-                    "pattern": "needle"
-                })
-                .as_object()
-                .unwrap()
-                .clone(),
-            ),
-        )
-        .await?;
-
-    let text_content = grep_result.content.first().and_then(|c| c.as_text()).ok_or("Expected text content")?;
-    let parsed: serde_json::Value = serde_json::from_str(&text_content.text)?;
-    let matches = parsed["matches"].as_array().ok_or("matches should be an array")?;
+    let mcp = TestClient::start(|| CodingMcp::new().with_root_dir(workspace.clone())).await?;
+    let parsed = mcp.call("grep", GrepInput { pattern: "needle".to_string(), ..Default::default() }).await?;
+    let matches = parsed["matches"].as_array().ok_or_else(|| test_error("matches should be an array"))?;
     assert!(matches.iter().any(|m| m["file"].as_str().unwrap().ends_with("root_only.txt")));
 
-    let find_result = client
-        .call_tool(
-            CallToolRequestParams::new("find").with_arguments(
-                serde_json::json!({
-                    "pattern": "*.rs"
-                })
-                .as_object()
-                .unwrap()
-                .clone(),
-            ),
-        )
-        .await?;
-
-    let text_content = find_result.content.first().and_then(|c| c.as_text()).ok_or("Expected text content")?;
-    let parsed: serde_json::Value = serde_json::from_str(&text_content.text)?;
+    let parsed = mcp.call("find", FindInput { pattern: "*.rs".to_string(), ..Default::default() }).await?;
     assert_eq!(parsed["searchPath"].as_str().unwrap(), workspace.to_str().unwrap());
-    let matches = parsed["matches"].as_array().ok_or("matches should be an array")?;
-
+    let matches = parsed["matches"].as_array().ok_or_else(|| test_error("matches should be an array"))?;
     assert!(matches.iter().any(|m| m.as_str().unwrap().ends_with("other.rs")));
     Ok(())
 }
 
 #[tokio::test]
-async fn test_ast_grep_uses_workspace_root_when_no_path_given() -> Result<(), Box<dyn std::error::Error>> {
+async fn test_ast_grep_uses_workspace_root_when_no_path_given() -> TestResult {
     let temp = tempfile::tempdir()?;
     let workspace = temp.path().to_path_buf();
     fs::write(workspace.join("lib.rs"), "fn target() {}\nfn other() {}\n")?;
 
-    let server_service = CodingMcp::new().with_root_dir(workspace.clone());
-    let client_info = ClientInfo::new(ClientCapabilities::default(), Implementation::new("test-client", "0.1.0"));
-    let (_server_handle, client) = connect(server_service, client_info).await?;
-    let result = client
-        .call_tool(
-            CallToolRequestParams::new("ast_grep").with_arguments(
-                serde_json::json!({
-                    "language": "rs",
-                    "pattern": "fn $NAME() {}"
-                })
-                .as_object()
-                .unwrap()
-                .clone(),
-            ),
+    let mcp = TestClient::start(|| CodingMcp::new().with_root_dir(workspace.clone())).await?;
+    let parsed = mcp
+        .call(
+            "ast_grep",
+            AstGrepInput { language: "rs".to_string(), pattern: "fn $NAME() {}".to_string(), ..Default::default() },
         )
         .await?;
-
-    let text_content = result.content.first().and_then(|c| c.as_text()).ok_or("Expected text content")?;
-    let parsed: serde_json::Value = serde_json::from_str(&text_content.text)?;
-    let matches = parsed["matches"].as_array().ok_or("matches should be an array")?;
+    let matches = parsed["matches"].as_array().ok_or_else(|| test_error("matches should be an array"))?;
     assert_eq!(parsed["searchPath"].as_str().unwrap(), workspace.to_str().unwrap());
     assert!(matches.iter().any(|m| {
         m["file"].as_str().unwrap().ends_with("lib.rs")
@@ -479,11 +216,7 @@ async fn test_ast_grep_uses_workspace_root_when_no_path_given() -> Result<(), Bo
 
 #[cfg(feature = "test-helpers")]
 #[tokio::test]
-async fn test_read_before_edit_safety_with_relative_path_normalization() -> Result<(), Box<dyn std::error::Error>> {
-    use mcp_servers::coding::tools::edit_file::EditFileArgs;
-    use mcp_servers::coding::tools::read_file::ReadFileArgs;
-    use mcp_servers::file_ops::FileEdit;
-
+async fn test_read_before_edit_safety_with_relative_path_normalization() -> TestResult {
     let temp = tempfile::tempdir()?;
     let workspace = temp.path().to_path_buf();
     let test_file = temp.path().join("test.txt");
@@ -491,7 +224,7 @@ async fn test_read_before_edit_safety_with_relative_path_normalization() -> Resu
 
     let server = CodingMcp::new().with_root_dir(workspace);
 
-    server.test_read_file(ReadFileArgs { file_path: "test.txt".to_string(), offset: None, limit: None }).await?;
+    server.test_read_file(ReadFileArgs { file_path: "test.txt".to_string(), ..Default::default() }).await?;
 
     let result = server
         .test_edit_file(EditFileArgs {

--- a/crates/mcp-servers/tests/common/mod.rs
+++ b/crates/mcp-servers/tests/common/mod.rs
@@ -1,4 +1,4 @@
-//! Shared test helpers for LSP end-to-end tests.
+//! Shared test helpers for MCP integration tests.
 
 #![allow(dead_code)]
 
@@ -6,16 +6,78 @@ use aether_lspd::testing::TestProject;
 use mcp_servers::coding::CodingMcp;
 use mcp_utils::testing::connect;
 use rmcp::RoleClient;
-use rmcp::model::{CallToolRequestParams, ClientCapabilities, ClientInfo, Implementation};
+use rmcp::model::{CallToolRequestParams, CallToolResult, ClientCapabilities, ClientInfo, Implementation};
 use rmcp::service::RunningService;
+use rmcp::{RoleServer, Service};
+use serde::Serialize;
 use std::time::{Duration, Instant};
 
 /// Default timeout for polling operations (60 seconds).
 const POLL_TIMEOUT: Duration = Duration::from_mins(1);
 const POLL_INTERVAL: Duration = Duration::from_millis(500);
 
+pub type TestResult<T = ()> = Result<T, Box<dyn std::error::Error>>;
+
 pub fn test_client_info() -> ClientInfo {
-    ClientInfo::new(ClientCapabilities::default(), Implementation::new("lsp-e2e-test", "0.1.0"))
+    ClientInfo::new(ClientCapabilities::default(), Implementation::new("test-client", "0.1.0"))
+}
+
+pub fn test_error(message: impl Into<String>) -> std::io::Error {
+    std::io::Error::other(message.into())
+}
+
+/// Generic test client wrapping a connected MCP server.
+pub struct TestClient<T: Service<RoleServer>, U: Service<RoleClient> = ClientInfo> {
+    _server_handle: RunningService<RoleServer, T>,
+    client: RunningService<RoleClient, U>,
+}
+
+impl<T: Service<RoleServer>> TestClient<T, ClientInfo> {
+    /// Connect a default test `ClientInfo` to a server built by `configure`.
+    ///
+    /// Use the closure to apply `.with_root_dir(...)`, `.with_lsp(...)`, etc.
+    pub async fn start(configure: impl FnOnce() -> T) -> TestResult<Self> {
+        let (server_handle, client) = connect(configure(), test_client_info()).await?;
+        Ok(Self { _server_handle: server_handle, client })
+    }
+}
+
+impl<T: Service<RoleServer>, U: Service<RoleClient>> TestClient<T, U> {
+    /// Connect a caller-provided client to a server built by `configure_server`.
+    ///
+    /// Use this when the test needs to intercept client-side behaviour (for
+    /// example, auto-responding to elicitation requests via `McpClient`).
+    pub async fn start_with(configure_server: impl FnOnce() -> T, client: U) -> TestResult<Self> {
+        let (server_handle, client) = connect(configure_server(), client).await?;
+        Ok(Self { _server_handle: server_handle, client })
+    }
+
+    /// Call a tool with typed args, returning the first text content parsed as JSON.
+    pub async fn call<V: Serialize>(&self, tool: &str, args: V) -> TestResult<serde_json::Value> {
+        let result = self.call_raw(tool, args).await?;
+
+        let text = result
+            .content
+            .first()
+            .and_then(|c| c.as_text())
+            .ok_or_else(|| test_error(format!("{tool} should return text content")))?;
+
+        Ok(serde_json::from_str(&text.text)?)
+    }
+
+    /// Call a tool with typed args, returning the raw MCP tool result.
+    pub async fn call_raw<V: Serialize>(&self, tool: &str, args: V) -> TestResult<CallToolResult> {
+        let args = serde_json::to_value(args)?;
+        let arguments =
+            args.as_object().ok_or_else(|| test_error("tool arguments must serialize to a JSON object"))?.clone();
+
+        Ok(self.client.call_tool(CallToolRequestParams::new(tool.to_string()).with_arguments(arguments)).await?)
+    }
+
+    /// Borrow the raw client for cases that need `CallToolRequestParams` directly
+    pub fn raw(&self) -> &RunningService<RoleClient, U> {
+        &self.client
+    }
 }
 
 /// Connect a `CodingMcp` server to a test project with LSP enabled.
@@ -24,7 +86,7 @@ pub fn test_client_info() -> ClientInfo {
 /// alive (bind it to `_server_handle`) for the connection to stay open.
 pub async fn connect_lsp(
     project: &impl TestProject,
-) -> (rmcp::service::RunningService<rmcp::RoleServer, CodingMcp>, RunningService<RoleClient, ClientInfo>) {
+) -> (RunningService<RoleServer, CodingMcp>, RunningService<RoleClient, ClientInfo>) {
     let server = CodingMcp::new().with_lsp(project.root().to_path_buf());
     connect(server, test_client_info()).await.expect("Failed to connect")
 }

--- a/crates/mcp-servers/tests/plan_mcp.rs
+++ b/crates/mcp-servers/tests/plan_mcp.rs
@@ -1,12 +1,11 @@
+mod common;
+
+use common::{TestClient, TestResult};
+use mcp_servers::file_ops::FileEdit;
+use mcp_servers::plan::{EditPlanInput, SubmitPlanInput, WritePlanInput};
 use mcp_servers::{DEFAULT_PLAN_PROMPT, PlanMcp};
 use mcp_utils::client::{McpClient, McpClientEvent};
-use mcp_utils::testing::connect;
-use rmcp::model::{
-    CallToolRequestParams, CallToolResult, ClientCapabilities, ClientInfo, CreateElicitationRequestParams,
-    CreateElicitationResult, ElicitationAction, GetPromptRequestParams, Implementation,
-};
-use rmcp::service::RunningService;
-use rmcp::{RoleClient, Service};
+use rmcp::model::{CreateElicitationRequestParams, CreateElicitationResult, ElicitationAction, GetPromptRequestParams};
 use serde_json::json;
 use std::fs;
 use std::sync::Arc;
@@ -14,143 +13,30 @@ use tempfile::TempDir;
 use tokio::sync::{RwLock, mpsc};
 use utils::plan_review::PlanReviewElicitationMeta;
 
-#[tokio::test]
-async fn submit_plan_attaches_plan_review_metadata_and_preserves_schema() {
-    let temp_dir = TempDir::new().expect("create temp dir");
-    let plan_content = "# Plan\n\nShip the feature.";
-
-    let server = PlanMcp::new().with_plans_dir(temp_dir.path().to_path_buf());
-    let (_server_handle, client_handle) = connect(server, silent_client()).await.expect("connect client");
-    write_plan(&client_handle, "example", plan_content).await;
-
-    let (event_tx, event_rx) = mpsc::channel(8);
-    let client =
-        McpClient::new(test_client_info(), "plan-test-server".to_string(), event_tx, Arc::new(RwLock::new(Vec::new())));
-
-    let task_handle = respond_to_elicitation_request(
-        event_rx,
-        CreateElicitationResult {
-            action: ElicitationAction::Accept,
-            content: Some(json!({ "decision": "approve" })),
-            meta: None,
-        },
-    );
-
-    let server = PlanMcp::new().with_plans_dir(temp_dir.path().to_path_buf());
-    let (_server_handle, client_handle) = connect(server, client).await.expect("connect client");
-
-    let result = submit_plan(&client_handle, "example").await;
-    assert_eq!(result["approved"], true);
-    assert!(result["feedback"].is_null());
-
-    let plan_path = temp_dir.path().join("example-plan.md");
-    let elicitation_request = task_handle.await.expect("script task panicked").expect("expected elicitation request");
-    let CreateElicitationRequestParams::FormElicitationParams { meta, requested_schema, .. } = elicitation_request
-    else {
-        panic!("submit_plan should issue form elicitation request");
-    };
-
-    let required = requested_schema.required.clone().unwrap_or_default();
-    assert_eq!(required, vec!["decision".to_string()]);
-    assert!(requested_schema.properties.contains_key("decision"));
-    assert!(requested_schema.properties.contains_key("feedback"));
-
-    let meta = meta.expect("plan review metadata should be set");
-    let parsed_meta = PlanReviewElicitationMeta::parse(Some(&meta.0)).expect("should parse plan review metadata");
-    assert_eq!(parsed_meta.ui, "planReview");
-    assert_eq!(parsed_meta.plan_path, plan_path.display().to_string());
-    assert_eq!(parsed_meta.markdown, plan_content);
+fn silent_client() -> McpClient {
+    let (event_tx, _event_rx) = mpsc::channel(8);
+    McpClient::new(
+        common::test_client_info(),
+        "plan-test-server".to_string(),
+        event_tx,
+        Arc::new(RwLock::new(Vec::new())),
+    )
 }
 
-#[tokio::test]
-async fn write_plan_creates_plan_file_from_name() {
-    let temp_dir = TempDir::new().expect("create temp dir");
-    let server = PlanMcp::new().with_plans_dir(temp_dir.path().to_path_buf());
-    let (_server_handle, client_handle) = connect(server, silent_client()).await.expect("connect client");
-    let result = write_plan(&client_handle, "auth-refactor", "# Plan\n\nDo it.").await;
-    let plan_path = temp_dir.path().join("auth-refactor-plan.md");
-
-    assert_eq!(result["planName"], "auth-refactor");
-    assert_eq!(result["planPath"], plan_path.display().to_string());
-    assert_eq!(fs::read_to_string(plan_path).expect("read plan"), "# Plan\n\nDo it.");
+fn write_plan_input(plan_name: &str, content: &str) -> WritePlanInput {
+    WritePlanInput { plan_name: plan_name.to_string(), content: content.to_string() }
 }
 
-#[tokio::test]
-async fn edit_plan_updates_existing_plan_file_from_name() {
-    let temp_dir = TempDir::new().expect("create temp dir");
-    let server = PlanMcp::new().with_plans_dir(temp_dir.path().to_path_buf());
-    let (_server_handle, client_handle) = connect(server, silent_client()).await.expect("connect client");
-    write_plan(&client_handle, "auth-refactor", "# Plan\n\nOld approach.").await;
-
-    let result = edit_plan(&client_handle, "auth-refactor", "Old approach", "New approach", false).await;
-    let plan_path = temp_dir.path().join("auth-refactor-plan.md");
-    assert_eq!(result["replacementsMade"], 1);
-    assert_eq!(fs::read_to_string(plan_path).expect("read plan"), "# Plan\n\nNew approach.");
+fn edit_plan_input(plan_name: &str, edits: Vec<FileEdit>) -> EditPlanInput {
+    EditPlanInput { plan_name: plan_name.to_string(), edits }
 }
 
-#[tokio::test]
-async fn edit_plan_applies_batch_in_single_call() -> Result<(), Box<dyn std::error::Error>> {
-    let temp_dir = TempDir::new()?;
-    let server = PlanMcp::new().with_plans_dir(temp_dir.path().to_path_buf());
-    let (_server_handle, client_handle) = connect(server, silent_client()).await?;
-    write_plan(&client_handle, "feature", "# Plan\nStep one\nStep two\n").await;
-
-    let request = CallToolRequestParams::new("edit_plan").with_arguments(
-        json!({
-            "planName": "feature",
-            "edits": [
-                { "oldString": "Step one", "newString": "Step ONE" },
-                { "oldString": "Step two", "newString": "Step TWO" }
-            ]
-        })
-        .as_object()
-        .ok_or("edit_plan arguments")?
-        .clone(),
-    );
-    let result = client_handle.call_tool(request).await?;
-    let text = result.content.first().and_then(|content| content.as_text()).ok_or("edit_plan text content")?;
-    let parsed: serde_json::Value = serde_json::from_str(&text.text)?;
-
-    assert_eq!(parsed["replacementsMade"], 2);
-    let plan_path = temp_dir.path().join("feature-plan.md");
-    assert_eq!(fs::read_to_string(plan_path)?, "# Plan\nStep ONE\nStep TWO\n");
-    Ok(())
+fn submit_plan_input(plan_name: &str) -> SubmitPlanInput {
+    SubmitPlanInput { plan_name: plan_name.to_string() }
 }
 
-#[tokio::test]
-async fn plan_name_rejects_path_traversal() {
-    let temp_dir = TempDir::new().expect("create temp dir");
-    let server = PlanMcp::new().with_plans_dir(temp_dir.path().to_path_buf());
-    let (_server_handle, client_handle) = connect(server, silent_client()).await.expect("connect client");
-    let request = CallToolRequestParams::new("write_plan")
-        .with_arguments(json!({ "planName": "../escape", "content": "# Plan" }).as_object().unwrap().clone());
-    let result = client_handle.call_tool(request).await.expect("call write_plan");
-    assert!(result.is_error.unwrap_or(false), "expected invalid plan name to be rejected: {result:?}");
-}
-
-#[tokio::test]
-async fn write_plan_rejects_empty_content() {
-    let temp_dir = TempDir::new().expect("create temp dir");
-    let server = PlanMcp::new().with_plans_dir(temp_dir.path().to_path_buf());
-    let (_server_handle, client_handle) = connect(server, silent_client()).await.expect("connect client");
-    let request = CallToolRequestParams::new("write_plan")
-        .with_arguments(json!({ "planName": "blank", "content": "   \n\t" }).as_object().unwrap().clone());
-    let result = client_handle.call_tool(request).await.expect("call write_plan");
-
-    assert!(result.is_error.unwrap_or(false), "expected empty content to be rejected: {result:?}");
-}
-
-#[tokio::test]
-async fn submit_plan_errors_on_missing_plan() {
-    let temp_dir = TempDir::new().expect("create temp dir");
-    let server = PlanMcp::new().with_plans_dir(temp_dir.path().to_path_buf());
-    let (_server_handle, client_handle) = connect(server, silent_client()).await.expect("connect client");
-    let result = submit_plan_raw(&client_handle, "missing").await;
-    assert!(result.is_error.unwrap_or(false), "expected error for missing plan: {result:?}");
-}
-
-fn test_client_info() -> ClientInfo {
-    ClientInfo::new(ClientCapabilities::default(), Implementation::new("plan-test-client", "0.1.0"))
+async fn submit_plan_raw(mcp: &TestClient<PlanMcp, McpClient>, plan_name: &str) -> rmcp::model::CallToolResult {
+    mcp.call_raw("submit_plan", submit_plan_input(plan_name)).await.expect("call submit_plan")
 }
 
 fn respond_to_elicitation_request(
@@ -169,78 +55,155 @@ fn respond_to_elicitation_request(
     })
 }
 
-async fn submit_plan<T: Service<RoleClient>>(
-    client: &RunningService<RoleClient, T>,
-    plan_name: &str,
-) -> serde_json::Value {
-    let request = CallToolRequestParams::new("submit_plan")
-        .with_arguments(json!({ "planName": plan_name }).as_object().unwrap().clone());
+#[tokio::test]
+async fn submit_plan_attaches_plan_review_metadata_and_preserves_schema() -> TestResult {
+    let temp_dir = TempDir::new()?;
+    let plan_content = "# Plan\n\nShip the feature.";
 
-    let result = client.call_tool(request).await.expect("call submit_plan");
-    let content = result.content.first().expect("Expected content");
-    let text = content.as_text().expect("Expected text content");
-    serde_json::from_str(&text.text).expect("Invalid JSON response")
-}
+    let mcp = TestClient::start_with(|| PlanMcp::new().with_plans_dir(temp_dir.path().to_path_buf()), silent_client())
+        .await?;
+    mcp.call("write_plan", write_plan_input("example", plan_content)).await?;
 
-async fn submit_plan_raw<T: Service<RoleClient>>(
-    client: &RunningService<RoleClient, T>,
-    plan_name: &str,
-) -> CallToolResult {
-    let request = CallToolRequestParams::new("submit_plan")
-        .with_arguments(json!({ "planName": plan_name }).as_object().unwrap().clone());
-    client.call_tool(request).await.expect("call submit_plan")
-}
-
-async fn write_plan<T: Service<RoleClient>>(
-    client: &RunningService<RoleClient, T>,
-    plan_name: &str,
-    content: &str,
-) -> serde_json::Value {
-    let request = CallToolRequestParams::new("write_plan")
-        .with_arguments(json!({ "planName": plan_name, "content": content }).as_object().unwrap().clone());
-
-    let result = client.call_tool(request).await.expect("call write_plan");
-    let content = result.content.first().expect("Expected content");
-    let text = content.as_text().expect("Expected text content");
-    serde_json::from_str(&text.text).expect("Invalid JSON response")
-}
-
-async fn edit_plan<T: Service<RoleClient>>(
-    client: &RunningService<RoleClient, T>,
-    plan_name: &str,
-    old_string: &str,
-    new_string: &str,
-    replace_all: bool,
-) -> serde_json::Value {
-    let request = CallToolRequestParams::new("edit_plan").with_arguments(
-        json!({
-            "planName": plan_name,
-            "edits": [{
-                "oldString": old_string,
-                "newString": new_string,
-                "replaceAll": replace_all
-            }]
-        })
-        .as_object()
-        .unwrap()
-        .clone(),
+    let (event_tx, event_rx) = mpsc::channel(8);
+    let client = McpClient::new(
+        common::test_client_info(),
+        "plan-test-server".to_string(),
+        event_tx,
+        Arc::new(RwLock::new(Vec::new())),
     );
 
-    let result = client.call_tool(request).await.expect("call edit_plan");
-    let content = result.content.first().expect("Expected content");
-    let text = content.as_text().expect("Expected text content");
-    serde_json::from_str(&text.text).expect("Invalid JSON response")
+    let task_handle = respond_to_elicitation_request(
+        event_rx,
+        CreateElicitationResult {
+            action: ElicitationAction::Accept,
+            content: Some(json!({ "decision": "approve" })),
+            meta: None,
+        },
+    );
+
+    let mcp = TestClient::start_with(|| PlanMcp::new().with_plans_dir(temp_dir.path().to_path_buf()), client).await?;
+    let result = mcp.call("submit_plan", submit_plan_input("example")).await?;
+    assert_eq!(result["approved"], true);
+    assert!(result["feedback"].is_null());
+
+    let plan_path = temp_dir.path().join("example-plan.md");
+    let elicitation_request = task_handle.await?.expect("expected elicitation request");
+    let CreateElicitationRequestParams::FormElicitationParams { meta, requested_schema, .. } = elicitation_request
+    else {
+        panic!("submit_plan should issue form elicitation request");
+    };
+
+    let required = requested_schema.required.clone().unwrap_or_default();
+    assert_eq!(required, vec!["decision".to_string()]);
+    assert!(requested_schema.properties.contains_key("decision"));
+    assert!(requested_schema.properties.contains_key("feedback"));
+
+    let meta = meta.expect("plan review metadata should be set");
+    let parsed_meta = PlanReviewElicitationMeta::parse(Some(&meta.0)).expect("should parse plan review metadata");
+    assert_eq!(parsed_meta.ui, "planReview");
+    assert_eq!(parsed_meta.plan_path, plan_path.display().to_string());
+    assert_eq!(parsed_meta.markdown, plan_content);
+    Ok(())
 }
 
-fn silent_client() -> McpClient {
-    let (event_tx, _event_rx) = mpsc::channel(8);
-    McpClient::new(test_client_info(), "plan-test-server".to_string(), event_tx, Arc::new(RwLock::new(Vec::new())))
+#[tokio::test]
+async fn write_plan_creates_plan_file_from_name() -> TestResult {
+    let temp_dir = TempDir::new()?;
+    let mcp = TestClient::start_with(|| PlanMcp::new().with_plans_dir(temp_dir.path().to_path_buf()), silent_client())
+        .await?;
+    let result = mcp.call("write_plan", write_plan_input("auth-refactor", "# Plan\n\nDo it.")).await?;
+    let plan_path = temp_dir.path().join("auth-refactor-plan.md");
+
+    assert_eq!(result["planName"], "auth-refactor");
+    assert_eq!(result["planPath"], plan_path.display().to_string());
+    assert_eq!(fs::read_to_string(plan_path)?, "# Plan\n\nDo it.");
+    Ok(())
+}
+
+#[tokio::test]
+async fn edit_plan_updates_existing_plan_file_from_name() -> TestResult {
+    let temp_dir = TempDir::new()?;
+    let mcp = TestClient::start_with(|| PlanMcp::new().with_plans_dir(temp_dir.path().to_path_buf()), silent_client())
+        .await?;
+    mcp.call("write_plan", write_plan_input("auth-refactor", "# Plan\n\nOld approach.")).await?;
+
+    let result = mcp
+        .call(
+            "edit_plan",
+            edit_plan_input(
+                "auth-refactor",
+                vec![FileEdit {
+                    old_string: "Old approach".to_string(),
+                    new_string: "New approach".to_string(),
+                    replace_all: false,
+                }],
+            ),
+        )
+        .await?;
+    let plan_path = temp_dir.path().join("auth-refactor-plan.md");
+    assert_eq!(result["replacementsMade"], 1);
+    assert_eq!(fs::read_to_string(plan_path)?, "# Plan\n\nNew approach.");
+    Ok(())
+}
+
+#[tokio::test]
+async fn edit_plan_applies_batch_in_single_call() -> TestResult {
+    let temp_dir = TempDir::new()?;
+    let mcp = TestClient::start_with(|| PlanMcp::new().with_plans_dir(temp_dir.path().to_path_buf()), silent_client())
+        .await?;
+    mcp.call("write_plan", write_plan_input("feature", "# Plan\nStep one\nStep two\n")).await?;
+
+    let parsed = mcp
+        .call(
+            "edit_plan",
+            edit_plan_input(
+                "feature",
+                vec![FileEdit::new("Step one", "Step ONE"), FileEdit::new("Step two", "Step TWO")],
+            ),
+        )
+        .await?;
+
+    assert_eq!(parsed["replacementsMade"], 2);
+    let plan_path = temp_dir.path().join("feature-plan.md");
+    assert_eq!(fs::read_to_string(plan_path)?, "# Plan\nStep ONE\nStep TWO\n");
+    Ok(())
+}
+
+#[tokio::test]
+async fn plan_name_rejects_path_traversal() -> TestResult {
+    let temp_dir = TempDir::new()?;
+    let mcp = TestClient::start_with(|| PlanMcp::new().with_plans_dir(temp_dir.path().to_path_buf()), silent_client())
+        .await?;
+    let result = mcp.call_raw("write_plan", write_plan_input("../escape", "# Plan")).await?;
+    assert!(result.is_error.unwrap_or(false), "expected invalid plan name to be rejected: {result:?}");
+    Ok(())
+}
+
+#[tokio::test]
+async fn write_plan_rejects_empty_content() -> TestResult {
+    let temp_dir = TempDir::new()?;
+    let mcp = TestClient::start_with(|| PlanMcp::new().with_plans_dir(temp_dir.path().to_path_buf()), silent_client())
+        .await?;
+    let result = mcp.call_raw("write_plan", write_plan_input("blank", "   \n\t")).await?;
+
+    assert!(result.is_error.unwrap_or(false), "expected empty content to be rejected: {result:?}");
+    Ok(())
+}
+
+#[tokio::test]
+async fn submit_plan_errors_on_missing_plan() {
+    let temp_dir = TempDir::new().expect("create temp dir");
+    let mcp = TestClient::start_with(|| PlanMcp::new().with_plans_dir(temp_dir.path().to_path_buf()), silent_client())
+        .await
+        .expect("connect client");
+    let result = submit_plan_raw(&mcp, "missing").await;
+    assert!(result.is_error.unwrap_or(false), "expected error for missing plan: {result:?}");
 }
 
 #[tokio::test]
 async fn list_prompts_returns_plan_prompt() {
-    let (_server_handle, client_handle) = connect(PlanMcp::new(), silent_client()).await.expect("connect client");
-    let result = client_handle.list_prompts(None).await.expect("list prompts");
+    let mcp = TestClient::start_with(PlanMcp::new, silent_client()).await.expect("connect client");
+    let result = mcp.raw().list_prompts(None).await.expect("list prompts");
 
     assert_eq!(result.prompts.len(), 1);
     assert_eq!(result.prompts[0].name, "plan");
@@ -252,8 +215,8 @@ async fn list_prompts_returns_plan_prompt() {
 
 #[tokio::test]
 async fn get_prompt_returns_default_body_when_unconfigured() {
-    let (_server_handle, client_handle) = connect(PlanMcp::new(), silent_client()).await.expect("connect client");
-    let result = client_handle.get_prompt(GetPromptRequestParams::new("plan")).await.expect("get prompt");
+    let mcp = TestClient::start_with(PlanMcp::new, silent_client()).await.expect("connect client");
+    let result = mcp.raw().get_prompt(GetPromptRequestParams::new("plan")).await.expect("get prompt");
 
     assert_eq!(result.messages.len(), 1);
     let text = extract_user_text(&result.messages[0]);
@@ -262,11 +225,11 @@ async fn get_prompt_returns_default_body_when_unconfigured() {
 
 #[tokio::test]
 async fn get_prompt_substitutes_arguments() {
-    let (_server_handle, client_handle) = connect(PlanMcp::new(), silent_client()).await.expect("connect client");
+    let mcp = TestClient::start_with(PlanMcp::new, silent_client()).await.expect("connect client");
 
     let args = json!({ "ARGUMENTS": "wire up the widget" }).as_object().unwrap().clone();
     let request = GetPromptRequestParams::new("plan").with_arguments(args);
-    let result = client_handle.get_prompt(request).await.expect("get prompt");
+    let result = mcp.raw().get_prompt(request).await.expect("get prompt");
 
     let text = extract_user_text(&result.messages[0]);
     assert!(text.contains("<task>wire up the widget</task>"), "expected substituted task in: {text}");
@@ -279,10 +242,10 @@ async fn get_prompt_uses_configured_prompt_file() {
     let path = temp_dir.path().join("custom.md");
     fs::write(&path, "custom plan mode body").expect("write custom prompt");
 
-    let server = PlanMcp::new().with_prompt_file(path);
-    let (_server_handle, client_handle) = connect(server, silent_client()).await.expect("connect client");
-
-    let result = client_handle.get_prompt(GetPromptRequestParams::new("plan")).await.expect("get prompt");
+    let mcp = TestClient::start_with(|| PlanMcp::new().with_prompt_file(path), silent_client())
+        .await
+        .expect("connect client");
+    let result = mcp.raw().get_prompt(GetPromptRequestParams::new("plan")).await.expect("get prompt");
     assert_eq!(extract_user_text(&result.messages[0]), "custom plan mode body");
 }
 
@@ -291,10 +254,10 @@ async fn get_prompt_falls_back_when_configured_file_missing() {
     let temp_dir = TempDir::new().expect("tempdir");
     let missing = temp_dir.path().join("not-there.md");
 
-    let server = PlanMcp::new().with_prompt_file(missing);
-    let (_server_handle, client_handle) = connect(server, silent_client()).await.expect("connect client");
-
-    let result = client_handle.get_prompt(GetPromptRequestParams::new("plan")).await.expect("get prompt");
+    let mcp = TestClient::start_with(|| PlanMcp::new().with_prompt_file(missing), silent_client())
+        .await
+        .expect("connect client");
+    let result = mcp.raw().get_prompt(GetPromptRequestParams::new("plan")).await.expect("get prompt");
     assert_eq!(extract_user_text(&result.messages[0]), DEFAULT_PLAN_PROMPT);
 }
 
@@ -306,66 +269,92 @@ fn extract_user_text(message: &rmcp::model::PromptMessage) -> String {
 }
 
 #[tokio::test]
-async fn submit_plan_runs_external_command_and_forwards_stdout_as_feedback() {
-    let temp_dir = TempDir::new().expect("tempdir");
+async fn submit_plan_runs_external_command_and_forwards_stdout_as_feedback() -> TestResult {
+    let temp_dir = TempDir::new()?;
     let plan_path = temp_dir.path().join("plan-plan.md");
-    fs::write(&plan_path, "# Plan\n\nDo the thing.").expect("write plan");
+    fs::write(&plan_path, "# Plan\n\nDo the thing.")?;
 
-    let server = PlanMcp::new().with_plans_dir(temp_dir.path().to_path_buf()).with_submit_command(vec![
-        "/bin/sh".into(),
-        "-c".into(),
-        r#"printf "feedback for %s" "$1""#.into(),
-        "--".into(),
-    ]);
-    let (_server, client) = connect(server, silent_client()).await.expect("connect");
+    let mcp = TestClient::start_with(
+        || {
+            PlanMcp::new().with_plans_dir(temp_dir.path().to_path_buf()).with_submit_command(vec![
+                "/bin/sh".into(),
+                "-c".into(),
+                r#"printf "feedback for %s" "$1""#.into(),
+                "--".into(),
+            ])
+        },
+        silent_client(),
+    )
+    .await?;
 
-    let result = submit_plan(&client, "plan").await;
+    let result = mcp.call("submit_plan", submit_plan_input("plan")).await?;
     assert_eq!(result["approved"], false);
     let feedback = result["feedback"].as_str().expect("feedback string");
     let expected = format!("feedback for {}", plan_path.display());
     assert_eq!(feedback, expected, "expected verbatim stdout forwarded to feedback");
+    Ok(())
 }
 
 #[tokio::test]
-async fn submit_plan_external_command_forwards_empty_stdout() {
-    let temp_dir = TempDir::new().expect("tempdir");
+async fn submit_plan_external_command_forwards_empty_stdout() -> TestResult {
+    let temp_dir = TempDir::new()?;
     let plan_path = temp_dir.path().join("plan-plan.md");
-    fs::write(&plan_path, "# Plan").expect("write plan");
+    fs::write(&plan_path, "# Plan")?;
 
-    let server =
-        PlanMcp::new().with_plans_dir(temp_dir.path().to_path_buf()).with_submit_command(vec!["/usr/bin/true".into()]);
-    let (_server, client) = connect(server, silent_client()).await.expect("connect");
+    let mcp = TestClient::start_with(
+        || {
+            PlanMcp::new()
+                .with_plans_dir(temp_dir.path().to_path_buf())
+                .with_submit_command(vec!["/usr/bin/true".into()])
+        },
+        silent_client(),
+    )
+    .await?;
 
-    let result = submit_plan(&client, "plan").await;
+    let result = mcp.call("submit_plan", submit_plan_input("plan")).await?;
     assert_eq!(result["approved"], false);
     assert_eq!(result["feedback"], "", "empty stdout should still be forwarded as empty feedback");
+    Ok(())
 }
 
 #[tokio::test]
-async fn submit_plan_external_command_errors_on_nonzero_exit() {
-    let temp_dir = TempDir::new().expect("tempdir");
+async fn submit_plan_external_command_errors_on_nonzero_exit() -> TestResult {
+    let temp_dir = TempDir::new()?;
     let plan_path = temp_dir.path().join("plan-plan.md");
-    fs::write(&plan_path, "# Plan").expect("write plan");
+    fs::write(&plan_path, "# Plan")?;
 
-    let server =
-        PlanMcp::new().with_plans_dir(temp_dir.path().to_path_buf()).with_submit_command(vec!["/usr/bin/false".into()]);
-    let (_server, client) = connect(server, silent_client()).await.expect("connect");
+    let mcp = TestClient::start_with(
+        || {
+            PlanMcp::new()
+                .with_plans_dir(temp_dir.path().to_path_buf())
+                .with_submit_command(vec!["/usr/bin/false".into()])
+        },
+        silent_client(),
+    )
+    .await?;
 
-    let result = submit_plan_raw(&client, "plan").await;
+    let result = submit_plan_raw(&mcp, "plan").await;
     assert!(result.is_error.unwrap_or(false), "expected tool error for nonzero exit: {result:?}");
+    Ok(())
 }
 
 #[tokio::test]
-async fn submit_plan_external_command_errors_on_missing_binary() {
-    let temp_dir = TempDir::new().expect("tempdir");
+async fn submit_plan_external_command_errors_on_missing_binary() -> TestResult {
+    let temp_dir = TempDir::new()?;
     let plan_path = temp_dir.path().join("plan-plan.md");
-    fs::write(&plan_path, "# Plan").expect("write plan");
+    fs::write(&plan_path, "# Plan")?;
 
-    let server = PlanMcp::new()
-        .with_plans_dir(temp_dir.path().to_path_buf())
-        .with_submit_command(vec!["aether-plan-mcp-does-not-exist-xyz".into()]);
-    let (_server, client) = connect(server, silent_client()).await.expect("connect");
+    let mcp = TestClient::start_with(
+        || {
+            PlanMcp::new()
+                .with_plans_dir(temp_dir.path().to_path_buf())
+                .with_submit_command(vec!["aether-plan-mcp-does-not-exist-xyz".into()])
+        },
+        silent_client(),
+    )
+    .await?;
 
-    let result = submit_plan_raw(&client, "plan").await;
+    let result = submit_plan_raw(&mcp, "plan").await;
     assert!(result.is_error.unwrap_or(false), "expected tool error for missing binary: {result:?}");
+    Ok(())
 }

--- a/crates/mcp-servers/tests/plugins_mcp_agents.rs
+++ b/crates/mcp-servers/tests/plugins_mcp_agents.rs
@@ -1,14 +1,26 @@
+mod common;
+
 use aether_auth::FakeOAuthCredentialStore;
 use aether_project::{AetherSettings, AetherSettingsSource, AgentCatalog, SettingsFileSource};
+use common::{TestClient, TestResult};
 use mcp_servers::subagents::SubAgentsMcp;
-use mcp_utils::testing::connect;
-use rmcp::model::{CallToolRequestParams, ClientCapabilities, ClientInfo, Implementation};
-use rmcp::service::RunningService;
-use rmcp::{RoleClient, RoleServer};
+use mcp_servers::subagents::tools::{SpawnSubAgentsInput, SubAgentTask};
 use std::fs;
 use std::path::Path;
 use std::sync::Arc;
 use tempfile::TempDir;
+
+fn spawn_input(tasks: &[(&str, &str)]) -> SpawnSubAgentsInput {
+    SpawnSubAgentsInput {
+        tasks: tasks
+            .iter()
+            .map(|(agent_name, prompt)| SubAgentTask {
+                agent_name: (*agent_name).to_string(),
+                prompt: (*prompt).to_string(),
+            })
+            .collect(),
+    }
+}
 
 #[tokio::test]
 async fn test_spawn_agent_with_coding_mcp_from_settings_catalog() {
@@ -33,75 +45,44 @@ async fn test_spawn_agent_with_coding_mcp_from_settings_catalog() {
     ];
 
     let temp_dir = create_test_files(&test_files);
-    let (_server_handle, _client) = create_test_client(temp_dir.path()).await;
+    let _mcp = TestClient::start(|| create_test_server(temp_dir.path())).await.unwrap();
 }
 
 #[tokio::test]
-async fn test_spawn_subagent_codex_uses_oauth_store() {
+async fn test_spawn_subagent_codex_uses_oauth_store() -> TestResult {
     let temp_dir = create_project_with_codex_agent();
-    let (_server_handle, client) = connect(
-        create_test_server(temp_dir.path()).with_oauth_credential_store(Arc::new(FakeOAuthCredentialStore::new())),
-        ClientInfo::new(ClientCapabilities::default(), Implementation::new("test-client", "0.1.0")),
-    )
-    .await
-    .expect("Failed to connect MCP server and client");
+    let mcp = TestClient::start(|| {
+        create_test_server(temp_dir.path()).with_oauth_credential_store(Arc::new(FakeOAuthCredentialStore::new()))
+    })
+    .await?;
 
-    let args = {
-        let mut args = serde_json::Map::new();
-        args.insert("tasks".to_string(), serde_json::json!([{ "agentName": "explorer", "prompt": "Read README.md" }]));
-        args
-    };
+    let parsed = mcp.call("spawn_subagent", spawn_input(&[("explorer", "Read README.md")])).await?;
 
-    let result = client
-        .call_tool(CallToolRequestParams::new("spawn_subagent").with_arguments(args))
-        .await
-        .expect("Failed to call spawn_subagent tool");
-
-    let text = result.content.first().and_then(|c| c.as_text()).expect("Expected text content");
-    let parsed: serde_json::Value = serde_json::from_str(&text.text).expect("Invalid JSON response");
     let error = parsed["results"][0]["error"].as_str().expect("Expected sub-agent error");
-    assert!(error.contains("No Codex OAuth credentials found"),);
+    assert!(error.contains("No Codex OAuth credentials found"));
+    Ok(())
 }
 
 #[tokio::test]
-async fn test_spawn_subagents_empty_tasks() {
+async fn test_spawn_subagents_empty_tasks() -> TestResult {
     let temp_dir = TempDir::new().expect("Failed to create temp directory");
-    let (_server_handle, client) = create_test_client(temp_dir.path()).await;
+    let mcp = TestClient::start(|| create_test_server(temp_dir.path())).await?;
 
-    let mut args = serde_json::Map::new();
-    args.insert("tasks".to_string(), serde_json::json!([]));
-    let result = client
-        .call_tool(CallToolRequestParams::new("spawn_subagent").with_arguments(args))
-        .await
-        .expect("Failed to call spawn_subagent tool");
+    let parsed = mcp.call("spawn_subagent", spawn_input(&[])).await?;
 
-    if let Some(content) = result.content.first() {
-        if let Some(text_content) = content.as_text() {
-            let parsed: serde_json::Value = serde_json::from_str(&text_content.text).expect("Invalid JSON response");
-
-            let results = parsed["results"].as_array().expect("Expected results array");
-            assert_eq!(results.len(), 0);
-            assert_eq!(parsed["successCount"], 0);
-            assert_eq!(parsed["errorCount"], 0);
-        } else {
-            panic!("Expected text content");
-        }
-    } else {
-        panic!("Expected content in result");
-    }
+    let results = parsed["results"].as_array().expect("Expected results array");
+    assert_eq!(results.len(), 0);
+    assert_eq!(parsed["successCount"], 0);
+    assert_eq!(parsed["errorCount"], 0);
+    Ok(())
 }
 
 #[tokio::test]
-async fn test_spawn_subagent_errors_when_no_invocable_agents() {
+async fn test_spawn_subagent_errors_when_no_invocable_agents() -> TestResult {
     let temp_dir = TempDir::new().expect("Failed to create temp directory");
-    let (_server_handle, client) = create_test_client(temp_dir.path()).await;
+    let mcp = TestClient::start(|| create_test_server(temp_dir.path())).await?;
 
-    let mut args = serde_json::Map::new();
-    args.insert("tasks".to_string(), serde_json::json!([{ "agentName": "any-agent", "prompt": "Do something" }]));
-    let result = client
-        .call_tool(CallToolRequestParams::new("spawn_subagent").with_arguments(args))
-        .await
-        .expect("Tool call should succeed at protocol level");
+    let result = mcp.call_raw("spawn_subagent", spawn_input(&[("any-agent", "Do something")])).await?;
 
     let text = result.content.first().and_then(|c| c.as_text()).expect("Expected text content in error response");
     assert!(
@@ -109,90 +90,44 @@ async fn test_spawn_subagent_errors_when_no_invocable_agents() {
         "Error message should explain no agents are registered, got: {}",
         text.text,
     );
+    Ok(())
 }
 
 #[tokio::test]
-async fn test_spawn_subagent_agent_not_found() {
+async fn test_spawn_subagent_agent_not_found() -> TestResult {
     let temp_dir = create_project_with_invocable_agent();
-    let (_server_handle, client) = create_test_client(temp_dir.path()).await;
+    let mcp = TestClient::start(|| create_test_server(temp_dir.path())).await?;
 
-    let mut args = serde_json::Map::new();
-    args.insert(
-        "tasks".to_string(),
-        serde_json::json!([{
-            "agentName": "nonexistent-agent",
-            "prompt": "Do something"
-        }]),
-    );
-    let result = client
-        .call_tool(CallToolRequestParams::new("spawn_subagent").with_arguments(args))
-        .await
-        .expect("Failed to call spawn_subagent tool");
+    let parsed = mcp.call("spawn_subagent", spawn_input(&[("nonexistent-agent", "Do something")])).await?;
 
-    if let Some(content) = result.content.first() {
-        if let Some(text_content) = content.as_text() {
-            let parsed: serde_json::Value = serde_json::from_str(&text_content.text).expect("Invalid JSON response");
+    let results = parsed["results"].as_array().expect("Expected results array");
+    assert_eq!(results.len(), 1);
 
-            let results = parsed["results"].as_array().expect("Expected results array");
-            assert_eq!(results.len(), 1);
+    let first_result = &results[0];
+    assert_eq!(first_result["status"], "error");
+    assert_eq!(first_result["agentName"], "nonexistent-agent");
+    assert!(first_result["error"].as_str().unwrap().contains("not found"));
 
-            let first_result = &results[0];
-            assert_eq!(first_result["status"], "error");
-            assert_eq!(first_result["agentName"], "nonexistent-agent");
-            assert!(first_result["error"].as_str().unwrap().contains("not found"));
-
-            assert_eq!(parsed["successCount"], 0);
-            assert_eq!(parsed["errorCount"], 1);
-        } else {
-            panic!("Expected text content");
-        }
-    } else {
-        panic!("Expected content in result");
-    }
+    assert_eq!(parsed["successCount"], 0);
+    assert_eq!(parsed["errorCount"], 1);
+    Ok(())
 }
 
 #[tokio::test]
-async fn test_spawn_subagents_task_id_assignment() {
+async fn test_spawn_subagents_task_id_assignment() -> TestResult {
     let temp_dir = create_project_with_invocable_agent();
-    let (_server_handle, client) = create_test_client(temp_dir.path()).await;
+    let mcp = TestClient::start(|| create_test_server(temp_dir.path())).await?;
 
-    let mut args = serde_json::Map::new();
-    args.insert(
-        "tasks".to_string(),
-        serde_json::json!([
-            {
-                "agentName": "missing-agent-a",
-                "prompt": "First task"
-            },
-            {
-                "agentName": "missing-agent-b",
-                "prompt": "Second task"
-            }
-        ]),
-    );
-    let result = client
-        .call_tool(CallToolRequestParams::new("spawn_subagent").with_arguments(args))
-        .await
-        .expect("Failed to call spawn_subagent tool");
+    let parsed = mcp
+        .call("spawn_subagent", spawn_input(&[("missing-agent-a", "First task"), ("missing-agent-b", "Second task")]))
+        .await?;
 
-    if let Some(content) = result.content.first() {
-        if let Some(text_content) = content.as_text() {
-            let parsed: serde_json::Value = serde_json::from_str(&text_content.text).expect("Invalid JSON response");
+    let results = parsed["results"].as_array().expect("Expected results array");
+    assert_eq!(results.len(), 2);
 
-            let results = parsed["results"].as_array().expect("Expected results array");
-            assert_eq!(results.len(), 2);
-
-            let first_result = &results[0];
-            assert_eq!(first_result["taskId"], "task_0");
-
-            let second_result = &results[1];
-            assert_eq!(second_result["taskId"], "task_1");
-        } else {
-            panic!("Expected text content");
-        }
-    } else {
-        panic!("Expected content in result");
-    }
+    assert_eq!(results[0]["taskId"], "task_0");
+    assert_eq!(results[1]["taskId"], "task_1");
+    Ok(())
 }
 
 fn create_test_files(files: &[(&str, &str)]) -> TempDir {
@@ -257,16 +192,4 @@ fn create_test_server(test_dir: &Path) -> SubAgentsMcp {
         AgentCatalog::from_settings(test_dir, settings).expect("Failed to create agent catalog")
     };
     SubAgentsMcp::new(catalog, test_dir.to_path_buf())
-}
-
-async fn create_test_client(
-    test_dir: &Path,
-) -> (RunningService<RoleServer, SubAgentsMcp>, RunningService<RoleClient, ClientInfo>) {
-    let server_service = create_test_server(test_dir);
-    let client_info = ClientInfo::new(ClientCapabilities::default(), Implementation::new("test-client", "0.1.0"));
-
-    let (server_handle, client) =
-        connect(server_service, client_info).await.expect("Failed to connect MCP server and client");
-
-    (server_handle, client)
 }

--- a/crates/mcp-servers/tests/plugins_mcp_skills.rs
+++ b/crates/mcp-servers/tests/plugins_mcp_skills.rs
@@ -1,6 +1,8 @@
+mod common;
+
+use common::{TestClient, TestResult};
 use mcp_servers::skills::SkillsMcp;
-use mcp_utils::testing::connect;
-use rmcp::model::{CallToolRequestParams, ClientCapabilities, ClientInfo, Implementation};
+use mcp_servers::skills::tools::{ListSkillsInput, LoadSkillsInput, SkillRequest};
 use serde::{Deserialize, Serialize};
 use std::fs;
 use std::path::{Path, PathBuf};
@@ -27,25 +29,17 @@ fn create_test_files(files: &[(&str, &str)]) -> TempDir {
     temp_dir
 }
 
-async fn create_test_client(
-    test_dir: &Path,
-) -> (
-    rmcp::service::RunningService<rmcp::RoleServer, SkillsMcp>,
-    rmcp::service::RunningService<rmcp::RoleClient, rmcp::model::ClientInfo>,
-) {
-    let server_service = SkillsMcp::new(&[test_dir.join("skills")], test_dir.join("notes"));
-    let client_info = ClientInfo::new(ClientCapabilities::default(), Implementation::new("test-client", "0.1.0"));
-
-    let (server_handle, client) =
-        connect(server_service, client_info).await.expect("Failed to connect MCP server and client");
-
-    (server_handle, client)
+fn build_server(test_dir: &Path) -> SkillsMcp {
+    SkillsMcp::new(&[test_dir.join("skills")], test_dir.join("notes"))
 }
 
-fn parse_tool_result(result: &rmcp::model::CallToolResult) -> serde_json::Value {
-    let content = result.content.first().expect("Expected content");
-    let text = content.as_text().expect("Expected text content");
-    serde_json::from_str(&text.text).expect("Invalid JSON response")
+fn load_skills_input(requests: &[(&str, Option<&str>)]) -> LoadSkillsInput {
+    LoadSkillsInput {
+        requests: requests
+            .iter()
+            .map(|(name, path)| SkillRequest { name: (*name).to_string(), path: path.map(str::to_string) })
+            .collect(),
+    }
 }
 
 #[tokio::test]
@@ -77,7 +71,7 @@ async fn test_load_from_nested_directories() {
 }
 
 #[tokio::test]
-async fn test_load_skills_tool() {
+async fn test_load_skills_tool() -> TestResult {
     let test_files = vec![
         (
             "skills/skill-1/SKILL.md",
@@ -94,28 +88,11 @@ async fn test_load_skills_tool() {
     ];
 
     let temp_dir = create_test_files(&test_files);
-    let (_server_handle, client) = create_test_client(temp_dir.path()).await;
+    let mcp = TestClient::start(|| build_server(temp_dir.path())).await?;
 
-    // Test loading multiple skills using new requests API
-    let result = client
-        .call_tool(
-            CallToolRequestParams::new("get_skills").with_arguments(
-                serde_json::json!({
-                    "requests": [
-                        { "name": "skill-1" },
-                        { "name": "skill-2" },
-                        { "name": "skill-3" }
-                    ]
-                })
-                .as_object()
-                .unwrap()
-                .clone(),
-            ),
-        )
-        .await
-        .expect("Failed to call get_skills tool");
+    let parsed =
+        mcp.call("get_skills", load_skills_input(&[("skill-1", None), ("skill-2", None), ("skill-3", None)])).await?;
 
-    let parsed = parse_tool_result(&result);
     let files = parsed["files"].as_array().expect("Expected files array");
     assert_eq!(files.len(), 3);
 
@@ -128,10 +105,11 @@ async fn test_load_skills_tool() {
 
     let skill3 = files.iter().find(|s| s["name"] == "skill-3").unwrap();
     assert!(skill3["content"].as_str().unwrap().contains("This is skill 3"));
+    Ok(())
 }
 
 #[tokio::test]
-async fn test_list_skills_only_returns_agent_invocable_entries() {
+async fn test_list_skills_only_returns_agent_invocable_entries() -> TestResult {
     let test_files = vec![
         ("skills/zeta/SKILL.md", "---\ndescription: Zeta\nagent-invocable: true\ntags:\n  - systems\n---\n# Zeta"),
         (
@@ -149,17 +127,10 @@ async fn test_list_skills_only_returns_agent_invocable_entries() {
     ];
 
     let temp_dir = create_test_files(&test_files);
-    let (_server_handle, client) = create_test_client(temp_dir.path()).await;
+    let mcp = TestClient::start(|| build_server(temp_dir.path())).await?;
 
-    let result = client
-        .call_tool(
-            CallToolRequestParams::new("list_skills")
-                .with_arguments(serde_json::json!({}).as_object().unwrap().clone()),
-        )
-        .await
-        .expect("Failed to call list_skills");
+    let parsed = mcp.call("list_skills", ListSkillsInput::default()).await?;
 
-    let parsed = parse_tool_result(&result);
     assert_eq!(parsed["status"], "success");
     assert_eq!(parsed["count"], 2);
     assert_eq!(parsed["message"], "Found 2 skills");
@@ -170,10 +141,11 @@ async fn test_list_skills_only_returns_agent_invocable_entries() {
 
     assert!(skills.iter().all(|entry| entry.get("content").is_none()));
     assert!(skills.iter().all(|entry| entry.get("availableFiles").is_none()));
+    Ok(())
 }
 
 #[tokio::test]
-async fn test_load_skills_with_missing() {
+async fn test_load_skills_with_missing() -> TestResult {
     let test_files = vec![
         ("skills/skill-1/SKILL.md", "---\ndescription: First skill\nagent-invocable: true\n---\n# Skill 1\n\nContent."),
         (
@@ -183,31 +155,15 @@ async fn test_load_skills_with_missing() {
     ];
 
     let temp_dir = create_test_files(&test_files);
-    let (_server_handle, client) = create_test_client(temp_dir.path()).await;
+    let mcp = TestClient::start(|| build_server(temp_dir.path())).await?;
 
-    let result = client
-        .call_tool(
-            CallToolRequestParams::new("get_skills").with_arguments(
-                serde_json::json!({
-                    "requests": [
-                        { "name": "skill-1" },
-                        { "name": "nonexistent-skill" },
-                        { "name": "skill-2" }
-                    ]
-                })
-                .as_object()
-                .unwrap()
-                .clone(),
-            ),
-        )
-        .await
-        .expect("Failed to call get_skills tool");
+    let parsed = mcp
+        .call("get_skills", load_skills_input(&[("skill-1", None), ("nonexistent-skill", None), ("skill-2", None)]))
+        .await?;
 
-    let parsed = parse_tool_result(&result);
     let files = parsed["files"].as_array().unwrap();
     assert_eq!(files.len(), 3);
 
-    // skill-1 and skill-2 should have content
     let skill1 = files.iter().find(|s| s["name"] == "skill-1").unwrap();
     assert!(skill1["content"].is_string());
     assert!(skill1["error"].is_null());
@@ -216,14 +172,14 @@ async fn test_load_skills_with_missing() {
     assert!(skill2["content"].is_string());
     assert!(skill2["error"].is_null());
 
-    // nonexistent-skill should have error
     let missing = files.iter().find(|s| s["name"] == "nonexistent-skill").unwrap();
     assert!(missing["content"].is_null());
     assert!(missing["error"].as_str().unwrap().contains("not found"));
+    Ok(())
 }
 
 #[tokio::test]
-async fn test_get_skills_rejects_non_agent_invocable_prompts() {
+async fn test_get_skills_rejects_non_agent_invocable_prompts() -> TestResult {
     let test_files = vec![
         ("skills/allowed/SKILL.md", "---\ndescription: Allowed\nagent-invocable: true\n---\n# Allowed"),
         (
@@ -237,27 +193,12 @@ async fn test_get_skills_rejects_non_agent_invocable_prompts() {
     ];
 
     let temp_dir = create_test_files(&test_files);
-    let (_server_handle, client) = create_test_client(temp_dir.path()).await;
+    let mcp = TestClient::start(|| build_server(temp_dir.path())).await?;
 
-    let result = client
-        .call_tool(
-            CallToolRequestParams::new("get_skills").with_arguments(
-                serde_json::json!({
-                    "requests": [
-                        { "name": "allowed" },
-                        { "name": "user-only" },
-                        { "name": "rule-only" }
-                    ]
-                })
-                .as_object()
-                .unwrap()
-                .clone(),
-            ),
-        )
-        .await
-        .expect("Failed to call get_skills tool");
+    let parsed = mcp
+        .call("get_skills", load_skills_input(&[("allowed", None), ("user-only", None), ("rule-only", None)]))
+        .await?;
 
-    let parsed = parse_tool_result(&result);
     let files = parsed["files"].as_array().expect("Expected files array");
 
     let allowed = files.iter().find(|entry| entry["name"] == "allowed").unwrap();
@@ -271,10 +212,11 @@ async fn test_get_skills_rejects_non_agent_invocable_prompts() {
     let rule_only = files.iter().find(|entry| entry["name"] == "rule-only").unwrap();
     assert!(rule_only["content"].is_null());
     assert!(rule_only["error"].as_str().unwrap().contains("not agent-invocable"));
+    Ok(())
 }
 
 #[tokio::test]
-async fn test_load_auxiliary_file() {
+async fn test_load_auxiliary_file() -> TestResult {
     let test_files = vec![
         (
             "skills/test-skill/SKILL.md",
@@ -285,119 +227,63 @@ async fn test_load_auxiliary_file() {
     ];
 
     let temp_dir = create_test_files(&test_files);
-    let (_server_handle, client) = create_test_client(temp_dir.path()).await;
+    let mcp = TestClient::start(|| build_server(temp_dir.path())).await?;
 
-    // Load SKILL.md first - should get available_files
-    let result = client
-        .call_tool(
-            CallToolRequestParams::new("get_skills").with_arguments(
-                serde_json::json!({
-                    "requests": [{ "name": "test-skill" }]
-                })
-                .as_object()
-                .unwrap()
-                .clone(),
-            ),
-        )
-        .await
-        .expect("Failed to call get_skills");
-
-    let parsed = parse_tool_result(&result);
+    let parsed = mcp.call("get_skills", load_skills_input(&[("test-skill", None)])).await?;
     let file = &parsed["files"][0];
 
-    // Check available_files
     let available = file["availableFiles"].as_array().unwrap();
     assert!(available.contains(&serde_json::json!("references/REF.md")));
     assert!(available.contains(&serde_json::json!("traits.md")));
 
-    // Load auxiliary file
-    let result_aux = client
-        .call_tool(
-            CallToolRequestParams::new("get_skills").with_arguments(
-                serde_json::json!({
-                    "requests": [{ "name": "test-skill", "path": "traits.md" }]
-                })
-                .as_object()
-                .unwrap()
-                .clone(),
-            ),
-        )
-        .await
-        .expect("Failed to call get_skills");
-
-    let parsed_aux = parse_tool_result(&result_aux);
+    let parsed_aux = mcp.call("get_skills", load_skills_input(&[("test-skill", Some("traits.md"))])).await?;
     let aux_file = &parsed_aux["files"][0];
 
     assert_eq!(aux_file["path"], "traits.md");
     assert!(aux_file["content"].as_str().unwrap().contains("Traits content"));
-    // available_files should be absent (skipped when empty) for non-SKILL.md
     assert!(aux_file.get("availableFiles").is_none());
+    Ok(())
 }
 
 #[tokio::test]
-async fn test_reject_traversal() {
+async fn test_reject_traversal() -> TestResult {
     let test_files = vec![("skills/test-skill/SKILL.md", "---\ndescription: Test\nagent-invocable: true\n---\n# Test")];
 
     let temp_dir = create_test_files(&test_files);
-    let (_server_handle, client) = create_test_client(temp_dir.path()).await;
+    let mcp = TestClient::start(|| build_server(temp_dir.path())).await?;
 
-    let result = client
-        .call_tool(
-            CallToolRequestParams::new("get_skills").with_arguments(
-                serde_json::json!({
-                    "requests": [{ "name": "test-skill", "path": "../other-skill/SKILL.md" }]
-                })
-                .as_object()
-                .unwrap()
-                .clone(),
-            ),
-        )
-        .await
-        .expect("Failed to call get_skills");
-
-    let parsed = parse_tool_result(&result);
+    let parsed = mcp.call("get_skills", load_skills_input(&[("test-skill", Some("../other-skill/SKILL.md"))])).await?;
     let file = &parsed["files"][0];
 
     assert!(file["error"].as_str().unwrap().contains("traversal"));
+    Ok(())
 }
 
 #[tokio::test]
-async fn test_reject_absolute_path() {
+async fn test_reject_absolute_path() -> TestResult {
     let test_files = vec![("skills/test-skill/SKILL.md", "---\ndescription: Test\nagent-invocable: true\n---\n# Test")];
 
     let temp_dir = create_test_files(&test_files);
-    let (_server_handle, client) = create_test_client(temp_dir.path()).await;
+    let mcp = TestClient::start(|| build_server(temp_dir.path())).await?;
 
-    let result = client
-        .call_tool(
-            CallToolRequestParams::new("get_skills").with_arguments(
-                serde_json::json!({
-                    "requests": [{ "name": "test-skill", "path": "/etc/passwd" }]
-                })
-                .as_object()
-                .unwrap()
-                .clone(),
-            ),
-        )
-        .await
-        .expect("Failed to call get_skills");
-
-    let parsed = parse_tool_result(&result);
+    let parsed = mcp.call("get_skills", load_skills_input(&[("test-skill", Some("/etc/passwd"))])).await?;
     let file = &parsed["files"][0];
 
     assert!(file["error"].as_str().unwrap().contains("Absolute"));
+    Ok(())
 }
 
 #[tokio::test]
-async fn list_skills_input_schema_has_properties_object() {
+async fn list_skills_input_schema_has_properties_object() -> TestResult {
     let temp_dir = create_test_files(&[]);
-    let (_server_handle, client) = create_test_client(temp_dir.path()).await;
+    let mcp = TestClient::start(|| build_server(temp_dir.path())).await?;
 
-    let tools = client.peer().list_all_tools().await.expect("list tools");
+    let tools = mcp.raw().peer().list_all_tools().await?;
     let tool = tools.into_iter().find(|tool| tool.name.as_ref() == "list_skills").expect("list_skills tool present");
 
     let schema = serde_json::Value::Object((*tool.input_schema).clone());
     assert_eq!(schema.get("type").and_then(|v| v.as_str()), Some("object"));
     let properties = schema.get("properties").expect("object schema must include a properties key");
     assert!(properties.is_object(), "properties must be an object, got: {properties}");
+    Ok(())
 }

--- a/crates/mcp-servers/tests/skills_self_improvement.rs
+++ b/crates/mcp-servers/tests/skills_self_improvement.rs
@@ -1,240 +1,135 @@
+mod common;
+
+use common::{TestClient, TestResult};
 use mcp_servers::skills::SkillsMcp;
-use mcp_utils::testing::connect;
+use mcp_servers::skills::tools::{ListSkillsInput, LoadSkillsInput, SaveNoteInput, SearchNotesInput, SkillRequest};
 use rmcp::ServerHandler;
-use rmcp::model::{CallToolRequestParams, ClientCapabilities, ClientInfo, Implementation};
 use std::path::Path;
 use tempfile::TempDir;
 
-async fn create_test_client(
-    test_dir: &Path,
-) -> (
-    rmcp::service::RunningService<rmcp::RoleServer, SkillsMcp>,
-    rmcp::service::RunningService<rmcp::RoleClient, ClientInfo>,
-) {
-    let server_service = SkillsMcp::new(&[test_dir.join("skills")], test_dir.join("notes"));
-    let client_info = ClientInfo::new(ClientCapabilities::default(), Implementation::new("test-client", "0.1.0"));
-
-    connect(server_service, client_info).await.expect("Failed to connect MCP server and client")
+fn build_server(test_dir: &Path) -> SkillsMcp {
+    SkillsMcp::new(&[test_dir.join("skills")], test_dir.join("notes"))
 }
 
-fn call_tool_params(name: &str, args: &serde_json::Value) -> CallToolRequestParams {
-    CallToolRequestParams::new(name.to_string()).with_arguments(args.as_object().unwrap().clone())
+fn save_note_input(topic: &str, content: &str, tags: &[&str]) -> SaveNoteInput {
+    SaveNoteInput {
+        topic: topic.to_string(),
+        content: content.to_string(),
+        tags: tags.iter().map(|tag| (*tag).to_string()).collect(),
+    }
 }
 
-fn parse_tool_result(result: &rmcp::model::CallToolResult) -> serde_json::Value {
-    let content = result.content.first().expect("Expected content");
-    let text = content.as_text().expect("Expected text content");
-    serde_json::from_str(&text.text).expect("Invalid JSON response")
+fn search_notes_input(query: &str) -> SearchNotesInput {
+    SearchNotesInput { query: query.to_string() }
+}
+
+fn load_skills_input(requests: &[(&str, Option<&str>)]) -> LoadSkillsInput {
+    LoadSkillsInput {
+        requests: requests
+            .iter()
+            .map(|(name, path)| SkillRequest { name: (*name).to_string(), path: path.map(str::to_string) })
+            .collect(),
+    }
 }
 
 #[tokio::test]
-async fn test_save_note_creates_new() {
-    let temp_dir = TempDir::new().unwrap();
+async fn test_save_note_creates_new() -> TestResult {
+    let temp_dir = TempDir::new()?;
+    let mcp = TestClient::start(|| build_server(temp_dir.path())).await?;
 
-    let (_server, client) = create_test_client(temp_dir.path()).await;
-
-    let result = client
-        .call_tool(call_tool_params(
+    let parsed = mcp
+        .call(
             "save_note",
-            &serde_json::json!({
-                "topic": "agent-spec",
-                "content": "Core owns AgentSpec type; CLI owns settings.json parsing.",
-                "tags": ["aether", "architecture"]
-            }),
-        ))
-        .await
-        .expect("save_note failed");
+            save_note_input(
+                "agent-spec",
+                "Core owns AgentSpec type; CLI owns settings.json parsing.",
+                &["aether", "architecture"],
+            ),
+        )
+        .await?;
 
-    let parsed = parse_tool_result(&result);
     assert_eq!(parsed["topic"], "agent-spec");
     assert_eq!(parsed["status"], "created");
     assert!(parsed["content"].as_str().unwrap().contains("Core owns AgentSpec"));
 
-    // Verify file on disk
     let note_md = temp_dir.path().join("notes/agent-spec.md");
     assert!(note_md.exists());
-    let content = std::fs::read_to_string(&note_md).unwrap();
+    let content = std::fs::read_to_string(&note_md)?;
     assert!(content.contains("topic: agent-spec"));
     assert!(content.contains("- aether"));
     assert!(content.contains("- architecture"));
+    Ok(())
 }
 
 #[tokio::test]
-async fn test_save_note_appends_to_existing() {
-    let temp_dir = TempDir::new().unwrap();
+async fn test_save_note_appends_to_existing() -> TestResult {
+    let temp_dir = TempDir::new()?;
+    let mcp = TestClient::start(|| build_server(temp_dir.path())).await?;
 
-    let (_server, client) = create_test_client(temp_dir.path()).await;
+    mcp.call("save_note", save_note_input("agent-spec", "First learning.", &["aether"])).await?;
 
-    // First note
-    client
-        .call_tool(call_tool_params(
-            "save_note",
-            &serde_json::json!({
-                "topic": "agent-spec",
-                "content": "First learning.",
-                "tags": ["aether"]
-            }),
-        ))
-        .await
-        .unwrap();
+    let parsed = mcp.call("save_note", save_note_input("agent-spec", "Second learning.", &["architecture"])).await?;
 
-    // Second note on same topic
-    let result = client
-        .call_tool(call_tool_params(
-            "save_note",
-            &serde_json::json!({
-                "topic": "agent-spec",
-                "content": "Second learning.",
-                "tags": ["architecture"]
-            }),
-        ))
-        .await
-        .unwrap();
-
-    let parsed = parse_tool_result(&result);
     assert_eq!(parsed["status"], "appended");
     let content = parsed["content"].as_str().unwrap();
     assert!(content.contains("First learning."));
     assert!(content.contains("Second learning."));
 
-    // Verify tags merged on disk
-    let file = std::fs::read_to_string(temp_dir.path().join("notes/agent-spec.md")).unwrap();
+    let file = std::fs::read_to_string(temp_dir.path().join("notes/agent-spec.md"))?;
     assert!(file.contains("- aether"));
     assert!(file.contains("- architecture"));
+    Ok(())
 }
 
 #[tokio::test]
-async fn test_save_note_rejects_empty_content() {
-    let temp_dir = TempDir::new().unwrap();
+async fn test_save_note_rejects_empty_content() -> TestResult {
+    let temp_dir = TempDir::new()?;
+    let mcp = TestClient::start(|| build_server(temp_dir.path())).await?;
 
-    let (_server, client) = create_test_client(temp_dir.path()).await;
-
-    let result = client
-        .call_tool(call_tool_params(
-            "save_note",
-            &serde_json::json!({
-                "topic": "test",
-                "content": "   "
-            }),
-        ))
-        .await
-        .unwrap();
+    let result = mcp.call_raw("save_note", save_note_input("test", "   ", &[])).await?;
 
     assert!(result.is_error.unwrap_or(false));
+    Ok(())
 }
 
 #[tokio::test]
-async fn test_search_notes_by_topic() {
-    let temp_dir = TempDir::new().unwrap();
+async fn test_search_notes_by_topic() -> TestResult {
+    let temp_dir = TempDir::new()?;
+    let mcp = TestClient::start(|| build_server(temp_dir.path())).await?;
 
-    let (_server, client) = create_test_client(temp_dir.path()).await;
+    mcp.call("save_note", save_note_input("agent-spec", "AgentSpec learning.", &["aether"])).await?;
+    mcp.call("save_note", save_note_input("testing-conventions", "Use Fake prefix.", &["testing"])).await?;
 
-    // Create two notes
-    client
-        .call_tool(call_tool_params(
-            "save_note",
-            &serde_json::json!({
-                "topic": "agent-spec",
-                "content": "AgentSpec learning.",
-                "tags": ["aether"]
-            }),
-        ))
-        .await
-        .unwrap();
-
-    client
-        .call_tool(call_tool_params(
-            "save_note",
-            &serde_json::json!({
-                "topic": "testing-conventions",
-                "content": "Use Fake prefix.",
-                "tags": ["testing"]
-            }),
-        ))
-        .await
-        .unwrap();
-
-    // Search by topic substring
-    let result = client
-        .call_tool(call_tool_params(
-            "search_notes",
-            &serde_json::json!({
-                "query": "agent"
-            }),
-        ))
-        .await
-        .unwrap();
-
-    let parsed = parse_tool_result(&result);
+    let parsed = mcp.call("search_notes", search_notes_input("agent")).await?;
     let results = parsed["results"].as_array().unwrap();
     assert_eq!(results.len(), 1);
     assert_eq!(results[0]["topic"], "agent-spec");
+    Ok(())
 }
 
 #[tokio::test]
-async fn test_search_notes_by_tag() {
-    let temp_dir = TempDir::new().unwrap();
+async fn test_search_notes_by_tag() -> TestResult {
+    let temp_dir = TempDir::new()?;
+    let mcp = TestClient::start(|| build_server(temp_dir.path())).await?;
 
-    let (_server, client) = create_test_client(temp_dir.path()).await;
+    mcp.call("save_note", save_note_input("agent-spec", "Learning 1.", &["aether"])).await?;
+    mcp.call("save_note", save_note_input("mcp-setup", "Learning 2.", &["aether"])).await?;
 
-    client
-        .call_tool(call_tool_params(
-            "save_note",
-            &serde_json::json!({
-                "topic": "agent-spec",
-                "content": "Learning 1.",
-                "tags": ["aether"]
-            }),
-        ))
-        .await
-        .unwrap();
-
-    client
-        .call_tool(call_tool_params(
-            "save_note",
-            &serde_json::json!({
-                "topic": "mcp-setup",
-                "content": "Learning 2.",
-                "tags": ["aether"]
-            }),
-        ))
-        .await
-        .unwrap();
-
-    let result = client
-        .call_tool(call_tool_params(
-            "search_notes",
-            &serde_json::json!({
-                "query": "aether"
-            }),
-        ))
-        .await
-        .unwrap();
-
-    let parsed = parse_tool_result(&result);
+    let parsed = mcp.call("search_notes", search_notes_input("aether")).await?;
     let results = parsed["results"].as_array().unwrap();
     assert_eq!(results.len(), 2);
+    Ok(())
 }
 
 #[tokio::test]
-async fn test_search_notes_empty_results() {
-    let temp_dir = TempDir::new().unwrap();
+async fn test_search_notes_empty_results() -> TestResult {
+    let temp_dir = TempDir::new()?;
+    let mcp = TestClient::start(|| build_server(temp_dir.path())).await?;
 
-    let (_server, client) = create_test_client(temp_dir.path()).await;
-
-    let result = client
-        .call_tool(call_tool_params(
-            "search_notes",
-            &serde_json::json!({
-                "query": "nonexistent"
-            }),
-        ))
-        .await
-        .unwrap();
-
-    let parsed = parse_tool_result(&result);
+    let parsed = mcp.call("search_notes", search_notes_input("nonexistent")).await?;
     let results = parsed["results"].as_array().unwrap();
     assert!(results.is_empty());
+    Ok(())
 }
 
 #[tokio::test]
@@ -269,85 +164,39 @@ async fn test_instructions_reference_list_skills_and_do_not_embed_catalog_entrie
 }
 
 #[tokio::test]
-async fn test_full_lifecycle() {
-    let temp_dir = TempDir::new().unwrap();
+async fn test_full_lifecycle() -> TestResult {
+    let temp_dir = TempDir::new()?;
 
-    // Curated skill must exist before the client starts so the catalog picks it up.
     let skills_dir = temp_dir.path().join("skills").join("curated");
-    std::fs::create_dir_all(&skills_dir).unwrap();
+    std::fs::create_dir_all(&skills_dir)?;
     std::fs::write(
         skills_dir.join("SKILL.md"),
         "---\ndescription: Curated skill\nagent-invocable: true\n---\n# Curated\n\nHand-written skill.",
-    )
-    .unwrap();
+    )?;
 
-    let (_server, client) = create_test_client(temp_dir.path()).await;
+    let mcp = TestClient::start(|| build_server(temp_dir.path())).await?;
 
-    // 1. Save a note
-    let result = client
-        .call_tool(call_tool_params(
-            "save_note",
-            &serde_json::json!({
-                "topic": "lifecycle-topic",
-                "content": "First insight.",
-                "tags": ["test"]
-            }),
-        ))
-        .await
-        .unwrap();
-    let parsed = parse_tool_result(&result);
+    let parsed = mcp.call("save_note", save_note_input("lifecycle-topic", "First insight.", &["test"])).await?;
     assert_eq!(parsed["status"], "created");
 
-    // 2. Append to the same topic
-    let result = client
-        .call_tool(call_tool_params(
-            "save_note",
-            &serde_json::json!({
-                "topic": "lifecycle-topic",
-                "content": "Second insight.",
-                "tags": ["lifecycle"]
-            }),
-        ))
-        .await
-        .unwrap();
-    let parsed = parse_tool_result(&result);
+    let parsed = mcp.call("save_note", save_note_input("lifecycle-topic", "Second insight.", &["lifecycle"])).await?;
     assert_eq!(parsed["status"], "appended");
     let content = parsed["content"].as_str().unwrap();
     assert!(content.contains("First insight."));
     assert!(content.contains("Second insight."));
 
-    // 3. Search for the note
-    let result = client
-        .call_tool(call_tool_params(
-            "search_notes",
-            &serde_json::json!({
-                "query": "lifecycle"
-            }),
-        ))
-        .await
-        .unwrap();
-    let parsed = parse_tool_result(&result);
+    let parsed = mcp.call("search_notes", search_notes_input("lifecycle")).await?;
     let results = parsed["results"].as_array().unwrap();
     assert_eq!(results.len(), 1);
     assert!(results[0]["content"].as_str().unwrap().contains("Second insight."));
     assert!(results[0]["tags"].as_array().unwrap().iter().any(|t| t == "test"));
     assert!(results[0]["tags"].as_array().unwrap().iter().any(|t| t == "lifecycle"));
 
-    // 4. Discover skills, then load curated content
-    let result = client.call_tool(call_tool_params("list_skills", &serde_json::json!({}))).await.unwrap();
-    let parsed = parse_tool_result(&result);
+    let parsed = mcp.call("list_skills", ListSkillsInput::default()).await?;
     let skills = parsed["skills"].as_array().unwrap();
     assert!(skills.iter().any(|entry| entry["name"] == "curated"));
 
-    let result = client
-        .call_tool(call_tool_params(
-            "get_skills",
-            &serde_json::json!({
-                "requests": [{ "name": "curated" }]
-            }),
-        ))
-        .await
-        .unwrap();
-    let parsed = parse_tool_result(&result);
+    let parsed = mcp.call("get_skills", load_skills_input(&[("curated", None)])).await?;
     assert!(parsed["files"][0]["content"].as_str().unwrap().contains("Hand-written skill."));
+    Ok(())
 }

--- a/crates/wisp/tests/app_tests/command_picker_tests.rs
+++ b/crates/wisp/tests/app_tests/command_picker_tests.rs
@@ -1,41 +1,36 @@
 use agent_client_protocol::schema as acp;
-use tui::testing::TestTerminal;
 use tui::{KeyCode, KeyEvent, KeyEventKind, KeyEventState, KeyModifiers};
 
 use super::common::*;
 
 #[tokio::test]
-async fn test_slash_opens_command_picker() {
-    let terminal = TestTerminal::new(80, 24);
-    let mut renderer = Renderer::new(terminal, TEST_AGENT.to_string(), &[], (80, 24));
-    renderer.initial_render().unwrap();
+async fn test_slash_opens_command_picker() -> TestResult {
+    let mut renderer = RendererTest::new().size((80, 24)).build()?;
 
-    send_key(&mut renderer, KeyCode::Char('/'), KeyModifiers::empty()).await;
+    press(&mut renderer, KeyCode::Char('/')).await?;
 
     assert!(has_command_picker(renderer.writer()), "Typing / on empty buffer should open command picker");
+    Ok(())
 }
 
 #[tokio::test]
-async fn test_slash_mid_input_no_picker() {
-    let terminal = TestTerminal::new(80, 24);
-    let mut renderer = Renderer::new(terminal, TEST_AGENT.to_string(), &[], (80, 24));
-    renderer.initial_render().unwrap();
+async fn test_slash_mid_input_no_picker() -> TestResult {
+    let mut renderer = RendererTest::new().size((80, 24)).build()?;
 
-    type_string(&mut renderer, "hello/").await;
+    type_string(&mut renderer, "hello/").await?;
 
     assert!(!has_command_picker(renderer.writer()), "Typing / mid-input should not open command picker");
+    Ok(())
 }
 
 #[tokio::test]
-async fn test_command_picker_esc_clears() {
-    let terminal = TestTerminal::new(80, 24);
-    let mut renderer = Renderer::new(terminal, TEST_AGENT.to_string(), &[], (80, 24));
-    renderer.initial_render().unwrap();
+async fn test_command_picker_esc_clears() -> TestResult {
+    let mut renderer = RendererTest::new().size((80, 24)).build()?;
 
-    send_key(&mut renderer, KeyCode::Char('/'), KeyModifiers::empty()).await;
+    press(&mut renderer, KeyCode::Char('/')).await?;
     assert!(has_command_picker(renderer.writer()), "Command picker should be open");
 
-    send_key(&mut renderer, KeyCode::Esc, KeyModifiers::empty()).await;
+    press(&mut renderer, Esc).await?;
 
     assert!(!has_command_picker(renderer.writer()), "Esc should close command picker");
     let lines = renderer.writer().get_lines();
@@ -44,59 +39,53 @@ async fn test_command_picker_esc_clears() {
         "Input buffer should retain '/' after Esc (matches file picker behavior).\nBuffer:\n{}",
         lines.join("\n")
     );
+    Ok(())
 }
 
 #[tokio::test]
-async fn test_command_picker_backspace_empty_closes() {
-    let terminal = TestTerminal::new(80, 24);
-    let mut renderer = Renderer::new(terminal, TEST_AGENT.to_string(), &[], (80, 24));
-    renderer.initial_render().unwrap();
+async fn test_command_picker_backspace_empty_closes() -> TestResult {
+    let mut renderer = RendererTest::new().size((80, 24)).build()?;
 
-    send_key(&mut renderer, KeyCode::Char('/'), KeyModifiers::empty()).await;
+    press(&mut renderer, KeyCode::Char('/')).await?;
     assert!(has_command_picker(renderer.writer()), "Command picker should be open");
 
-    send_key(&mut renderer, KeyCode::Backspace, KeyModifiers::empty()).await;
+    press(&mut renderer, Backspace).await?;
 
     assert!(!has_command_picker(renderer.writer()), "Backspace on empty query should close command picker");
+    Ok(())
 }
 
 #[tokio::test]
-async fn test_available_commands_update_stored() {
-    let terminal = TestTerminal::new(80, 24);
-    let mut renderer = Renderer::new(terminal, TEST_AGENT.to_string(), &[], (80, 24));
-    renderer.initial_render().unwrap();
+async fn test_available_commands_update_stored() -> TestResult {
+    let mut renderer = RendererTest::new().size((80, 24)).build()?;
 
-    renderer
-        .on_session_update(acp::SessionUpdate::AvailableCommandsUpdate(acp::AvailableCommandsUpdate::new(vec![
-            acp::AvailableCommand::new("search", "Search code"),
-            acp::AvailableCommand::new("web", "Browse the web"),
-        ])))
-        .unwrap();
+    renderer.on_session_update(acp::SessionUpdate::AvailableCommandsUpdate(acp::AvailableCommandsUpdate::new(
+        vec![acp::AvailableCommand::new("search", "Search code"), acp::AvailableCommand::new("web", "Browse the web")],
+    )))?;
 
     // Open command picker and verify commands appear in rendered output
-    send_key(&mut renderer, KeyCode::Char('/'), KeyModifiers::empty()).await;
+    press(&mut renderer, KeyCode::Char('/')).await?;
 
     let names = command_picker_visible_names(renderer.writer());
     assert!(names.iter().any(|n| n == "search"), "Picker should show 'search' command. Got: {names:?}");
     assert!(names.iter().any(|n| n == "web"), "Picker should show 'web' command. Got: {names:?}");
+    Ok(())
 }
 
 #[tokio::test]
-async fn test_available_commands_update_extracts_hint() {
-    let terminal = TestTerminal::new(80, 24);
-    let mut renderer = Renderer::new(terminal, TEST_AGENT.to_string(), &[], (80, 24));
-    renderer.initial_render().unwrap();
+async fn test_available_commands_update_extracts_hint() -> TestResult {
+    let mut renderer = RendererTest::new().size((80, 24)).build()?;
 
-    renderer
-        .on_session_update(acp::SessionUpdate::AvailableCommandsUpdate(acp::AvailableCommandsUpdate::new(vec![
+    renderer.on_session_update(acp::SessionUpdate::AvailableCommandsUpdate(acp::AvailableCommandsUpdate::new(
+        vec![
             acp::AvailableCommand::new("search", "Search code")
                 .input(acp::AvailableCommandInput::Unstructured(acp::UnstructuredCommandInput::new("query pattern"))),
             acp::AvailableCommand::new("config", "Open settings"),
-        ])))
-        .unwrap();
+        ],
+    )))?;
 
     // Open command picker and verify the hint appears in rendered output
-    send_key(&mut renderer, KeyCode::Char('/'), KeyModifiers::empty()).await;
+    press(&mut renderer, KeyCode::Char('/')).await?;
 
     let lines = renderer.writer().get_lines();
     assert!(
@@ -104,36 +93,32 @@ async fn test_available_commands_update_extracts_hint() {
         "Hint text should appear in command picker.\nBuffer:\n{}",
         lines.join("\n")
     );
+    Ok(())
 }
 
 #[tokio::test]
-async fn test_command_picker_shows_mcp_commands() {
-    let terminal = TestTerminal::new(80, 24);
-    let mut renderer = Renderer::new(terminal, TEST_AGENT.to_string(), &[], (80, 24));
-    renderer.initial_render().unwrap();
+async fn test_command_picker_shows_mcp_commands() -> TestResult {
+    let mut renderer = RendererTest::new().size((80, 24)).build()?;
 
     // Feed available commands
-    renderer
-        .on_session_update(acp::SessionUpdate::AvailableCommandsUpdate(acp::AvailableCommandsUpdate::new(vec![
-            acp::AvailableCommand::new("search", "Search code"),
-        ])))
-        .unwrap();
+    renderer.on_session_update(acp::SessionUpdate::AvailableCommandsUpdate(acp::AvailableCommandsUpdate::new(
+        vec![acp::AvailableCommand::new("search", "Search code")],
+    )))?;
 
     // Open picker
-    send_key(&mut renderer, KeyCode::Char('/'), KeyModifiers::empty()).await;
+    press(&mut renderer, KeyCode::Char('/')).await?;
 
     let names = command_picker_visible_names(renderer.writer());
     assert!(names.iter().any(|n| n == "settings"), "Picker should include built-in settings command. Got: {names:?}");
     assert!(names.iter().any(|n| n == "search"), "Picker should include MCP search command. Got: {names:?}");
+    Ok(())
 }
 
 #[tokio::test]
-async fn test_command_picker_ctrl_c_exits() {
-    let terminal = TestTerminal::new(80, 24);
-    let mut renderer = Renderer::new(terminal, TEST_AGENT.to_string(), &[], (80, 24));
-    renderer.initial_render().unwrap();
+async fn test_command_picker_ctrl_c_exits() -> TestResult {
+    let mut renderer = RendererTest::new().size((80, 24)).build()?;
 
-    send_key(&mut renderer, KeyCode::Char('/'), KeyModifiers::empty()).await;
+    press(&mut renderer, KeyCode::Char('/')).await?;
     assert!(has_command_picker(renderer.writer()), "Command picker should be open");
 
     let action = renderer
@@ -143,8 +128,7 @@ async fn test_command_picker_ctrl_c_exits() {
             kind: KeyEventKind::Press,
             state: KeyEventState::empty(),
         })
-        .await
-        .unwrap();
+        .await?;
     assert!(matches!(action, LoopAction::Continue), "first Ctrl-C should not exit");
 
     let action = renderer
@@ -154,7 +138,7 @@ async fn test_command_picker_ctrl_c_exits() {
             kind: KeyEventKind::Press,
             state: KeyEventState::empty(),
         })
-        .await
-        .unwrap();
+        .await?;
     assert!(matches!(action, LoopAction::Exit), "second Ctrl-C should exit");
+    Ok(())
 }

--- a/crates/wisp/tests/app_tests/common.rs
+++ b/crates/wisp/tests/app_tests/common.rs
@@ -4,9 +4,10 @@ use acp_utils::notifications::{AetherCapabilities, WorkspaceListResponse};
 use acp_utils::notifications::{ElicitationParams, WorkspaceEntry};
 use acp_utils::notifications::{ElicitationResponse, WorkspaceMoveResponse};
 use agent_client_protocol::Responder;
-use agent_client_protocol::schema as acp;
+use agent_client_protocol::schema::{self as acp, AuthMethod, SessionCapabilities, SessionConfigOption};
 use std::path::PathBuf;
 use tokio::sync::mpsc::UnboundedReceiver;
+pub(super) use tui::KeyCode::{Backspace, Down, Enter, Esc, Up};
 use tui::Renderer as FrameRenderer;
 use tui::RendererCommand;
 use tui::Theme;
@@ -21,6 +22,9 @@ pub(super) const TEST_AGENT: &str = "test-agent";
 pub(super) const TEST_WIDTH: u16 = 200;
 pub(super) const TEST_WORKSPACE_DIR: &str = "~/code/foo";
 pub(super) const TEST_GIT_REF: &str = "main";
+
+/// Result type for tests and helpers so fallible operations propagate with `?` instead of panicking.
+pub(super) type TestResult<T = ()> = Result<T, Box<dyn std::error::Error>>;
 
 pub(super) fn test_workspace_status() -> WorkspaceStatus {
     WorkspaceStatus::new(TEST_WORKSPACE_DIR, Some(TEST_GIT_REF.to_string()))
@@ -102,178 +106,104 @@ pub(super) enum LoopAction {
 
 pub(super) struct Renderer {
     app: App,
-    frame_renderer: FrameRenderer<TestTerminal>,
+    frame: FrameRenderer<TestTerminal>,
+    commands: UnboundedReceiver<PromptCommand>,
 }
 
-struct RendererOptions<'a> {
-    terminal: TestTerminal,
-    agent_name: String,
-    config_options: &'a [acp::SessionConfigOption],
-    prompt_capabilities: acp::PromptCapabilities,
-    session_capabilities: acp::SessionCapabilities,
-    auth_methods: Vec<acp::AuthMethod>,
-    prompt_handle: AcpPromptHandle,
+#[must_use]
+pub(super) struct RendererTest {
     size: (u16, u16),
+    agent_name: String,
+    config_options: Vec<SessionConfigOption>,
+    session_capabilities: SessionCapabilities,
+    auth_methods: Vec<AuthMethod>,
 }
 
-impl Renderer {
-    pub(super) fn new(
-        terminal: TestTerminal,
-        agent_name: String,
-        config_options: &[acp::SessionConfigOption],
-        size: (u16, u16),
-    ) -> Self {
-        Self::new_with_auth_methods(terminal, agent_name, config_options, vec![], size)
+impl Default for RendererTest {
+    fn default() -> Self {
+        Self::new()
     }
+}
 
-    pub(super) fn new_with_auth_methods(
-        terminal: TestTerminal,
-        agent_name: String,
-        config_options: &[acp::SessionConfigOption],
-        auth_methods: Vec<acp::AuthMethod>,
-        size: (u16, u16),
-    ) -> Self {
-        Self::new_with_prompt_capabilities_and_auth_methods(
-            terminal,
-            agent_name,
-            config_options,
-            acp::PromptCapabilities::new(),
-            auth_methods,
-            size,
-        )
-    }
-
-    pub(super) fn new_with_prompt_capabilities(
-        terminal: TestTerminal,
-        agent_name: String,
-        prompt_capabilities: acp::PromptCapabilities,
-        size: (u16, u16),
-    ) -> Self {
-        Self::new_with_options(RendererOptions {
-            terminal,
-            agent_name,
-            config_options: &[],
-            prompt_capabilities,
-            session_capabilities: prompt_search_session_capabilities(),
-            auth_methods: vec![],
-            prompt_handle: AcpPromptHandle::noop(),
-            size,
-        })
-    }
-
-    pub(super) fn new_recording(
-        terminal: TestTerminal,
-        agent_name: String,
-        config_options: &[acp::SessionConfigOption],
-        size: (u16, u16),
-    ) -> (Self, UnboundedReceiver<PromptCommand>) {
-        Self::new_recording_with_session_capabilities(
-            terminal,
-            agent_name,
-            config_options,
-            preview_session_capabilities(),
-            size,
-        )
-    }
-
-    pub(super) fn new_without_session_preview(
-        terminal: TestTerminal,
-        agent_name: String,
-        config_options: &[acp::SessionConfigOption],
-        size: (u16, u16),
-    ) -> (Self, UnboundedReceiver<PromptCommand>) {
-        Self::new_recording_with_session_capabilities(
-            terminal,
-            agent_name,
-            config_options,
-            acp::SessionCapabilities::new(),
-            size,
-        )
-    }
-
-    pub(super) fn new_recording_with_session_capabilities(
-        terminal: TestTerminal,
-        agent_name: String,
-        config_options: &[acp::SessionConfigOption],
-        session_capabilities: acp::SessionCapabilities,
-        size: (u16, u16),
-    ) -> (Self, UnboundedReceiver<PromptCommand>) {
-        let (prompt_handle, rx) = AcpPromptHandle::recording();
-        let renderer = Self::new_with_options(RendererOptions {
-            terminal,
-            agent_name,
-            config_options,
-            prompt_capabilities: acp::PromptCapabilities::new(),
-            session_capabilities,
-            auth_methods: vec![],
-            prompt_handle,
-            size,
-        });
-        (renderer, rx)
-    }
-
-    fn new_with_prompt_capabilities_and_auth_methods(
-        terminal: TestTerminal,
-        agent_name: String,
-        config_options: &[acp::SessionConfigOption],
-        prompt_capabilities: acp::PromptCapabilities,
-        auth_methods: Vec<acp::AuthMethod>,
-        size: (u16, u16),
-    ) -> Self {
-        Self::new_with_options(RendererOptions {
-            terminal,
-            agent_name,
-            config_options,
-            prompt_capabilities,
+impl RendererTest {
+    pub(super) fn new() -> Self {
+        Self {
+            size: (TEST_WIDTH, 40),
+            agent_name: TEST_AGENT.to_string(),
+            config_options: Vec::new(),
             session_capabilities: preview_session_capabilities(),
-            auth_methods,
-            prompt_handle: AcpPromptHandle::noop(),
-            size,
-        })
+            auth_methods: Vec::new(),
+        }
     }
 
-    fn new_with_options(options: RendererOptions<'_>) -> Self {
-        let RendererOptions {
-            terminal,
-            agent_name,
-            config_options,
-            prompt_capabilities,
-            session_capabilities,
-            auth_methods,
-            prompt_handle,
-            size,
-        } = options;
+    pub(super) fn size(mut self, size: (u16, u16)) -> Self {
+        self.size = size;
+        self
+    }
+
+    pub(super) fn agent_name(mut self, agent_name: impl Into<String>) -> Self {
+        self.agent_name = agent_name.into();
+        self
+    }
+
+    pub(super) fn config_options(mut self, config_options: &[acp::SessionConfigOption]) -> Self {
+        self.config_options = config_options.to_vec();
+        self
+    }
+
+    pub(super) fn session_capabilities(mut self, session_capabilities: acp::SessionCapabilities) -> Self {
+        self.session_capabilities = session_capabilities;
+        self
+    }
+
+    pub(super) fn auth_methods(mut self, auth_methods: Vec<acp::AuthMethod>) -> Self {
+        self.auth_methods = auth_methods;
+        self
+    }
+
+    pub(super) fn build(self) -> TestResult<Renderer> {
+        let (prompt_handle, commands) = AcpPromptHandle::recording();
         let app = App::new(AppInfo {
             session_id: acp::SessionId::new("test"),
-            agent_name,
-            prompt_capabilities,
-            session_capabilities,
-            config_options: config_options.to_vec(),
-            auth_methods,
+            agent_name: self.agent_name,
+            prompt_capabilities: acp::PromptCapabilities::new(),
+            session_capabilities: self.session_capabilities,
+            config_options: self.config_options,
+            auth_methods: self.auth_methods,
             working_dir: PathBuf::from("."),
             workspace_status: test_workspace_status(),
             prompt_handle,
             settings: wisp::settings::WispSettings::default()
                 .with_default_status_line(wisp::settings::StatusLineSettings::defaults()),
         });
-        let frame_renderer = FrameRenderer::new(terminal, Theme::default(), size);
-        Self { app, frame_renderer }
+        let terminal = TestTerminal::new(self.size.0, self.size.1);
+        let frame = FrameRenderer::new(terminal, Theme::default(), self.size);
+        let mut renderer = Renderer { app, frame, commands };
+        renderer.initial_render()?;
+        Ok(renderer)
     }
+}
 
+impl Renderer {
     pub(super) fn needs_mouse_capture(&self) -> bool {
         self.app.needs_mouse_capture()
     }
 
     pub(super) fn writer(&self) -> &TestTerminal {
-        self.frame_renderer.writer()
+        self.frame.writer()
+    }
+
+    /// Prompt commands the app has dispatched, for tests that assert on dispatched commands.
+    pub(super) fn commands(&mut self) -> &mut UnboundedReceiver<PromptCommand> {
+        &mut self.commands
     }
 
     pub(super) fn test_writer_mut(&mut self) -> &mut TestTerminal {
-        self.frame_renderer.test_writer_mut()
+        self.frame.test_writer_mut()
     }
 
     pub(super) fn render(&mut self) -> std::io::Result<()> {
-        self.frame_renderer.render_frame(|ctx| self.app.render(ctx))
+        self.frame.render_frame(|ctx| self.app.render(ctx))
     }
 
     pub(super) fn initial_render(&mut self) -> std::io::Result<()> {
@@ -357,7 +287,7 @@ impl Renderer {
     }
 
     pub(super) async fn on_resize_event(&mut self, cols: u16, rows: u16) -> Result<(), Box<dyn std::error::Error>> {
-        self.frame_renderer.on_resize((cols, rows));
+        self.frame.on_resize((cols, rows));
         self.handle_terminal_event(Event::Resize((cols, rows).into())).await?;
         Ok(())
     }
@@ -482,14 +412,14 @@ impl Renderer {
         }
 
         if let EventOutcome::Render { commands } = outcome {
-            self.frame_renderer.apply_commands(commands)?;
+            self.frame.apply_commands(commands)?;
             self.render()?;
         }
         Ok(LoopAction::Continue)
     }
 
     fn drain_and_render(&mut self, commands: Vec<RendererCommand>) -> Result<LoopAction, Box<dyn std::error::Error>> {
-        self.frame_renderer.apply_commands(commands)?;
+        self.frame.apply_commands(commands)?;
 
         if self.app.exit_requested() {
             return Ok(LoopAction::Exit);
@@ -586,30 +516,20 @@ pub(super) fn command_picker_visible_names(terminal: &TestTerminal) -> Vec<Strin
     names
 }
 
-/// Build a renderer with the default test agent and config and run the initial frame so
-/// keystroke-driven tests start from a clean rendered state.
-pub(super) fn new_test_renderer(size: (u16, u16)) -> Renderer {
-    let terminal = TestTerminal::new(size.0, size.1);
-    let mut renderer = Renderer::new(terminal, TEST_AGENT.to_string(), &[], size);
-    renderer.initial_render().unwrap();
-    renderer
-}
-
-pub(super) fn render_with_size(events: Vec<TestEvent>, size: (u16, u16)) -> Renderer {
-    let terminal = TestTerminal::new(size.0, size.1);
-    let mut renderer = Renderer::new(terminal, TEST_AGENT.to_string(), &[], size);
+pub(super) fn render_with_size(events: Vec<TestEvent>, size: (u16, u16)) -> TestResult<Renderer> {
+    let mut renderer = RendererTest::new().size(size).build()?;
 
     for event in events {
         match event {
-            TestEvent::Update(update) => renderer.on_session_update(*update).unwrap(),
-            TestEvent::PromptDone => renderer.on_prompt_done().unwrap(),
+            TestEvent::Update(update) => renderer.on_session_update(*update)?,
+            TestEvent::PromptDone => renderer.on_prompt_done()?,
         }
     }
 
-    renderer
+    Ok(renderer)
 }
 
-pub(super) fn render(events: Vec<TestEvent>) -> Renderer {
+pub(super) fn render(events: Vec<TestEvent>) -> TestResult<Renderer> {
     render_with_size(events, (TEST_WIDTH, 40))
 }
 
@@ -677,7 +597,7 @@ pub(super) fn tool_update_with_args(id: &str, args: &str) -> TestEvent {
     ))))
 }
 
-pub(super) async fn type_string(renderer: &mut Renderer, text: &str) {
+pub(super) async fn type_string(renderer: &mut Renderer, text: &str) -> TestResult {
     for ch in text.chars() {
         let key_event = KeyEvent {
             code: KeyCode::Char(ch),
@@ -685,39 +605,24 @@ pub(super) async fn type_string(renderer: &mut Renderer, text: &str) {
             kind: KeyEventKind::Press,
             state: KeyEventState::empty(),
         };
-        renderer.on_key_event(key_event).await.unwrap();
+        renderer.on_key_event(key_event).await?;
     }
+    Ok(())
 }
 
-pub(super) async fn press_enter(renderer: &mut Renderer) {
-    let enter_event = KeyEvent {
-        code: KeyCode::Enter,
-        modifiers: KeyModifiers::empty(),
-        kind: KeyEventKind::Press,
-        state: KeyEventState::empty(),
-    };
-    renderer.on_key_event(enter_event).await.unwrap();
+pub(super) async fn press(renderer: &mut Renderer, code: KeyCode) -> TestResult {
+    press_with_modifiers(renderer, code, KeyModifiers::empty()).await
 }
 
-pub(super) async fn press_shift_enter(renderer: &mut Renderer) {
-    send_key(renderer, KeyCode::Enter, KeyModifiers::SHIFT).await;
-}
-
-pub(super) async fn press_backspace(renderer: &mut Renderer) {
-    let backspace_event = KeyEvent {
-        code: KeyCode::Backspace,
-        modifiers: KeyModifiers::empty(),
-        kind: KeyEventKind::Press,
-        state: KeyEventState::empty(),
-    };
-    renderer.on_key_event(backspace_event).await.unwrap();
-}
-
-pub(super) async fn send_key(renderer: &mut Renderer, code: KeyCode, modifiers: KeyModifiers) {
+pub(super) async fn press_with_modifiers(
+    renderer: &mut Renderer,
+    code: KeyCode,
+    modifiers: KeyModifiers,
+) -> TestResult {
     renderer
         .on_key_event(KeyEvent { code, modifiers, kind: KeyEventKind::Press, state: KeyEventState::empty() })
-        .await
-        .unwrap();
+        .await?;
+    Ok(())
 }
 
 pub(super) fn make_settings_options() -> Vec<acp::SessionConfigOption> {
@@ -742,33 +647,30 @@ pub(super) fn make_settings_options() -> Vec<acp::SessionConfigOption> {
 }
 
 /// Create a renderer with settings options and open the settings menu.
-pub(super) async fn open_settings(config_options: &[acp::SessionConfigOption], size: (u16, u16)) -> Renderer {
-    let terminal = TestTerminal::new(size.0, size.1);
-    let mut renderer = Renderer::new(terminal, TEST_AGENT.to_string(), config_options, size);
-    renderer.initial_render().unwrap();
-    type_string(&mut renderer, "/settings").await;
-    press_enter(&mut renderer).await;
-    renderer
+pub(super) async fn open_settings(
+    config_options: &[acp::SessionConfigOption],
+    size: (u16, u16),
+) -> TestResult<Renderer> {
+    let mut renderer = RendererTest::new().size(size).config_options(config_options).build()?;
+    type_string(&mut renderer, "/settings").await?;
+    press(&mut renderer, Enter).await?;
+    Ok(renderer)
 }
 
-pub(super) async fn press_down(renderer: &mut Renderer) {
-    send_key(renderer, KeyCode::Down, KeyModifiers::empty()).await;
+pub(super) async fn open_resume_picker(renderer: &mut Renderer) -> TestResult {
+    type_string(renderer, "/resume").await?;
+    press(renderer, Enter).await
 }
 
-pub(super) async fn press_up(renderer: &mut Renderer) {
-    send_key(renderer, KeyCode::Up, KeyModifiers::empty()).await;
-}
-
-pub(super) async fn press_esc(renderer: &mut Renderer) {
-    send_key(renderer, KeyCode::Esc, KeyModifiers::empty()).await;
-}
-
-pub(super) async fn load_session_via_picker(renderer: &mut Renderer, session_id: acp::SessionId, cwd: PathBuf) {
-    type_string(renderer, "/resume").await;
-    press_enter(renderer).await;
+pub(super) async fn load_session_via_picker(
+    renderer: &mut Renderer,
+    session_id: acp::SessionId,
+    cwd: PathBuf,
+) -> TestResult {
+    open_resume_picker(renderer).await?;
     let info = acp::SessionInfo::new(session_id, cwd).title("Resumable session".to_string());
-    renderer.on_sessions_listed(vec![info]).unwrap();
-    press_enter(renderer).await;
+    renderer.on_sessions_listed(vec![info])?;
+    press(renderer, Enter).await
 }
 
 /// Assert that any terminal line contains the given text, panicking with a buffer dump.

--- a/crates/wisp/tests/app_tests/file_picker_tests.rs
+++ b/crates/wisp/tests/app_tests/file_picker_tests.rs
@@ -1,13 +1,10 @@
-use tui::testing::TestTerminal;
 use tui::{KeyCode, KeyEvent, KeyEventKind, KeyEventState, KeyModifiers};
 
 use super::common::*;
 
 #[tokio::test]
-async fn test_ctrl_c_exits_while_file_picker_is_open() {
-    let terminal = TestTerminal::new(80, 24);
-    let mut renderer = Renderer::new(terminal, TEST_AGENT.to_string(), &[], (80, 24));
-    renderer.initial_render().unwrap();
+async fn test_ctrl_c_exits_while_file_picker_is_open() -> TestResult {
+    let mut renderer = RendererTest::new().size((80, 24)).build()?;
 
     renderer
         .on_key_event(KeyEvent {
@@ -16,8 +13,7 @@ async fn test_ctrl_c_exits_while_file_picker_is_open() {
             kind: KeyEventKind::Press,
             state: KeyEventState::empty(),
         })
-        .await
-        .unwrap();
+        .await?;
     assert!(has_file_picker(renderer.writer()), "File picker should be open after typing @");
 
     let action = renderer
@@ -27,17 +23,15 @@ async fn test_ctrl_c_exits_while_file_picker_is_open() {
             kind: KeyEventKind::Press,
             state: KeyEventState::empty(),
         })
-        .await
-        .unwrap();
+        .await?;
 
     assert!(matches!(action, LoopAction::Exit));
+    Ok(())
 }
 
 #[tokio::test]
-async fn test_space_closes_file_picker_without_selection() {
-    let terminal = TestTerminal::new(80, 24);
-    let mut renderer = Renderer::new(terminal, TEST_AGENT.to_string(), &[], (80, 24));
-    renderer.initial_render().unwrap();
+async fn test_space_closes_file_picker_without_selection() -> TestResult {
+    let mut renderer = RendererTest::new().size((80, 24)).build()?;
 
     renderer
         .on_key_event(KeyEvent {
@@ -46,8 +40,7 @@ async fn test_space_closes_file_picker_without_selection() {
             kind: KeyEventKind::Press,
             state: KeyEventState::empty(),
         })
-        .await
-        .unwrap();
+        .await?;
     assert!(has_file_picker(renderer.writer()), "File picker should be open");
 
     renderer
@@ -57,8 +50,8 @@ async fn test_space_closes_file_picker_without_selection() {
             kind: KeyEventKind::Press,
             state: KeyEventState::empty(),
         })
-        .await
-        .unwrap();
+        .await?;
 
     assert!(!has_file_picker(renderer.writer()), "File picker should be closed");
+    Ok(())
 }

--- a/crates/wisp/tests/app_tests/git_diff_tests.rs
+++ b/crates/wisp/tests/app_tests/git_diff_tests.rs
@@ -1,49 +1,47 @@
-use tui::testing::TestTerminal;
 use tui::{KeyCode, KeyModifiers};
 
 use super::common::*;
 
 #[tokio::test]
-async fn ctrl_g_toggles_git_diff_and_mouse_capture() {
-    let terminal = TestTerminal::new(TEST_WIDTH, 40);
-    let mut renderer = Renderer::new(terminal, TEST_AGENT.to_string(), &[], (TEST_WIDTH, 40));
-    renderer.initial_render().unwrap();
+async fn ctrl_g_toggles_git_diff_and_mouse_capture() -> TestResult {
+    let mut renderer = RendererTest::new().size((TEST_WIDTH, 40)).build()?;
 
     assert!(!renderer.needs_mouse_capture());
 
-    send_key(&mut renderer, KeyCode::Char('g'), KeyModifiers::CONTROL).await;
+    press_with_modifiers(&mut renderer, KeyCode::Char('g'), KeyModifiers::CONTROL).await?;
     assert!(renderer.needs_mouse_capture(), "git diff mode should capture mouse input");
 
-    send_key(&mut renderer, KeyCode::Char('g'), KeyModifiers::CONTROL).await;
+    press_with_modifiers(&mut renderer, KeyCode::Char('g'), KeyModifiers::CONTROL).await?;
     assert!(!renderer.needs_mouse_capture(), "closing git diff should release mouse capture");
+    Ok(())
 }
 
 #[tokio::test]
-async fn ctrl_g_is_ignored_while_modal_is_open() {
-    let mut renderer = open_settings(&make_settings_options(), (TEST_WIDTH, 40)).await;
+async fn ctrl_g_is_ignored_while_modal_is_open() -> TestResult {
+    let mut renderer = open_settings(&make_settings_options(), (TEST_WIDTH, 40)).await?;
     assert!(has_settings_menu(renderer.writer()), "settings menu should be visible");
 
-    send_key(&mut renderer, KeyCode::Char('g'), KeyModifiers::CONTROL).await;
+    press_with_modifiers(&mut renderer, KeyCode::Char('g'), KeyModifiers::CONTROL).await?;
 
     assert!(has_settings_menu(renderer.writer()), "settings menu should remain visible");
     assert!(renderer.needs_mouse_capture(), "modal should continue capturing mouse input");
+    Ok(())
 }
 
 #[tokio::test]
-async fn esc_in_git_diff_does_not_cancel_waiting_prompt() {
-    let terminal = TestTerminal::new(TEST_WIDTH, 40);
-    let mut renderer = Renderer::new(terminal, TEST_AGENT.to_string(), &[], (TEST_WIDTH, 40));
-    renderer.initial_render().unwrap();
+async fn esc_in_git_diff_does_not_cancel_waiting_prompt() -> TestResult {
+    let mut renderer = RendererTest::new().size((TEST_WIDTH, 40)).build()?;
 
-    type_string(&mut renderer, "hello").await;
-    press_enter(&mut renderer).await;
+    type_string(&mut renderer, "hello").await?;
+    press(&mut renderer, Enter).await?;
     assert_buffer_contains(renderer.writer(), "esc to interrupt");
 
-    send_key(&mut renderer, KeyCode::Char('g'), KeyModifiers::CONTROL).await;
+    press_with_modifiers(&mut renderer, KeyCode::Char('g'), KeyModifiers::CONTROL).await?;
     assert!(renderer.needs_mouse_capture(), "git diff should be active");
 
-    press_esc(&mut renderer).await;
+    press(&mut renderer, Esc).await?;
 
     assert!(!renderer.needs_mouse_capture(), "Esc in git diff should close diff mode");
     assert_buffer_contains(renderer.writer(), "esc to interrupt");
+    Ok(())
 }

--- a/crates/wisp/tests/app_tests/input_prompt_tests.rs
+++ b/crates/wisp/tests/app_tests/input_prompt_tests.rs
@@ -1,4 +1,4 @@
-use tui::testing::{TestTerminal, assert_buffer_eq};
+use tui::testing::assert_buffer_eq;
 use tui::{KeyCode, KeyEvent, KeyEventKind, KeyEventState, KeyModifiers};
 
 use super::common::*;
@@ -17,72 +17,61 @@ fn expected_multiline_prompt(width: u16, lines: &[&str]) -> Vec<String> {
 }
 
 #[tokio::test]
-async fn test_user_message_submission() {
-    let terminal = TestTerminal::new(TEST_WIDTH, 40);
-    let mut renderer = Renderer::new(terminal, TEST_AGENT.to_string(), &[], (TEST_WIDTH, 40));
+async fn test_user_message_submission() -> TestResult {
+    let mut renderer = RendererTest::new().size((TEST_WIDTH, 40)).build()?;
 
-    renderer.initial_render().unwrap();
-
-    type_string(&mut renderer, "Hello world").await;
-    press_enter(&mut renderer).await;
+    type_string(&mut renderer, "Hello world").await?;
+    press(&mut renderer, Enter).await?;
 
     // Simulate the agent finishing so the grid loader clears
-    renderer.on_prompt_done().unwrap();
+    renderer.on_prompt_done()?;
 
     let expected = expected_with_prompt(&["", &p("Hello world"), ""], TEST_WIDTH, "", TEST_AGENT);
     assert_buffer_eq(renderer.writer(), &expected);
+    Ok(())
 }
 
 #[tokio::test]
-async fn prompt_done_bells_after_submitted_prompt_without_changing_buffer() {
-    let terminal = TestTerminal::new(TEST_WIDTH, 40);
-    let mut renderer = Renderer::new(terminal, TEST_AGENT.to_string(), &[], (TEST_WIDTH, 40));
-
-    renderer.initial_render().unwrap();
-    type_string(&mut renderer, "Hello world").await;
-    press_enter(&mut renderer).await;
+async fn prompt_done_bells_after_submitted_prompt_without_changing_buffer() -> TestResult {
+    let mut renderer = RendererTest::new().size((TEST_WIDTH, 40)).build()?;
+    type_string(&mut renderer, "Hello world").await?;
+    press(&mut renderer, Enter).await?;
     assert_eq!(renderer.writer().bell_count(), 0);
 
-    renderer.on_prompt_done().unwrap();
+    renderer.on_prompt_done()?;
     assert_eq!(renderer.writer().bell_count(), 1);
+    Ok(())
 }
 
 #[tokio::test]
-async fn test_typing_renders_within_bordered_input() {
-    let terminal = TestTerminal::new(80, 24);
-    let mut renderer = Renderer::new(terminal, TEST_AGENT.to_string(), &[], (80, 24));
+async fn test_typing_renders_within_bordered_input() -> TestResult {
+    let mut renderer = RendererTest::new().size((80, 24)).build()?;
 
-    renderer.initial_render().unwrap();
-
-    type_string(&mut renderer, "hello").await;
+    type_string(&mut renderer, "hello").await?;
 
     let expected = expected_prompt(80, "hello", TEST_AGENT);
     assert_buffer_eq(renderer.writer(), &expected);
+    Ok(())
 }
 
 #[tokio::test]
-async fn test_backspace_updates_within_border() {
-    let terminal = TestTerminal::new(80, 24);
-    let mut renderer = Renderer::new(terminal, TEST_AGENT.to_string(), &[], (80, 24));
+async fn test_backspace_updates_within_border() -> TestResult {
+    let mut renderer = RendererTest::new().size((80, 24)).build()?;
 
-    renderer.initial_render().unwrap();
-
-    type_string(&mut renderer, "hello").await;
-    press_backspace(&mut renderer).await;
+    type_string(&mut renderer, "hello").await?;
+    press(&mut renderer, Backspace).await?;
 
     let expected = expected_prompt(80, "hell", TEST_AGENT);
     assert_buffer_eq(renderer.writer(), &expected);
+    Ok(())
 }
 
 #[tokio::test]
-async fn test_wrapped_input_prompt_rerender_has_single_prompt() {
-    let terminal = TestTerminal::new(32, 24);
-    let mut renderer = Renderer::new(terminal, TEST_AGENT.to_string(), &[], (32, 24));
-
-    renderer.initial_render().unwrap();
-    type_string(&mut renderer, "this input prompt is long enough to wrap across multiple rows").await;
-    press_backspace(&mut renderer).await;
-    press_backspace(&mut renderer).await;
+async fn test_wrapped_input_prompt_rerender_has_single_prompt() -> TestResult {
+    let mut renderer = RendererTest::new().size((32, 24)).build()?;
+    type_string(&mut renderer, "this input prompt is long enough to wrap across multiple rows").await?;
+    press(&mut renderer, Backspace).await?;
+    press(&mut renderer, Backspace).await?;
 
     let lines = renderer.writer().get_lines();
     let rule = "─".repeat(32);
@@ -96,19 +85,18 @@ async fn test_wrapped_input_prompt_rerender_has_single_prompt() {
         lines.join("\n")
     );
     assert!(content_rows >= 2, "Expected wrapped prompt content rows.\nBuffer:\n{}", lines.join("\n"));
+    Ok(())
 }
 
 #[tokio::test]
-async fn test_resize_after_terminal_reflow_keeps_single_prompt() {
-    let terminal = TestTerminal::new(80, 24);
-    let mut renderer = Renderer::new(terminal, TEST_AGENT.to_string(), &[], (80, 24));
-    renderer.initial_render().unwrap();
+async fn test_resize_after_terminal_reflow_keeps_single_prompt() -> TestResult {
+    let mut renderer = RendererTest::new().size((80, 24)).build()?;
 
     let input = "this input prompt is long enough to wrap across multiple rows and should reflow cleanly on resize";
-    type_string(&mut renderer, input).await;
+    type_string(&mut renderer, input).await?;
 
     renderer.test_writer_mut().resize_preserving_transcript(32, 24);
-    renderer.on_resize_event(32, 24).await.unwrap();
+    renderer.on_resize_event(32, 24).await?;
 
     let lines = renderer.writer().get_lines();
     let rule = "─".repeat(32);
@@ -126,48 +114,43 @@ async fn test_resize_after_terminal_reflow_keeps_single_prompt() {
         "Expected wrapped prompt content rows after resize reflow.\nBuffer:\n{}",
         lines.join("\n")
     );
+    Ok(())
 }
 
 #[tokio::test]
-async fn test_empty_prompt_renders_bordered_box() {
-    let terminal = TestTerminal::new(80, 24);
-    let mut renderer = Renderer::new(terminal, TEST_AGENT.to_string(), &[], (80, 24));
-
-    renderer.initial_render().unwrap();
+async fn test_empty_prompt_renders_bordered_box() -> TestResult {
+    let renderer = RendererTest::new().size((80, 24)).build()?;
 
     let expected = expected_prompt(80, "", TEST_AGENT);
     assert_buffer_eq(renderer.writer(), &expected);
+    Ok(())
 }
 
 #[tokio::test]
-async fn test_paste_inserts_all_text_at_once() {
-    let terminal = TestTerminal::new(80, 24);
-    let mut renderer = Renderer::new(terminal, TEST_AGENT.to_string(), &[], (80, 24));
-    renderer.initial_render().unwrap();
+async fn test_paste_inserts_all_text_at_once() -> TestResult {
+    let mut renderer = RendererTest::new().size((80, 24)).build()?;
 
-    renderer.on_paste("hello world").await.unwrap();
+    renderer.on_paste("hello world").await?;
 
     let expected = expected_prompt(80, "hello world", TEST_AGENT);
     assert_buffer_eq(renderer.writer(), &expected);
+    Ok(())
 }
 
 #[tokio::test]
-async fn test_paste_strips_control_characters() {
-    let terminal = TestTerminal::new(80, 24);
-    let mut renderer = Renderer::new(terminal, TEST_AGENT.to_string(), &[], (80, 24));
-    renderer.initial_render().unwrap();
+async fn test_paste_strips_control_characters() -> TestResult {
+    let mut renderer = RendererTest::new().size((80, 24)).build()?;
 
-    renderer.on_paste("line1\nline2\ttab").await.unwrap();
+    renderer.on_paste("line1\nline2\ttab").await?;
 
     let expected = expected_prompt(80, "line1line2tab", TEST_AGENT);
     assert_buffer_eq(renderer.writer(), &expected);
+    Ok(())
 }
 
 #[tokio::test]
-async fn test_paste_closes_file_picker() {
-    let terminal = TestTerminal::new(80, 24);
-    let mut renderer = Renderer::new(terminal, TEST_AGENT.to_string(), &[], (80, 24));
-    renderer.initial_render().unwrap();
+async fn test_paste_closes_file_picker() -> TestResult {
+    let mut renderer = RendererTest::new().size((80, 24)).build()?;
 
     // Open file picker with @
     renderer
@@ -177,26 +160,24 @@ async fn test_paste_closes_file_picker() {
             kind: KeyEventKind::Press,
             state: KeyEventState::empty(),
         })
-        .await
-        .unwrap();
+        .await?;
     assert!(has_file_picker(renderer.writer()), "File picker should be open");
 
     // Paste should close the picker and append text
-    renderer.on_paste("pasted text").await.unwrap();
+    renderer.on_paste("pasted text").await?;
 
     assert!(!has_file_picker(renderer.writer()), "File picker should be closed");
     let expected = expected_prompt(80, "@pasted text", TEST_AGENT);
     assert_buffer_eq(renderer.writer(), &expected);
+    Ok(())
 }
 
 #[tokio::test]
-async fn test_cursor_position_after_whitespace_wrap() {
+async fn test_cursor_position_after_whitespace_wrap() -> TestResult {
     let width: u16 = 12;
-    let terminal = TestTerminal::new(width, 24);
-    let mut renderer = Renderer::new(terminal, TEST_AGENT.to_string(), &[], (width, 24));
-    renderer.initial_render().unwrap();
+    let mut renderer = RendererTest::new().size((width, 24)).build()?;
 
-    type_string(&mut renderer, "abc def ghi").await;
+    type_string(&mut renderer, "abc def ghi").await?;
 
     let rule = "─".repeat(width as usize);
     let mut expected = vec![rule.clone(), "> abc def".to_string(), "  ghi".to_string(), rule.clone()];
@@ -207,7 +188,7 @@ async fn test_cursor_position_after_whitespace_wrap() {
     assert_eq!(cursor_row, 2, "cursor should be on the second content row (row 2)");
     assert_eq!(cursor_col, 5, "cursor should be at col 5 (2 prefix + 3 for 'ghi')");
 
-    type_string(&mut renderer, "j").await;
+    type_string(&mut renderer, "j").await?;
 
     let mut expected_after = vec![rule.clone(), "> abc def".to_string(), "  ghij".to_string(), rule];
     expected_after.extend(expected_status_line_rows(width, TEST_AGENT));
@@ -216,16 +197,15 @@ async fn test_cursor_position_after_whitespace_wrap() {
     let (cursor_col_after, cursor_row_after) = renderer.writer().cursor_position();
     assert_eq!(cursor_row_after, 2, "cursor should stay on the second content row after typing 'j'");
     assert_eq!(cursor_col_after, 6, "cursor should advance to col 6 (2 prefix + 4 for 'ghij')");
+    Ok(())
 }
 
 #[tokio::test]
-async fn test_cursor_position_after_multi_mention_wrap() {
+async fn test_cursor_position_after_multi_mention_wrap() -> TestResult {
     let width: u16 = 12;
-    let terminal = TestTerminal::new(width, 24);
-    let mut renderer = Renderer::new(terminal, TEST_AGENT.to_string(), &[], (width, 24));
-    renderer.initial_render().unwrap();
+    let mut renderer = RendererTest::new().size((width, 24)).build()?;
 
-    type_string(&mut renderer, "@aaaaa @bbbbbb").await;
+    type_string(&mut renderer, "@aaaaa @bbbbbb").await?;
 
     let rule = "─".repeat(width as usize);
     let lines = renderer.writer().get_lines();
@@ -235,17 +215,16 @@ async fn test_cursor_position_after_multi_mention_wrap() {
     let (cursor_col, cursor_row) = renderer.writer().cursor_position();
     assert_eq!(cursor_row, 2, "cursor should be on the second content row (row 2)");
     assert_eq!(cursor_col, 9, "cursor should be at col 9 (2 prefix + 7 for '@bbbbbb')");
+    Ok(())
 }
 
 #[tokio::test]
-async fn test_shift_enter_creates_hard_line_break() {
-    let terminal = TestTerminal::new(80, 24);
-    let mut renderer = Renderer::new(terminal, TEST_AGENT.to_string(), &[], (80, 24));
-    renderer.initial_render().unwrap();
+async fn test_shift_enter_creates_hard_line_break() -> TestResult {
+    let mut renderer = RendererTest::new().size((80, 24)).build()?;
 
-    type_string(&mut renderer, "line one").await;
-    press_shift_enter(&mut renderer).await;
-    type_string(&mut renderer, "line two").await;
+    type_string(&mut renderer, "line one").await?;
+    press_with_modifiers(&mut renderer, Enter, KeyModifiers::SHIFT).await?;
+    type_string(&mut renderer, "line two").await?;
 
     let expected = expected_multiline_prompt(80, &["line one", "line two"]);
     assert_buffer_eq(renderer.writer(), &expected);
@@ -253,87 +232,83 @@ async fn test_shift_enter_creates_hard_line_break() {
     let (cursor_col, cursor_row) = renderer.writer().cursor_position();
     assert_eq!(cursor_row, 2);
     assert_eq!(cursor_col, 10);
+    Ok(())
 }
 
 #[tokio::test]
-async fn test_alt_enter_creates_hard_line_break() {
-    let terminal = TestTerminal::new(80, 24);
-    let mut renderer = Renderer::new(terminal, TEST_AGENT.to_string(), &[], (80, 24));
-    renderer.initial_render().unwrap();
+async fn test_alt_enter_creates_hard_line_break() -> TestResult {
+    let mut renderer = RendererTest::new().size((80, 24)).build()?;
 
-    type_string(&mut renderer, "hello").await;
-    send_key(&mut renderer, KeyCode::Enter, KeyModifiers::ALT).await;
+    type_string(&mut renderer, "hello").await?;
+    press_with_modifiers(&mut renderer, Enter, KeyModifiers::ALT).await?;
 
     let expected = expected_multiline_prompt(80, &["hello", ""]);
     assert_buffer_eq(renderer.writer(), &expected);
     assert_eq!(renderer.writer().cursor_position(), (2, 2));
+    Ok(())
 }
 
 #[tokio::test]
-async fn test_alt_enter_closes_command_picker_and_inserts_newline() {
-    let terminal = TestTerminal::new(80, 24);
-    let mut renderer = Renderer::new(terminal, TEST_AGENT.to_string(), &[], (80, 24));
-    renderer.initial_render().unwrap();
+async fn test_alt_enter_closes_command_picker_and_inserts_newline() -> TestResult {
+    let mut renderer = RendererTest::new().size((80, 24)).build()?;
 
-    type_string(&mut renderer, "/").await;
+    type_string(&mut renderer, "/").await?;
     assert!(has_command_picker(renderer.writer()));
-    send_key(&mut renderer, KeyCode::Enter, KeyModifiers::ALT).await;
+    press_with_modifiers(&mut renderer, Enter, KeyModifiers::ALT).await?;
 
     let expected = expected_multiline_prompt(80, &["/", ""]);
     assert_buffer_eq(renderer.writer(), &expected);
+    Ok(())
 }
 
 #[tokio::test]
-async fn test_up_arrow_moves_cursor_across_hard_newline() {
-    let terminal = TestTerminal::new(80, 24);
-    let mut renderer = Renderer::new(terminal, TEST_AGENT.to_string(), &[], (80, 24));
-    renderer.initial_render().unwrap();
+async fn test_up_arrow_moves_cursor_across_hard_newline() -> TestResult {
+    let mut renderer = RendererTest::new().size((80, 24)).build()?;
 
-    type_string(&mut renderer, "line one").await;
-    press_shift_enter(&mut renderer).await;
-    type_string(&mut renderer, "line two").await;
-    press_up(&mut renderer).await;
-    type_string(&mut renderer, "!").await;
+    type_string(&mut renderer, "line one").await?;
+    press_with_modifiers(&mut renderer, Enter, KeyModifiers::SHIFT).await?;
+    type_string(&mut renderer, "line two").await?;
+    press(&mut renderer, Up).await?;
+    type_string(&mut renderer, "!").await?;
 
     let expected = expected_multiline_prompt(80, &["line one!", "line two"]);
     assert_buffer_eq(renderer.writer(), &expected);
     assert_eq!(renderer.writer().cursor_position(), (11, 1));
+    Ok(())
 }
 
 #[tokio::test]
-async fn test_down_arrow_moves_cursor_across_hard_newline() {
-    let terminal = TestTerminal::new(80, 24);
-    let mut renderer = Renderer::new(terminal, TEST_AGENT.to_string(), &[], (80, 24));
-    renderer.initial_render().unwrap();
+async fn test_down_arrow_moves_cursor_across_hard_newline() -> TestResult {
+    let mut renderer = RendererTest::new().size((80, 24)).build()?;
 
-    type_string(&mut renderer, "line one").await;
-    press_shift_enter(&mut renderer).await;
-    type_string(&mut renderer, "line two").await;
-    press_up(&mut renderer).await;
-    press_down(&mut renderer).await;
-    type_string(&mut renderer, "!").await;
+    type_string(&mut renderer, "line one").await?;
+    press_with_modifiers(&mut renderer, Enter, KeyModifiers::SHIFT).await?;
+    type_string(&mut renderer, "line two").await?;
+    press(&mut renderer, Up).await?;
+    press(&mut renderer, Down).await?;
+    type_string(&mut renderer, "!").await?;
 
     let expected = expected_multiline_prompt(80, &["line one", "line two!"]);
     assert_buffer_eq(renderer.writer(), &expected);
     assert_eq!(renderer.writer().cursor_position(), (11, 2));
+    Ok(())
 }
 
 #[tokio::test]
-async fn test_ctrl_a_and_ctrl_e_move_within_hard_newline() {
-    let terminal = TestTerminal::new(80, 24);
-    let mut renderer = Renderer::new(terminal, TEST_AGENT.to_string(), &[], (80, 24));
-    renderer.initial_render().unwrap();
+async fn test_ctrl_a_and_ctrl_e_move_within_hard_newline() -> TestResult {
+    let mut renderer = RendererTest::new().size((80, 24)).build()?;
 
-    type_string(&mut renderer, "line one").await;
-    press_shift_enter(&mut renderer).await;
-    type_string(&mut renderer, "line two").await;
+    type_string(&mut renderer, "line one").await?;
+    press_with_modifiers(&mut renderer, Enter, KeyModifiers::SHIFT).await?;
+    type_string(&mut renderer, "line two").await?;
 
-    send_key(&mut renderer, KeyCode::Char('a'), KeyModifiers::CONTROL).await;
-    type_string(&mut renderer, "[").await;
-    send_key(&mut renderer, KeyCode::Char('e'), KeyModifiers::CONTROL).await;
-    type_string(&mut renderer, "]").await;
+    press_with_modifiers(&mut renderer, KeyCode::Char('a'), KeyModifiers::CONTROL).await?;
+    type_string(&mut renderer, "[").await?;
+    press_with_modifiers(&mut renderer, KeyCode::Char('e'), KeyModifiers::CONTROL).await?;
+    type_string(&mut renderer, "]").await?;
 
     let expected = expected_multiline_prompt(80, &["line one", "[line two]"]);
     assert_buffer_eq(renderer.writer(), &expected);
     assert_eq!(renderer.writer().cursor_position(), (12, 2));
+    Ok(())
 }

--- a/crates/wisp/tests/app_tests/lifecycle_tests.rs
+++ b/crates/wisp/tests/app_tests/lifecycle_tests.rs
@@ -1,57 +1,52 @@
-use tui::testing::TestTerminal;
 use tui::{KeyCode, KeyEvent, KeyModifiers};
 
 use super::common::*;
 
 #[tokio::test]
-async fn test_connection_closed_exits() {
-    let terminal = TestTerminal::new(TEST_WIDTH, 40);
-    let mut renderer = Renderer::new(terminal, TEST_AGENT.to_string(), &[], (TEST_WIDTH, 40));
-    renderer.initial_render().unwrap();
+async fn test_connection_closed_exits() -> TestResult {
+    let mut renderer = RendererTest::new().size((TEST_WIDTH, 40)).build()?;
 
-    let action = renderer.on_connection_closed().unwrap();
+    let action = renderer.on_connection_closed()?;
     assert!(matches!(action, LoopAction::Exit));
+    Ok(())
 }
 
 #[tokio::test]
-async fn test_ctrl_c_emits_exit() {
-    let terminal = TestTerminal::new(TEST_WIDTH, 40);
-    let mut renderer = Renderer::new(terminal, TEST_AGENT.to_string(), &[], (TEST_WIDTH, 40));
-    renderer.initial_render().unwrap();
+async fn test_ctrl_c_emits_exit() -> TestResult {
+    let mut renderer = RendererTest::new().size((TEST_WIDTH, 40)).build()?;
 
-    let action = renderer.on_key_event(KeyEvent::new(KeyCode::Char('c'), KeyModifiers::CONTROL)).await.unwrap();
+    let action = renderer.on_key_event(KeyEvent::new(KeyCode::Char('c'), KeyModifiers::CONTROL)).await?;
     assert!(matches!(action, LoopAction::Continue), "first Ctrl-C should not exit");
 
-    let action = renderer.on_key_event(KeyEvent::new(KeyCode::Char('c'), KeyModifiers::CONTROL)).await.unwrap();
+    let action = renderer.on_key_event(KeyEvent::new(KeyCode::Char('c'), KeyModifiers::CONTROL)).await?;
     assert!(matches!(action, LoopAction::Exit), "second Ctrl-C should exit");
+    Ok(())
 }
 
 #[tokio::test]
-async fn test_escape_while_waiting_emits_cancel() {
-    let terminal = TestTerminal::new(TEST_WIDTH, 40);
-    let mut renderer = Renderer::new(terminal, TEST_AGENT.to_string(), &[], (TEST_WIDTH, 40));
-    renderer.initial_render().unwrap();
+async fn test_escape_while_waiting_emits_cancel() -> TestResult {
+    let mut renderer = RendererTest::new().size((TEST_WIDTH, 40)).build()?;
 
     // Submit a prompt to enter waiting state
-    type_string(&mut renderer, "Hello").await;
-    press_enter(&mut renderer).await;
+    type_string(&mut renderer, "Hello").await?;
+    press(&mut renderer, Enter).await?;
 
     // Press Escape while waiting — should cancel
-    let action = renderer.on_key_event(KeyEvent::new(KeyCode::Esc, KeyModifiers::NONE)).await.unwrap();
+    let action = renderer.on_key_event(KeyEvent::new(KeyCode::Esc, KeyModifiers::NONE)).await?;
 
     assert!(matches!(action, LoopAction::Continue));
+    Ok(())
 }
 
 #[tokio::test]
-async fn test_escape_while_not_waiting_does_nothing() {
-    let terminal = TestTerminal::new(TEST_WIDTH, 40);
-    let mut renderer = Renderer::new(terminal, TEST_AGENT.to_string(), &[], (TEST_WIDTH, 40));
-    renderer.initial_render().unwrap();
+async fn test_escape_while_not_waiting_does_nothing() -> TestResult {
+    let mut renderer = RendererTest::new().size((TEST_WIDTH, 40)).build()?;
 
     let lines_before = renderer.writer().get_lines();
 
-    renderer.on_key_event(KeyEvent::new(KeyCode::Esc, KeyModifiers::NONE)).await.unwrap();
+    renderer.on_key_event(KeyEvent::new(KeyCode::Esc, KeyModifiers::NONE)).await?;
 
     let lines_after = renderer.writer().get_lines();
     assert_eq!(lines_before, lines_after, "Escape should be a no-op when not waiting");
+    Ok(())
 }

--- a/crates/wisp/tests/app_tests/mcp_oauth_elicitation_tests.rs
+++ b/crates/wisp/tests/app_tests/mcp_oauth_elicitation_tests.rs
@@ -9,24 +9,20 @@ use acp_utils::{
 use tokio::task::LocalSet;
 
 #[tokio::test(flavor = "current_thread")]
-async fn oauth_url_prompt_is_rendered_inline_in_settings_overlay() {
+async fn oauth_url_prompt_is_rendered_inline_in_settings_overlay() -> TestResult {
     Box::pin(LocalSet::new().run_until(async {
-        let mut renderer = open_settings(&[], (TEST_WIDTH, 40)).await;
-        renderer
-            .on_mcp_notification(McpNotification::ServerStatus {
-                servers: vec![oauth_server_status("linear", McpServerStatus::NeedsOAuth)],
-            })
-            .unwrap();
+        let mut renderer = open_settings(&[], (TEST_WIDTH, 40)).await?;
+        renderer.on_mcp_notification(McpNotification::ServerStatus {
+            servers: vec![oauth_server_status("linear", McpServerStatus::NeedsOAuth)],
+        })?;
 
-        press_enter(&mut renderer).await;
+        press(&mut renderer, Enter).await?;
         let (cx, mut peer) = test_connection().await;
         let (responder, rx) = peer.fake_elicitation(&cx).await;
-        renderer
-            .on_elicitation_request(
-                url_elicitation_params("linear", "Authorize linear?", "aether-oauth", "https://linear.app/oauth"),
-                responder,
-            )
-            .unwrap();
+        renderer.on_elicitation_request(
+            url_elicitation_params("linear", "Authorize linear?", "aether-oauth", "https://linear.app/oauth"),
+            responder,
+        )?;
 
         assert_buffer_contains(renderer.writer(), "Configuration");
         assert_buffer_contains(renderer.writer(), "Open browser to authorize linear MCP access");
@@ -34,72 +30,65 @@ async fn oauth_url_prompt_is_rendered_inline_in_settings_overlay() {
         assert_buffer_contains(renderer.writer(), "Copy Link");
         assert!(!renderer.needs_mouse_capture(), "settings URL prompt should allow terminal text selection");
 
-        press_esc(&mut renderer).await;
+        press(&mut renderer, Esc).await?;
         let response = rx.await.expect("URL elicitation should be answered");
         assert_eq!(response.action, ElicitationAction::Cancel);
         assert_buffer_contains(renderer.writer(), "Configuration");
+        Ok(())
     }))
-    .await;
+    .await
 }
 
 #[tokio::test(flavor = "current_thread")]
-async fn oauth_url_completion_accepts_and_clears_settings_prompt() {
+async fn oauth_url_completion_accepts_and_clears_settings_prompt() -> TestResult {
     Box::pin(LocalSet::new().run_until(async {
-        let mut renderer = open_settings(&[], (TEST_WIDTH, 40)).await;
-        renderer
-            .on_mcp_notification(McpNotification::ServerStatus {
-                servers: vec![oauth_server_status("linear", McpServerStatus::Authenticating)],
-            })
-            .unwrap();
+        let mut renderer = open_settings(&[], (TEST_WIDTH, 40)).await?;
+        renderer.on_mcp_notification(McpNotification::ServerStatus {
+            servers: vec![oauth_server_status("linear", McpServerStatus::Authenticating)],
+        })?;
 
-        press_enter(&mut renderer).await;
+        press(&mut renderer, Enter).await?;
         let (cx, mut peer) = test_connection().await;
         let (responder, rx) = peer.fake_elicitation(&cx).await;
-        renderer
-            .on_elicitation_request(
-                url_elicitation_params("linear", "Authorize linear?", "aether-oauth", "https://linear.app/oauth"),
-                responder,
-            )
-            .unwrap();
+        renderer.on_elicitation_request(
+            url_elicitation_params("linear", "Authorize linear?", "aether-oauth", "https://linear.app/oauth"),
+            responder,
+        )?;
 
         assert_buffer_contains(renderer.writer(), "Open browser to authorize linear MCP access");
 
-        renderer
-            .on_mcp_notification(McpNotification::UrlElicitationComplete(completion("linear", "aether-oauth")))
-            .unwrap();
+        renderer.on_mcp_notification(McpNotification::UrlElicitationComplete(completion("linear", "aether-oauth")))?;
 
         let response = rx.await.expect("completion should answer URL elicitation");
         assert_eq!(response.action, ElicitationAction::Accept);
         assert_buffer_contains(renderer.writer(), "Configuration");
         assert_buffer_not_contains(renderer.writer(), "Open browser to authorize linear MCP access");
+        Ok(())
     }))
-    .await;
+    .await
 }
 
 #[tokio::test(flavor = "current_thread")]
-async fn conversation_url_prompt_still_completes_when_settings_is_closed() {
+async fn conversation_url_prompt_still_completes_when_settings_is_closed() -> TestResult {
     LocalSet::new()
         .run_until(async {
-            let mut renderer = new_test_renderer((TEST_WIDTH, 40));
+            let mut renderer = RendererTest::new().size((TEST_WIDTH, 40)).build()?;
             let (cx, mut peer) = acp_utils::testing::test_connection().await;
             let (responder, rx) = peer.fake_elicitation(&cx).await;
-            renderer
-                .on_elicitation_request(
-                    url_elicitation_params("github", "Authorize GitHub", "el-1", "https://github.com/login/oauth"),
-                    responder,
-                )
-                .unwrap();
+            renderer.on_elicitation_request(
+                url_elicitation_params("github", "Authorize GitHub", "el-1", "https://github.com/login/oauth"),
+                responder,
+            )?;
             assert_buffer_contains(renderer.writer(), "Authorize GitHub");
 
-            renderer
-                .on_mcp_notification(McpNotification::UrlElicitationComplete(completion("github", "el-1")))
-                .unwrap();
+            renderer.on_mcp_notification(McpNotification::UrlElicitationComplete(completion("github", "el-1")))?;
 
             let response = rx.await.expect("completion should answer URL elicitation");
             assert_eq!(response.action, ElicitationAction::Accept);
             assert_buffer_contains(renderer.writer(), "github finished the browser flow");
+            Ok(())
         })
-        .await;
+        .await
 }
 
 fn url_elicitation_params(

--- a/crates/wisp/tests/app_tests/message_streaming_tests.rs
+++ b/crates/wisp/tests/app_tests/message_streaming_tests.rs
@@ -1,104 +1,91 @@
 use agent_client_protocol::schema as acp;
-use tui::testing::{TestTerminal, assert_buffer_eq};
+use tui::testing::assert_buffer_eq;
 
 use super::common::*;
 
 #[tokio::test]
-async fn test_agent_message_text_chunks() {
-    let renderer = render(vec![text_chunk("Hello"), text_chunk(" World"), prompt_done()]);
+async fn test_agent_message_text_chunks() -> TestResult {
+    let renderer = render(vec![text_chunk("Hello"), text_chunk(" World"), prompt_done()])?;
 
     let expected = expected_with_prompt(&[&p("Hello World")], TEST_WIDTH, "", TEST_AGENT);
     assert_buffer_eq(renderer.writer(), &expected);
+    Ok(())
 }
 
 #[tokio::test]
-async fn test_agent_thought_chunks() {
-    let renderer = render(vec![thought_chunk("Plan"), thought_chunk(" this"), prompt_done()]);
+async fn test_agent_thought_chunks() -> TestResult {
+    let renderer = render(vec![thought_chunk("Plan"), thought_chunk(" this"), prompt_done()])?;
 
     let expected = expected_with_prompt(&[&p("Plan this")], TEST_WIDTH, "", TEST_AGENT);
     assert_buffer_eq(renderer.writer(), &expected);
+    Ok(())
 }
 
 #[tokio::test]
-async fn test_agent_message_chunks_stream_before_prompt_done() {
-    let terminal = TestTerminal::new(TEST_WIDTH, 40);
-    let mut renderer = Renderer::new(terminal, TEST_AGENT.to_string(), &[], (TEST_WIDTH, 40));
-    renderer.initial_render().unwrap();
+async fn test_agent_message_chunks_stream_before_prompt_done() -> TestResult {
+    let mut renderer = RendererTest::new().size((TEST_WIDTH, 40)).build()?;
 
-    renderer
-        .on_session_update(acp::SessionUpdate::AgentMessageChunk(acp::ContentChunk::new(acp::ContentBlock::Text(
-            acp::TextContent::new("Hello"),
-        ))))
-        .unwrap();
-    renderer
-        .on_session_update(acp::SessionUpdate::AgentMessageChunk(acp::ContentChunk::new(acp::ContentBlock::Text(
-            acp::TextContent::new(" World"),
-        ))))
-        .unwrap();
+    renderer.on_session_update(acp::SessionUpdate::AgentMessageChunk(acp::ContentChunk::new(
+        acp::ContentBlock::Text(acp::TextContent::new("Hello")),
+    )))?;
+    renderer.on_session_update(acp::SessionUpdate::AgentMessageChunk(acp::ContentChunk::new(
+        acp::ContentBlock::Text(acp::TextContent::new(" World")),
+    )))?;
 
     let expected = expected_with_prompt(&[&p("Hello World")], TEST_WIDTH, "", TEST_AGENT);
     assert_buffer_eq(renderer.writer(), &expected);
+    Ok(())
 }
 
 #[tokio::test]
-async fn test_thought_and_text_chunks_stream_before_prompt_done() {
-    let terminal = TestTerminal::new(TEST_WIDTH, 40);
-    let mut renderer = Renderer::new(terminal, TEST_AGENT.to_string(), &[], (TEST_WIDTH, 40));
-    renderer.initial_render().unwrap();
+async fn test_thought_and_text_chunks_stream_before_prompt_done() -> TestResult {
+    let mut renderer = RendererTest::new().size((TEST_WIDTH, 40)).build()?;
 
-    renderer
-        .on_session_update(acp::SessionUpdate::AgentThoughtChunk(acp::ContentChunk::new(acp::ContentBlock::Text(
-            acp::TextContent::new("Thinking"),
-        ))))
-        .unwrap();
-    renderer
-        .on_session_update(acp::SessionUpdate::AgentMessageChunk(acp::ContentChunk::new(acp::ContentBlock::Text(
-            acp::TextContent::new("Done"),
-        ))))
-        .unwrap();
+    renderer.on_session_update(acp::SessionUpdate::AgentThoughtChunk(acp::ContentChunk::new(
+        acp::ContentBlock::Text(acp::TextContent::new("Thinking")),
+    )))?;
+    renderer.on_session_update(acp::SessionUpdate::AgentMessageChunk(acp::ContentChunk::new(
+        acp::ContentBlock::Text(acp::TextContent::new("Done")),
+    )))?;
 
     let expected = expected_with_prompt(&[&p("Thinking"), "", &p("Done")], TEST_WIDTH, "", TEST_AGENT);
     assert_buffer_eq(renderer.writer(), &expected);
+    Ok(())
 }
 
 #[tokio::test]
-async fn test_text_and_thought_chunks_stream_in_arrival_order() {
-    let terminal = TestTerminal::new(TEST_WIDTH, 40);
-    let mut renderer = Renderer::new(terminal, TEST_AGENT.to_string(), &[], (TEST_WIDTH, 40));
-    renderer.initial_render().unwrap();
+async fn test_text_and_thought_chunks_stream_in_arrival_order() -> TestResult {
+    let mut renderer = RendererTest::new().size((TEST_WIDTH, 40)).build()?;
 
-    renderer
-        .on_session_update(acp::SessionUpdate::AgentMessageChunk(acp::ContentChunk::new(acp::ContentBlock::Text(
-            acp::TextContent::new("A"),
-        ))))
-        .unwrap();
-    renderer
-        .on_session_update(acp::SessionUpdate::AgentThoughtChunk(acp::ContentChunk::new(acp::ContentBlock::Text(
-            acp::TextContent::new("B"),
-        ))))
-        .unwrap();
-    renderer
-        .on_session_update(acp::SessionUpdate::AgentMessageChunk(acp::ContentChunk::new(acp::ContentBlock::Text(
-            acp::TextContent::new("C"),
-        ))))
-        .unwrap();
+    renderer.on_session_update(acp::SessionUpdate::AgentMessageChunk(acp::ContentChunk::new(
+        acp::ContentBlock::Text(acp::TextContent::new("A")),
+    )))?;
+    renderer.on_session_update(acp::SessionUpdate::AgentThoughtChunk(acp::ContentChunk::new(
+        acp::ContentBlock::Text(acp::TextContent::new("B")),
+    )))?;
+    renderer.on_session_update(acp::SessionUpdate::AgentMessageChunk(acp::ContentChunk::new(
+        acp::ContentBlock::Text(acp::TextContent::new("C")),
+    )))?;
 
     let expected = expected_with_prompt(&[&p("A"), "", &p("B"), "", &p("C")], TEST_WIDTH, "", TEST_AGENT);
     assert_buffer_eq(renderer.writer(), &expected);
+    Ok(())
 }
 
 #[tokio::test]
-async fn test_thought_prefix_resets_after_non_thought_boundary() {
-    let renderer = render(vec![thought_chunk("Plan"), text_chunk("Answer"), thought_chunk("Refine"), prompt_done()]);
+async fn test_thought_prefix_resets_after_non_thought_boundary() -> TestResult {
+    let renderer = render(vec![thought_chunk("Plan"), text_chunk("Answer"), thought_chunk("Refine"), prompt_done()])?;
 
     let expected = expected_with_prompt(&[&p("Plan"), "", &p("Answer"), "", &p("Refine")], TEST_WIDTH, "", TEST_AGENT);
     assert_buffer_eq(renderer.writer(), &expected);
+    Ok(())
 }
 
 #[tokio::test]
-async fn test_multiline_thought_prefixes_only_first_line() {
-    let renderer = render(vec![thought_chunk("line one\nline two"), prompt_done()]);
+async fn test_multiline_thought_prefixes_only_first_line() -> TestResult {
+    let renderer = render(vec![thought_chunk("line one\nline two"), prompt_done()])?;
 
     let expected = expected_with_prompt(&[&p("line one"), &p("line two")], TEST_WIDTH, "", TEST_AGENT);
     assert_buffer_eq(renderer.writer(), &expected);
+    Ok(())
 }

--- a/crates/wisp/tests/app_tests/mode_cycling_tests.rs
+++ b/crates/wisp/tests/app_tests/mode_cycling_tests.rs
@@ -1,11 +1,10 @@
 use agent_client_protocol::schema as acp;
-use tui::testing::TestTerminal;
 use tui::{KeyCode, KeyEvent, KeyModifiers};
 
 use super::common::*;
 
 #[tokio::test]
-async fn test_shift_tab_cycles_mode_option() {
+async fn test_shift_tab_cycles_mode_option() -> TestResult {
     let options = vec![
         acp::SessionConfigOption::select(
             "mode",
@@ -19,17 +18,16 @@ async fn test_shift_tab_cycles_mode_option() {
         .category(acp::SessionConfigOptionCategory::Mode),
     ];
 
-    let terminal = TestTerminal::new(TEST_WIDTH, 40);
-    let mut renderer = Renderer::new(terminal, TEST_AGENT.to_string(), &options, (TEST_WIDTH, 40));
-    renderer.initial_render().unwrap();
+    let mut renderer = RendererTest::new().config_options(&options).build()?;
 
-    let action = renderer.on_key_event(KeyEvent::new(KeyCode::BackTab, KeyModifiers::SHIFT)).await.unwrap();
+    let action = renderer.on_key_event(KeyEvent::new(KeyCode::BackTab, KeyModifiers::SHIFT)).await?;
 
     assert!(matches!(action, LoopAction::Continue));
+    Ok(())
 }
 
 #[tokio::test]
-async fn test_shift_tab_wraps_mode_option() {
+async fn test_shift_tab_wraps_mode_option() -> TestResult {
     let options = vec![
         acp::SessionConfigOption::select(
             "mode",
@@ -43,15 +41,14 @@ async fn test_shift_tab_wraps_mode_option() {
         .category(acp::SessionConfigOptionCategory::Mode),
     ];
 
-    let terminal = TestTerminal::new(TEST_WIDTH, 40);
-    let mut renderer = Renderer::new(terminal, TEST_AGENT.to_string(), &options, (TEST_WIDTH, 40));
-    renderer.initial_render().unwrap();
+    let mut renderer = RendererTest::new().config_options(&options).build()?;
 
-    renderer.on_key_event(KeyEvent::new(KeyCode::BackTab, KeyModifiers::SHIFT)).await.unwrap();
+    renderer.on_key_event(KeyEvent::new(KeyCode::BackTab, KeyModifiers::SHIFT)).await?;
+    Ok(())
 }
 
 #[tokio::test]
-async fn test_shift_tab_ignored_when_overlay_consumes_input() {
+async fn test_shift_tab_ignored_when_overlay_consumes_input() -> TestResult {
     let options = vec![
         acp::SessionConfigOption::select(
             "mode",
@@ -62,24 +59,23 @@ async fn test_shift_tab_ignored_when_overlay_consumes_input() {
         .category(acp::SessionConfigOptionCategory::Mode),
     ];
 
-    let terminal = TestTerminal::new(TEST_WIDTH, 40);
-    let mut renderer = Renderer::new(terminal, TEST_AGENT.to_string(), &options, (TEST_WIDTH, 40));
-    renderer.initial_render().unwrap();
+    let mut renderer = RendererTest::new().config_options(&options).build()?;
 
     // Open settings overlay
-    type_string(&mut renderer, "/settings").await;
-    press_enter(&mut renderer).await;
+    type_string(&mut renderer, "/settings").await?;
+    press(&mut renderer, Enter).await?;
     assert!(has_settings_menu(renderer.writer()), "Settings overlay should be visible");
 
     // Send shift+tab — should be swallowed by the overlay
-    renderer.on_key_event(KeyEvent::new(KeyCode::BackTab, KeyModifiers::SHIFT)).await.unwrap();
+    renderer.on_key_event(KeyEvent::new(KeyCode::BackTab, KeyModifiers::SHIFT)).await?;
 
     // Overlay should still be visible
     assert!(has_settings_menu(renderer.writer()), "Settings overlay should still be visible after shift+tab");
+    Ok(())
 }
 
 #[tokio::test]
-async fn test_shift_tab_noop_when_no_cycleable_option_exists() {
+async fn test_shift_tab_noop_when_no_cycleable_option_exists() -> TestResult {
     let options = vec![
         acp::SessionConfigOption::select(
             "model",
@@ -90,20 +86,19 @@ async fn test_shift_tab_noop_when_no_cycleable_option_exists() {
         .category(acp::SessionConfigOptionCategory::Model),
     ];
 
-    let terminal = TestTerminal::new(TEST_WIDTH, 40);
-    let mut renderer = Renderer::new(terminal, TEST_AGENT.to_string(), &options, (TEST_WIDTH, 40));
-    renderer.initial_render().unwrap();
+    let mut renderer = RendererTest::new().config_options(&options).build()?;
 
     let lines_before = renderer.writer().get_lines();
 
-    renderer.on_key_event(KeyEvent::new(KeyCode::BackTab, KeyModifiers::SHIFT)).await.unwrap();
+    renderer.on_key_event(KeyEvent::new(KeyCode::BackTab, KeyModifiers::SHIFT)).await?;
 
     let lines_after = renderer.writer().get_lines();
     assert_eq!(lines_before, lines_after, "Shift+Tab should be a no-op when no cycleable mode option");
+    Ok(())
 }
 
 #[tokio::test]
-async fn test_tab_cycles_reasoning_option() {
+async fn test_tab_cycles_reasoning_option() -> TestResult {
     use acp_utils::config_option_id::ConfigOptionId;
 
     let options = vec![acp::SessionConfigOption::select(
@@ -117,23 +112,21 @@ async fn test_tab_cycles_reasoning_option() {
         ],
     )];
 
-    let terminal = TestTerminal::new(TEST_WIDTH, 40);
-    let mut renderer = Renderer::new(terminal, TEST_AGENT.to_string(), &options, (TEST_WIDTH, 40));
-    renderer.initial_render().unwrap();
+    let mut renderer = RendererTest::new().config_options(&options).build()?;
 
-    renderer.on_key_event(KeyEvent::new(KeyCode::Tab, KeyModifiers::NONE)).await.unwrap();
+    renderer.on_key_event(KeyEvent::new(KeyCode::Tab, KeyModifiers::NONE)).await?;
+    Ok(())
 }
 
 #[tokio::test]
-async fn test_tab_noop_when_no_reasoning_option() {
-    let terminal = TestTerminal::new(TEST_WIDTH, 40);
-    let mut renderer = Renderer::new(terminal, TEST_AGENT.to_string(), &[], (TEST_WIDTH, 40));
-    renderer.initial_render().unwrap();
+async fn test_tab_noop_when_no_reasoning_option() -> TestResult {
+    let mut renderer = RendererTest::new().size((TEST_WIDTH, 40)).build()?;
 
     let lines_before = renderer.writer().get_lines();
 
-    renderer.on_key_event(KeyEvent::new(KeyCode::Tab, KeyModifiers::NONE)).await.unwrap();
+    renderer.on_key_event(KeyEvent::new(KeyCode::Tab, KeyModifiers::NONE)).await?;
 
     let lines_after = renderer.writer().get_lines();
     assert_eq!(lines_before, lines_after, "Tab should be a no-op when no reasoning option");
+    Ok(())
 }

--- a/crates/wisp/tests/app_tests/notifications_tests.rs
+++ b/crates/wisp/tests/app_tests/notifications_tests.rs
@@ -1,14 +1,11 @@
 use acp_utils::notifications::{ContextUsageParams, SubAgentEvent, SubAgentProgressParams, SubAgentToolRequest};
 use agent_client_protocol::schema as acp;
-use tui::testing::TestTerminal;
 
 use super::common::*;
 
 #[tokio::test]
-async fn test_sub_agent_progress_notification_triggers_render() {
-    let terminal = TestTerminal::new(TEST_WIDTH, 40);
-    let mut renderer = Renderer::new(terminal, TEST_AGENT.to_string(), &[], (TEST_WIDTH, 40));
-    renderer.initial_render().unwrap();
+async fn test_sub_agent_progress_notification_triggers_render() -> TestResult {
+    let mut renderer = RendererTest::new().size((TEST_WIDTH, 40)).build()?;
 
     let params = SubAgentProgressParams {
         parent_tool_id: "p1".to_string(),
@@ -22,17 +19,16 @@ async fn test_sub_agent_progress_notification_triggers_render() {
             },
         },
     };
-    renderer.on_sub_agent_progress(params).unwrap();
+    renderer.on_sub_agent_progress(params)?;
 
     let lines = renderer.writer().get_lines();
     assert!(!lines.is_empty());
+    Ok(())
 }
 
 #[tokio::test]
-async fn test_context_usage_notification_updates_nominal_display() {
-    let terminal = TestTerminal::new(TEST_WIDTH, 40);
-    let mut renderer = Renderer::new(terminal, TEST_AGENT.to_string(), &[], (TEST_WIDTH, 40));
-    renderer.initial_render().unwrap();
+async fn test_context_usage_notification_updates_nominal_display() -> TestResult {
+    let mut renderer = RendererTest::new().size((TEST_WIDTH, 40)).build()?;
 
     let params = ContextUsageParams {
         usage_ratio: Some(0.75),
@@ -48,7 +44,7 @@ async fn test_context_usage_notification_updates_nominal_display() {
         total_cache_creation_tokens: 0,
         total_reasoning_tokens: 0,
     };
-    renderer.on_context_usage(params).unwrap();
+    renderer.on_context_usage(params)?;
 
     let lines = renderer.writer().get_lines();
     assert!(
@@ -56,13 +52,12 @@ async fn test_context_usage_notification_updates_nominal_display() {
         "Status line should show nominal context usage.\nBuffer:\n{}",
         lines.join("\n")
     );
+    Ok(())
 }
 
 #[tokio::test]
-async fn test_context_usage_notification_with_unknown_limit_clears_meter() {
-    let terminal = TestTerminal::new(TEST_WIDTH, 40);
-    let mut renderer = Renderer::new(terminal, TEST_AGENT.to_string(), &[], (TEST_WIDTH, 40));
-    renderer.initial_render().unwrap();
+async fn test_context_usage_notification_with_unknown_limit_clears_meter() -> TestResult {
+    let mut renderer = RendererTest::new().size((TEST_WIDTH, 40)).build()?;
 
     let nominal = ContextUsageParams {
         usage_ratio: Some(0.67),
@@ -78,7 +73,7 @@ async fn test_context_usage_notification_with_unknown_limit_clears_meter() {
         total_cache_creation_tokens: 0,
         total_reasoning_tokens: 0,
     };
-    renderer.on_context_usage(nominal).unwrap();
+    renderer.on_context_usage(nominal)?;
 
     let cleared = ContextUsageParams {
         usage_ratio: None,
@@ -94,7 +89,7 @@ async fn test_context_usage_notification_with_unknown_limit_clears_meter() {
         total_cache_creation_tokens: 0,
         total_reasoning_tokens: 0,
     };
-    renderer.on_context_usage(cleared).unwrap();
+    renderer.on_context_usage(cleared)?;
 
     let lines = renderer.writer().get_lines();
     assert!(
@@ -102,24 +97,21 @@ async fn test_context_usage_notification_with_unknown_limit_clears_meter() {
         "Context segment should not be shown when limit is unknown.\nBuffer:\n{}",
         lines.join("\n")
     );
+    Ok(())
 }
 
 #[tokio::test]
-async fn test_context_cleared_notification_resets_conversation() {
-    let terminal = TestTerminal::new(TEST_WIDTH, 40);
-    let mut renderer = Renderer::new(terminal, TEST_AGENT.to_string(), &[], (TEST_WIDTH, 40));
-    renderer.initial_render().unwrap();
+async fn test_context_cleared_notification_resets_conversation() -> TestResult {
+    let mut renderer = RendererTest::new().size((TEST_WIDTH, 40)).build()?;
 
-    renderer
-        .on_session_update(acp::SessionUpdate::AgentMessageChunk(acp::ContentChunk::new(acp::ContentBlock::Text(
-            acp::TextContent::new("hello world"),
-        ))))
-        .unwrap();
+    renderer.on_session_update(acp::SessionUpdate::AgentMessageChunk(acp::ContentChunk::new(
+        acp::ContentBlock::Text(acp::TextContent::new("hello world")),
+    )))?;
 
     let lines = renderer.writer().get_lines();
     assert!(lines.iter().any(|l| l.contains("hello world")), "Content should be visible before clear");
 
-    renderer.on_context_cleared().unwrap();
+    renderer.on_context_cleared()?;
 
     let lines = renderer.writer().get_lines();
     assert!(
@@ -127,24 +119,22 @@ async fn test_context_cleared_notification_resets_conversation() {
         "Content should be cleared after context_cleared.\nBuffer:\n{}",
         lines.join("\n")
     );
+    Ok(())
 }
 
 #[tokio::test]
-async fn test_on_tick_requests_render_while_completed_entries() {
-    let terminal = TestTerminal::new(TEST_WIDTH, 40);
-    let mut renderer = Renderer::new(terminal, TEST_AGENT.to_string(), &[], (TEST_WIDTH, 40));
-    renderer.initial_render().unwrap();
+async fn test_on_tick_requests_render_while_completed_entries() -> TestResult {
+    let mut renderer = RendererTest::new().size((TEST_WIDTH, 40)).build()?;
 
-    renderer
-        .on_session_update(acp::SessionUpdate::Plan(acp::Plan::new(vec![acp::PlanEntry::new(
-            "1",
-            acp::PlanEntryPriority::Medium,
-            acp::PlanEntryStatus::Completed,
-        )])))
-        .unwrap();
+    renderer.on_session_update(acp::SessionUpdate::Plan(acp::Plan::new(vec![acp::PlanEntry::new(
+        "1",
+        acp::PlanEntryPriority::Medium,
+        acp::PlanEntryStatus::Completed,
+    )])))?;
 
-    renderer.on_tick().await.unwrap();
+    renderer.on_tick().await?;
 
     let lines = renderer.writer().get_lines();
     assert!(!lines.is_empty());
+    Ok(())
 }

--- a/crates/wisp/tests/app_tests/progress_indicator_tests.rs
+++ b/crates/wisp/tests/app_tests/progress_indicator_tests.rs
@@ -1,39 +1,32 @@
-use tui::testing::{TestTerminal, assert_buffer_eq};
+use tui::testing::assert_buffer_eq;
 
 use super::common::*;
 
 #[tokio::test]
-async fn test_spinner_visible_after_prompt_submit() {
-    let terminal = TestTerminal::new(TEST_WIDTH, 40);
-    let mut renderer = Renderer::new(terminal, TEST_AGENT.to_string(), &[], (TEST_WIDTH, 40));
+async fn test_spinner_visible_after_prompt_submit() -> TestResult {
+    let mut renderer = RendererTest::new().size((TEST_WIDTH, 40)).build()?;
 
-    renderer.initial_render().unwrap();
-
-    type_string(&mut renderer, "Hello").await;
-    press_enter(&mut renderer).await;
+    type_string(&mut renderer, "Hello").await?;
+    press(&mut renderer, Enter).await?;
 
     let lines = renderer.writer().get_lines();
     let has_interrupt = lines.iter().any(|l| l.contains("esc to interrupt"));
     assert!(has_interrupt, "Progress indicator should be visible after prompt submit.\nBuffer:\n{}", lines.join("\n"));
+    Ok(())
 }
 
 #[tokio::test]
-async fn test_spinner_persists_on_session_update() {
+async fn test_spinner_persists_on_session_update() -> TestResult {
     use agent_client_protocol::schema as acp;
 
-    let terminal = TestTerminal::new(TEST_WIDTH, 40);
-    let mut renderer = Renderer::new(terminal, TEST_AGENT.to_string(), &[], (TEST_WIDTH, 40));
+    let mut renderer = RendererTest::new().size((TEST_WIDTH, 40)).build()?;
 
-    renderer.initial_render().unwrap();
+    type_string(&mut renderer, "Hello").await?;
+    press(&mut renderer, Enter).await?;
 
-    type_string(&mut renderer, "Hello").await;
-    press_enter(&mut renderer).await;
-
-    renderer
-        .on_session_update(acp::SessionUpdate::AgentMessageChunk(acp::ContentChunk::new(acp::ContentBlock::Text(
-            acp::TextContent::new("Hi"),
-        ))))
-        .unwrap();
+    renderer.on_session_update(acp::SessionUpdate::AgentMessageChunk(acp::ContentChunk::new(
+        acp::ContentBlock::Text(acp::TextContent::new("Hi")),
+    )))?;
 
     let lines = renderer.writer().get_lines();
     let has_interrupt = lines.iter().any(|l| l.contains("esc to interrupt"));
@@ -42,67 +35,60 @@ async fn test_spinner_persists_on_session_update() {
         "Progress indicator should persist while waiting for response.\nBuffer:\n{}",
         lines.join("\n")
     );
+    Ok(())
 }
 
 #[tokio::test]
-async fn test_spinner_disappears_on_prompt_done() {
-    let terminal = TestTerminal::new(TEST_WIDTH, 40);
-    let mut renderer = Renderer::new(terminal, TEST_AGENT.to_string(), &[], (TEST_WIDTH, 40));
+async fn test_spinner_disappears_on_prompt_done() -> TestResult {
+    let mut renderer = RendererTest::new().size((TEST_WIDTH, 40)).build()?;
 
-    renderer.initial_render().unwrap();
+    type_string(&mut renderer, "Hello").await?;
+    press(&mut renderer, Enter).await?;
 
-    type_string(&mut renderer, "Hello").await;
-    press_enter(&mut renderer).await;
-
-    renderer.on_prompt_done().unwrap();
+    renderer.on_prompt_done()?;
 
     let lines = renderer.writer().get_lines();
     let has_braille = lines.iter().any(|l| "⠒⠮⠷⢷⡾⣯⣽⣿⣭⢯".chars().any(|c| l.contains(c)));
     assert!(!has_braille, "Spinner should disappear after prompt done.\nBuffer:\n{}", lines.join("\n"));
+    Ok(())
 }
 
 #[tokio::test]
-async fn test_spinner_not_visible_on_initial_render() {
-    let terminal = TestTerminal::new(80, 24);
-    let mut renderer = Renderer::new(terminal, TEST_AGENT.to_string(), &[], (80, 24));
-
-    renderer.initial_render().unwrap();
+async fn test_spinner_not_visible_on_initial_render() -> TestResult {
+    let renderer = RendererTest::new().size((80, 24)).build()?;
 
     let expected = expected_prompt(80, "", TEST_AGENT);
     assert_buffer_eq(renderer.writer(), &expected);
+    Ok(())
 }
 
 #[tokio::test]
-async fn test_on_tick_advances_animation() {
-    let terminal = TestTerminal::new(TEST_WIDTH, 40);
-    let mut renderer = Renderer::new(terminal, TEST_AGENT.to_string(), &[], (TEST_WIDTH, 40));
+async fn test_on_tick_advances_animation() -> TestResult {
+    let mut renderer = RendererTest::new().size((TEST_WIDTH, 40)).build()?;
 
-    renderer.initial_render().unwrap();
-
-    type_string(&mut renderer, "Hello").await;
-    press_enter(&mut renderer).await;
+    type_string(&mut renderer, "Hello").await?;
+    press(&mut renderer, Enter).await?;
 
     let lines_before: Vec<String> = renderer.writer().get_lines();
 
-    renderer.on_tick().await.unwrap();
+    renderer.on_tick().await?;
 
     let lines_after: Vec<String> = renderer.writer().get_lines();
 
     assert_ne!(lines_before, lines_after, "on_tick should advance the animation and produce a different frame");
+    Ok(())
 }
 
 #[tokio::test]
-async fn test_on_tick_noop_when_not_waiting() {
-    let terminal = TestTerminal::new(80, 24);
-    let mut renderer = Renderer::new(terminal, TEST_AGENT.to_string(), &[], (80, 24));
-
-    renderer.initial_render().unwrap();
+async fn test_on_tick_noop_when_not_waiting() -> TestResult {
+    let mut renderer = RendererTest::new().size((80, 24)).build()?;
 
     let lines_before: Vec<String> = renderer.writer().get_lines();
 
-    renderer.on_tick().await.unwrap();
+    renderer.on_tick().await?;
 
     let lines_after: Vec<String> = renderer.writer().get_lines();
 
     assert_eq!(lines_before, lines_after, "on_tick should be a no-op when not waiting for response");
+    Ok(())
 }

--- a/crates/wisp/tests/app_tests/prompt_search_tests.rs
+++ b/crates/wisp/tests/app_tests/prompt_search_tests.rs
@@ -1,24 +1,16 @@
 use super::common::*;
 use acp_utils::notifications::{PromptSearchResponse, PromptSearchResult};
-use agent_client_protocol::schema as acp;
 use std::path::PathBuf;
-use tui::testing::{TestTerminal, assert_buffer_eq};
+use tui::testing::assert_buffer_eq;
 use tui::{KeyCode, KeyModifiers};
 
 #[tokio::test]
-async fn prompt_search_prefills_selected_history_result() {
-    let terminal = TestTerminal::new(80, 24);
-    let mut renderer = Renderer::new_with_prompt_capabilities(
-        terminal,
-        TEST_AGENT.to_string(),
-        prompt_search_capabilities(),
-        (80, 24),
-    );
-    renderer.initial_render().unwrap();
+async fn prompt_search_prefills_selected_history_result() -> TestResult {
+    let mut renderer = prompt_search_renderer((80, 24))?;
 
-    send_key(&mut renderer, KeyCode::Char('r'), KeyModifiers::CONTROL).await;
-    type_string(&mut renderer, "hello").await;
-    renderer.on_prompt_search_results(response("hello", vec![result("hello world", 0, 5)])).unwrap();
+    press_with_modifiers(&mut renderer, KeyCode::Char('r'), KeyModifiers::CONTROL).await?;
+    type_string(&mut renderer, "hello").await?;
+    renderer.on_prompt_search_results(response("hello", vec![result("hello world", 0, 5)]))?;
 
     let rule = "─".repeat(80);
     let mut expected = vec![rule.clone(), "> hello world".to_string(), rule, "history search: hello".to_string()];
@@ -27,128 +19,91 @@ async fn prompt_search_prefills_selected_history_result() {
     assert_buffer_eq(renderer.writer(), &expected);
     let (cursor_col, cursor_row) = renderer.writer().cursor_position();
     assert_eq!((cursor_col, cursor_row), (7, 1));
+    Ok(())
 }
 
 #[tokio::test]
-async fn prompt_search_restore_draft_on_escape() {
-    let terminal = TestTerminal::new(80, 24);
-    let mut renderer = Renderer::new_with_prompt_capabilities(
-        terminal,
-        TEST_AGENT.to_string(),
-        prompt_search_capabilities(),
-        (80, 24),
-    );
-    renderer.initial_render().unwrap();
+async fn prompt_search_restore_draft_on_escape() -> TestResult {
+    let mut renderer = prompt_search_renderer((80, 24))?;
 
-    type_string(&mut renderer, "draft").await;
-    send_key(&mut renderer, KeyCode::Char('r'), KeyModifiers::CONTROL).await;
-    type_string(&mut renderer, "hello").await;
-    renderer.on_prompt_search_results(response("hello", vec![result("hello world", 0, 5)])).unwrap();
-    press_esc(&mut renderer).await;
+    type_string(&mut renderer, "draft").await?;
+    press_with_modifiers(&mut renderer, KeyCode::Char('r'), KeyModifiers::CONTROL).await?;
+    type_string(&mut renderer, "hello").await?;
+    renderer.on_prompt_search_results(response("hello", vec![result("hello world", 0, 5)]))?;
+    press(&mut renderer, Esc).await?;
 
     assert_buffer_eq(renderer.writer(), &expected_prompt(80, "draft", TEST_AGENT));
+    Ok(())
 }
 
 #[tokio::test]
-async fn prompt_search_shows_backend_errors() {
-    let terminal = TestTerminal::new(80, 24);
-    let mut renderer = Renderer::new_with_prompt_capabilities(
-        terminal,
-        TEST_AGENT.to_string(),
-        prompt_search_capabilities(),
-        (80, 24),
-    );
-    renderer.initial_render().unwrap();
+async fn prompt_search_shows_backend_errors() -> TestResult {
+    let mut renderer = prompt_search_renderer((80, 24))?;
 
-    send_key(&mut renderer, KeyCode::Char('r'), KeyModifiers::CONTROL).await;
-    type_string(&mut renderer, "hello").await;
-    renderer.on_prompt_search_failed("hello", "boom").unwrap();
+    press_with_modifiers(&mut renderer, KeyCode::Char('r'), KeyModifiers::CONTROL).await?;
+    type_string(&mut renderer, "hello").await?;
+    renderer.on_prompt_search_failed("hello", "boom")?;
 
     assert_buffer_contains(renderer.writer(), "history search: hello");
     assert_buffer_contains(renderer.writer(), "error: boom");
+    Ok(())
 }
 
 #[tokio::test]
-async fn ctrl_r_opens_prompt_search_when_capability_is_enabled() {
-    let terminal = TestTerminal::new(80, 24);
-    let mut renderer = Renderer::new_with_prompt_capabilities(
-        terminal,
-        TEST_AGENT.to_string(),
-        prompt_search_capabilities(),
-        (80, 24),
-    );
-    renderer.initial_render().unwrap();
+async fn ctrl_r_opens_prompt_search_when_capability_is_enabled() -> TestResult {
+    let mut renderer = prompt_search_renderer((80, 24))?;
 
-    send_key(&mut renderer, KeyCode::Char('r'), KeyModifiers::CONTROL).await;
-    type_string(&mut renderer, "h").await;
+    press_with_modifiers(&mut renderer, KeyCode::Char('r'), KeyModifiers::CONTROL).await?;
+    type_string(&mut renderer, "h").await?;
 
     assert_buffer_contains(renderer.writer(), "history search: h");
     assert_buffer_contains(renderer.writer(), "searching…");
+    Ok(())
 }
 
 #[tokio::test]
-async fn ctrl_r_is_noop_when_prompt_search_capability_is_missing() {
-    let terminal = TestTerminal::new(80, 24);
-    let mut renderer = Renderer::new(terminal, TEST_AGENT.to_string(), &[], (80, 24));
-    renderer.initial_render().unwrap();
+async fn ctrl_r_is_noop_when_prompt_search_capability_is_missing() -> TestResult {
+    let mut renderer = RendererTest::new().size((80, 24)).build()?;
 
-    send_key(&mut renderer, KeyCode::Char('r'), KeyModifiers::CONTROL).await;
+    press_with_modifiers(&mut renderer, KeyCode::Char('r'), KeyModifiers::CONTROL).await?;
     assert_buffer_eq(renderer.writer(), &expected_prompt(80, "", TEST_AGENT));
+    Ok(())
 }
 
 #[tokio::test]
-async fn prompt_search_enter_confirms_selected_result() {
-    let terminal = TestTerminal::new(80, 24);
-    let mut renderer = Renderer::new_with_prompt_capabilities(
-        terminal,
-        TEST_AGENT.to_string(),
-        prompt_search_capabilities(),
-        (80, 24),
-    );
-    renderer.initial_render().unwrap();
+async fn prompt_search_enter_confirms_selected_result() -> TestResult {
+    let mut renderer = prompt_search_renderer((80, 24))?;
 
-    send_key(&mut renderer, KeyCode::Char('r'), KeyModifiers::CONTROL).await;
-    type_string(&mut renderer, "hello").await;
-    renderer.on_prompt_search_results(response("hello", vec![result("hello world", 0, 5)])).unwrap();
-    press_enter(&mut renderer).await;
+    press_with_modifiers(&mut renderer, KeyCode::Char('r'), KeyModifiers::CONTROL).await?;
+    type_string(&mut renderer, "hello").await?;
+    renderer.on_prompt_search_results(response("hello", vec![result("hello world", 0, 5)]))?;
+    press(&mut renderer, Enter).await?;
 
     assert_buffer_eq(renderer.writer(), &expected_prompt(80, "hello world", TEST_AGENT));
     let (cursor_col, cursor_row) = renderer.writer().cursor_position();
     assert_eq!((cursor_col, cursor_row), (13, 1));
+    Ok(())
 }
 
 #[tokio::test]
-async fn stale_prompt_search_response_does_not_overwrite_current_selection() {
-    let terminal = TestTerminal::new(80, 24);
-    let mut renderer = Renderer::new_with_prompt_capabilities(
-        terminal,
-        TEST_AGENT.to_string(),
-        prompt_search_capabilities(),
-        (80, 24),
-    );
-    renderer.initial_render().unwrap();
+async fn stale_prompt_search_response_does_not_overwrite_current_selection() -> TestResult {
+    let mut renderer = prompt_search_renderer((80, 24))?;
 
-    send_key(&mut renderer, KeyCode::Char('r'), KeyModifiers::CONTROL).await;
-    type_string(&mut renderer, "he").await;
-    renderer.on_prompt_search_results(response("he", vec![result("hello world", 0, 2)])).unwrap();
-    renderer.on_prompt_search_results(response("h", vec![result("OTHER", 0, 1)])).unwrap();
+    press_with_modifiers(&mut renderer, KeyCode::Char('r'), KeyModifiers::CONTROL).await?;
+    type_string(&mut renderer, "he").await?;
+    renderer.on_prompt_search_results(response("he", vec![result("hello world", 0, 2)]))?;
+    renderer.on_prompt_search_results(response("h", vec![result("OTHER", 0, 1)]))?;
 
     assert_buffer_contains(renderer.writer(), "> hello world");
     assert_buffer_not_contains(renderer.writer(), "> OTHER");
+    Ok(())
 }
 
 #[tokio::test]
-async fn prompt_search_empty_query_renders_instruction() {
-    let terminal = TestTerminal::new(80, 24);
-    let mut renderer = Renderer::new_with_prompt_capabilities(
-        terminal,
-        TEST_AGENT.to_string(),
-        prompt_search_capabilities(),
-        (80, 24),
-    );
-    renderer.initial_render().unwrap();
+async fn prompt_search_empty_query_renders_instruction() -> TestResult {
+    let mut renderer = prompt_search_renderer((80, 24))?;
 
-    send_key(&mut renderer, KeyCode::Char('r'), KeyModifiers::CONTROL).await;
+    press_with_modifiers(&mut renderer, KeyCode::Char('r'), KeyModifiers::CONTROL).await?;
 
     let rule = "─".repeat(80);
     let expected = vec![
@@ -160,23 +115,17 @@ async fn prompt_search_empty_query_renders_instruction() {
         expected_status_line(80, TEST_AGENT),
     ];
     assert_buffer_eq(renderer.writer(), &expected);
+    Ok(())
 }
 
 #[tokio::test]
-async fn prompt_search_empty_results_render_no_matches() {
-    let terminal = TestTerminal::new(80, 24);
-    let mut renderer = Renderer::new_with_prompt_capabilities(
-        terminal,
-        TEST_AGENT.to_string(),
-        prompt_search_capabilities(),
-        (80, 24),
-    );
-    renderer.initial_render().unwrap();
+async fn prompt_search_empty_results_render_no_matches() -> TestResult {
+    let mut renderer = prompt_search_renderer((80, 24))?;
 
-    type_string(&mut renderer, "draft").await;
-    send_key(&mut renderer, KeyCode::Char('r'), KeyModifiers::CONTROL).await;
-    type_string(&mut renderer, "zzz").await;
-    renderer.on_prompt_search_results(response("zzz", vec![])).unwrap();
+    type_string(&mut renderer, "draft").await?;
+    press_with_modifiers(&mut renderer, KeyCode::Char('r'), KeyModifiers::CONTROL).await?;
+    type_string(&mut renderer, "zzz").await?;
+    renderer.on_prompt_search_results(response("zzz", vec![]))?;
 
     let rule = "─".repeat(80);
     let expected = vec![
@@ -188,62 +137,44 @@ async fn prompt_search_empty_results_render_no_matches() {
         expected_status_line(80, TEST_AGENT),
     ];
     assert_buffer_eq(renderer.writer(), &expected);
+    Ok(())
 }
 
 #[tokio::test]
-async fn prompt_search_enter_without_selection_restores_draft() {
-    let terminal = TestTerminal::new(80, 24);
-    let mut renderer = Renderer::new_with_prompt_capabilities(
-        terminal,
-        TEST_AGENT.to_string(),
-        prompt_search_capabilities(),
-        (80, 24),
-    );
-    renderer.initial_render().unwrap();
+async fn prompt_search_enter_without_selection_restores_draft() -> TestResult {
+    let mut renderer = prompt_search_renderer((80, 24))?;
 
-    type_string(&mut renderer, "draft").await;
-    send_key(&mut renderer, KeyCode::Char('r'), KeyModifiers::CONTROL).await;
-    type_string(&mut renderer, "zzz").await;
-    renderer.on_prompt_search_results(response("zzz", vec![])).unwrap();
-    press_enter(&mut renderer).await;
+    type_string(&mut renderer, "draft").await?;
+    press_with_modifiers(&mut renderer, KeyCode::Char('r'), KeyModifiers::CONTROL).await?;
+    type_string(&mut renderer, "zzz").await?;
+    renderer.on_prompt_search_results(response("zzz", vec![]))?;
+    press(&mut renderer, Enter).await?;
 
     assert_buffer_eq(renderer.writer(), &expected_prompt(80, "draft", TEST_AGENT));
+    Ok(())
 }
 
 #[tokio::test]
-async fn prompt_search_paste_sanitizes_query() {
-    let terminal = TestTerminal::new(80, 24);
-    let mut renderer = Renderer::new_with_prompt_capabilities(
-        terminal,
-        TEST_AGENT.to_string(),
-        prompt_search_capabilities(),
-        (80, 24),
-    );
-    renderer.initial_render().unwrap();
+async fn prompt_search_paste_sanitizes_query() -> TestResult {
+    let mut renderer = prompt_search_renderer((80, 24))?;
 
-    send_key(&mut renderer, KeyCode::Char('r'), KeyModifiers::CONTROL).await;
-    renderer.on_paste("hello\nworld").await.unwrap();
+    press_with_modifiers(&mut renderer, KeyCode::Char('r'), KeyModifiers::CONTROL).await?;
+    renderer.on_paste("hello\nworld").await?;
 
     assert_buffer_contains(renderer.writer(), "history search: helloworld");
     assert_buffer_contains(renderer.writer(), "searching…");
+    Ok(())
 }
 
 #[tokio::test]
-async fn prompt_search_backspace_to_empty_restores_draft_but_keeps_picker_open() {
-    let terminal = TestTerminal::new(80, 24);
-    let mut renderer = Renderer::new_with_prompt_capabilities(
-        terminal,
-        TEST_AGENT.to_string(),
-        prompt_search_capabilities(),
-        (80, 24),
-    );
-    renderer.initial_render().unwrap();
+async fn prompt_search_backspace_to_empty_restores_draft_but_keeps_picker_open() -> TestResult {
+    let mut renderer = prompt_search_renderer((80, 24))?;
 
-    type_string(&mut renderer, "draft").await;
-    send_key(&mut renderer, KeyCode::Char('r'), KeyModifiers::CONTROL).await;
-    type_string(&mut renderer, "h").await;
-    renderer.on_prompt_search_results(response("h", vec![result("hello", 0, 1)])).unwrap();
-    press_backspace(&mut renderer).await;
+    type_string(&mut renderer, "draft").await?;
+    press_with_modifiers(&mut renderer, KeyCode::Char('r'), KeyModifiers::CONTROL).await?;
+    type_string(&mut renderer, "h").await?;
+    renderer.on_prompt_search_results(response("h", vec![result("hello", 0, 1)]))?;
+    press(&mut renderer, Backspace).await?;
 
     let rule = "─".repeat(80);
     let expected = vec![
@@ -255,62 +186,49 @@ async fn prompt_search_backspace_to_empty_restores_draft_but_keeps_picker_open()
         expected_status_line(80, TEST_AGENT),
     ];
     assert_buffer_eq(renderer.writer(), &expected);
+    Ok(())
 }
 
 #[tokio::test]
-async fn prompt_search_up_and_down_change_selected_prompt() {
-    let terminal = TestTerminal::new(80, 24);
-    let mut renderer = Renderer::new_with_prompt_capabilities(
-        terminal,
-        TEST_AGENT.to_string(),
-        prompt_search_capabilities(),
-        (80, 24),
-    );
-    renderer.initial_render().unwrap();
+async fn prompt_search_up_and_down_change_selected_prompt() -> TestResult {
+    let mut renderer = prompt_search_renderer((80, 24))?;
 
-    send_key(&mut renderer, KeyCode::Char('r'), KeyModifiers::CONTROL).await;
-    type_string(&mut renderer, "h").await;
-    renderer.on_prompt_search_results(response("h", vec![result("hello", 0, 1), result("hey", 0, 1)])).unwrap();
+    press_with_modifiers(&mut renderer, KeyCode::Char('r'), KeyModifiers::CONTROL).await?;
+    type_string(&mut renderer, "h").await?;
+    renderer.on_prompt_search_results(response("h", vec![result("hello", 0, 1), result("hey", 0, 1)]))?;
     assert_buffer_contains(renderer.writer(), "> hello");
 
-    press_down(&mut renderer).await;
+    press(&mut renderer, Down).await?;
     assert_buffer_contains(renderer.writer(), "> hey");
 
-    send_key(&mut renderer, KeyCode::Up, KeyModifiers::empty()).await;
+    press(&mut renderer, Up).await?;
     assert_buffer_contains(renderer.writer(), "> hello");
+    Ok(())
 }
 
 #[tokio::test]
-async fn prompt_search_rows_truncate_prompt_and_show_cwd_basename() {
-    let terminal = TestTerminal::new(40, 24);
-    let mut renderer = Renderer::new_with_prompt_capabilities(
-        terminal,
-        TEST_AGENT.to_string(),
-        prompt_search_capabilities(),
-        (40, 24),
-    );
-    renderer.initial_render().unwrap();
+async fn prompt_search_rows_truncate_prompt_and_show_cwd_basename() -> TestResult {
+    let mut renderer = prompt_search_renderer((40, 24))?;
 
-    send_key(&mut renderer, KeyCode::Char('r'), KeyModifiers::CONTROL).await;
-    type_string(&mut renderer, "quick").await;
-    renderer
-        .on_prompt_search_results(response(
-            "quick",
-            vec![result_with_cwd(
-                "the quick brown fox jumps over the lazy dog",
-                4,
-                9,
-                PathBuf::from("/some/deeply/nested/project/repo-name"),
-            )],
-        ))
-        .unwrap();
+    press_with_modifiers(&mut renderer, KeyCode::Char('r'), KeyModifiers::CONTROL).await?;
+    type_string(&mut renderer, "quick").await?;
+    renderer.on_prompt_search_results(response(
+        "quick",
+        vec![result_with_cwd(
+            "the quick brown fox jumps over the lazy dog",
+            4,
+            9,
+            PathBuf::from("/some/deeply/nested/project/repo-name"),
+        )],
+    ))?;
 
     assert_buffer_contains(renderer.writer(), "...");
     assert_buffer_contains(renderer.writer(), "repo-name");
+    Ok(())
 }
 
-fn prompt_search_capabilities() -> acp::PromptCapabilities {
-    acp::PromptCapabilities::new()
+fn prompt_search_renderer(size: (u16, u16)) -> TestResult<Renderer> {
+    RendererTest::new().size(size).session_capabilities(prompt_search_session_capabilities()).build()
 }
 
 fn result(prompt: &str, start: usize, end: usize) -> PromptSearchResult {

--- a/crates/wisp/tests/app_tests/session_tests.rs
+++ b/crates/wisp/tests/app_tests/session_tests.rs
@@ -3,133 +3,109 @@ use acp_utils::notifications::{SessionDisplayMeta, SessionPreviewResponse, Sessi
 use agent_client_protocol::schema as acp;
 use std::path::PathBuf;
 use tokio::sync::mpsc::UnboundedReceiver;
-use tui::testing::{TestTerminal, assert_buffer_eq};
+use tui::testing::assert_buffer_eq;
 use tui::{KeyCode, KeyEvent, KeyModifiers};
 
 use super::common::*;
 
 #[tokio::test]
-async fn test_resume_picker_shows_search_box_and_filters() {
-    let terminal = TestTerminal::new(TEST_WIDTH, 40);
-    let mut renderer = Renderer::new(terminal, TEST_AGENT.to_string(), &[], (TEST_WIDTH, 40));
-    renderer.initial_render().unwrap();
+async fn test_resume_picker_shows_search_box_and_filters() -> TestResult {
+    let mut renderer = RendererTest::new().size((TEST_WIDTH, 40)).build()?;
 
-    type_string(&mut renderer, "/resume").await;
-    press_enter(&mut renderer).await;
-    renderer
-        .on_sessions_listed(vec![
-            acp::SessionInfo::new("session-login", PathBuf::from("/repo/auth")).title("Fix login redirect".to_string()),
-            acp::SessionInfo::new("session-billing", PathBuf::from("/repo/billing"))
-                .title("Billing cleanup".to_string()),
-        ])
-        .unwrap();
+    open_resume_picker(&mut renderer).await?;
+    renderer.on_sessions_listed(vec![
+        acp::SessionInfo::new("session-login", PathBuf::from("/repo/auth")).title("Fix login redirect".to_string()),
+        acp::SessionInfo::new("session-billing", PathBuf::from("/repo/billing")).title("Billing cleanup".to_string()),
+    ])?;
 
     assert_buffer_contains(renderer.writer(), "🔍 Search");
     assert_buffer_contains(renderer.writer(), "type to search title or path");
     assert_buffer_not_contains(renderer.writer(), "Resume a previous session");
-    type_string(&mut renderer, "login").await;
+    type_string(&mut renderer, "login").await?;
     assert_buffer_contains(renderer.writer(), "Fix login redirect");
     assert_buffer_not_contains(renderer.writer(), "Billing cleanup");
+    Ok(())
 }
 
 #[tokio::test]
-async fn test_resume_picker_space_appends_to_query() {
-    let terminal = TestTerminal::new(TEST_WIDTH, 40);
-    let mut renderer = Renderer::new(terminal, TEST_AGENT.to_string(), &[], (TEST_WIDTH, 40));
-    renderer.initial_render().unwrap();
+async fn test_resume_picker_space_appends_to_query() -> TestResult {
+    let mut renderer = RendererTest::new().size((TEST_WIDTH, 40)).build()?;
 
-    type_string(&mut renderer, "/resume").await;
-    press_enter(&mut renderer).await;
-    renderer
-        .on_sessions_listed(vec![
-            session_info("session-login", "/repo/auth", "Fix login redirect"),
-            session_info("session-billing", "/repo/billing", "Billing cleanup"),
-        ])
-        .unwrap();
+    open_resume_picker(&mut renderer).await?;
+    renderer.on_sessions_listed(vec![
+        session_info("session-login", "/repo/auth", "Fix login redirect"),
+        session_info("session-billing", "/repo/billing", "Billing cleanup"),
+    ])?;
 
-    type_string(&mut renderer, "Fix ").await;
+    type_string(&mut renderer, "Fix ").await?;
 
     assert_buffer_contains(renderer.writer(), "Fix login redirect");
     assert_buffer_not_contains(renderer.writer(), "Billing cleanup");
+    Ok(())
 }
 
 #[tokio::test]
-async fn test_resume_picker_empty_and_filtered_empty_states() {
-    let terminal = TestTerminal::new(TEST_WIDTH, 40);
-    let mut renderer = Renderer::new(terminal, TEST_AGENT.to_string(), &[], (TEST_WIDTH, 40));
-    renderer.initial_render().unwrap();
+async fn test_resume_picker_empty_and_filtered_empty_states() -> TestResult {
+    let mut renderer = RendererTest::new().size((TEST_WIDTH, 40)).build()?;
 
-    type_string(&mut renderer, "/resume").await;
-    press_enter(&mut renderer).await;
-    renderer.on_sessions_listed(vec![]).unwrap();
+    open_resume_picker(&mut renderer).await?;
+    renderer.on_sessions_listed(vec![])?;
     assert_buffer_contains(renderer.writer(), "No previous sessions found.");
 
-    let terminal = TestTerminal::new(TEST_WIDTH, 40);
-    let mut renderer = Renderer::new(terminal, TEST_AGENT.to_string(), &[], (TEST_WIDTH, 40));
-    renderer.initial_render().unwrap();
-    type_string(&mut renderer, "/resume").await;
-    press_enter(&mut renderer).await;
-    renderer.on_sessions_listed(vec![session_info("session-login", "/repo/auth", "Fix login redirect")]).unwrap();
-    type_string(&mut renderer, "nomatch").await;
+    let mut renderer = RendererTest::new().size((TEST_WIDTH, 40)).build()?;
+    open_resume_picker(&mut renderer).await?;
+    renderer.on_sessions_listed(vec![session_info("session-login", "/repo/auth", "Fix login redirect")])?;
+    type_string(&mut renderer, "nomatch").await?;
     assert_buffer_contains(renderer.writer(), "(no matching sessions)");
+    Ok(())
 }
 
 #[tokio::test]
-async fn test_resume_picker_uses_cwd_basename_title_fallback() {
-    let terminal = TestTerminal::new(TEST_WIDTH, 40);
-    let mut renderer = Renderer::new(terminal, TEST_AGENT.to_string(), &[], (TEST_WIDTH, 40));
-    renderer.initial_render().unwrap();
+async fn test_resume_picker_uses_cwd_basename_title_fallback() -> TestResult {
+    let mut renderer = RendererTest::new().size((TEST_WIDTH, 40)).build()?;
 
-    type_string(&mut renderer, "/resume").await;
-    press_enter(&mut renderer).await;
+    open_resume_picker(&mut renderer).await?;
     renderer
-        .on_sessions_listed(vec![acp::SessionInfo::new("session-untitled", PathBuf::from("/repo/fallback-name"))])
-        .unwrap();
+        .on_sessions_listed(vec![acp::SessionInfo::new("session-untitled", PathBuf::from("/repo/fallback-name"))])?;
 
     assert_buffer_contains(renderer.writer(), "fallback-name");
+    Ok(())
 }
 
 #[tokio::test]
-async fn test_resume_picker_mouse_scroll_moves_selection_and_requests_preview() {
-    let terminal = TestTerminal::new(TEST_WIDTH, 40);
-    let (mut renderer, mut commands) = Renderer::new_recording(terminal, TEST_AGENT.to_string(), &[], (TEST_WIDTH, 40));
-    renderer.initial_render().unwrap();
+async fn test_resume_picker_mouse_scroll_moves_selection_and_requests_preview() -> TestResult {
+    let mut renderer = RendererTest::new().build()?;
 
-    type_string(&mut renderer, "/resume").await;
-    press_enter(&mut renderer).await;
-    assert_list_sessions_command(&mut commands);
-    renderer
-        .on_sessions_listed(vec![
-            session_info("session-login", "/repo/auth", "Fix login redirect"),
-            session_info("session-billing", "/repo/billing", "Billing cleanup"),
-        ])
-        .unwrap();
-    assert_session_preview_command(&mut commands, "session-login");
+    open_resume_picker(&mut renderer).await?;
+    assert_list_sessions_command(renderer.commands());
+    renderer.on_sessions_listed(vec![
+        session_info("session-login", "/repo/auth", "Fix login redirect"),
+        session_info("session-billing", "/repo/billing", "Billing cleanup"),
+    ])?;
+    assert_session_preview_command(renderer.commands(), "session-login");
 
-    renderer.on_mouse_scroll_down().await.unwrap();
+    renderer.on_mouse_scroll_down().await?;
 
-    assert_session_preview_command(&mut commands, "session-billing");
+    assert_session_preview_command(renderer.commands(), "session-billing");
     assert_buffer_contains(renderer.writer(), "Billing cleanup");
-    renderer.on_mouse_scroll_up().await.unwrap();
+    renderer.on_mouse_scroll_up().await?;
     assert_buffer_contains(renderer.writer(), "Fix login redirect");
+    Ok(())
 }
 
 #[tokio::test]
-async fn test_resume_picker_shows_metadata_and_lazy_preview() {
-    let terminal = TestTerminal::new(TEST_WIDTH, 40);
-    let mut renderer = Renderer::new(terminal, TEST_AGENT.to_string(), &[], (TEST_WIDTH, 40));
-    renderer.initial_render().unwrap();
+async fn test_resume_picker_shows_metadata_and_lazy_preview() -> TestResult {
+    let mut renderer = RendererTest::new().size((TEST_WIDTH, 40)).build()?;
 
-    type_string(&mut renderer, "/resume").await;
-    press_enter(&mut renderer).await;
-    renderer.on_sessions_listed(vec![session_info("session-login", "/repo/auth", "Fix login redirect")]).unwrap();
+    open_resume_picker(&mut renderer).await?;
+    renderer.on_sessions_listed(vec![session_info("session-login", "/repo/auth", "Fix login redirect")])?;
 
     assert_buffer_contains(renderer.writer(), "Fix login redirect");
     assert_buffer_contains(renderer.writer(), &format!("auth · {} · claude-sonnet-4-5 · planner", expected_date()));
     assert_buffer_contains(renderer.writer(), "Session preview");
     assert_buffer_contains(renderer.writer(), "Loading…");
 
-    renderer.on_session_preview_loaded(preview("session-login", "/repo/auth", false)).unwrap();
+    renderer.on_session_preview_loaded(preview("session-login", "/repo/auth", false))?;
 
     assert_buffer_contains(renderer.writer(), &format!("Created: {}", expected_date()));
     assert_buffer_not_contains(renderer.writer(), "Prompt: Fix login redirect");
@@ -138,98 +114,86 @@ async fn test_resume_picker_shows_metadata_and_lazy_preview() {
     assert_buffer_contains(renderer.writer(), "Model: claude-sonnet-4-5  Mode: planner");
     assert_buffer_contains(renderer.writer(), "assistant: Updated the auth callback");
     assert_buffer_contains(renderer.writer(), "Tool calls: 2");
+    Ok(())
 }
 
 #[tokio::test]
-async fn test_resume_picker_hides_preview_on_narrow_terminal() {
-    let terminal = TestTerminal::new(80, 24);
-    let mut renderer = Renderer::new(terminal, TEST_AGENT.to_string(), &[], (80, 24));
-    renderer.initial_render().unwrap();
+async fn test_resume_picker_hides_preview_on_narrow_terminal() -> TestResult {
+    let mut renderer = RendererTest::new().size((80, 24)).build()?;
 
-    type_string(&mut renderer, "/resume").await;
-    press_enter(&mut renderer).await;
-    renderer.on_sessions_listed(vec![session_info("session-login", "/repo/auth", "Fix login redirect")]).unwrap();
-    renderer.on_session_preview_loaded(preview("session-login", "/repo/auth", true)).unwrap();
+    open_resume_picker(&mut renderer).await?;
+    renderer.on_sessions_listed(vec![session_info("session-login", "/repo/auth", "Fix login redirect")])?;
+    renderer.on_session_preview_loaded(preview("session-login", "/repo/auth", true))?;
 
     assert_buffer_contains(renderer.writer(), "Fix login redirect");
     assert_buffer_contains(renderer.writer(), &format!("auth · {} · claude-sonnet-4-5 · planner", expected_date()));
     assert_buffer_not_contains(renderer.writer(), "Session preview");
     assert_buffer_not_contains(renderer.writer(), "… preview truncated");
+    Ok(())
 }
 
 #[tokio::test]
-async fn test_resume_picker_requests_preview_on_highlight_change_and_reuses_loaded_preview() {
-    let terminal = TestTerminal::new(TEST_WIDTH, 40);
-    let mut renderer = Renderer::new(terminal, TEST_AGENT.to_string(), &[], (TEST_WIDTH, 40));
-    renderer.initial_render().unwrap();
+async fn test_resume_picker_requests_preview_on_highlight_change_and_reuses_loaded_preview() -> TestResult {
+    let mut renderer = RendererTest::new().size((TEST_WIDTH, 40)).build()?;
 
-    type_string(&mut renderer, "/resume").await;
-    press_enter(&mut renderer).await;
-    renderer
-        .on_sessions_listed(vec![
-            session_info("session-login", "/repo/auth", "Fix login redirect"),
-            session_info("session-billing", "/repo/billing", "Billing cleanup"),
-        ])
-        .unwrap();
-    renderer.on_session_preview_loaded(preview("session-login", "/repo/auth", false)).unwrap();
+    open_resume_picker(&mut renderer).await?;
+    renderer.on_sessions_listed(vec![
+        session_info("session-login", "/repo/auth", "Fix login redirect"),
+        session_info("session-billing", "/repo/billing", "Billing cleanup"),
+    ])?;
+    renderer.on_session_preview_loaded(preview("session-login", "/repo/auth", false))?;
 
-    press_down(&mut renderer).await;
+    press(&mut renderer, Down).await?;
     assert_buffer_contains(renderer.writer(), "Loading…");
-    renderer.on_session_preview_failed("session-billing", "missing session").unwrap();
+    renderer.on_session_preview_failed("session-billing", "missing session")?;
     assert_buffer_contains(renderer.writer(), "Error: missing session");
 
-    press_up(&mut renderer).await;
+    press(&mut renderer, Up).await?;
     assert_buffer_contains(renderer.writer(), "user: Fix login redirect");
     assert_buffer_not_contains(renderer.writer(), "Loading…");
     assert_buffer_not_contains(renderer.writer(), "Error: missing session");
+    Ok(())
 }
 
 #[tokio::test]
-async fn test_resume_picker_dispatches_preview_requests_and_respects_capability() {
-    let terminal = TestTerminal::new(TEST_WIDTH, 40);
-    let (mut renderer, mut commands) = Renderer::new_recording(terminal, TEST_AGENT.to_string(), &[], (TEST_WIDTH, 40));
-    renderer.initial_render().unwrap();
+async fn test_resume_picker_dispatches_preview_requests_and_respects_capability() -> TestResult {
+    let mut renderer = RendererTest::new().build()?;
 
-    type_string(&mut renderer, "/resume").await;
-    press_enter(&mut renderer).await;
-    assert_list_sessions_command(&mut commands);
-    renderer
-        .on_sessions_listed(vec![
-            session_info("session-login", "/repo/auth", "Fix login redirect"),
-            session_info("session-billing", "/repo/billing", "Billing cleanup"),
-        ])
-        .unwrap();
+    open_resume_picker(&mut renderer).await?;
+    assert_list_sessions_command(renderer.commands());
+    renderer.on_sessions_listed(vec![
+        session_info("session-login", "/repo/auth", "Fix login redirect"),
+        session_info("session-billing", "/repo/billing", "Billing cleanup"),
+    ])?;
 
-    assert_session_preview_command(&mut commands, "session-login");
-    renderer.on_session_preview_loaded(preview("session-login", "/repo/auth", false)).unwrap();
+    assert_session_preview_command(renderer.commands(), "session-login");
+    renderer.on_session_preview_loaded(preview("session-login", "/repo/auth", false))?;
 
-    press_down(&mut renderer).await;
-    assert_session_preview_command(&mut commands, "session-billing");
-    renderer.on_session_preview_loaded(preview("session-billing", "/repo/billing", false)).unwrap();
+    press(&mut renderer, Down).await?;
+    assert_session_preview_command(renderer.commands(), "session-billing");
+    renderer.on_session_preview_loaded(preview("session-billing", "/repo/billing", false))?;
 
-    press_up(&mut renderer).await;
-    assert!(commands.try_recv().is_err(), "loaded previews should not be requested again");
+    press(&mut renderer, Up).await?;
+    assert!(renderer.commands().try_recv().is_err(), "loaded previews should not be requested again");
 
-    let terminal = TestTerminal::new(TEST_WIDTH, 40);
-    let (mut renderer, mut commands) =
-        Renderer::new_without_session_preview(terminal, TEST_AGENT.to_string(), &[], (TEST_WIDTH, 40));
-    renderer.initial_render().unwrap();
-    type_string(&mut renderer, "/resume").await;
-    press_enter(&mut renderer).await;
-    assert_list_sessions_command(&mut commands);
-    renderer.on_sessions_listed(vec![session_info("session-login", "/repo/auth", "Fix login redirect")]).unwrap();
-    assert!(commands.try_recv().is_err(), "missing sessionPreview capability should suppress preview requests");
+    let mut renderer = RendererTest::new().session_capabilities(acp::SessionCapabilities::new()).build()?;
+    open_resume_picker(&mut renderer).await?;
+    assert_list_sessions_command(renderer.commands());
+    renderer.on_sessions_listed(vec![session_info("session-login", "/repo/auth", "Fix login redirect")])?;
+    assert!(
+        renderer.commands().try_recv().is_err(),
+        "missing sessionPreview capability should suppress preview requests"
+    );
+    Ok(())
 }
 
 #[tokio::test]
-async fn test_prompt_done_clears_running_tool_spinner() {
-    let terminal = TestTerminal::new(TEST_WIDTH, 40);
-    let mut renderer = Renderer::new(terminal, TEST_AGENT.to_string(), &[], (TEST_WIDTH, 40));
-    renderer.initial_render().unwrap();
+async fn test_prompt_done_clears_running_tool_spinner() -> TestResult {
+    let mut renderer = RendererTest::new().size((TEST_WIDTH, 40)).build()?;
 
-    renderer.on_session_update(acp::SessionUpdate::ToolCall(acp::ToolCall::new("tool-1", "Read file"))).unwrap();
+    renderer.on_session_update(acp::SessionUpdate::ToolCall(acp::ToolCall::new("tool-1", "Read file")))?;
 
-    renderer.on_prompt_done().unwrap();
+    renderer.on_prompt_done()?;
 
     // Ensure prompt_done triggers a render and clears the progress indicator.
     let lines = renderer.writer().get_lines();
@@ -239,21 +203,18 @@ async fn test_prompt_done_clears_running_tool_spinner() {
         "Progress indicator should not remain visible after prompt_done.\nBuffer:\n{}",
         lines.join("\n")
     );
+    Ok(())
 }
 
 #[tokio::test]
-async fn test_prompt_done_flush_respects_rendering() {
-    let terminal = TestTerminal::new(TEST_WIDTH, 40);
-    let mut renderer = Renderer::new(terminal, TEST_AGENT.to_string(), &[], (TEST_WIDTH, 40));
-    renderer.initial_render().unwrap();
+async fn test_prompt_done_flush_respects_rendering() -> TestResult {
+    let mut renderer = RendererTest::new().size((TEST_WIDTH, 40)).build()?;
 
-    renderer
-        .on_session_update(acp::SessionUpdate::AgentThoughtChunk(acp::ContentChunk::new(acp::ContentBlock::Text(
-            acp::TextContent::new("theme should be preserved"),
-        ))))
-        .unwrap();
+    renderer.on_session_update(acp::SessionUpdate::AgentThoughtChunk(acp::ContentChunk::new(
+        acp::ContentBlock::Text(acp::TextContent::new("theme should be preserved")),
+    )))?;
 
-    renderer.on_prompt_done().unwrap();
+    renderer.on_prompt_done()?;
 
     // Should render successfully
     let lines = renderer.writer().get_lines();
@@ -262,99 +223,85 @@ async fn test_prompt_done_flush_respects_rendering() {
         "Thought text should be visible after prompt_done.\nBuffer:\n{}",
         lines.join("\n")
     );
+    Ok(())
 }
 
 #[tokio::test]
-async fn test_streaming_chunks_keep_waiting_for_response() {
-    let terminal = TestTerminal::new(TEST_WIDTH, 40);
-    let mut renderer = Renderer::new(terminal, TEST_AGENT.to_string(), &[], (TEST_WIDTH, 40));
-    renderer.initial_render().unwrap();
+async fn test_streaming_chunks_keep_waiting_for_response() -> TestResult {
+    let mut renderer = RendererTest::new().size((TEST_WIDTH, 40)).build()?;
 
     // Submit prompt to enter waiting state
-    type_string(&mut renderer, "Hello").await;
-    press_enter(&mut renderer).await;
+    type_string(&mut renderer, "Hello").await?;
+    press(&mut renderer, Enter).await?;
 
     // Send a streaming chunk (should not clear waiting state)
-    renderer
-        .on_session_update(acp::SessionUpdate::AgentMessageChunk(acp::ContentChunk::new(acp::ContentBlock::Text(
-            acp::TextContent::new("hello"),
-        ))))
-        .unwrap();
+    renderer.on_session_update(acp::SessionUpdate::AgentMessageChunk(acp::ContentChunk::new(
+        acp::ContentBlock::Text(acp::TextContent::new("hello")),
+    )))?;
 
     // Escape should still trigger cancel (proving we're still waiting)
-    let action = renderer.on_key_event(KeyEvent::new(KeyCode::Esc, KeyModifiers::NONE)).await.unwrap();
+    let action = renderer.on_key_event(KeyEvent::new(KeyCode::Esc, KeyModifiers::NONE)).await?;
 
     // If we're still waiting, escape triggers cancel effect which is handled
     assert!(matches!(action, LoopAction::Continue));
+    Ok(())
 }
 
 #[tokio::test]
-async fn test_on_tick_without_active_state_is_noop() {
-    let terminal = TestTerminal::new(TEST_WIDTH, 40);
-    let mut renderer = Renderer::new(terminal, TEST_AGENT.to_string(), &[], (TEST_WIDTH, 40));
-    renderer.initial_render().unwrap();
+async fn test_on_tick_without_active_state_is_noop() -> TestResult {
+    let mut renderer = RendererTest::new().size((TEST_WIDTH, 40)).build()?;
 
     let lines_before = renderer.writer().get_lines();
 
-    renderer.on_tick().await.unwrap();
+    renderer.on_tick().await?;
 
     let lines_after = renderer.writer().get_lines();
     assert_eq!(lines_before, lines_after, "Tick should be a no-op when nothing active");
+    Ok(())
 }
 
 #[tokio::test]
-async fn test_in_progress_tool_call_visible_after_initial_render() {
-    let terminal = TestTerminal::new(TEST_WIDTH, 40);
-    let mut renderer = Renderer::new(terminal, TEST_AGENT.to_string(), &[], (TEST_WIDTH, 40));
+async fn test_in_progress_tool_call_visible_after_initial_render() -> TestResult {
+    let mut renderer = RendererTest::new().size((TEST_WIDTH, 40)).build()?;
 
-    renderer.initial_render().unwrap();
-
-    renderer
-        .on_session_update(acp::SessionUpdate::ToolCall(
-            acp::ToolCall::new("call_1".to_string(), "Read").raw_input(serde_json::json!({"file": "test.rs"})),
-        ))
-        .unwrap();
+    renderer.on_session_update(acp::SessionUpdate::ToolCall(
+        acp::ToolCall::new("call_1".to_string(), "Read").raw_input(serde_json::json!({"file": "test.rs"})),
+    ))?;
 
     let expected = expected_with_prompt(&[&p("⠒ Read"), "", &p(PROGRESS_LINE), ""], TEST_WIDTH, "", TEST_AGENT);
     assert_buffer_eq(renderer.writer(), &expected);
+    Ok(())
 }
 
 #[tokio::test]
-async fn test_in_progress_tool_call_renders_correctly_after_resize() {
-    let terminal = TestTerminal::new(TEST_WIDTH, 40);
-    let mut renderer = Renderer::new(terminal, TEST_AGENT.to_string(), &[], (TEST_WIDTH, 40));
-    renderer.initial_render().unwrap();
+async fn test_in_progress_tool_call_renders_correctly_after_resize() -> TestResult {
+    let mut renderer = RendererTest::new().size((TEST_WIDTH, 40)).build()?;
 
-    renderer
-        .on_session_update(acp::SessionUpdate::ToolCall(
-            acp::ToolCall::new("call_1".to_string(), "Read").raw_input(serde_json::json!({"file": "test.rs"})),
-        ))
-        .unwrap();
+    renderer.on_session_update(acp::SessionUpdate::ToolCall(
+        acp::ToolCall::new("call_1".to_string(), "Read").raw_input(serde_json::json!({"file": "test.rs"})),
+    ))?;
 
     // Terminal resize triggers full re-render at new width
-    renderer.on_resize_event(100, 30).await.unwrap();
+    renderer.on_resize_event(100, 30).await?;
 
     let expected = expected_with_prompt(&[&p("⠒ Read"), "", &p(PROGRESS_LINE), ""], 100, "", TEST_AGENT);
     assert_buffer_eq(renderer.writer(), &expected);
+    Ok(())
 }
 
 /// Bug repro: completed conversation content must re-render at the new width
 /// after a terminal resize. Previously, completed turns were drained to
 /// fixed-width terminal scrollback and could not be re-rendered.
 #[tokio::test]
-async fn test_completed_content_re_renders_at_new_width_after_resize() {
+async fn test_completed_content_re_renders_at_new_width_after_resize() -> TestResult {
     let initial_width: u16 = 40;
-    let terminal = TestTerminal::new(initial_width, 20);
-    let mut renderer = Renderer::new(terminal, TEST_AGENT.to_string(), &[], (initial_width, 20));
-    renderer.initial_render().unwrap();
+    let mut renderer = RendererTest::new().size((initial_width, 20)).build()?;
 
     // Complete a full turn: text + tool call + prompt_done
-    renderer
-        .on_session_update(acp::SessionUpdate::AgentMessageChunk(acp::ContentChunk::new(acp::ContentBlock::Text(
-            acp::TextContent::new("First answer"),
-        ))))
-        .unwrap();
-    renderer.on_prompt_done().unwrap();
+    renderer.on_session_update(acp::SessionUpdate::AgentMessageChunk(acp::ContentChunk::new(
+        acp::ContentBlock::Text(acp::TextContent::new("First answer")),
+    )))?;
+    renderer.on_prompt_done()?;
 
     // Verify content is visible at original width
     let lines_before = renderer.writer().get_lines();
@@ -367,7 +314,7 @@ async fn test_completed_content_re_renders_at_new_width_after_resize() {
     // Widen the terminal — resize both the renderer and the TestTerminal buffer
     let new_width: u16 = 100;
     renderer.test_writer_mut().resize(new_width, 20);
-    renderer.on_resize_event(new_width, 20).await.unwrap();
+    renderer.on_resize_event(new_width, 20).await?;
 
     // Content from the completed turn must still be visible and the prompt
     // must be rendered at the new width
@@ -380,6 +327,7 @@ async fn test_completed_content_re_renders_at_new_width_after_resize() {
 
     let expected = expected_with_prompt(&[&p("First answer")], new_width, "", TEST_AGENT);
     assert_buffer_eq(renderer.writer(), &expected);
+    Ok(())
 }
 
 /// Bug repro: the prompt box must not garble after resizing when there is
@@ -387,29 +335,23 @@ async fn test_completed_content_re_renders_at_new_width_after_resize() {
 /// counts caused the `VisualFrame` visible/scrollback split to break,
 /// producing duplicated or corrupted prompt lines.
 #[tokio::test]
-async fn test_prompt_not_garbled_after_resize_with_completed_content() {
-    let terminal = TestTerminal::new(80, 12);
-    let mut renderer = Renderer::new(terminal, TEST_AGENT.to_string(), &[], (80, 12));
-    renderer.initial_render().unwrap();
+async fn test_prompt_not_garbled_after_resize_with_completed_content() -> TestResult {
+    let mut renderer = RendererTest::new().size((80, 12)).build()?;
 
     // Build up several completed turns so there's content above the prompt
-    renderer
-        .on_session_update(acp::SessionUpdate::AgentMessageChunk(acp::ContentChunk::new(acp::ContentBlock::Text(
-            acp::TextContent::new("Turn one"),
-        ))))
-        .unwrap();
-    renderer.on_prompt_done().unwrap();
+    renderer.on_session_update(acp::SessionUpdate::AgentMessageChunk(acp::ContentChunk::new(
+        acp::ContentBlock::Text(acp::TextContent::new("Turn one")),
+    )))?;
+    renderer.on_prompt_done()?;
 
-    renderer
-        .on_session_update(acp::SessionUpdate::AgentMessageChunk(acp::ContentChunk::new(acp::ContentBlock::Text(
-            acp::TextContent::new("Turn two"),
-        ))))
-        .unwrap();
-    renderer.on_prompt_done().unwrap();
+    renderer.on_session_update(acp::SessionUpdate::AgentMessageChunk(acp::ContentChunk::new(
+        acp::ContentBlock::Text(acp::TextContent::new("Turn two")),
+    )))?;
+    renderer.on_prompt_done()?;
 
     // Resize the terminal
     renderer.test_writer_mut().resize(60, 10);
-    renderer.on_resize_event(60, 10).await.unwrap();
+    renderer.on_resize_event(60, 10).await?;
 
     let lines = renderer.writer().get_lines();
 
@@ -424,42 +366,40 @@ async fn test_prompt_not_garbled_after_resize_with_completed_content() {
     let turn_two_count = lines.iter().filter(|l| l.contains("Turn two")).count();
     assert_eq!(turn_one_count, 1, "Turn one should appear exactly once after resize.\nBuffer:\n{}", lines.join("\n"));
     assert_eq!(turn_two_count, 1, "Turn two should appear exactly once after resize.\nBuffer:\n{}", lines.join("\n"));
+    Ok(())
 }
 
 #[tokio::test]
-async fn test_replay_history_only_visible_after_session_loaded() {
-    let mut renderer = new_test_renderer((TEST_WIDTH, 40));
+async fn test_replay_history_only_visible_after_session_loaded() -> TestResult {
+    let mut renderer = RendererTest::new().size((TEST_WIDTH, 40)).build()?;
     let resumed = acp::SessionId::new("resumed-session");
-    load_session_via_picker(&mut renderer, resumed.clone(), std::path::PathBuf::from("/project")).await;
+    load_session_via_picker(&mut renderer, resumed.clone(), std::path::PathBuf::from("/project")).await?;
 
     let first_msg = "1st";
     let second_msg = "2nd";
-    renderer
-        .on_session_update_for(
-            resumed.clone(),
-            acp::SessionUpdate::UserMessageChunk(acp::ContentChunk::new(acp::ContentBlock::Text(
-                acp::TextContent::new(first_msg),
-            ))),
-        )
-        .unwrap();
+    renderer.on_session_update_for(
+        resumed.clone(),
+        acp::SessionUpdate::UserMessageChunk(acp::ContentChunk::new(acp::ContentBlock::Text(acp::TextContent::new(
+            first_msg,
+        )))),
+    )?;
 
-    renderer
-        .on_session_update_for(
-            resumed.clone(),
-            acp::SessionUpdate::AgentMessageChunk(acp::ContentChunk::new(acp::ContentBlock::Text(
-                acp::TextContent::new(second_msg),
-            ))),
-        )
-        .unwrap();
+    renderer.on_session_update_for(
+        resumed.clone(),
+        acp::SessionUpdate::AgentMessageChunk(acp::ContentChunk::new(acp::ContentBlock::Text(acp::TextContent::new(
+            second_msg,
+        )))),
+    )?;
 
     assert_buffer_not_contains(renderer.writer(), first_msg);
     assert_buffer_not_contains(renderer.writer(), second_msg);
-    renderer.on_session_loaded(resumed, vec![]).unwrap();
+    renderer.on_session_loaded(resumed, vec![])?;
 
     let lines = renderer.writer().get_lines();
     let early_idx = lines.iter().position(|l| l.contains(first_msg)).expect("early line present");
     let late_idx = lines.iter().position(|l| l.contains(second_msg)).expect("late line present");
     assert!(early_idx < late_idx);
+    Ok(())
 }
 
 fn assert_list_sessions_command(commands: &mut UnboundedReceiver<PromptCommand>) {

--- a/crates/wisp/tests/app_tests/settings_menu_tests.rs
+++ b/crates/wisp/tests/app_tests/settings_menu_tests.rs
@@ -4,15 +4,15 @@ use tui::KeyEvent;
 use tui::KeyEventKind;
 use tui::KeyEventState;
 use tui::KeyModifiers;
-use tui::testing::TestTerminal;
 
 use super::common::*;
 
 #[tokio::test]
-async fn test_settings_command_opens_menu() {
-    let r = open_settings(&make_settings_options(), (80, 24)).await;
+async fn test_settings_command_opens_menu() -> TestResult {
+    let r = open_settings(&make_settings_options(), (80, 24)).await?;
     assert!(has_settings_menu(r.writer()), "Settings menu should be visible");
     assert!(!has_settings_picker(r.writer()), "Settings picker should not be visible");
+    Ok(())
 }
 
 fn make_provider_auth_methods() -> Vec<acp::AuthMethod> {
@@ -23,94 +23,90 @@ fn make_provider_auth_methods() -> Vec<acp::AuthMethod> {
 }
 
 #[tokio::test]
-async fn test_auth_methods_updated_notification_refreshes_provider_login_and_persists_on_reopen() {
-    let terminal = TestTerminal::new(TEST_WIDTH, 40);
-    let mut r = Renderer::new_with_auth_methods(
-        terminal,
-        TEST_AGENT.to_string(),
-        &[],
-        make_provider_auth_methods(),
-        (TEST_WIDTH, 40),
-    );
-    r.initial_render().unwrap();
-    type_string(&mut r, "/settings").await;
-    press_enter(&mut r).await;
-    press_down(&mut r).await;
-    press_down(&mut r).await;
+async fn test_auth_methods_updated_notification_refreshes_provider_login_and_persists_on_reopen() -> TestResult {
+    let mut r = RendererTest::new().auth_methods(make_provider_auth_methods()).build()?;
+    type_string(&mut r, "/settings").await?;
+    press(&mut r, Enter).await?;
+    press(&mut r, Down).await?;
+    press(&mut r, Down).await?;
 
-    press_enter(&mut r).await;
+    press(&mut r, Enter).await?;
     assert_buffer_contains(r.writer(), "Anthropic  ⚡ needs login");
 
     let updated = vec![
         acp::AuthMethod::Agent(acp::AuthMethodAgent::new("anthropic", "Anthropic").description("authenticated")),
         acp::AuthMethod::Agent(acp::AuthMethodAgent::new("openrouter", "OpenRouter")),
     ];
-    r.on_auth_methods_updated(acp_utils::notifications::AuthMethodsUpdatedParams { auth_methods: updated }).unwrap();
+    r.on_auth_methods_updated(acp_utils::notifications::AuthMethodsUpdatedParams { auth_methods: updated })?;
     assert_buffer_contains(r.writer(), "Anthropic  ✓ logged in");
 
-    press_esc(&mut r).await;
+    press(&mut r, Esc).await?;
     assert!(has_settings_menu(r.writer()));
-    press_enter(&mut r).await;
+    press(&mut r, Enter).await?;
     assert_buffer_contains(r.writer(), "Anthropic  ✓ logged in");
+    Ok(())
 }
 
 #[tokio::test]
-async fn test_settings_menu_esc_closes() {
-    let mut r = open_settings(&make_settings_options(), (80, 24)).await;
+async fn test_settings_menu_esc_closes() -> TestResult {
+    let mut r = open_settings(&make_settings_options(), (80, 24)).await?;
     assert!(has_settings_menu(r.writer()));
     assert!(!has_settings_picker(r.writer()));
 
     // Open the picker
-    press_enter(&mut r).await;
+    press(&mut r, Enter).await?;
     assert!(has_settings_menu(r.writer()));
     assert!(has_settings_picker(r.writer()));
 
     // First ESC closes picker
-    press_esc(&mut r).await;
+    press(&mut r, Esc).await?;
     assert!(has_settings_menu(r.writer()));
     assert!(!has_settings_picker(r.writer()));
 
     // Second ESC closes menu
-    press_esc(&mut r).await;
+    press(&mut r, Esc).await?;
     assert!(!has_settings_menu(r.writer()));
+    Ok(())
 }
 
 #[tokio::test]
-async fn test_settings_menu_arrow_navigation_single_entry() {
-    let mut r = open_settings(&make_settings_options(), (80, 24)).await;
+async fn test_settings_menu_arrow_navigation_single_entry() -> TestResult {
+    let mut r = open_settings(&make_settings_options(), (80, 24)).await?;
     assert!(has_settings_menu(r.writer()));
 
-    press_enter(&mut r).await;
+    press(&mut r, Enter).await?;
     assert_buffer_contains(r.writer(), "Model search");
 
-    press_esc(&mut r).await;
-    press_down(&mut r).await;
-    press_enter(&mut r).await;
+    press(&mut r, Esc).await?;
+    press(&mut r, Down).await?;
+    press(&mut r, Enter).await?;
     assert_buffer_contains(r.writer(), "Theme search");
 
-    press_esc(&mut r).await;
-    press_down(&mut r).await;
-    press_enter(&mut r).await;
+    press(&mut r, Esc).await?;
+    press(&mut r, Down).await?;
+    press(&mut r, Enter).await?;
     assert_buffer_contains(r.writer(), "no MCP servers configured");
 
-    press_esc(&mut r).await;
-    press_down(&mut r).await;
-    press_enter(&mut r).await;
+    press(&mut r, Esc).await?;
+    press(&mut r, Down).await?;
+    press(&mut r, Enter).await?;
     assert_buffer_contains(r.writer(), "Model search");
+    Ok(())
 }
 
 #[tokio::test]
-async fn test_settings_single_option_shows_model_picker() {
-    let mut r = open_settings(&make_settings_options(), (80, 24)).await;
-    press_enter(&mut r).await;
+async fn test_settings_single_option_shows_model_picker() -> TestResult {
+    let mut r = open_settings(&make_settings_options(), (80, 24)).await?;
+    press(&mut r, Enter).await?;
     assert!(has_settings_picker(r.writer()));
     assert_buffer_contains(r.writer(), "Model search");
+    Ok(())
 }
 
 #[tokio::test]
-async fn test_settings_picker_focuses_cursor_on_overlay_query() {
-    let mut r = open_settings(&make_settings_options(), (80, 24)).await;
-    press_enter(&mut r).await;
+async fn test_settings_picker_focuses_cursor_on_overlay_query() -> TestResult {
+    let mut r = open_settings(&make_settings_options(), (80, 24)).await?;
+    press(&mut r, Enter).await?;
 
     let lines = r.writer().get_lines();
     #[allow(clippy::cast_possible_truncation)]
@@ -118,18 +114,20 @@ async fn test_settings_picker_focuses_cursor_on_overlay_query() {
     let (cursor_col, cursor_row) = r.writer().cursor_position();
     assert_eq!(cursor_row, search_row);
     assert_eq!(cursor_col, 18);
+    Ok(())
 }
 
 #[tokio::test]
-async fn test_settings_picker_filters_model_options() {
-    let mut r = open_settings(&make_settings_options(), (80, 24)).await;
-    press_enter(&mut r).await;
-    type_string(&mut r, "claude").await;
+async fn test_settings_picker_filters_model_options() -> TestResult {
+    let mut r = open_settings(&make_settings_options(), (80, 24)).await?;
+    press(&mut r, Enter).await?;
+    type_string(&mut r, "claude").await?;
     assert_buffer_contains(r.writer(), "Claude Sonnet");
+    Ok(())
 }
 
 #[tokio::test]
-async fn test_settings_menu_swallows_other_keys() {
+async fn test_settings_menu_swallows_other_keys() -> TestResult {
     let config = vec![
         acp::SessionConfigOption::select("model", "Model", "m1", vec![acp::SessionConfigSelectOption::new("m1", "M1")]),
         acp::SessionConfigOption::select(
@@ -139,15 +137,16 @@ async fn test_settings_menu_swallows_other_keys() {
             vec![acp::SessionConfigSelectOption::new("dark", "Dark")],
         ),
     ];
-    let mut r = open_settings(&config, (80, 24)).await;
-    send_key(&mut r, KeyCode::Char('z'), KeyModifiers::empty()).await;
+    let mut r = open_settings(&config, (80, 24)).await?;
+    press(&mut r, KeyCode::Char('z')).await?;
     assert!(has_settings_menu(r.writer()));
     assert_buffer_not_contains(r.writer(), "z");
+    Ok(())
 }
 
 #[tokio::test]
-async fn test_settings_menu_ctrl_c_exits() {
-    let mut r = open_settings(&make_settings_options(), (80, 24)).await;
+async fn test_settings_menu_ctrl_c_exits() -> TestResult {
+    let mut r = open_settings(&make_settings_options(), (80, 24)).await?;
     let action = r
         .on_key_event(KeyEvent {
             code: KeyCode::Char('c'),
@@ -155,8 +154,7 @@ async fn test_settings_menu_ctrl_c_exits() {
             kind: KeyEventKind::Press,
             state: KeyEventState::empty(),
         })
-        .await
-        .unwrap();
+        .await?;
     assert!(matches!(action, LoopAction::Continue), "first Ctrl-C should not exit");
     let action = r
         .on_key_event(KeyEvent {
@@ -165,14 +163,14 @@ async fn test_settings_menu_ctrl_c_exits() {
             kind: KeyEventKind::Press,
             state: KeyEventState::empty(),
         })
-        .await
-        .unwrap();
+        .await?;
     assert!(matches!(action, LoopAction::Exit), "second Ctrl-C should exit");
+    Ok(())
 }
 
 #[tokio::test]
-async fn test_settings_menu_updates_on_config_option_event() {
-    let mut r = open_settings(&make_settings_options(), (80, 24)).await;
+async fn test_settings_menu_updates_on_config_option_event() -> TestResult {
+    let mut r = open_settings(&make_settings_options(), (80, 24)).await?;
     let new_config = vec![
         acp::SessionConfigOption::select(
             "model",
@@ -185,73 +183,72 @@ async fn test_settings_menu_updates_on_config_option_event() {
         )
         .category(acp::SessionConfigOptionCategory::Model),
     ];
-    r.on_session_update(acp::SessionUpdate::ConfigOptionUpdate(acp::ConfigOptionUpdate::new(new_config))).unwrap();
+    r.on_session_update(acp::SessionUpdate::ConfigOptionUpdate(acp::ConfigOptionUpdate::new(new_config)))?;
     assert_buffer_contains(r.writer(), "Claude Sonnet");
+    Ok(())
 }
 
 #[tokio::test]
-async fn test_settings_clears_input_buffer() {
-    let r = open_settings(&make_settings_options(), (80, 24)).await;
+async fn test_settings_clears_input_buffer() -> TestResult {
+    let r = open_settings(&make_settings_options(), (80, 24)).await?;
     assert_buffer_not_contains(r.writer(), "/settings");
+    Ok(())
 }
 
 #[tokio::test]
-async fn test_settings_with_no_options_shows_placeholder() {
-    let r = open_settings(&[], (80, 24)).await;
+async fn test_settings_with_no_options_shows_placeholder() -> TestResult {
+    let r = open_settings(&[], (80, 24)).await?;
     assert!(has_settings_menu(r.writer()));
     assert_buffer_contains(r.writer(), "MCP Servers");
+    Ok(())
 }
 
 #[tokio::test]
-async fn test_settings_overlay_renders_after_large_overflow_scrollback() {
+async fn test_settings_overlay_renders_after_large_overflow_scrollback() -> TestResult {
     let config_options = make_settings_options();
-    let terminal = TestTerminal::new(80, 8);
-    let mut r = Renderer::new(terminal, TEST_AGENT.to_string(), &config_options, (80, 8));
-    r.initial_render().unwrap();
+    let mut r = RendererTest::new().size((80, 8)).config_options(&config_options).build()?;
 
     for i in 0..50 {
         r.on_session_update(acp::SessionUpdate::AgentMessageChunk(acp::ContentChunk::new(acp::ContentBlock::Text(
             acp::TextContent::new(format!("Line {i:02} with enough content to wrap in 40 cols")),
-        ))))
-        .unwrap();
+        ))))?;
     }
 
-    type_string(&mut r, "/settings").await;
-    press_enter(&mut r).await;
+    type_string(&mut r, "/settings").await?;
+    press(&mut r, Enter).await?;
     assert!(has_settings_menu(r.writer()));
     assert_buffer_contains(r.writer(), "Configuration");
     assert_buffer_contains(r.writer(), "Model");
+    Ok(())
 }
 
 #[tokio::test]
-async fn test_settings_overlay_open_close_after_overflow_keeps_prompt_and_layout_valid() {
+async fn test_settings_overlay_open_close_after_overflow_keeps_prompt_and_layout_valid() -> TestResult {
     let config_options = make_settings_options();
-    let terminal = TestTerminal::new(80, 8);
-    let mut r = Renderer::new(terminal, TEST_AGENT.to_string(), &config_options, (80, 8));
-    r.initial_render().unwrap();
+    let mut r = RendererTest::new().size((80, 8)).config_options(&config_options).build()?;
 
     for i in 0..50 {
         r.on_session_update(acp::SessionUpdate::AgentMessageChunk(acp::ContentChunk::new(acp::ContentBlock::Text(
             acp::TextContent::new(format!("Line {i:02} with enough content to wrap in 40 cols")),
-        ))))
-        .unwrap();
+        ))))?;
     }
 
-    type_string(&mut r, "/settings").await;
-    press_enter(&mut r).await;
+    type_string(&mut r, "/settings").await?;
+    press(&mut r, Enter).await?;
     assert!(has_settings_menu(r.writer()));
     assert_buffer_contains(r.writer(), "Configuration");
 
-    press_esc(&mut r).await;
+    press(&mut r, Esc).await?;
     assert!(!has_settings_menu(r.writer()));
 
     let lines = r.writer().get_lines();
     assert!(lines.iter().any(|l| l.chars().all(|c| c == '─') && !l.is_empty()), "Prompt rule should be visible");
     assert!(lines.iter().any(|l| !l.trim().is_empty()), "Frame should not be empty");
+    Ok(())
 }
 
 #[tokio::test]
-async fn test_settings_option_update_refreshes_mode_display() {
+async fn test_settings_option_update_refreshes_mode_display() -> TestResult {
     let initial = vec![
         acp::SessionConfigOption::select(
             "mode",
@@ -264,9 +261,7 @@ async fn test_settings_option_update_refreshes_mode_display() {
         )
         .category(acp::SessionConfigOptionCategory::Mode),
     ];
-    let terminal = TestTerminal::new(TEST_WIDTH, 40);
-    let mut r = Renderer::new(terminal, TEST_AGENT.to_string(), &initial, (TEST_WIDTH, 40));
-    r.initial_render().unwrap();
+    let mut r = RendererTest::new().config_options(&initial).build()?;
 
     let updated = vec![
         acp::SessionConfigOption::select(
@@ -280,37 +275,39 @@ async fn test_settings_option_update_refreshes_mode_display() {
         )
         .category(acp::SessionConfigOptionCategory::Mode),
     ];
-    r.on_session_update(acp::SessionUpdate::ConfigOptionUpdate(acp::ConfigOptionUpdate::new(updated))).unwrap();
+    r.on_session_update(acp::SessionUpdate::ConfigOptionUpdate(acp::ConfigOptionUpdate::new(updated)))?;
     assert_buffer_contains(r.writer(), "Coder");
+    Ok(())
 }
 
 #[tokio::test]
-async fn test_server_status_notification_updates_overlay_state() {
-    let mut r = open_settings(&[], (TEST_WIDTH, 40)).await;
+async fn test_server_status_notification_updates_overlay_state() -> TestResult {
+    let mut r = open_settings(&[], (TEST_WIDTH, 40)).await?;
     let notification = acp_utils::notifications::McpNotification::ServerStatus {
         servers: vec![acp_utils::notifications::McpServerStatusEntry::new(
             "docs",
             acp_utils::notifications::McpServerStatus::Connected { tool_count: 0 },
         )],
     };
-    r.on_mcp_notification(notification).unwrap();
+    r.on_mcp_notification(notification)?;
     assert!(has_settings_menu(r.writer()));
+    Ok(())
 }
 
 #[tokio::test]
-async fn test_empty_server_status_notification_clears_open_settings_menu_summary() {
-    let mut r = open_settings(&[], (TEST_WIDTH, 40)).await;
+async fn test_empty_server_status_notification_clears_open_settings_menu_summary() -> TestResult {
+    let mut r = open_settings(&[], (TEST_WIDTH, 40)).await?;
     r.on_mcp_notification(acp_utils::notifications::McpNotification::ServerStatus {
         servers: vec![acp_utils::notifications::McpServerStatusEntry::new(
             "docs",
             acp_utils::notifications::McpServerStatus::Connected { tool_count: 0 },
         )],
-    })
-    .unwrap();
+    })?;
     assert_buffer_contains(r.writer(), "MCP Servers: 1 connected");
 
-    r.on_mcp_notification(acp_utils::notifications::McpNotification::ServerStatus { servers: vec![] }).unwrap();
+    r.on_mcp_notification(acp_utils::notifications::McpNotification::ServerStatus { servers: vec![] })?;
 
     assert_buffer_contains(r.writer(), "MCP Servers: none");
     assert_buffer_not_contains(r.writer(), "MCP Servers: 1 connected");
+    Ok(())
 }

--- a/crates/wisp/tests/app_tests/small_terminal_tests.rs
+++ b/crates/wisp/tests/app_tests/small_terminal_tests.rs
@@ -1,20 +1,21 @@
 use super::common::*;
 
 #[tokio::test]
-async fn test_no_ghost_on_tool_completion_small_terminal() {
+async fn test_no_ghost_on_tool_completion_small_terminal() -> TestResult {
     let args = r#"{"file": "a.rs"}"#;
     let renderer = render_with_size(
         vec![tool_call("Read", args), tool_complete("call_Read"), text_chunk("Done"), prompt_done()],
         (80, 8),
-    );
+    )?;
 
     let lines = renderer.writer().get_lines();
     let tool_count = lines.iter().filter(|l| l.contains("Read")).count();
     assert_eq!(tool_count, 1, "Tool name should appear exactly once, got {tool_count}.\nBuffer:\n{}", lines.join("\n"));
+    Ok(())
 }
 
 #[tokio::test]
-async fn test_tool_updates_in_place_after_scrollback_push() {
+async fn test_tool_updates_in_place_after_scrollback_push() -> TestResult {
     let renderer = render_with_size(
         vec![
             tool_call_with_id("Read", "call_1", r#"{"file": "a.rs"}"#),
@@ -25,7 +26,7 @@ async fn test_tool_updates_in_place_after_scrollback_push() {
             tool_complete("call_2"),
         ],
         (80, 10),
-    );
+    )?;
 
     let lines = renderer.writer().get_lines();
     let write_count = lines.iter().filter(|l| l.contains("Write")).count();
@@ -35,13 +36,14 @@ async fn test_tool_updates_in_place_after_scrollback_push() {
         "Write tool should appear exactly once, got {write_count}.\nBuffer:\n{}",
         lines.join("\n")
     );
+    Ok(())
 }
 
 #[tokio::test]
-async fn test_wrapped_tool_update_does_not_duplicate_lines() {
+async fn test_wrapped_tool_update_does_not_duplicate_lines() -> TestResult {
     let long_args = r#"{"file":"src/some/really/long/path/that/forces/tool/status/wrapping.rs"}"#;
     let renderer =
-        render_with_size(vec![tool_call_with_id("Read", "call_1", long_args), tool_complete("call_1")], (40, 12));
+        render_with_size(vec![tool_call_with_id("Read", "call_1", long_args), tool_complete("call_1")], (40, 12))?;
 
     let lines = renderer.writer().get_lines();
     let read_count = lines.iter().filter(|l| l.contains("Read")).count();
@@ -56,10 +58,11 @@ async fn test_wrapped_tool_update_does_not_duplicate_lines() {
         "Completed status should be visible after wrapped update.\nBuffer:\n{}",
         lines.join("\n")
     );
+    Ok(())
 }
 
 #[tokio::test]
-async fn test_multiple_scrollback_pushes_tiny_terminal() {
+async fn test_multiple_scrollback_pushes_tiny_terminal() -> TestResult {
     let renderer = render_with_size(
         vec![
             text_chunk("First message"),
@@ -70,18 +73,19 @@ async fn test_multiple_scrollback_pushes_tiny_terminal() {
             prompt_done(),
         ],
         (80, 8),
-    );
+    )?;
 
     let lines = renderer.writer().get_lines();
     assert!(lines.iter().any(|l| l.contains('>')), "Prompt should be visible.\nBuffer:\n{}", lines.join("\n"));
+    Ok(())
 }
 
 #[tokio::test]
-async fn test_prompt_done_does_not_duplicate_overflowed_lines() {
+async fn test_prompt_done_does_not_duplicate_overflowed_lines() -> TestResult {
     let markers: Vec<String> = (1..=16).map(|i| format!("L{i:02}")).collect();
     let chunk = format!("```text\n{}\n```", markers.join("\n"));
 
-    let renderer = render_with_size(vec![text_chunk(&chunk), prompt_done()], (40, 8));
+    let renderer = render_with_size(vec![text_chunk(&chunk), prompt_done()], (40, 8))?;
 
     let transcript = renderer.writer().get_transcript_lines();
     for marker in markers.iter().take(8) {
@@ -93,4 +97,5 @@ async fn test_prompt_done_does_not_duplicate_overflowed_lines() {
             transcript.join("\n")
         );
     }
+    Ok(())
 }

--- a/crates/wisp/tests/app_tests/status_line_tests.rs
+++ b/crates/wisp/tests/app_tests/status_line_tests.rs
@@ -1,16 +1,11 @@
 use agent_client_protocol::schema as acp;
 use tui::KeyCode;
-use tui::KeyModifiers;
-use tui::testing::TestTerminal;
 
 use super::common::*;
 
 #[tokio::test]
-async fn test_status_line_shows_workspace_on_left() {
-    let terminal = TestTerminal::new(TEST_WIDTH, 24);
-    let mut renderer = Renderer::new(terminal, TEST_AGENT.to_string(), &[], (TEST_WIDTH, 24));
-
-    renderer.initial_render().unwrap();
+async fn test_status_line_shows_workspace_on_left() -> TestResult {
+    let renderer = RendererTest::new().size((TEST_WIDTH, 24)).build()?;
 
     let lines = renderer.writer().get_lines();
     let status_line = lines
@@ -18,14 +13,12 @@ async fn test_status_line_shows_workspace_on_left() {
         .find(|line| line.contains(TEST_WORKSPACE_DIR) && line.contains(TEST_GIT_REF) && line.contains(TEST_AGENT))
         .unwrap_or_else(|| panic!("Status line should show workspace and agent.\nBuffer:\n{}", lines.join("\n")));
     assert!(status_line.find(TEST_WORKSPACE_DIR).unwrap() < status_line.find(TEST_AGENT).unwrap());
+    Ok(())
 }
 
 #[tokio::test]
-async fn test_status_line_shows_agent_name() {
-    let terminal = TestTerminal::new(80, 24);
-    let mut renderer = Renderer::new(terminal, "claude-code".to_string(), &[], (80, 24));
-
-    renderer.initial_render().unwrap();
+async fn test_status_line_shows_agent_name() -> TestResult {
+    let renderer = RendererTest::new().size((80, 24)).agent_name("claude-code").build()?;
 
     let lines = renderer.writer().get_lines();
     assert!(
@@ -33,10 +26,11 @@ async fn test_status_line_shows_agent_name() {
         "Status line should show agent name.\nBuffer:\n{}",
         lines.join("\n")
     );
+    Ok(())
 }
 
 #[tokio::test]
-async fn test_status_line_shows_model_from_config_options() {
+async fn test_status_line_shows_model_from_config_options() -> TestResult {
     let config_options = vec![
         acp::SessionConfigOption::select(
             "model",
@@ -47,10 +41,8 @@ async fn test_status_line_shows_model_from_config_options() {
         .category(acp::SessionConfigOptionCategory::Model),
     ];
 
-    let terminal = TestTerminal::new(80, 24);
-    let mut renderer = Renderer::new(terminal, "aether-acp".to_string(), &config_options, (80, 24));
-
-    renderer.initial_render().unwrap();
+    let renderer =
+        RendererTest::new().size((80, 24)).agent_name("aether-acp").config_options(&config_options).build()?;
 
     let lines = renderer.writer().get_lines();
     assert!(
@@ -58,10 +50,11 @@ async fn test_status_line_shows_model_from_config_options() {
         "Status line should show agent name and model.\nBuffer:\n{}",
         lines.join("\n")
     );
+    Ok(())
 }
 
 #[tokio::test]
-async fn test_status_line_updates_on_config_option_update() {
+async fn test_status_line_updates_on_config_option_update() -> TestResult {
     let config_options = vec![
         acp::SessionConfigOption::select(
             "model",
@@ -72,9 +65,8 @@ async fn test_status_line_updates_on_config_option_update() {
         .category(acp::SessionConfigOptionCategory::Model),
     ];
 
-    let terminal = TestTerminal::new(80, 24);
-    let mut renderer = Renderer::new(terminal, "aether-acp".to_string(), &config_options, (80, 24));
-    renderer.initial_render().unwrap();
+    let mut renderer =
+        RendererTest::new().size((80, 24)).agent_name("aether-acp").config_options(&config_options).build()?;
 
     // Send a ConfigOptionUpdate with a new model
     let new_config_options = vec![
@@ -88,8 +80,7 @@ async fn test_status_line_updates_on_config_option_update() {
     ];
 
     renderer
-        .on_session_update(acp::SessionUpdate::ConfigOptionUpdate(acp::ConfigOptionUpdate::new(new_config_options)))
-        .unwrap();
+        .on_session_update(acp::SessionUpdate::ConfigOptionUpdate(acp::ConfigOptionUpdate::new(new_config_options)))?;
 
     let lines = renderer.writer().get_lines();
     assert!(
@@ -102,23 +93,21 @@ async fn test_status_line_updates_on_config_option_update() {
         "Status line should no longer show old model.\nBuffer:\n{}",
         lines.join("\n")
     );
+    Ok(())
 }
 
 #[tokio::test]
-async fn test_available_commands_update_is_forwarded() {
-    let terminal = TestTerminal::new(TEST_WIDTH, 40);
-    let mut renderer = Renderer::new(terminal, TEST_AGENT.to_string(), &[], (TEST_WIDTH, 40));
-    renderer.initial_render().unwrap();
+async fn test_available_commands_update_is_forwarded() -> TestResult {
+    let mut renderer = RendererTest::new().size((TEST_WIDTH, 40)).build()?;
 
-    renderer
-        .on_session_update(acp::SessionUpdate::AvailableCommandsUpdate(acp::AvailableCommandsUpdate::new(vec![
-            acp::AvailableCommand::new("search", "Search code"),
-        ])))
-        .unwrap();
+    renderer.on_session_update(acp::SessionUpdate::AvailableCommandsUpdate(acp::AvailableCommandsUpdate::new(
+        vec![acp::AvailableCommand::new("search", "Search code")],
+    )))?;
 
     // Open the command picker with /
-    send_key(&mut renderer, KeyCode::Char('/'), KeyModifiers::empty()).await;
+    press(&mut renderer, KeyCode::Char('/')).await?;
 
     let names = command_picker_visible_names(renderer.writer());
     assert!(names.iter().any(|n| n == "search"), "Command picker should show 'search' command. Got: {names:?}");
+    Ok(())
 }

--- a/crates/wisp/tests/app_tests/tool_calls_tests.rs
+++ b/crates/wisp/tests/app_tests/tool_calls_tests.rs
@@ -3,8 +3,8 @@ use tui::testing::assert_buffer_eq;
 use super::common::*;
 
 #[tokio::test]
-async fn test_tool_calls_interleave_with_thought_and_text_in_arrival_order() {
-    let renderer = render(vec![thought_chunk("Thinking"), tool_call("search", r#"{"q":"rust"}"#), text_chunk("Done")]);
+async fn test_tool_calls_interleave_with_thought_and_text_in_arrival_order() -> TestResult {
+    let renderer = render(vec![thought_chunk("Thinking"), tool_call("search", r#"{"q":"rust"}"#), text_chunk("Done")])?;
 
     let expected = expected_with_prompt(
         &[&p("Thinking"), "", &p("⠒ search"), "", &p("Done"), "", &p(PROGRESS_LINE), ""],
@@ -13,27 +13,30 @@ async fn test_tool_calls_interleave_with_thought_and_text_in_arrival_order() {
         TEST_AGENT,
     );
     assert_buffer_eq(renderer.writer(), &expected);
+    Ok(())
 }
 
 #[tokio::test]
-async fn test_agent_message_tool_call() {
-    let renderer = render(vec![tool_call("test_tool", r#"{"arg1": "value1"}"#)]);
+async fn test_agent_message_tool_call() -> TestResult {
+    let renderer = render(vec![tool_call("test_tool", r#"{"arg1": "value1"}"#)])?;
 
     let expected = expected_with_prompt(&[&p("⠒ test_tool"), "", &p(PROGRESS_LINE), ""], TEST_WIDTH, "", TEST_AGENT);
     assert_buffer_eq(renderer.writer(), &expected);
+    Ok(())
 }
 
 #[tokio::test]
-async fn test_agent_message_tool_result() {
+async fn test_agent_message_tool_result() -> TestResult {
     let args = r#"{"arg1": "value1"}"#;
-    let renderer = render(vec![tool_call("test_tool", args), tool_complete("call_test_tool")]);
+    let renderer = render(vec![tool_call("test_tool", args), tool_complete("call_test_tool")])?;
 
     let expected = expected_with_prompt(&[&p(r#"✓ test_tool {"arg1":"value1"}"#)], TEST_WIDTH, "", TEST_AGENT);
     assert_buffer_eq(renderer.writer(), &expected);
+    Ok(())
 }
 
 #[tokio::test]
-async fn test_multiple_messages_sequence() {
+async fn test_multiple_messages_sequence() -> TestResult {
     let args = r#"{"query": "test"}"#;
     let renderer = render(vec![
         text_chunk("Processing your request"),
@@ -42,7 +45,7 @@ async fn test_multiple_messages_sequence() {
         tool_complete("call_search"),
         text_chunk("Found results"),
         prompt_done(),
-    ]);
+    ])?;
 
     let expected = expected_with_prompt(
         &[&p("Processing your request"), "", &p(r#"✓ search {"query":"test"}"#), "", &p("Found results")],
@@ -51,39 +54,45 @@ async fn test_multiple_messages_sequence() {
         TEST_AGENT,
     );
     assert_buffer_eq(renderer.writer(), &expected);
+    Ok(())
 }
 
 #[tokio::test]
-async fn test_streaming_tool_call_arguments() {
+async fn test_streaming_tool_call_arguments() -> TestResult {
     let renderer = render(vec![
         tool_call_with_id("Read", "call_1", ""),
         tool_update_with_args("call_1", r#"{"file":"test.rs"}"#),
         tool_complete("call_1"),
-    ]);
+    ])?;
 
     let expected = expected_with_prompt(&[&p(r#"✓ Read {"file":"test.rs"}"#)], TEST_WIDTH, "", TEST_AGENT);
     assert_buffer_eq(renderer.writer(), &expected);
+    Ok(())
 }
 
 #[tokio::test]
-async fn test_in_progress_tool_call_updates_from_duplicate_requests() {
-    let renderer =
-        render(vec![tool_call_with_id("Read", "call_1", ""), tool_call_with_id("", "call_1", r#"{"file":"test.rs"}"#)]);
+async fn test_in_progress_tool_call_updates_from_duplicate_requests() -> TestResult {
+    let renderer = render(vec![
+        tool_call_with_id("Read", "call_1", ""),
+        tool_call_with_id("", "call_1", r#"{"file":"test.rs"}"#),
+    ])?;
 
     let expected = expected_with_prompt(&[&p("⠒ Read"), "", &p(PROGRESS_LINE), ""], TEST_WIDTH, "", TEST_AGENT);
     assert_buffer_eq(renderer.writer(), &expected);
+    Ok(())
 }
 
 #[tokio::test]
-async fn test_tool_progress_renders_running_tool() {
-    let renderer = render(vec![tool_call_with_id("Read", "call_1", r#"{"file":"test.rs"}"#)]);
+async fn test_tool_progress_renders_running_tool() -> TestResult {
+    let renderer = render(vec![tool_call_with_id("Read", "call_1", r#"{"file":"test.rs"}"#)])?;
 
     let expected = expected_with_prompt(&[&p("⠒ Read"), "", &p(PROGRESS_LINE), ""], TEST_WIDTH, "", TEST_AGENT);
     assert_buffer_eq(renderer.writer(), &expected);
+    Ok(())
 }
 
 #[tokio::test]
-async fn test_multiple_parallel_tool_calls() {
+async fn test_multiple_parallel_tool_calls() -> TestResult {
     let args1 = r#"{"file": "test.rs"}"#;
     let args2 = r#"{"pattern": "foo"}"#;
     let args3 = r#"{"path": "src/"}"#;
@@ -95,7 +104,7 @@ async fn test_multiple_parallel_tool_calls() {
         tool_complete("call_Read"),
         tool_complete("call_Grep"),
         tool_complete("call_Glob"),
-    ]);
+    ])?;
 
     let expected = expected_with_prompt(
         &[&p(r#"✓ Read {"file":"test.rs"}"#), &p(r#"✓ Grep {"pattern":"foo"}"#), &p(r#"✓ Glob {"path":"src/"}"#)],
@@ -104,17 +113,18 @@ async fn test_multiple_parallel_tool_calls() {
         TEST_AGENT,
     );
     assert_buffer_eq(renderer.writer(), &expected);
+    Ok(())
 }
 
 #[tokio::test]
-async fn test_prompt_done_finalizes_running_tool_calls() {
+async fn test_prompt_done_finalizes_running_tool_calls() -> TestResult {
     let renderer = render(vec![
         tool_call_with_id("Read", "call_1", r#"{"file": "a.rs"}"#),
         tool_call_with_id("Write", "call_2", r#"{"file": "b.rs"}"#),
         tool_complete("call_1"),
         text_chunk("Done reading"),
         prompt_done(),
-    ]);
+    ])?;
 
     let expected = expected_with_prompt(
         &[&p(r#"✓ Read {"file":"a.rs"}"#), &p(r#"✓ Write {"file":"b.rs"}"#), "", &p("Done reading")],
@@ -123,10 +133,11 @@ async fn test_prompt_done_finalizes_running_tool_calls() {
         TEST_AGENT,
     );
     assert_buffer_eq(renderer.writer(), &expected);
+    Ok(())
 }
 
 #[tokio::test]
-async fn test_late_result_after_prompt_done() {
+async fn test_late_result_after_prompt_done() -> TestResult {
     let renderer = render(vec![
         tool_call_with_id("Read", "call_1", r#"{"file": "a.rs"}"#),
         tool_call_with_id("Write", "call_2", r#"{"file": "b.rs"}"#),
@@ -134,7 +145,7 @@ async fn test_late_result_after_prompt_done() {
         text_chunk("Done reading"),
         prompt_done(),
         tool_complete("call_2"),
-    ]);
+    ])?;
 
     let expected = expected_with_prompt(
         &[&p(r#"✓ Read {"file":"a.rs"}"#), &p(r#"✓ Write {"file":"b.rs"}"#), "", &p("Done reading")],
@@ -143,10 +154,11 @@ async fn test_late_result_after_prompt_done() {
         TEST_AGENT,
     );
     assert_buffer_eq(renderer.writer(), &expected);
+    Ok(())
 }
 
 #[tokio::test]
-async fn test_tool_complete_with_display_meta_shows_display_value() {
+async fn test_tool_complete_with_display_meta_shows_display_value() -> TestResult {
     let renderer = render(vec![
         tool_call_with_id("read_file", "call_1", r#"{"filePath":"/Users/josh/code/aether/Cargo.toml"}"#),
         tool_complete_with_display_meta(
@@ -156,16 +168,17 @@ async fn test_tool_complete_with_display_meta_shows_display_value() {
                 "value": "Cargo.toml, 156 lines"
             }),
         ),
-    ]);
+    ])?;
 
     let expected = expected_with_prompt(&[&p("✓ Read file (Cargo.toml, 156 lines)")], TEST_WIDTH, "", TEST_AGENT);
     assert_buffer_eq(renderer.writer(), &expected);
+    Ok(())
 }
 
 #[tokio::test]
-async fn test_tool_complete_without_display_meta_shows_raw_args() {
+async fn test_tool_complete_without_display_meta_shows_raw_args() -> TestResult {
     let args = r#"{"filePath":"/Users/josh/code/aether/Cargo.toml"}"#;
-    let renderer = render(vec![tool_call_with_id("read_file", "call_1", args), tool_complete("call_1")]);
+    let renderer = render(vec![tool_call_with_id("read_file", "call_1", args), tool_complete("call_1")])?;
 
     let expected = expected_with_prompt(
         &[&p(r#"✓ read_file {"filePath":"/Users/josh/code/aether/Cargo.toml"}"#)],
@@ -174,20 +187,22 @@ async fn test_tool_complete_without_display_meta_shows_raw_args() {
         TEST_AGENT,
     );
     assert_buffer_eq(renderer.writer(), &expected);
+    Ok(())
 }
 
 #[tokio::test]
-async fn test_running_tool_hides_raw_args() {
-    let renderer = render(vec![tool_call_with_id("read_file", "call_1", r#"{"filePath":"Cargo.toml"}"#)]);
+async fn test_running_tool_hides_raw_args() -> TestResult {
+    let renderer = render(vec![tool_call_with_id("read_file", "call_1", r#"{"filePath":"Cargo.toml"}"#)])?;
 
     let lines = renderer.writer().get_lines();
     let tool_line = lines.iter().find(|l| l.contains("read_file")).unwrap();
     assert!(!tool_line.contains("filePath"), "Running tool should hide raw args: {tool_line}");
     assert_eq!(tool_line.trim(), "⠒ read_file", "Running tool should show only name: {tool_line}");
+    Ok(())
 }
 
 #[tokio::test]
-async fn test_display_meta_title_overrides_tool_name() {
+async fn test_display_meta_title_overrides_tool_name() -> TestResult {
     let renderer = render(vec![
         tool_call_with_id("coding__read_file", "call_1", r#"{"filePath":"main.rs"}"#),
         tool_complete_with_display_meta(
@@ -197,16 +212,17 @@ async fn test_display_meta_title_overrides_tool_name() {
                 "value": "main.rs, 42 lines"
             }),
         ),
-    ]);
+    ])?;
 
     let lines = renderer.writer().get_lines();
     let tool_line = lines.iter().find(|l| l.contains("✓")).unwrap();
     assert!(tool_line.contains("Read file"), "Display title should override raw tool name: {tool_line}");
     assert!(tool_line.contains("(main.rs, 42 lines)"), "Display value should appear in parens: {tool_line}");
+    Ok(())
 }
 
 #[tokio::test]
-async fn test_multiple_tools_with_mixed_display_meta() {
+async fn test_multiple_tools_with_mixed_display_meta() -> TestResult {
     let renderer = render(vec![
         tool_call_with_id("read_file", "call_1", r#"{"filePath":"Cargo.toml"}"#),
         tool_call_with_id("external_tool", "call_2", r#"{"key":"value"}"#),
@@ -218,7 +234,7 @@ async fn test_multiple_tools_with_mixed_display_meta() {
             }),
         ),
         tool_complete("call_2"),
-    ]);
+    ])?;
 
     let expected = expected_with_prompt(
         &[&p("✓ Read file (Cargo.toml, 156 lines)"), &p(r#"✓ external_tool {"key":"value"}"#)],
@@ -227,10 +243,11 @@ async fn test_multiple_tools_with_mixed_display_meta() {
         TEST_AGENT,
     );
     assert_buffer_eq(renderer.writer(), &expected);
+    Ok(())
 }
 
 #[tokio::test]
-async fn test_command_display_meta_shows_exit_code() {
+async fn test_command_display_meta_shows_exit_code() -> TestResult {
     let renderer = render(vec![
         tool_call_with_id("bash", "call_1", r#"{"command":"cargo test"}"#),
         tool_complete_with_display_meta(
@@ -240,8 +257,9 @@ async fn test_command_display_meta_shows_exit_code() {
                 "value": "cargo test (exit 0)"
             }),
         ),
-    ]);
+    ])?;
 
     let expected = expected_with_prompt(&[&p("✓ Run command (cargo test (exit 0))")], TEST_WIDTH, "", TEST_AGENT);
     assert_buffer_eq(renderer.writer(), &expected);
+    Ok(())
 }

--- a/crates/wisp/tests/app_tests/workspace_move_tests.rs
+++ b/crates/wisp/tests/app_tests/workspace_move_tests.rs
@@ -3,55 +3,48 @@ use acp_utils::notifications::{WorkspaceEntry, WorkspaceMoveTarget};
 use agent_client_protocol::schema as acp;
 use std::{io, path::PathBuf};
 use tokio::sync::mpsc::UnboundedReceiver;
-use tui::testing::TestTerminal;
-use tui::{KeyCode, KeyModifiers};
 
 use super::common::*;
 
 #[tokio::test]
-async fn move_command_is_listed_only_when_capability_advertised() {
-    let (mut renderer, _commands) = workspace_renderer();
-    renderer.initial_render().unwrap();
-    type_string(&mut renderer, "/").await;
+async fn move_command_is_listed_only_when_capability_advertised() -> TestResult {
+    let mut renderer = workspace_renderer()?;
+    type_string(&mut renderer, "/").await?;
     let names = command_picker_visible_names(renderer.writer());
     assert!(names.iter().any(|n| n == "move"), "expected /move in {names:?}");
 
-    let terminal = TestTerminal::new(TEST_WIDTH, 40);
-    let (mut renderer, _commands) = Renderer::new_recording(terminal, TEST_AGENT.to_string(), &[], (TEST_WIDTH, 40));
-    renderer.initial_render().unwrap();
-    type_string(&mut renderer, "/").await;
+    let mut renderer = RendererTest::new().build()?;
+    type_string(&mut renderer, "/").await?;
     let names = command_picker_visible_names(renderer.writer());
     assert!(!names.iter().any(|n| n == "move"), "did not expect /move in {names:?}");
+    Ok(())
 }
 
 #[tokio::test]
-async fn move_command_requests_workspace_list() {
-    let (mut renderer, mut commands) = workspace_renderer();
-    renderer.initial_render().unwrap();
+async fn move_command_requests_workspace_list() -> TestResult {
+    let mut renderer = workspace_renderer()?;
 
-    type_string(&mut renderer, "/move").await;
-    press_enter(&mut renderer).await;
+    type_string(&mut renderer, "/move").await?;
+    press(&mut renderer, Enter).await?;
 
-    match commands.try_recv().expect("expected list workspaces command") {
+    match renderer.commands().try_recv().expect("expected list workspaces command") {
         PromptCommand::ListWorkspaces(params) => assert_eq!(params.session_id, "test"),
         other => panic!("expected ListWorkspaces command, got {other:?}"),
     }
+    Ok(())
 }
 
 #[tokio::test]
-async fn workspaces_listed_opens_picker_hiding_current_workspace() {
-    let (mut renderer, _commands) = workspace_renderer();
-    renderer.initial_render().unwrap();
+async fn workspaces_listed_opens_picker_hiding_current_workspace() -> TestResult {
+    let mut renderer = workspace_renderer()?;
 
-    type_string(&mut renderer, "/move").await;
-    press_enter(&mut renderer).await;
-    renderer
-        .on_workspaces_listed(vec![
-            entry("/repo/aether", true),
-            entry("/repo/aether-fix", false),
-            entry("/repo/aether-experiment", false),
-        ])
-        .unwrap();
+    type_string(&mut renderer, "/move").await?;
+    press(&mut renderer, Enter).await?;
+    renderer.on_workspaces_listed(vec![
+        entry("/repo/aether", true),
+        entry("/repo/aether-fix", false),
+        entry("/repo/aether-experiment", false),
+    ])?;
 
     assert_buffer_contains(renderer.writer(), "Move to workspace");
     assert_buffer_contains(renderer.writer(), "aether-fix");
@@ -59,21 +52,21 @@ async fn workspaces_listed_opens_picker_hiding_current_workspace() {
     assert_buffer_contains(renderer.writer(), "Create new workspace");
     let lines = renderer.writer().get_lines();
     assert!(!lines.iter().any(|l| l.trim() == "/repo/aether"), "current workspace should be hidden");
+    Ok(())
 }
 
 #[tokio::test]
-async fn selecting_existing_workspace_sends_move_command() {
-    let (mut renderer, mut commands) = workspace_renderer();
-    renderer.initial_render().unwrap();
+async fn selecting_existing_workspace_sends_move_command() -> TestResult {
+    let mut renderer = workspace_renderer()?;
 
-    type_string(&mut renderer, "/move").await;
-    press_enter(&mut renderer).await;
-    drain(&mut commands);
-    renderer.on_workspaces_listed(vec![entry("/repo/aether", true), entry("/repo/aether-fix", false)]).unwrap();
+    type_string(&mut renderer, "/move").await?;
+    press(&mut renderer, Enter).await?;
+    drain(renderer.commands());
+    renderer.on_workspaces_listed(vec![entry("/repo/aether", true), entry("/repo/aether-fix", false)])?;
 
-    press_enter(&mut renderer).await;
+    press(&mut renderer, Enter).await?;
 
-    match commands.try_recv().expect("expected move workspace command") {
+    match renderer.commands().try_recv().expect("expected move workspace command") {
         PromptCommand::MoveWorkspace(params) => {
             assert_eq!(params.session_id, "test");
             assert_eq!(params.target, WorkspaceMoveTarget::Existing { path: PathBuf::from("/repo/aether-fix") });
@@ -83,26 +76,25 @@ async fn selecting_existing_workspace_sends_move_command() {
     assert_buffer_not_contains(renderer.writer(), "Move to workspace");
     assert_buffer_contains(renderer.writer(), "Moving workspace...");
     assert_buffer_not_contains(renderer.writer(), "esc to interrupt");
+    Ok(())
 }
 
 #[tokio::test]
-async fn workspace_move_spinner_transitions_to_session_load_and_clears_when_loaded()
--> Result<(), Box<dyn std::error::Error>> {
-    let (mut renderer, mut commands) = workspace_renderer();
-    renderer.initial_render()?;
+async fn workspace_move_spinner_transitions_to_session_load_and_clears_when_loaded() -> TestResult {
+    let mut renderer = workspace_renderer()?;
 
-    type_string(&mut renderer, "/move").await;
-    press_enter(&mut renderer).await;
-    drain(&mut commands);
+    type_string(&mut renderer, "/move").await?;
+    press(&mut renderer, Enter).await?;
+    drain(renderer.commands());
     renderer.on_workspaces_listed(vec![entry("/repo/aether", true), entry("/repo/aether-fix", false)])?;
-    press_enter(&mut renderer).await;
-    drain(&mut commands);
+    press(&mut renderer, Enter).await?;
+    drain(renderer.commands());
 
     assert_buffer_contains(renderer.writer(), "Moving workspace...");
 
     renderer.on_workspace_moved(PathBuf::from("/elsewhere/aether-2"))?;
 
-    let command = commands.try_recv().map_err(|_| io::Error::other("expected load session command"))?;
+    let command = renderer.commands().try_recv().map_err(|_| io::Error::other("expected load session command"))?;
     let PromptCommand::LoadSession { session_id, cwd } = command else {
         return Err(io::Error::other(format!("expected LoadSession command, got {command:?}")).into());
     };
@@ -119,60 +111,59 @@ async fn workspace_move_spinner_transitions_to_session_load_and_clears_when_load
 }
 
 #[tokio::test]
-async fn create_new_workspace_flow_submits_typed_name() {
-    let (mut renderer, mut commands) = workspace_renderer();
-    renderer.initial_render().unwrap();
+async fn create_new_workspace_flow_submits_typed_name() -> TestResult {
+    let mut renderer = workspace_renderer()?;
 
-    type_string(&mut renderer, "/move").await;
-    press_enter(&mut renderer).await;
-    drain(&mut commands);
-    renderer.on_workspaces_listed(vec![entry("/repo/aether", true), entry("/repo/aether-fix", false)]).unwrap();
+    type_string(&mut renderer, "/move").await?;
+    press(&mut renderer, Enter).await?;
+    drain(renderer.commands());
+    renderer.on_workspaces_listed(vec![entry("/repo/aether", true), entry("/repo/aether-fix", false)])?;
 
-    send_key(&mut renderer, KeyCode::Down, KeyModifiers::NONE).await;
-    press_enter(&mut renderer).await;
+    press(&mut renderer, Down).await?;
+    press(&mut renderer, Enter).await?;
     assert_buffer_contains(renderer.writer(), "New workspace name");
     assert_buffer_contains(renderer.writer(), "will be created in");
 
-    type_string(&mut renderer, "aether-2").await;
-    press_enter(&mut renderer).await;
+    type_string(&mut renderer, "aether-2").await?;
+    press(&mut renderer, Enter).await?;
 
-    match commands.try_recv().expect("expected move workspace command") {
+    match renderer.commands().try_recv().expect("expected move workspace command") {
         PromptCommand::MoveWorkspace(params) => {
             assert_eq!(params.target, WorkspaceMoveTarget::New { name: "aether-2".to_string() });
         }
         other => panic!("expected MoveWorkspace command, got {other:?}"),
     }
+    Ok(())
 }
 
 #[tokio::test]
-async fn escape_in_name_input_returns_to_workspace_list() {
-    let (mut renderer, mut commands) = workspace_renderer();
-    renderer.initial_render().unwrap();
+async fn escape_in_name_input_returns_to_workspace_list() -> TestResult {
+    let mut renderer = workspace_renderer()?;
 
-    type_string(&mut renderer, "/move").await;
-    press_enter(&mut renderer).await;
-    drain(&mut commands);
-    renderer.on_workspaces_listed(vec![entry("/repo/aether", true), entry("/repo/aether-fix", false)]).unwrap();
+    type_string(&mut renderer, "/move").await?;
+    press(&mut renderer, Enter).await?;
+    drain(renderer.commands());
+    renderer.on_workspaces_listed(vec![entry("/repo/aether", true), entry("/repo/aether-fix", false)])?;
 
-    send_key(&mut renderer, KeyCode::Down, KeyModifiers::NONE).await;
-    press_enter(&mut renderer).await;
+    press(&mut renderer, Down).await?;
+    press(&mut renderer, Enter).await?;
     assert_buffer_contains(renderer.writer(), "New workspace name");
 
-    send_key(&mut renderer, KeyCode::Esc, KeyModifiers::NONE).await;
+    press(&mut renderer, Esc).await?;
 
     assert_buffer_contains(renderer.writer(), "Move to workspace");
     assert_buffer_contains(renderer.writer(), "aether-fix");
-    assert!(drain(&mut commands).is_empty(), "escape should not send commands");
+    assert!(drain(renderer.commands()).is_empty(), "escape should not send commands");
+    Ok(())
 }
 
 #[tokio::test]
-async fn workspace_moved_updates_status_line_and_reloads_session() {
-    let (mut renderer, mut commands) = workspace_renderer();
-    renderer.initial_render().unwrap();
+async fn workspace_moved_updates_status_line_and_reloads_session() -> TestResult {
+    let mut renderer = workspace_renderer()?;
 
-    renderer.on_workspace_moved(PathBuf::from("/elsewhere/aether-2")).unwrap();
+    renderer.on_workspace_moved(PathBuf::from("/elsewhere/aether-2"))?;
 
-    match commands.try_recv().expect("expected load session command") {
+    match renderer.commands().try_recv().expect("expected load session command") {
         PromptCommand::LoadSession { session_id, cwd } => {
             assert_eq!(session_id.0.as_ref(), "test");
             assert_eq!(cwd, PathBuf::from("/elsewhere/aether-2"));
@@ -180,122 +171,116 @@ async fn workspace_moved_updates_status_line_and_reloads_session() {
         other => panic!("expected LoadSession command, got {other:?}"),
     }
     assert_buffer_contains(renderer.writer(), "/elsewhere/aether-2");
+    Ok(())
 }
 
 #[tokio::test]
-async fn workspace_move_failure_is_reported_in_conversation() {
-    let (mut renderer, _commands) = workspace_renderer();
-    renderer.initial_render().unwrap();
+async fn workspace_move_failure_is_reported_in_conversation() -> TestResult {
+    let mut renderer = workspace_renderer()?;
 
-    renderer.on_workspace_move_failed("target workspace has uncommitted changes: /repo/aether-fix").unwrap();
+    renderer.on_workspace_move_failed("target workspace has uncommitted changes: /repo/aether-fix")?;
 
     assert_buffer_not_contains(renderer.writer(), "Moving workspace...");
     assert_buffer_contains(renderer.writer(), "[wisp] Workspace move failed:");
     assert_buffer_contains(renderer.writer(), "uncommitted changes");
+    Ok(())
 }
 
 #[tokio::test]
-async fn move_command_is_rejected_while_waiting_for_response() {
-    let (mut renderer, mut commands) = workspace_renderer();
-    renderer.initial_render().unwrap();
+async fn move_command_is_rejected_while_waiting_for_response() -> TestResult {
+    let mut renderer = workspace_renderer()?;
 
-    type_string(&mut renderer, "hello").await;
-    press_enter(&mut renderer).await;
-    drain(&mut commands);
+    type_string(&mut renderer, "hello").await?;
+    press(&mut renderer, Enter).await?;
+    drain(renderer.commands());
 
-    type_string(&mut renderer, "/move").await;
-    press_enter(&mut renderer).await;
+    type_string(&mut renderer, "/move").await?;
+    press(&mut renderer, Enter).await?;
 
     assert_buffer_contains(renderer.writer(), "[wisp] Cannot move workspaces while a prompt is running.");
-    assert!(drain(&mut commands).is_empty(), "no command should be sent while waiting");
+    assert!(drain(renderer.commands()).is_empty(), "no command should be sent while waiting");
+    Ok(())
 }
 
 #[tokio::test]
-async fn closing_workspace_picker_allows_move_to_be_requested_again() {
-    let (mut renderer, mut commands) = workspace_renderer();
-    renderer.initial_render().unwrap();
+async fn closing_workspace_picker_allows_move_to_be_requested_again() -> TestResult {
+    let mut renderer = workspace_renderer()?;
 
-    type_string(&mut renderer, "/move").await;
-    press_enter(&mut renderer).await;
-    drain(&mut commands);
-    renderer.on_workspaces_listed(vec![entry("/repo/aether", true), entry("/repo/aether-fix", false)]).unwrap();
+    type_string(&mut renderer, "/move").await?;
+    press(&mut renderer, Enter).await?;
+    drain(renderer.commands());
+    renderer.on_workspaces_listed(vec![entry("/repo/aether", true), entry("/repo/aether-fix", false)])?;
 
-    send_key(&mut renderer, KeyCode::Esc, KeyModifiers::NONE).await;
-    type_string(&mut renderer, "/move").await;
-    press_enter(&mut renderer).await;
+    press(&mut renderer, Esc).await?;
+    type_string(&mut renderer, "/move").await?;
+    press(&mut renderer, Enter).await?;
 
-    match commands.try_recv().expect("expected list workspaces command") {
+    match renderer.commands().try_recv().expect("expected list workspaces command") {
         PromptCommand::ListWorkspaces(params) => assert_eq!(params.session_id, "test"),
         other => panic!("expected ListWorkspaces command, got {other:?}"),
     }
+    Ok(())
 }
 
 #[tokio::test]
-async fn mouse_selecting_existing_workspace_sends_move_command() {
-    let (mut renderer, mut commands) = workspace_renderer();
-    renderer.initial_render().unwrap();
+async fn mouse_selecting_existing_workspace_sends_move_command() -> TestResult {
+    let mut renderer = workspace_renderer()?;
 
-    type_string(&mut renderer, "/move").await;
-    press_enter(&mut renderer).await;
-    drain(&mut commands);
-    renderer.on_workspaces_listed(vec![entry("/repo/aether", true), entry("/repo/aether-fix", false)]).unwrap();
+    type_string(&mut renderer, "/move").await?;
+    press(&mut renderer, Enter).await?;
+    drain(renderer.commands());
+    renderer.on_workspaces_listed(vec![entry("/repo/aether", true), entry("/repo/aether-fix", false)])?;
 
-    renderer.on_mouse_down(4, 4).await.unwrap();
+    renderer.on_mouse_down(4, 4).await?;
 
-    match commands.try_recv().expect("expected move workspace command") {
+    match renderer.commands().try_recv().expect("expected move workspace command") {
         PromptCommand::MoveWorkspace(params) => {
             assert_eq!(params.target, WorkspaceMoveTarget::Existing { path: PathBuf::from("/repo/aether-fix") });
         }
         other => panic!("expected MoveWorkspace command, got {other:?}"),
     }
+    Ok(())
 }
 
 #[tokio::test]
-async fn rejected_move_while_waiting_preserves_draft() {
-    let (mut renderer, mut commands) = workspace_renderer();
-    renderer.initial_render().unwrap();
+async fn rejected_move_while_waiting_preserves_draft() -> TestResult {
+    let mut renderer = workspace_renderer()?;
 
-    type_string(&mut renderer, "hello").await;
-    press_enter(&mut renderer).await;
-    drain(&mut commands);
+    type_string(&mut renderer, "hello").await?;
+    press(&mut renderer, Enter).await?;
+    drain(renderer.commands());
 
-    type_string(&mut renderer, "/move").await;
-    press_enter(&mut renderer).await;
+    type_string(&mut renderer, "/move").await?;
+    press(&mut renderer, Enter).await?;
 
     assert_buffer_contains(renderer.writer(), "[wisp] Cannot move workspaces while a prompt is running.");
     assert_buffer_contains(renderer.writer(), "> /move");
-    assert!(drain(&mut commands).is_empty(), "no command should be sent while waiting");
+    assert!(drain(renderer.commands()).is_empty(), "no command should be sent while waiting");
+    Ok(())
 }
 
 #[tokio::test]
-async fn move_command_is_rejected_while_workspace_list_is_pending() {
-    let (mut renderer, mut commands) = workspace_renderer();
-    renderer.initial_render().unwrap();
+async fn move_command_is_rejected_while_workspace_list_is_pending() -> TestResult {
+    let mut renderer = workspace_renderer()?;
 
-    type_string(&mut renderer, "/move").await;
-    press_enter(&mut renderer).await;
-    drain(&mut commands);
+    type_string(&mut renderer, "/move").await?;
+    press(&mut renderer, Enter).await?;
+    drain(renderer.commands());
 
-    type_string(&mut renderer, "/move").await;
-    press_enter(&mut renderer).await;
+    type_string(&mut renderer, "/move").await?;
+    press(&mut renderer, Enter).await?;
 
     assert_buffer_contains(
         renderer.writer(),
         "[wisp] Cannot move workspaces while another workspace move is in progress.",
     );
     assert_buffer_contains(renderer.writer(), "> /move");
-    assert!(drain(&mut commands).is_empty(), "no second list command should be sent");
+    assert!(drain(renderer.commands()).is_empty(), "no second list command should be sent");
+    Ok(())
 }
 
-fn workspace_renderer() -> (Renderer, UnboundedReceiver<PromptCommand>) {
-    let terminal = TestTerminal::new(TEST_WIDTH, 40);
-    Renderer::new_recording_with_session_capabilities(
-        terminal,
-        TEST_AGENT.to_string(),
-        &[],
-        workspace_session_capabilities(),
-        (TEST_WIDTH, 40),
-    )
+fn workspace_renderer() -> TestResult<Renderer> {
+    RendererTest::new().session_capabilities(workspace_session_capabilities()).build()
 }
 
 fn entry(path: &str, is_current: bool) -> WorkspaceEntry {


### PR DESCRIPTION
This PR cleans up some of the automated tests in `mcp-servers` and `wisp` by introducing a pair of tests builders to make it less verbose to write tests.