### PR TITLE
chore(ci): Fix ts evals namespace

### DIFF
--- a/.github/workflows/release-evals.yml
+++ b/.github/workflows/release-evals.yml
@@ -1,9 +1,9 @@
-name: Release Evals
+name: Release Evals (TS)
 
 on:
   push:
     tags:
-      - "aether-evals-v*"
+      - "aether-evals-ts-v*"
 
 permissions:
   contents: read


### PR DESCRIPTION
Namespaces the TS eval package differently than the rust one to avoid collisions with tags triggering releases