### PR TITLE
chore: reduce development compile costs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4845,7 +4845,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d1f571c72940a19d9532fe52dbea8bc9912bf1d766c2970bb824056b86f3f59"
 dependencies = [
  "async-trait",
- "base64 0.22.1",
  "chrono",
  "futures",
  "http 1.4.2",
@@ -5872,7 +5871,6 @@ dependencies = [
  "bytes",
  "libc",
  "mio",
- "parking_lot",
  "pin-project-lite",
  "signal-hook-registry",
  "socket2 0.6.4",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ aws-sdk-bedrockruntime = "1.133.0"
 aws-smithy-types = ">=1.4.9, <1.6.0"
 
 # Async runtime
-tokio = { version = "^1.52.3", features = ["full"] }
+tokio = { version = "^1.52.3" }
 tokio-stream = { version = "^0.1.18", features = ["io-util"] }
 tokio-util = "^0.7.18"
 futures = "^0.3.32"
@@ -44,7 +44,7 @@ tracing-appender = "0.2"
 agent-client-protocol = "0.14.0"
 
 # MCP and API clients
-rmcp = { version = "^1.7.0", features = ["client", "server", "macros", "schemars", "auth", "elicitation", "transport-io"] }
+rmcp = { version = "^1.7.0", default-features = false }
 async-openai = { version = "^0.41.0", features = ["byot", "chat-completion", "responses"] }
 reqwest = { version = "^0.13.4", default-features = false, features = ["json", "query", "rustls", "http2", "stream"] }
 oauth2 = "5.0"
@@ -110,6 +110,9 @@ unicode-width = "0.2.2"
 tempfile = "3.27"
 async-trait = "0.1"
 testcontainers = "0.27.3"
+
+[profile.dev]
+debug = 1
 
 [profile.dist]
 inherits = "release"

--- a/crates/acp-utils/Cargo.toml
+++ b/crates/acp-utils/Cargo.toml
@@ -33,18 +33,18 @@ testing = ["client"]
 agent-client-protocol = { workspace = true }
 futures = { workspace = true }
 tokio-util = { workspace = true, features = ["compat"] }
-rmcp = { workspace = true }
+rmcp = { workspace = true, features = ["client", "elicitation"] }
 schemars = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 mcp_utils = { package = "aether-mcp-utils", path = "../mcp-utils", version = "0.5.24" }
-tokio = { workspace = true }
+tokio = { workspace = true, features = ["rt", "macros", "sync", "io-util", "process", "time"] }
 tracing = { workspace = true }
 utils = { package = "aether-utils", path = "../utils", version = "0.2.9" }
 async-trait = { workspace = true }
 thiserror = { workspace = true }
 
 [dev-dependencies]
-tokio = { workspace = true, features = ["full", "test-util"] }
+tokio = { workspace = true, features = ["test-util"] }
 serde_json = { workspace = true }
 tempfile = { workspace = true }

--- a/crates/aether-auth/Cargo.toml
+++ b/crates/aether-auth/Cargo.toml
@@ -31,14 +31,14 @@ futures = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 thiserror = { workspace = true }
-tokio = { workspace = true }
+tokio = { workspace = true, features = ["rt", "macros", "sync", "io-util", "net", "time"] }
 tracing = { workspace = true }
 
 # keyring feature
 keyring-core = { workspace = true, optional = true }
 
 # mcp feature
-rmcp = { workspace = true, optional = true }
+rmcp = { workspace = true, optional = true, features = ["auth", "client"] }
 oauth2 = { workspace = true }
 reqwest = { workspace = true }
 url = { workspace = true, optional = true }

--- a/crates/aether-cli/Cargo.toml
+++ b/crates/aether-cli/Cargo.toml
@@ -41,9 +41,9 @@ tui = { package = "aether-tui", path = "../tui", default-features = false, featu
 acp_utils = { package = "aether-acp-utils", path = "../acp-utils", features = ["server", "testing"], version = "0.3.30" }
 agent-client-protocol = { workspace = true }
 aether-lspd = { path = "../aether-lspd", version = "0.1.22" }
-rmcp = { workspace = true }
+rmcp = { workspace = true, features = ["client", "elicitation", "server", "transport-streamable-http-client-reqwest"] }
 thiserror = { workspace = true }
-tokio = { workspace = true }
+tokio = { workspace = true, features = ["rt", "rt-multi-thread", "macros", "sync", "io-util", "net", "fs", "time"] }
 tokio-util = { workspace = true, features = ["compat"] }
 serde = { workspace = true }
 serde_json = { workspace = true }

--- a/crates/aether-core/Cargo.toml
+++ b/crates/aether-core/Cargo.toml
@@ -29,10 +29,10 @@ futures = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 serde_yml = { workspace = true }
-tokio = { workspace = true }
+tokio = { workspace = true, features = ["rt", "rt-multi-thread", "macros", "sync", "time"] }
 tokio-stream = { workspace = true }
 async-openai = { workspace = true }
-rmcp = { workspace = true }
+rmcp = { workspace = true, features = ["client", "elicitation"] }
 schemars = { workspace = true }
 chrono = { workspace = true }
 tracing = { workspace = true }
@@ -49,7 +49,7 @@ llm = { package = "aether-llm", path = "../llm", version = "0.7.19", features = 
 utils = { package = "aether-utils", path = "../utils", version = "0.2.9" }
 
 [features]
-testing = []
+testing = ["rmcp/macros", "rmcp/server"]
 
 [dev-dependencies]
 aether-core = { package = "aether-agent-core", path = ".", features = ["testing"] }

--- a/crates/aether-evals/Cargo.toml
+++ b/crates/aether-evals/Cargo.toml
@@ -16,7 +16,7 @@ dist = false
 workspace = true
 
 [dependencies]
-tokio = { workspace = true }
+tokio = { workspace = true, features = ["rt", "macros", "io-util", "fs"] }
 futures = { workspace = true }
 async-stream = { workspace = true }
 serde = { workspace = true }

--- a/crates/aether-lspd/Cargo.toml
+++ b/crates/aether-lspd/Cargo.toml
@@ -29,7 +29,7 @@ path = "src/lib.rs"
 
 [dependencies]
 # Async runtime
-tokio = { workspace = true }
+tokio = { workspace = true, features = ["rt", "rt-multi-thread", "macros", "sync", "io-util", "net", "fs", "process", "time", "signal"] }
 futures = { workspace = true }
 
 # Serialization

--- a/crates/aether-project/Cargo.toml
+++ b/crates/aether-project/Cargo.toml
@@ -36,4 +36,4 @@ globset = { workspace = true }
 [dev-dependencies]
 aether-doctest = { path = "../doctest" }
 tempfile = { workspace = true }
-tokio = { workspace = true }
+tokio = { workspace = true, features = ["rt", "macros", "sync", "time"] }

--- a/crates/aether-telemetry/Cargo.toml
+++ b/crates/aether-telemetry/Cargo.toml
@@ -30,4 +30,4 @@ axum = { workspace = true }
 opentelemetry-proto = { version = "0.32.0", default-features = false, features = ["gen-tonic-messages", "trace", "metrics"] }
 opentelemetry_sdk = { version = "0.32.0", default-features = false, features = ["trace", "metrics", "rt-tokio", "testing"] }
 prost = "0.14"
-tokio = { workspace = true, features = ["test-util"] }
+tokio = { workspace = true, features = ["rt", "macros", "test-util"] }

--- a/crates/internal-evals/Cargo.toml
+++ b/crates/internal-evals/Cargo.toml
@@ -24,4 +24,4 @@ thiserror = { workspace = true }
 aether-core = { package = "aether-agent-core", path = "../aether-core" }
 tempfile = { workspace = true }
 testcontainers = { workspace = true }
-tokio = { workspace = true }
+tokio = { workspace = true, features = ["rt", "macros"] }

--- a/crates/llm/Cargo.toml
+++ b/crates/llm/Cargo.toml
@@ -43,7 +43,7 @@ thiserror = { workspace = true }
 time = { workspace = true, optional = true }
 uuid = { workspace = true }
 
-tokio = { workspace = true }
+tokio = { workspace = true, features = ["rt", "rt-multi-thread", "macros", "sync", "io-util", "net", "time"] }
 tokio-stream = { workspace = true }
 tokio-util = { workspace = true }
 

--- a/crates/mcp-servers/Cargo.toml
+++ b/crates/mcp-servers/Cargo.toml
@@ -75,17 +75,17 @@ subagents = [
 ]
 survey = []
 all = ["coding", "skills", "tasks", "subagents", "survey", "plan"]
-stdio = ["coding", "skills", "tasks", "survey", "subagents", "plan"]
+stdio = ["coding", "skills", "tasks", "survey", "subagents", "plan", "rmcp/transport-io"]
 
 [dependencies]
 # Always required
 serde = { workspace = true }
 serde_json = { workspace = true }
-tokio = { workspace = true }
-rmcp = { workspace = true }
+tokio = { workspace = true, features = ["rt", "macros", "sync", "io-util", "fs", "process", "time"] }
+rmcp = { workspace = true, features = ["elicitation", "macros", "server"] }
 schemars = { workspace = true }
 clap = { workspace = true, features = ["env"] }
-mcp_utils = { package = "aether-mcp-utils", path = "../mcp-utils", version = "0.5.24" }
+mcp_utils = { package = "aether-mcp-utils", path = "../mcp-utils", default-features = false, version = "0.5.24" }
 utils = { package = "aether-utils", path = "../utils", version = "0.2.9" }
 aether-lspd = { path = "../aether-lspd", optional = true, version = "0.1.22" }
 futures = { workspace = true, optional = true }
@@ -118,6 +118,7 @@ llm = { package = "aether-llm", path = "../llm", optional = true, version = "0.7
 tempfile = { workspace = true }
 aether-lspd = { path = "../aether-lspd", features = ["testing"], version = "0.1.22" }
 mcp-servers = { package = "aether-mcp-servers", path = ".", features = ["test-helpers"] }
+mcp_utils = { package = "aether-mcp-utils", path = "../mcp-utils", features = ["client"], version = "0.5.24" }
 
 [[bin]]
 name = "mcp-servers-stdio"

--- a/crates/mcp-utils/Cargo.toml
+++ b/crates/mcp-utils/Cargo.toml
@@ -38,8 +38,8 @@ client = [
 [dependencies]
 futures = { workspace = true }
 serde = { workspace = true }
-tokio = { workspace = true }
-rmcp = { workspace = true }
+tokio = { workspace = true, features = ["rt", "macros", "sync", "net", "time"] }
+rmcp = { workspace = true, features = ["client", "server"] }
 tracing = { workspace = true }
 utils = { package = "aether-utils", path = "../utils", version = "0.2.9" }
 schemars = { workspace = true }

--- a/crates/tui/Cargo.toml
+++ b/crates/tui/Cargo.toml
@@ -45,7 +45,7 @@ nucleo = { workspace = true, optional = true }
 similar = { workspace = true }
 unicode-width = { workspace = true }
 serde_json = { workspace = true }
-tokio = { workspace = true }
+tokio = { workspace = true, features = ["rt", "rt-multi-thread", "macros", "sync", "time"] }
 tokio-util = { workspace = true }
 tracing = { workspace = true }
 thiserror = { workspace = true }
@@ -54,4 +54,4 @@ thiserror = { workspace = true }
 tui = { package = "aether-tui", path = ".", features = ["testing"] }
 tempfile.workspace = true
 crossterm = { workspace = true }
-tokio = { workspace = true }
+tokio = { workspace = true, features = ["rt", "rt-multi-thread", "macros", "sync", "time"] }

--- a/crates/utils/Cargo.toml
+++ b/crates/utils/Cargo.toml
@@ -31,7 +31,7 @@ serde = { workspace = true }
 serde_json = { workspace = true }
 serde_yml = { workspace = true }
 thiserror = { workspace = true }
-tokio = { workspace = true }
+tokio = { workspace = true, features = ["rt", "macros", "process"] }
 tracing = { workspace = true }
 
 [dev-dependencies]

--- a/crates/wisp/Cargo.toml
+++ b/crates/wisp/Cargo.toml
@@ -33,7 +33,7 @@ tui = { package = "aether-tui", path = "../tui", version = "0.2.16" }
 utils = { package = "aether-utils", path = "../utils", version = "0.2.9" }
 agent-client-protocol = { workspace = true }
 base64 = { workspace = true }
-tokio = { workspace = true }
+tokio = { workspace = true, features = ["rt", "rt-multi-thread", "macros", "sync", "io-util", "fs", "process", "time"] }
 serde_json = { workspace = true }
 clap = { workspace = true }
 tracing = { workspace = true }


### PR DESCRIPTION
## Summary

- stop enabling Tokio's `full` feature workspace-wide and request only the features each crate uses
- disable RMCP default features and enable protocol and transport capabilities at their consumers
- keep `aether-mcp-utils` client dependencies out of server-only builds
- reduce development debug information from level 2 to level 1

## Motivation

The workspace-wide feature declarations caused unrelated crates and build dependencies to compile broader Tokio and RMCP graphs than they use. The development profile also emitted substantially more debug information than needed for normal local iteration.

In an isolated clean CLI build, changing the development debug level alone reduced wall time from 35.08s to 32.30s and artifacts from 6.0 GiB to 4.2 GiB. The narrower feature graph additionally removes unused `parking_lot` and RMCP `base64` dependencies from the lockfile.

## Validation

- `just test` — 3021 tests passed
- `just lint`
- workspace LSP diagnostics — 0 issues
