### PR TITLE
feat: Support instantiating eval workspaces from a git bundle file

### DIFF
--- a/crates/aether-evals/src/error.rs
+++ b/crates/aether-evals/src/error.rs
@@ -28,6 +28,9 @@ pub enum WorkspaceError {
 
     #[error("git workspace subdirectory does not exist: {}", path.display())]
     MissingSubdir { path: PathBuf },
+
+    #[error("git bundle file does not exist: {}", path.display())]
+    MissingBundle { path: PathBuf },
 }
 
 #[derive(Debug, Error)]

--- a/crates/aether-evals/src/evals/mod.rs
+++ b/crates/aether-evals/src/evals/mod.rs
@@ -5,4 +5,4 @@ mod workspace;
 pub use crate::agents::{ToolCall, Transcript, TranscriptError};
 pub use diff::{DiffStats, GitDiff};
 pub use task::Task;
-pub use workspace::{GitRepoSpec, RetainedWorkspaceInfo, Workspace, WorkspaceSource};
+pub use workspace::{GitBundleSpec, GitRepoSpec, RetainedWorkspaceInfo, Workspace, WorkspaceSource, create_git_bundle};

--- a/crates/aether-evals/src/evals/workspace.rs
+++ b/crates/aether-evals/src/evals/workspace.rs
@@ -21,12 +21,23 @@ pub struct Workspace {
 pub enum WorkspaceSource {
     Local,
     GitRepo { url: String, start_commit: String, gold_commit: String },
+    Bundle { start_commit: String, gold_commit: String },
 }
 
 #[derive(Debug, Clone, serde::Deserialize, JsonSchema)]
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
 pub struct GitRepoSpec {
     pub url: String,
+    pub start_commit: String,
+    pub gold_commit: String,
+    #[serde(default)]
+    pub subdir: Option<PathBuf>,
+}
+
+#[derive(Debug, Clone, serde::Deserialize, JsonSchema)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct GitBundleSpec {
+    pub bundle_path: PathBuf,
     pub start_commit: String,
     pub gold_commit: String,
     #[serde(default)]
@@ -81,28 +92,37 @@ impl Workspace {
         let temp_dir = new_temp_dir()?;
 
         tracing::debug!("Cloning git repo {} at commit {}", url, start_commit);
-        let repo = GitRepo::clone(&url, temp_dir.path())?;
-        repo.checkout(&start_commit)?;
+        let repo = GitRepo::clone(&url, temp_dir.path(), true)?;
 
+        let source = WorkspaceSource::GitRepo { url, start_commit: start_commit.clone(), gold_commit };
+        Self::from_cloned(temp_dir, &repo, &start_commit, subdir, source)
+    }
+
+    /// Instantiate a workspace from a local git bundle file
+    pub fn from_git_bundle(spec: GitBundleSpec) -> Result<Self, WorkspaceError> {
+        let GitBundleSpec { bundle_path, start_commit, gold_commit, subdir } = spec;
+        if !bundle_path.exists() {
+            return Err(WorkspaceError::MissingBundle { path: bundle_path });
+        }
+
+        tracing::debug!("Cloning git bundle {} at commit {}", bundle_path.display(), start_commit);
+        let temp_dir = new_temp_dir()?;
+        let repo = GitRepo::clone(&bundle_path, temp_dir.path(), false)?;
+        let source = WorkspaceSource::Bundle { start_commit: start_commit.clone(), gold_commit };
+        Self::from_cloned(temp_dir, &repo, &start_commit, subdir, source)
+    }
+
+    fn from_cloned(
+        temp_dir: TempDir,
+        repo: &GitRepo,
+        start_commit: &str,
+        subdir: Option<PathBuf>,
+        source: WorkspaceSource,
+    ) -> Result<Self, WorkspaceError> {
+        repo.checkout(start_commit)?;
         let root_path = temp_dir.path().to_path_buf();
-        let (path, relative_cwd) = match subdir {
-            None => (root_path.clone(), None),
-            Some(relative_cwd) => {
-                let working_path = root_path.join(&relative_cwd);
-                if !working_path.exists() {
-                    return Err(WorkspaceError::MissingSubdir { path: working_path });
-                }
-                (working_path, Some(relative_cwd))
-            }
-        };
-
-        Ok(Self {
-            path,
-            root_path,
-            relative_cwd,
-            source: WorkspaceSource::GitRepo { url, start_commit, gold_commit },
-            temp_dir,
-        })
+        let (path, relative_cwd) = resolve_subdir(&root_path, subdir)?;
+        Ok(Self { path, root_path, relative_cwd, source, temp_dir })
     }
 
     pub fn path(&self) -> &Path {
@@ -133,7 +153,7 @@ impl Workspace {
     }
 
     pub fn capture_git_diffs(&self) -> (Option<GitDiff>, Option<GitDiff>) {
-        let WorkspaceSource::GitRepo { start_commit, gold_commit, .. } = self.source() else {
+        let Some((start_commit, gold_commit)) = self.diff_commits() else {
             return (None, None);
         };
 
@@ -144,10 +164,45 @@ impl Workspace {
 
         (agent_diff, reference_diff)
     }
+
+    fn diff_commits(&self) -> Option<(&str, &str)> {
+        match &self.source {
+            WorkspaceSource::Local => None,
+            WorkspaceSource::GitRepo { start_commit, gold_commit, .. }
+            | WorkspaceSource::Bundle { start_commit, gold_commit } => Some((start_commit, gold_commit)),
+        }
+    }
+}
+
+const EVAL_START_REF: &str = "eval-start";
+const EVAL_GOLD_REF: &str = "eval-gold";
+
+/// Create a self-contained git bundle at `out` containing `spec`'s start and gold commits.
+pub fn create_git_bundle(spec: &GitRepoSpec, out: &Path) -> Result<(), WorkspaceError> {
+    let temp_dir = new_temp_dir()?;
+    let repo = GitRepo::init(temp_dir.path())?;
+    repo.fetch(&spec.url, &[&spec.start_commit, &spec.gold_commit])?;
+    repo.update_ref(&format!("refs/heads/{EVAL_START_REF}"), &spec.start_commit)?;
+    repo.update_ref(&format!("refs/heads/{EVAL_GOLD_REF}"), &spec.gold_commit)?;
+    repo.bundle(&[EVAL_START_REF, EVAL_GOLD_REF], out)?;
+    Ok(())
 }
 
 fn new_temp_dir() -> Result<tempfile::TempDir, WorkspaceError> {
     tempfile::tempdir().map_err(WorkspaceError::CreateTempDir)
+}
+
+fn resolve_subdir(root_path: &Path, subdir: Option<PathBuf>) -> Result<(PathBuf, Option<PathBuf>), WorkspaceError> {
+    match subdir {
+        None => Ok((root_path.to_path_buf(), None)),
+        Some(relative_cwd) => {
+            let working_path = root_path.join(&relative_cwd);
+            if !working_path.exists() {
+                return Err(WorkspaceError::MissingSubdir { path: working_path });
+            }
+            Ok((working_path, Some(relative_cwd)))
+        }
+    }
 }
 
 fn copy_dir_contents(src: &Path, dst: &Path) -> std::io::Result<()> {
@@ -171,6 +226,8 @@ fn copy_dir_contents(src: &Path, dst: &Path) -> std::io::Result<()> {
 mod tests {
     use super::*;
     use std::fs::{read_to_string, remove_dir_all};
+    use std::process::Command;
+    use tempfile::TempDir;
 
     #[test]
     fn persist_reports_root_and_path_for_local_workspace() {
@@ -181,5 +238,83 @@ mod tests {
         assert_eq!(retained.root_path, retained.path);
         assert_eq!(read_to_string(retained.path.join("notes.txt")).unwrap(), "hi\n");
         remove_dir_all(retained.root_path).unwrap();
+    }
+
+    #[test]
+    fn from_git_bundle_round_trips_checkout_subdir_and_diffs() {
+        let (repo, start, gold) = init_repo();
+        let bundle_dir = tempfile::tempdir().unwrap();
+        let bundle_path = bundle_dir.path().join("repo.bundle");
+        create_git_bundle(
+            &GitRepoSpec {
+                url: format!("file://{}", repo.path().display()),
+                start_commit: start.clone(),
+                gold_commit: gold.clone(),
+                subdir: None,
+            },
+            &bundle_path,
+        )
+        .unwrap();
+
+        let workspace = Workspace::from_git_bundle(GitBundleSpec {
+            bundle_path,
+            start_commit: start,
+            gold_commit: gold,
+            subdir: Some(PathBuf::from("pkg")),
+        })
+        .unwrap();
+
+        let (agent_diff, reference_diff) = workspace.capture_git_diffs();
+
+        assert_eq!(read_to_string(workspace.root_path().join("root.txt")).unwrap(), "root v1\n");
+        assert_eq!(workspace.relative_cwd(), Some(Path::new("pkg")));
+        assert_eq!(workspace.path(), workspace.root_path().join("pkg"));
+        assert!(reference_diff.unwrap().diff.contains("root v2"), "reference diff should span start..gold");
+        assert!(agent_diff.unwrap().diff.is_empty(), "no agent edits yet");
+
+        write(workspace.root_path().join("root.txt"), "root edited\n").unwrap();
+        let (agent_diff, _) = workspace.capture_git_diffs();
+
+        assert!(agent_diff.unwrap().diff.contains("root edited"), "agent diff should capture the edit");
+    }
+
+    #[test]
+    fn from_git_bundle_missing_file_errors() {
+        let result = Workspace::from_git_bundle(GitBundleSpec {
+            bundle_path: PathBuf::from("/nonexistent/repo.bundle"),
+            start_commit: "abc".into(),
+            gold_commit: "def".into(),
+            subdir: None,
+        });
+
+        assert!(matches!(result, Err(WorkspaceError::MissingBundle { .. })));
+    }
+
+    fn init_repo() -> (TempDir, String, String) {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path();
+        git(path, &["init", "--initial-branch", "main"]);
+        git(path, &["config", "user.email", "eval@example.com"]);
+        git(path, &["config", "user.name", "Eval"]);
+
+        write(path.join("root.txt"), "root v1\n").unwrap();
+        create_dir_all(path.join("pkg")).unwrap();
+        write(path.join("pkg").join("inner.txt"), "inner v1\n").unwrap();
+        git(path, &["add", "."]);
+        git(path, &["commit", "-m", "start"]);
+        let start = git(path, &["rev-parse", "HEAD"]);
+
+        write(path.join("root.txt"), "root v2\n").unwrap();
+        git(path, &["add", "."]);
+        git(path, &["commit", "-m", "gold"]);
+        let gold = git(path, &["rev-parse", "HEAD"]);
+
+        (dir, start, gold)
+    }
+
+    fn git(repo: &Path, args: &[&str]) -> String {
+        let output = Command::new("git").arg("-C").arg(repo).args(args).output().unwrap();
+        assert!(output.status.success(), "git {args:?} failed: {}", String::from_utf8_lossy(&output.stderr));
+        String::from_utf8(output.stdout).unwrap().trim().to_string()
     }
 }

--- a/crates/aether-evals/src/git_repo.rs
+++ b/crates/aether-evals/src/git_repo.rs
@@ -1,3 +1,4 @@
+use std::ffi::OsStr;
 use std::path::{Path, PathBuf};
 use std::process::Command;
 use thiserror::Error;
@@ -13,51 +14,64 @@ impl GitRepo {
         GitRepo { path: path.to_path_buf() }
     }
 
-    /// Clone a repository to the specified destination
-    ///
-    /// Uses a blobless partial clone (--filter=blob:none) with --no-checkout for efficiency.
-    /// This downloads commit history and tree structures but defers downloading file blobs
-    /// until they're needed (e.g., during checkout or diff operations).
-    ///
-    /// This significantly reduces clone time and disk space usage, especially for large repos,
-    /// while still allowing full git operations. Blobs are automatically fetched on-demand.
+    /// Initialize an empty repository at `dest`.
     #[tracing::instrument(skip(dest))]
-    pub fn clone(url: &str, dest: &Path) -> Result<Self, GitRepoError> {
-        tracing::debug!("Cloning repository from {} (blobless clone)", url);
-        let output = Command::new("git")
-            .arg("clone")
-            .arg("--no-checkout")
-            .arg("--filter=blob:none")
-            .arg(url)
-            .arg(dest)
-            .output()
-            .map_err(|e| GitRepoError::CommandFailed(format!("Failed to execute git clone: {e}")))?;
+    pub fn init(dest: &Path) -> Result<Self, GitRepoError> {
+        run_git(None, [OsStr::new("init"), dest.as_os_str()], GitRepoError::InitFailed)?;
+        Ok(GitRepo { path: dest.to_path_buf() })
+    }
 
-        if !output.status.success() {
-            let stderr = String::from_utf8_lossy(&output.stderr);
-            return Err(GitRepoError::CloneFailed(stderr.to_string()));
+    /// Clone `source` (a URL or a local bundle/path) into `dest` with `--no-checkout`.
+    ///
+    /// When `blobless` is true, uses a partial blobless clone (`--filter=blob:none`) that
+    /// defers downloading file blobs until they're needed -- cheaper for large repos. When
+    /// false, the full object set is downloaded so the clone is self-contained (e.g. so it
+    /// can be bundled, or because `source` is a bundle and not a promisor remote).
+    #[tracing::instrument(skip(source, dest))]
+    pub fn clone(source: impl AsRef<OsStr>, dest: &Path, blobless: bool) -> Result<Self, GitRepoError> {
+        let mut args = vec![OsStr::new("clone"), OsStr::new("--no-checkout")];
+        if blobless {
+            args.push(OsStr::new("--filter=blob:none"));
         }
-
+        args.push(source.as_ref());
+        args.push(dest.as_os_str());
+        run_git(None, args, GitRepoError::CloneFailed)?;
         Ok(GitRepo { path: dest.to_path_buf() })
     }
 
     /// Checkout a specific commit, branch, or tag
     #[tracing::instrument(skip(self))]
     pub fn checkout(&self, reference: &str) -> Result<(), GitRepoError> {
-        tracing::debug!("Checking out ref: {}", reference);
-        let output = Command::new("git")
-            .arg("-C")
-            .arg(&self.path)
-            .arg("checkout")
-            .arg(reference)
-            .output()
-            .map_err(|e| GitRepoError::CommandFailed(format!("Failed to execute git checkout: {e}")))?;
+        run_git(Some(&self.path), ["checkout", reference], |reason| GitRepoError::CheckoutFailed {
+            reference: reference.to_string(),
+            reason,
+        })?;
+        Ok(())
+    }
 
-        if !output.status.success() {
-            let stderr = String::from_utf8_lossy(&output.stderr);
-            return Err(GitRepoError::CheckoutFailed { reference: reference.to_string(), reason: stderr.to_string() });
-        }
+    /// Fetch `revs` from `remote` (a named remote or a URL) into this repository.
+    #[tracing::instrument(skip(self))]
+    pub fn fetch(&self, remote: &str, revs: &[&str]) -> Result<(), GitRepoError> {
+        let mut args = vec!["fetch", remote];
+        args.extend_from_slice(revs);
+        run_git(Some(&self.path), args, GitRepoError::FetchFailed)?;
+        Ok(())
+    }
 
+    /// Point a ref at a commit (e.g. to create a branch tip to bundle).
+    #[tracing::instrument(skip(self))]
+    pub fn update_ref(&self, name: &str, commit: &str) -> Result<(), GitRepoError> {
+        run_git(Some(&self.path), ["update-ref", name, commit], GitRepoError::UpdateRefFailed)?;
+        Ok(())
+    }
+
+    /// Create a self-contained git bundle at `out` containing the given refs and their
+    /// reachable objects.
+    #[tracing::instrument(skip(self, out))]
+    pub fn bundle(&self, revs: &[&str], out: &Path) -> Result<(), GitRepoError> {
+        let mut args = vec![OsStr::new("bundle"), OsStr::new("create"), out.as_os_str()];
+        args.extend(revs.iter().map(OsStr::new));
+        run_git(Some(&self.path), args, GitRepoError::BundleFailed)?;
         Ok(())
     }
 
@@ -73,31 +87,15 @@ impl GitRepo {
     /// * `diff_range("HEAD", None)` - unstaged changes (equivalent to `git diff`)
     #[tracing::instrument(skip(self))]
     pub fn diff_range(&self, from_commit: &str, to_commit: Option<&str>) -> Result<String, GitRepoError> {
-        let mut cmd = Command::new("git");
-        cmd.arg("-C").arg(&self.path).arg("diff");
-
-        if let Some(to) = to_commit {
-            tracing::debug!("Getting diff from {} to {}", from_commit, to);
-            cmd.arg(format!("{from_commit}..{to}"));
-        } else {
-            tracing::debug!("Getting diff from {} to working directory", from_commit);
-            cmd.arg(from_commit);
-        }
-
-        let output =
-            cmd.output().map_err(|e| GitRepoError::CommandFailed(format!("Failed to execute git diff: {e}")))?;
-
-        if !output.status.success() {
-            let stderr = String::from_utf8_lossy(&output.stderr);
-            return Err(GitRepoError::DiffFailed {
-                from: from_commit.to_string(),
-                to: to_commit.unwrap_or("working directory").to_string(),
-                reason: stderr.to_string(),
-            });
-        }
-
-        let diff = String::from_utf8_lossy(&output.stdout).to_string();
-        Ok(diff)
+        let range = match to_commit {
+            Some(to) => format!("{from_commit}..{to}"),
+            None => from_commit.to_string(),
+        };
+        run_git(Some(&self.path), ["diff", range.as_str()], |reason| GitRepoError::DiffFailed {
+            from: from_commit.to_string(),
+            to: to_commit.unwrap_or("working directory").to_string(),
+            reason,
+        })
     }
 
     /// Get the diff between two commits
@@ -115,13 +113,49 @@ impl GitRepo {
     }
 }
 
+/// Run `git` (optionally inside `cwd`) and return its stdout.
+///
+/// Spawn failures are surfaced as [`GitRepoError::CommandFailed`]; a non-zero exit is mapped
+/// to a caller-chosen variant via `on_failure`, which receives the captured stderr.
+fn run_git<T: IntoIterator<Item = U>, U: AsRef<OsStr>>(
+    cwd: Option<&Path>,
+    args: T,
+    on_failure: impl FnOnce(String) -> GitRepoError,
+) -> Result<String, GitRepoError> {
+    let mut cmd = Command::new("git");
+    if let Some(dir) = cwd {
+        cmd.arg("-C").arg(dir);
+    }
+
+    let output =
+        cmd.args(args).output().map_err(|e| GitRepoError::CommandFailed(format!("Failed to execute git: {e}")))?;
+
+    if !output.status.success() {
+        return Err(on_failure(String::from_utf8_lossy(&output.stderr).into_owned()));
+    }
+
+    Ok(String::from_utf8_lossy(&output.stdout).into_owned())
+}
+
 #[derive(Debug, Error)]
 pub enum GitRepoError {
     #[error("Git command failed: {0}")]
     CommandFailed(String),
 
+    #[error("Failed to initialize repository: {0}")]
+    InitFailed(String),
+
     #[error("Failed to clone repository: {0}")]
     CloneFailed(String),
+
+    #[error("Failed to fetch revisions: {0}")]
+    FetchFailed(String),
+
+    #[error("Failed to update ref: {0}")]
+    UpdateRefFailed(String),
+
+    #[error("Failed to create git bundle: {0}")]
+    BundleFailed(String),
 
     #[error("Failed to checkout '{reference}': {reason}")]
     CheckoutFailed { reference: String, reason: String },
@@ -259,7 +293,7 @@ mod tests {
         .to_string();
 
         let clone_dir = tempfile::tempdir().unwrap();
-        let repo = GitRepo::clone(source_path.to_str().unwrap(), clone_dir.path()).unwrap();
+        let repo = GitRepo::clone(source_path.to_str().unwrap(), clone_dir.path(), true).unwrap();
 
         let entries: Vec<_> = fs::read_dir(clone_dir.path())
             .unwrap()

--- a/crates/aether-evals/src/lib.rs
+++ b/crates/aether-evals/src/lib.rs
@@ -15,8 +15,8 @@ pub use assertions::{assert_tool_call_count, assert_tool_call_with_args, assert_
 pub use containers::{Container, ContainerBuilder, ContainerError, ExecOutput, Image, ImageParseError};
 pub use error::{EvalRunError, WorkspaceError};
 pub use evals::{
-    DiffStats, GitDiff, GitRepoSpec, RetainedWorkspaceInfo, Task, ToolCall, Transcript, TranscriptError, Workspace,
-    WorkspaceSource,
+    DiffStats, GitBundleSpec, GitDiff, GitRepoSpec, RetainedWorkspaceInfo, Task, ToolCall, Transcript, TranscriptError,
+    Workspace, WorkspaceSource, create_git_bundle,
 };
 pub use git_repo::GitRepoError;
 pub use judge::{

--- a/packages/aether-evals/package.json
+++ b/packages/aether-evals/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aether-agent/evals",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "Evaluation harness for the Aether agent SDK",
   "repository": {
     "type": "git",

--- a/packages/aether-evals/src/git.ts
+++ b/packages/aether-evals/src/git.ts
@@ -9,20 +9,62 @@ export class GitRepo {
     return new GitRepo(path);
   }
 
+  /** Initialize an empty repository at `dest`. */
+  static async init(dest: string, signal?: AbortSignal): Promise<GitRepo> {
+    await git(["init", dest], signal);
+    return new GitRepo(dest);
+  }
+
+  /**
+   * Clone `source` (a URL or a local bundle/path) into `dest` with `--no-checkout`.
+   *
+   * When `blobless` (the default), uses a partial blobless clone (`--filter=blob:none`)
+   * that defers blob downloads -- cheaper for large repos. Pass false to download the full
+   * object set so the clone is self-contained (e.g. when `source` is a bundle, which is not
+   * a promisor remote).
+   */
   static async clone(
-    url: string,
+    source: string,
     dest: string,
     signal?: AbortSignal,
+    blobless = true,
   ): Promise<GitRepo> {
-    await git(
-      ["clone", "--no-checkout", "--filter=blob:none", url, dest],
-      signal,
-    );
+    const filter = blobless ? ["--filter=blob:none"] : [];
+    await git(["clone", "--no-checkout", ...filter, source, dest], signal);
     return new GitRepo(dest);
   }
 
   async checkout(reference: string, signal?: AbortSignal): Promise<void> {
     await git(["-C", this.path, "checkout", reference], signal);
+  }
+
+  /** Fetch `revs` from `remote` (a named remote or a URL) into this repository. */
+  async fetch(
+    remote: string,
+    revs: string[],
+    signal?: AbortSignal,
+  ): Promise<void> {
+    await git(["-C", this.path, "fetch", remote, ...revs], signal);
+  }
+
+  async updateRef(
+    name: string,
+    commit: string,
+    signal?: AbortSignal,
+  ): Promise<void> {
+    await git(["-C", this.path, "update-ref", name, commit], signal);
+  }
+
+  /**
+   * Create a self-contained git bundle at `out` containing the given refs and their
+   * reachable objects.
+   */
+  async bundle(
+    revs: string[],
+    out: string,
+    signal?: AbortSignal,
+  ): Promise<void> {
+    await git(["-C", this.path, "bundle", "create", out, ...revs], signal);
   }
 
   async diff(

--- a/packages/aether-evals/src/index.ts
+++ b/packages/aether-evals/src/index.ts
@@ -38,8 +38,9 @@ export type {
   JudgeSummary,
 } from "./judge.js";
 export { Transcript, TranscriptError, ToolCall } from "./transcript.js";
-export { Workspace } from "./workspace.js";
+export { createGitBundle, Workspace } from "./workspace.js";
 export type {
+  GitBundleSpec,
   GitRepoSpec,
   RetainedWorkspaceInfo,
   WorkspaceSource,

--- a/packages/aether-evals/src/workspace.ts
+++ b/packages/aether-evals/src/workspace.ts
@@ -6,8 +6,18 @@ import { AetherSdkError } from "@aether-agent/sdk";
 import { diffStatsFromDiff, type GitDiff } from "./diff.js";
 import { GitRepo } from "./git.js";
 
+const EVAL_START_REF = "eval-start";
+const EVAL_GOLD_REF = "eval-gold";
+
 export interface GitRepoSpec {
   url: string;
+  startCommit: string;
+  goldCommit: string;
+  subdir?: string;
+}
+
+export interface GitBundleSpec {
+  bundlePath: string;
   startCommit: string;
   goldCommit: string;
   subdir?: string;
@@ -21,7 +31,8 @@ export interface RetainedWorkspaceInfo {
 /** Where an eval workspace came from. Git workspaces carry the commits for diffing. */
 export type WorkspaceSource =
   | "local"
-  | { git: { url: string; startCommit: string; goldCommit: string } };
+  | { git: { url: string; startCommit: string; goldCommit: string } }
+  | { bundle: { startCommit: string; goldCommit: string } };
 
 /** A workspace created on the host for an eval run. */
 export class Workspace implements AsyncDisposable {
@@ -90,23 +101,59 @@ export class Workspace implements AsyncDisposable {
     spec: GitRepoSpec,
     signal?: AbortSignal,
   ): Promise<Workspace> {
+    const { url, startCommit, goldCommit, subdir } = spec;
+    return Workspace.fromClone(
+      (rootPath) => GitRepo.clone(url, rootPath, signal),
+      startCommit,
+      subdir,
+      { git: { url, startCommit, goldCommit } },
+      signal,
+    );
+  }
+
+  /**
+   * Instantiate a workspace from a local git bundle file (see {@link createGitBundle}).
+   *
+   * The bundle must contain both `startCommit` and `goldCommit` so that checkout and
+   * reference diffing work without the originating remote.
+   */
+  static async fromGitBundle(
+    spec: GitBundleSpec,
+    signal?: AbortSignal,
+  ): Promise<Workspace> {
+    const { bundlePath, startCommit, goldCommit, subdir } = spec;
+    if (!(await pathExists(bundlePath))) {
+      throw new AetherSdkError(
+        "invalid_options",
+        `git bundle file does not exist: ${bundlePath}`,
+      );
+    }
+    return Workspace.fromClone(
+      (rootPath) => GitRepo.clone(bundlePath, rootPath, signal, false),
+      startCommit,
+      subdir,
+      { bundle: { startCommit, goldCommit } },
+      signal,
+    );
+  }
+
+  private static async fromClone(
+    clone: (rootPath: string) => Promise<GitRepo>,
+    startCommit: string,
+    subdir: string | undefined,
+    source: WorkspaceSource,
+    signal?: AbortSignal,
+  ): Promise<Workspace> {
     const rootPath = await createWorkspaceDir();
     try {
-      const { url, startCommit, goldCommit, subdir } = spec;
-      const repo = await GitRepo.clone(url, rootPath, signal);
+      const repo = await clone(rootPath);
       await repo.checkout(startCommit, signal);
-      const path = subdir ? join(rootPath, subdir) : rootPath;
-      if (subdir && !(await pathExists(path))) {
-        throw new AetherSdkError(
-          "invalid_options",
-          `git workspace subdirectory does not exist: ${path}`,
-        );
-      }
+      const path = await resolveSubdir(rootPath, subdir);
       return new Workspace({
         rootPath,
         path,
         relativeCwd: subdir ?? undefined,
-        source: { git: { url, startCommit, goldCommit } },
+        source,
       });
     } catch (err) {
       await rm(rootPath, { recursive: true, force: true });
@@ -127,10 +174,11 @@ export class Workspace implements AsyncDisposable {
     agentDiff?: GitDiff;
     referenceDiff?: GitDiff;
   }> {
-    if (this.source === "local") return {};
+    const commits = diffCommits(this.source);
+    if (!commits) return {};
 
     const repo = GitRepo.fromPath(this.path);
-    const { startCommit, goldCommit } = this.source.git;
+    const { startCommit, goldCommit } = commits;
     const [agentDiff, referenceDiff] = await Promise.all([
       captureDiff(() => repo.diffUnstaged()),
       captureDiff(() => repo.diff(startCommit, goldCommit)),
@@ -147,6 +195,38 @@ export class Workspace implements AsyncDisposable {
 
   [Symbol.asyncDispose](): Promise<void> {
     return this.cleanup();
+  }
+}
+
+/**
+ * Create a self-contained git bundle at `outPath` containing `spec`'s start and gold
+ * commits.
+ *
+ * Fetches only the start and gold commits (and their reachable objects) into a fresh repo,
+ * then writes a bundle that {@link Workspace.fromGitBundle} can later instantiate offline.
+ */
+export async function createGitBundle(
+  spec: GitRepoSpec,
+  outPath: string,
+  signal?: AbortSignal,
+): Promise<void> {
+  const tempDir = await createWorkspaceDir();
+  try {
+    const repo = await GitRepo.init(tempDir, signal);
+    await repo.fetch(spec.url, [spec.startCommit, spec.goldCommit], signal);
+    await repo.updateRef(
+      `refs/heads/${EVAL_START_REF}`,
+      spec.startCommit,
+      signal,
+    );
+    await repo.updateRef(
+      `refs/heads/${EVAL_GOLD_REF}`,
+      spec.goldCommit,
+      signal,
+    );
+    await repo.bundle([EVAL_START_REF, EVAL_GOLD_REF], outPath, signal);
+  } finally {
+    await rm(tempDir, { recursive: true, force: true });
   }
 }
 
@@ -184,4 +264,26 @@ async function pathExists(path: string): Promise<boolean> {
   } catch {
     return false;
   }
+}
+
+async function resolveSubdir(
+  rootPath: string,
+  subdir?: string,
+): Promise<string> {
+  if (!subdir) return rootPath;
+  const path = join(rootPath, subdir);
+  if (!(await pathExists(path))) {
+    throw new AetherSdkError(
+      "invalid_options",
+      `git workspace subdirectory does not exist: ${path}`,
+    );
+  }
+  return path;
+}
+
+function diffCommits(
+  source: WorkspaceSource,
+): { startCommit: string; goldCommit: string } | undefined {
+  if (source === "local") return undefined;
+  return "git" in source ? source.git : source.bundle;
 }

--- a/packages/aether-evals/test/workspace.test.ts
+++ b/packages/aether-evals/test/workspace.test.ts
@@ -5,7 +5,7 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
 
-import { Workspace } from "../src/workspace.js";
+import { createGitBundle, Workspace } from "../src/workspace.js";
 
 describe("createWorkspace", () => {
   it("creates an empty workspace", async () => {
@@ -127,6 +127,63 @@ describe("createWorkspace", () => {
     });
     expect(referenceDiff?.diff).toContain("+gold");
     expect(referenceDiff?.stats.filesChanged).toBe(2);
+  });
+
+  it("creates a bundle and instantiates a workspace from it, honoring subdir and diffs", async () => {
+    const repo = track(await mkdtemp(join(tmpdir(), "ws-repo-")));
+    const git = (...args: string[]) =>
+      execFileSync("git", args, { cwd: repo, stdio: "pipe" });
+    git("init", "--initial-branch", "main");
+    git("config", "user.email", "eval@example.com");
+    git("config", "user.name", "Eval");
+    await writeFile(join(repo, "root.txt"), "root v1\n");
+    await mkdir(join(repo, "pkg"), { recursive: true });
+    await writeFile(join(repo, "pkg", "inner.txt"), "inner v1\n");
+    git("add", ".");
+    git("commit", "-m", "start");
+    const startCommit = git("rev-parse", "HEAD").toString().trim();
+
+    await writeFile(join(repo, "root.txt"), "root v2\n");
+    git("add", ".");
+    git("commit", "-m", "gold");
+    const goldCommit = git("rev-parse", "HEAD").toString().trim();
+
+    const bundleDir = track(await mkdtemp(join(tmpdir(), "ws-bundle-")));
+    const bundlePath = join(bundleDir, "repo.bundle");
+    await createGitBundle(
+      { url: `file://${repo}`, startCommit, goldCommit },
+      bundlePath,
+    );
+
+    const ws = await Workspace.fromGitBundle({
+      bundlePath,
+      startCommit,
+      goldCommit,
+      subdir: "pkg",
+    });
+    cleanups.push(ws.rootPath);
+
+    expect(ws.relativeCwd).toBe("pkg");
+    expect(ws.path).toBe(join(ws.rootPath, "pkg"));
+    expect(await readFile(join(ws.rootPath, "root.txt"), "utf8")).toBe(
+      "root v1\n",
+    );
+    expect(ws.source).toEqual({ bundle: { startCommit, goldCommit } });
+
+    await writeFile(ws.join("inner.txt"), "inner edited\n");
+    const { agentDiff, referenceDiff } = await ws.captureGitDiffs();
+    expect(referenceDiff?.diff).toContain("root v2");
+    expect(agentDiff?.diff).toContain("inner edited");
+  });
+
+  it("rejects a missing bundle file", async () => {
+    await expect(
+      Workspace.fromGitBundle({
+        bundlePath: join(tmpdir(), "does-not-exist.bundle"),
+        startCommit: "abc",
+        goldCommit: "def",
+      }),
+    ).rejects.toThrow(/git bundle file does not exist/);
   });
 });
 


### PR DESCRIPTION
This PR adds a feature to our `aether-evals` Rust and TS libs to support instantiating a `Workspace` for evals  from a [git bundle](https://git-scm.com/docs/git-bundle) file. 

This makes it easy to hydrate workspaces from repo snapshots in say S3. 