### PR TITLE
fix(mcp-servers): Make web search tool retry on rate limit

### DIFF
--- a/crates/mcp-servers/Cargo.toml
+++ b/crates/mcp-servers/Cargo.toml
@@ -116,6 +116,7 @@ llm = { package = "aether-llm", path = "../llm", optional = true, version = "0.7
 
 [dev-dependencies]
 tempfile = { workspace = true }
+tokio = { workspace = true, features = ["test-util"] }
 aether-lspd = { path = "../aether-lspd", features = ["testing"], version = "0.1.23" }
 mcp-servers = { package = "aether-mcp-servers", path = ".", features = ["test-helpers"] }
 mcp_utils = { package = "aether-mcp-utils", path = "../mcp-utils", features = ["client"], version = "0.5.25" }

--- a/crates/mcp-servers/src/coding/error.rs
+++ b/crates/mcp-servers/src/coding/error.rs
@@ -200,7 +200,7 @@ pub enum WebFetchError {
 }
 
 /// Errors related to web search operations
-#[derive(Debug, Error)]
+#[derive(Debug, Clone, Error)]
 pub enum WebSearchError {
     /// Invalid search query
     #[error("Invalid search query: {0}")]
@@ -211,8 +211,8 @@ pub enum WebSearchError {
     ApiError(String),
 
     /// Rate limit exceeded
-    #[error("Rate limit exceeded: {0}")]
-    RateLimited(String),
+    #[error("Rate limit exceeded: {message}")]
+    RateLimited { message: String, retry_after: Option<std::time::Duration> },
 
     /// Request timed out
     #[error("Request timed out after {0}ms")]

--- a/crates/mcp-servers/src/coding/mod.rs
+++ b/crates/mcp-servers/src/coding/mod.rs
@@ -659,7 +659,29 @@ When using tools that take file paths, always use absolute paths from:
                 .to_string()
         })?;
 
-        searcher.search(args).await.map_err(|e| e.to_string()).map(Json)
+        let peer = context.peer.clone();
+        let progress_token = context.meta.get_progress_token();
+        searcher
+            .search(args, move |delay| {
+                let peer = peer.clone();
+                let progress_token = progress_token.clone();
+                async move {
+                    if let Some(token) = progress_token {
+                        let message = format!("Search rate limited; retrying in {} seconds.", delay.as_secs());
+                        let _ = peer
+                            .notify_progress(ProgressNotificationParam {
+                                progress_token: token,
+                                progress: 0.0,
+                                total: None,
+                                message: Some(message),
+                            })
+                            .await;
+                    }
+                }
+            })
+            .await
+            .map_err(|e| e.to_string())
+            .map(Json)
     }
 
     #[doc = include_str!("../lsp/tools/symbol_lookup/description.md")]

--- a/crates/mcp-servers/src/coding/tools/web_search/mod.rs
+++ b/crates/mcp-servers/src/coding/tools/web_search/mod.rs
@@ -8,12 +8,17 @@ pub use search_client::FakeSearchClient;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use std::collections::HashSet;
+use std::future::Future;
+use std::time::Duration;
 
 use crate::coding::error::WebSearchError;
 use mcp_utils::display_meta::{ToolDisplayMeta, ToolResultMeta};
 
 const DEFAULT_COUNT: u32 = 10;
 const MAX_COUNT: u32 = 20;
+const MAX_RATE_LIMIT_RETRIES: u32 = 3;
+const MAX_RETRY_AFTER: Duration = Duration::from_mins(1);
+const DEFAULT_RETRY_DELAY: Duration = Duration::from_secs(2);
 
 /// Input parameters for `web_search` tool
 #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
@@ -77,7 +82,11 @@ impl<C: SearchClient> WebSearcher<C> {
     }
 
     /// Performs a web search with the given parameters
-    pub async fn search(&self, args: WebSearchInput) -> Result<WebSearchOutput, WebSearchError> {
+    pub async fn search<T, U>(&self, args: WebSearchInput, mut on_retry: T) -> Result<WebSearchOutput, WebSearchError>
+    where
+        T: FnMut(Duration) -> U,
+        U: Future<Output = ()>,
+    {
         let query = args.query.trim();
 
         if query.is_empty() {
@@ -86,9 +95,22 @@ impl<C: SearchClient> WebSearcher<C> {
 
         let count = args.count.unwrap_or(DEFAULT_COUNT).min(MAX_COUNT);
 
-        let params = SearchParams { query: query.to_string(), count };
+        let query_owned = query.to_string();
+        let mut retries = 0;
+        let mut results = loop {
+            let params = SearchParams { query: query_owned.clone(), count };
 
-        let mut results = self.client.search(params).await?;
+            match self.client.search(params).await {
+                Ok(results) => break results,
+                Err(WebSearchError::RateLimited { retry_after, .. }) if retries < MAX_RATE_LIMIT_RETRIES => {
+                    let delay = retry_after.unwrap_or(DEFAULT_RETRY_DELAY).min(MAX_RETRY_AFTER);
+                    retries += 1;
+                    on_retry(delay).await;
+                    tokio::time::sleep(delay).await;
+                }
+                Err(error) => return Err(error),
+            }
+        };
 
         // Ensure we don't return more than requested
         if results.len() > count as usize {
@@ -180,6 +202,9 @@ fn extract_domain(url: &str) -> Option<String> {
 
 #[cfg(test)]
 mod tests {
+    use std::sync::{Arc, Mutex};
+    use std::time::Duration;
+
     use super::*;
 
     fn make_result(url: &str) -> RawSearchResult {
@@ -229,8 +254,80 @@ mod tests {
     #[tokio::test]
     async fn test_empty_query_returns_error() {
         let searcher = WebSearcher::with_client(FakeSearchClient::new());
-        let result = searcher.search(input("   ")).await;
+        let result = searcher.search(input("   "), |_| async {}).await;
         assert!(matches!(result, Err(WebSearchError::InvalidQuery(_))));
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn retries_rate_limited_search_after_retry_after_period() {
+        let client = FakeSearchClient::new().with_sequential_results(vec![
+            Err(WebSearchError::RateLimited {
+                message: "too many requests".to_string(),
+                retry_after: Some(Duration::ZERO),
+            }),
+            Ok(vec![make_result("https://example.com")]),
+        ]);
+        let searcher = WebSearcher::with_client(client);
+
+        let retry_delays = Arc::new(Mutex::new(Vec::new()));
+        let notified_delays = retry_delays.clone();
+        let output = searcher
+            .search(input("rust"), move |delay| {
+                let notified_delays = notified_delays.clone();
+                async move {
+                    notified_delays.lock().unwrap().push(delay);
+                }
+            })
+            .await
+            .unwrap();
+
+        assert_eq!(output.results.len(), 1);
+        assert_eq!(*retry_delays.lock().unwrap(), vec![Duration::ZERO]);
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn retries_rate_limited_search_when_retry_after_header_is_missing() {
+        let client = FakeSearchClient::new().with_sequential_results(vec![
+            Err(WebSearchError::RateLimited { message: "too many requests".to_string(), retry_after: None }),
+            Ok(vec![make_result("https://example.com")]),
+        ]);
+        let searcher = WebSearcher::with_client(client);
+
+        let retry_delays = Arc::new(Mutex::new(Vec::new()));
+        let notified_delays = retry_delays.clone();
+        let output = searcher
+            .search(input("rust"), move |delay| {
+                let notified_delays = notified_delays.clone();
+                async move {
+                    notified_delays.lock().unwrap().push(delay);
+                }
+            })
+            .await
+            .unwrap();
+
+        assert_eq!(output.results.len(), 1);
+        assert_eq!(retry_delays.lock().unwrap().len(), 1, "should have retried once");
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn returns_rate_limited_error_after_retry_budget_is_exhausted() {
+        let rate_limited = || -> Result<Vec<RawSearchResult>, WebSearchError> {
+            Err(WebSearchError::RateLimited {
+                message: "too many requests".to_string(),
+                retry_after: Some(Duration::ZERO),
+            })
+        };
+        let client = FakeSearchClient::new().with_sequential_results(vec![
+            rate_limited(),
+            rate_limited(),
+            rate_limited(),
+            rate_limited(),
+            Err(WebSearchError::ApiError("retry budget was exceeded".to_string())),
+        ]);
+        let searcher = WebSearcher::with_client(client);
+        let result = searcher.search(input("rust"), |_| async {}).await;
+
+        assert!(matches!(result, Err(WebSearchError::RateLimited { .. })));
     }
 
     #[tokio::test]
@@ -246,7 +343,7 @@ mod tests {
 
         let mut q = input("test query");
         q.count = Some(15);
-        let output = searcher.search(q).await.unwrap();
+        let output = searcher.search(q, |_| async {}).await.unwrap();
         assert_eq!(output.results.len(), 15);
     }
 
@@ -263,7 +360,7 @@ mod tests {
 
         let mut q = input("test query");
         q.blocked_domains = Some(strs(&["blocked.com"]));
-        let output = searcher.search(q).await.unwrap();
+        let output = searcher.search(q, |_| async {}).await.unwrap();
         assert_eq!(output.results.len(), 2);
         assert!(!output.results.iter().any(|r| r.url.contains("blocked.com")));
     }
@@ -278,7 +375,7 @@ mod tests {
                 description: "A systems language".to_string(),
             }],
         );
-        let output = searcher.search(input("rust programming")).await.unwrap();
+        let output = searcher.search(input("rust programming"), |_| async {}).await.unwrap();
         assert_eq!(output.results.len(), 1);
         assert_eq!(output.results[0].title, "Rust Language");
         assert_eq!(output.results[0].snippet, "A systems language");

--- a/crates/mcp-servers/src/coding/tools/web_search/search_client.rs
+++ b/crates/mcp-servers/src/coding/tools/web_search/search_client.rs
@@ -1,5 +1,6 @@
 //! Search client abstraction for web search operations
 
+use reqwest::header::RETRY_AFTER;
 use serde::Deserialize;
 use std::future::Future;
 use std::time::Duration;
@@ -97,10 +98,11 @@ impl SearchClient for BraveSearchClient {
         let status = response.status();
 
         if status.is_client_error() || status.is_server_error() {
+            let retry_after = parse_retry_after(response.headers().get(RETRY_AFTER));
             let error_text = response.text().await.unwrap_or_else(|_| "Unable to read error response".to_string());
 
             if status.as_u16() == 429 {
-                return Err(WebSearchError::RateLimited(error_text));
+                return Err(WebSearchError::RateLimited { message: error_text, retry_after });
             }
 
             return Err(WebSearchError::ApiError(format!("API returned {}: {error_text}", status.as_u16())));
@@ -125,6 +127,19 @@ impl SearchClient for BraveSearchClient {
     }
 }
 
+fn parse_retry_after(value: Option<&reqwest::header::HeaderValue>) -> Option<Duration> {
+    let value = value?.to_str().ok()?.trim();
+
+    value.parse::<u64>().ok().map(Duration::from_secs).or_else(|| {
+        chrono::DateTime::parse_from_rfc2822(value)
+            .ok()?
+            .with_timezone(&chrono::Utc)
+            .signed_duration_since(chrono::Utc::now())
+            .to_std()
+            .ok()
+    })
+}
+
 /// Brave API response structure
 #[derive(Debug, Deserialize)]
 struct BraveWebResponse {
@@ -143,6 +158,10 @@ struct BraveResult {
     description: String,
 }
 
+/// The result of a single search call: either matching results or an error.
+#[cfg(test)]
+type SearchOutcome = Result<Vec<RawSearchResult>, WebSearchError>;
+
 /// Fake search client for testing without network calls
 #[cfg(test)]
 #[derive(Debug, Clone)]
@@ -150,6 +169,9 @@ pub struct FakeSearchClient {
     responses: std::sync::Arc<std::sync::Mutex<std::collections::HashMap<String, Vec<RawSearchResult>>>>,
     search_history: std::sync::Arc<std::sync::Mutex<Vec<String>>>,
     default_response: Option<Vec<RawSearchResult>>,
+    /// When set, responses are served in call order (indexed by call count)
+    /// instead of being looked up by query. Use for retry/error tests.
+    sequential_responses: Option<std::sync::Arc<std::sync::Mutex<Vec<SearchOutcome>>>>,
 }
 
 #[cfg(test)]
@@ -166,6 +188,7 @@ impl FakeSearchClient {
             responses: std::sync::Arc::new(std::sync::Mutex::new(std::collections::HashMap::new())),
             search_history: std::sync::Arc::new(std::sync::Mutex::new(Vec::new())),
             default_response: None,
+            sequential_responses: None,
         }
     }
 
@@ -176,6 +199,13 @@ impl FakeSearchClient {
 
     pub fn with_default(mut self, results: Vec<RawSearchResult>) -> Self {
         self.default_response = Some(results);
+        self
+    }
+
+    /// Queue a sequence of responses served in call order, regardless of query.
+    /// Enables retry/error tests where the same query returns different results.
+    pub fn with_sequential_results(mut self, responses: Vec<SearchOutcome>) -> Self {
+        self.sequential_responses = Some(std::sync::Arc::new(std::sync::Mutex::new(responses)));
         self
     }
 
@@ -191,7 +221,18 @@ impl FakeSearchClient {
 #[cfg(test)]
 impl SearchClient for FakeSearchClient {
     async fn search(&self, params: SearchParams) -> Result<Vec<RawSearchResult>, WebSearchError> {
-        self.search_history.lock().unwrap().push(params.query.clone());
+        let call_index = {
+            let mut history = self.search_history.lock().unwrap();
+            let index = history.len();
+            history.push(params.query.clone());
+            index
+        };
+
+        if let Some(ref sequential) = self.sequential_responses {
+            return sequential.lock().unwrap().get(call_index).cloned().unwrap_or_else(|| {
+                Err(WebSearchError::ApiError(format!("No sequential response at index {call_index}")))
+            });
+        }
 
         let responses = self.responses.lock().unwrap();
         if let Some(results) = responses.get(&params.query) {


### PR DESCRIPTION
This PR makes the web search tool retry when it gets rate limited. 