### PR TITLE
fix: keep agent sessions responsive during in-flight work

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -33,6 +33,7 @@ dependencies = [
 name = "aether-acp-utils"
 version = "0.3.31"
 dependencies = [
+ "aether-acp-utils",
  "aether-mcp-utils",
  "aether-utils",
  "agent-client-protocol",
@@ -5871,6 +5872,7 @@ dependencies = [
  "bytes",
  "libc",
  "mio",
+ "parking_lot",
  "pin-project-lite",
  "signal-hook-registry",
  "socket2 0.6.4",

--- a/crates/acp-utils/Cargo.toml
+++ b/crates/acp-utils/Cargo.toml
@@ -45,6 +45,7 @@ async-trait = { workspace = true }
 thiserror = { workspace = true }
 
 [dev-dependencies]
-tokio = { workspace = true, features = ["test-util"] }
+aether-acp-utils = { path = ".", features = ["testing"] }
+tokio = { workspace = true, features = ["full", "test-util"] }
 serde_json = { workspace = true }
 tempfile = { workspace = true }

--- a/crates/acp-utils/src/client/event.rs
+++ b/crates/acp-utils/src/client/event.rs
@@ -23,6 +23,7 @@ pub enum AcpEvent {
     PromptError(Error),
     AuthenticateComplete { method_id: String },
     AuthenticateFailed { method_id: String, error: String },
+    ConfigOptionUpdateFailed { error: String },
     SessionsListed { sessions: Vec<SessionInfo> },
     SessionLoaded { session_id: SessionId, config_options: Vec<SessionConfigOption> },
     NewSessionCreated { session_id: SessionId, config_options: Vec<SessionConfigOption> },

--- a/crates/acp-utils/src/client/session.rs
+++ b/crates/acp-utils/src/client/session.rs
@@ -1,7 +1,6 @@
 use super::error::AcpClientError;
 use super::event::AcpEvent;
 use super::prompt_handle::{AcpPromptHandle, PromptCommand};
-use super::tokio_agent::TokioAcpAgent;
 use crate::notifications::{
     AuthMethodsUpdatedParams, ContextClearedParams, ContextUsageParams, ElicitationParams, McpNotification, McpRequest,
     SubAgentProgressParams,
@@ -13,7 +12,7 @@ use agent_client_protocol::schema::{
     RequestPermissionRequest, RequestPermissionResponse, SelectedPermissionOutcome, SessionCapabilities,
     SessionConfigOption, SessionId, SessionNotification, SessionUpdate, SetSessionConfigOptionRequest, TextContent,
 };
-use agent_client_protocol::{self as acp, Client, ConnectionTo, JsonRpcRequest};
+use agent_client_protocol::{self as acp, Client, ConnectTo, ConnectionTo, JsonRpcRequest};
 use tokio::sync::mpsc;
 use tracing::info;
 
@@ -31,13 +30,13 @@ pub struct AcpSession {
     pub prompt_handle: AcpPromptHandle,
 }
 
-/// Spawn an agent subprocess and establish an ACP session.
+/// Spawn an ACP agent and establish an ACP session.
 ///
 /// The connection auto-approves permissions, forwards session notifications as
 /// [`AcpEvent`]s, and tunnels elicitation requests through the `_aether/elicitation`
 /// extension method.
 pub async fn spawn_acp_session(
-    agent: TokioAcpAgent,
+    agent: impl ConnectTo<Client> + 'static,
     init_request: InitializeRequest,
     new_session_request: NewSessionRequest,
 ) -> Result<AcpSession, AcpClientError> {
@@ -70,7 +69,7 @@ pub async fn spawn_acp_session(
 
 #[allow(clippy::too_many_lines)]
 async fn run_client_connection(
-    agent: TokioAcpAgent,
+    agent: impl ConnectTo<Client> + 'static,
     event_tx: mpsc::UnboundedSender<AcpEvent>,
     cmd_rx: mpsc::UnboundedReceiver<PromptCommand>,
     init_tx: mpsc::UnboundedSender<InitializeResult>,
@@ -229,93 +228,34 @@ async fn run_main(
                             break;
                         }
                         Some(cmd) = cmd_rx.recv() => {
-                            handle_side_command(&cx, &event_tx, cmd).await;
+                            handle_command(&cx, &event_tx, cmd, ClientState::Prompting).await;
                         }
                     }
                 }
             }
-            PromptCommand::ListSessions => {
-                request_to_event(
-                    &cx,
-                    &event_tx,
-                    ListSessionsRequest::new(),
-                    |resp| AcpEvent::SessionsListed { sessions: resp.sessions },
-                    AcpEvent::PromptError,
-                )
-                .await;
-            }
-            PromptCommand::LoadSession { session_id, cwd } => {
-                request_to_event(
-                    &cx,
-                    &event_tx,
-                    LoadSessionRequest::new(session_id.clone(), cwd),
-                    |resp| AcpEvent::SessionLoaded {
-                        session_id,
-                        config_options: resp.config_options.unwrap_or_default(),
-                    },
-                    AcpEvent::PromptError,
-                )
-                .await;
-            }
-            PromptCommand::NewSession { cwd } => {
-                request_to_event(
-                    &cx,
-                    &event_tx,
-                    NewSessionRequest::new(cwd),
-                    |resp| AcpEvent::NewSessionCreated {
-                        session_id: resp.session_id,
-                        config_options: resp.config_options.unwrap_or_default(),
-                    },
-                    AcpEvent::PromptError,
-                )
-                .await;
-            }
-            PromptCommand::MoveWorkspace(params) => {
-                request_to_event(&cx, &event_tx, params, AcpEvent::WorkspaceMoved, |e| AcpEvent::WorkspaceMoveFailed {
-                    error: format!("{e}"),
-                })
-                .await;
-            }
-            cmd => handle_side_command(&cx, &event_tx, cmd).await,
+            cmd => handle_command(&cx, &event_tx, cmd, ClientState::Idle).await,
         }
     }
 }
 
-async fn handle_side_command(
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum ClientState {
+    Idle,
+    Prompting,
+}
+
+async fn handle_command(
     cx: &ConnectionTo<acp::Agent>,
     event_tx: &mpsc::UnboundedSender<AcpEvent>,
     cmd: PromptCommand,
+    state: ClientState,
 ) {
     match cmd {
-        PromptCommand::Cancel { session_id } => {
-            let _ = cx.send_notification(CancelNotification::new(session_id));
-        }
-        PromptCommand::SetConfigOption { session_id, config_id, value } => {
-            let req = SetSessionConfigOptionRequest::new(session_id.clone(), config_id, value);
-            match cx.send_request(req).block_task().await {
-                Ok(resp) => {
-                    let update = ConfigOptionUpdate::new(resp.config_options);
-                    let _ = event_tx.send(AcpEvent::SessionUpdate {
-                        session_id,
-                        update: Box::new(SessionUpdate::ConfigOptionUpdate(update)),
-                    });
-                }
-                Err(e) => {
-                    tracing::warn!("set_session_config_option failed: {e:?}");
-                }
-            }
-        }
         PromptCommand::Prompt { .. } => {
             tracing::warn!("ignoring duplicate Prompt while one is in-flight");
         }
-        PromptCommand::ListSessions => {
-            tracing::warn!("ignoring ListSessions while prompt is in-flight");
-        }
-        PromptCommand::LoadSession { .. } => {
-            tracing::warn!("ignoring LoadSession while prompt is in-flight");
-        }
-        PromptCommand::NewSession { .. } => {
-            tracing::warn!("ignoring NewSession while prompt is in-flight");
+        PromptCommand::Cancel { session_id } => {
+            let _ = cx.send_notification(CancelNotification::new(session_id));
         }
         PromptCommand::AuthenticateMcpServer { session_id, server_name } => {
             let msg = McpRequest::Authenticate { session_id: session_id.0.to_string(), server_name };
@@ -323,57 +263,142 @@ async fn handle_side_command(
                 tracing::warn!("authenticate_mcp_server notification failed: {e:?}");
             }
         }
+        PromptCommand::SetConfigOption { session_id, config_id, value } => {
+            let req = SetSessionConfigOptionRequest::new(session_id.clone(), config_id, value);
+            spawn_request_to_event(
+                cx,
+                event_tx,
+                req,
+                move |resp| {
+                    let update = ConfigOptionUpdate::new(resp.config_options);
+                    AcpEvent::SessionUpdate { session_id, update: Box::new(SessionUpdate::ConfigOptionUpdate(update)) }
+                },
+                |e| AcpEvent::ConfigOptionUpdateFailed { error: format!("{e:?}") },
+            );
+        }
         PromptCommand::Authenticate { method_id } => {
-            match cx.send_request(AuthenticateRequest::new(method_id.clone())).block_task().await {
-                Ok(_) => {
-                    let _ = event_tx.send(AcpEvent::AuthenticateComplete { method_id });
-                }
-                Err(e) => {
-                    tracing::warn!("authenticate failed: {e:?}");
-                    let _ = event_tx.send(AcpEvent::AuthenticateFailed { method_id, error: format!("{e:?}") });
-                }
-            }
+            let failed_method_id = method_id.clone();
+            spawn_request_to_event(
+                cx,
+                event_tx,
+                AuthenticateRequest::new(method_id.clone()),
+                move |_| AcpEvent::AuthenticateComplete { method_id },
+                move |e| AcpEvent::AuthenticateFailed { method_id: failed_method_id, error: format!("{e:?}") },
+            );
         }
         PromptCommand::SearchPrompts(params) => {
             let query = params.query.clone();
-            request_to_event(cx, event_tx, params, AcpEvent::PromptSearchResults, |e| AcpEvent::PromptSearchFailed {
-                query,
-                error: format!("{e}"),
-            })
-            .await;
+            spawn_request_to_event(cx, event_tx, params, AcpEvent::PromptSearchResults, move |e| {
+                AcpEvent::PromptSearchFailed { query, error: format!("{e}") }
+            });
         }
         PromptCommand::SessionPreview(params) => {
             let session_id = params.session_id.clone();
-            request_to_event(cx, event_tx, params, AcpEvent::SessionPreviewLoaded, |e| {
+            spawn_request_to_event(cx, event_tx, params, AcpEvent::SessionPreviewLoaded, move |e| {
                 AcpEvent::SessionPreviewFailed { session_id, error: format!("{e}") }
-            })
-            .await;
+            });
         }
         PromptCommand::ListWorkspaces(params) => {
-            request_to_event(cx, event_tx, params, AcpEvent::WorkspacesListed, |e| AcpEvent::WorkspaceListFailed {
+            spawn_request_to_event(cx, event_tx, params, AcpEvent::WorkspacesListed, |e| {
+                AcpEvent::WorkspaceListFailed { error: format!("{e}") }
+            });
+        }
+        cmd => handle_lifecycle_command(cx, event_tx, cmd, state).await,
+    }
+}
+
+/// Handle the session-lifecycle commands (`ListSessions`, `LoadSession`,
+/// `NewSession`, `MoveWorkspace`).
+async fn handle_lifecycle_command(
+    cx: &ConnectionTo<acp::Agent>,
+    event_tx: &mpsc::UnboundedSender<AcpEvent>,
+    cmd: PromptCommand,
+    state: ClientState,
+) {
+    if state == ClientState::Prompting {
+        tracing::warn!("ignoring session-lifecycle command while prompt is in-flight: {cmd:?}");
+        if matches!(cmd, PromptCommand::MoveWorkspace(_)) {
+            let _ = event_tx.send(AcpEvent::WorkspaceMoveFailed { error: "a prompt is in flight".to_string() });
+        }
+        return;
+    }
+
+    match cmd {
+        PromptCommand::ListSessions => {
+            request_to_event(
+                cx,
+                event_tx,
+                ListSessionsRequest::new(),
+                |resp| AcpEvent::SessionsListed { sessions: resp.sessions },
+                AcpEvent::PromptError,
+            )
+            .await;
+        }
+        PromptCommand::LoadSession { session_id, cwd } => {
+            request_to_event(
+                cx,
+                event_tx,
+                LoadSessionRequest::new(session_id.clone(), cwd),
+                |resp| AcpEvent::SessionLoaded { session_id, config_options: resp.config_options.unwrap_or_default() },
+                AcpEvent::PromptError,
+            )
+            .await;
+        }
+        PromptCommand::NewSession { cwd } => {
+            request_to_event(
+                cx,
+                event_tx,
+                NewSessionRequest::new(cwd),
+                |resp| AcpEvent::NewSessionCreated {
+                    session_id: resp.session_id,
+                    config_options: resp.config_options.unwrap_or_default(),
+                },
+                AcpEvent::PromptError,
+            )
+            .await;
+        }
+        PromptCommand::MoveWorkspace(params) => {
+            request_to_event(cx, event_tx, params, AcpEvent::WorkspaceMoved, |e| AcpEvent::WorkspaceMoveFailed {
                 error: format!("{e}"),
             })
             .await;
         }
-        PromptCommand::MoveWorkspace(_) => {
-            tracing::warn!("ignoring MoveWorkspace while prompt is in-flight");
-            let _ = event_tx.send(AcpEvent::WorkspaceMoveFailed { error: "a prompt is in flight".to_string() });
-        }
+        cmd => unreachable!("non-lifecycle command routed to handle_lifecycle_command: {cmd:?}"),
     }
 }
 
-async fn request_to_event<T: JsonRpcRequest>(
+fn request_to_event<T: JsonRpcRequest>(
     cx: &ConnectionTo<acp::Agent>,
     event_tx: &mpsc::UnboundedSender<AcpEvent>,
     params: T,
-    ok: impl FnOnce(T::Response) -> AcpEvent,
-    err: impl FnOnce(acp::Error) -> AcpEvent,
+    ok: impl FnOnce(T::Response) -> AcpEvent + Send + 'static,
+    err: impl FnOnce(acp::Error) -> AcpEvent + Send + 'static,
+) -> impl Future<Output = ()> + 'static {
+    let sent = cx.send_request(params);
+    let event_tx = event_tx.clone();
+    async move {
+        let event = match sent.block_task().await {
+            Ok(resp) => ok(resp),
+            Err(e) => err(e),
+        };
+        let _ = event_tx.send(event);
+    }
+}
+
+fn spawn_request_to_event<T: JsonRpcRequest>(
+    cx: &ConnectionTo<acp::Agent>,
+    event_tx: &mpsc::UnboundedSender<AcpEvent>,
+    params: T,
+    ok: impl FnOnce(T::Response) -> AcpEvent + Send + 'static,
+    err: impl FnOnce(acp::Error) -> AcpEvent + Send + 'static,
 ) {
-    let event = match cx.send_request(params).block_task().await {
-        Ok(resp) => ok(resp),
-        Err(e) => err(e),
-    };
-    let _ = event_tx.send(event);
+    let fut = request_to_event(cx, event_tx, params, ok, err);
+    if let Err(e) = cx.spawn(async move {
+        fut.await;
+        Ok(())
+    }) {
+        tracing::warn!("failed to spawn request task: {e:?}");
+    }
 }
 
 fn auto_approve_option(req: &RequestPermissionRequest) -> PermissionOptionId {

--- a/crates/acp-utils/tests/client_session.rs
+++ b/crates/acp-utils/tests/client_session.rs
@@ -1,0 +1,82 @@
+use acp_utils::client::spawn_acp_session;
+use acp_utils::testing::duplex_pair;
+use agent_client_protocol::schema::{
+    CancelNotification, Implementation, InitializeRequest, InitializeResponse, NewSessionRequest, NewSessionResponse,
+    PromptRequest, ProtocolVersion, SessionId, SetSessionConfigOptionRequest,
+};
+use agent_client_protocol::{self as acp, Agent};
+use std::path::PathBuf;
+use std::sync::Arc;
+use tokio::sync::Notify;
+use tokio::task::{LocalSet, spawn_local};
+
+#[tokio::test(flavor = "current_thread")]
+async fn cancel_reaches_the_agent_while_a_config_response_is_outstanding() {
+    LocalSet::new()
+        .run_until(async {
+            let (agent_transport, client_transport) = duplex_pair();
+            let cancelled = Arc::new(Notify::new());
+
+            let agent_builder = Agent
+                .builder()
+                .on_receive_request(
+                    async |_req: InitializeRequest, responder, _cx| {
+                        responder.respond(
+                            InitializeResponse::new(ProtocolVersion::V1)
+                                .agent_info(Implementation::new("Fake Agent", "0.0.0")),
+                        )
+                    },
+                    acp::on_receive_request!(),
+                )
+                .on_receive_request(
+                    async |_req: NewSessionRequest, responder, _cx| {
+                        responder.respond(NewSessionResponse::new(SessionId::new("sess-1")))
+                    },
+                    acp::on_receive_request!(),
+                )
+                .on_receive_request(
+                    // Never answer, so the prompt stays in flight for the whole test.
+                    async |_req: PromptRequest, responder, _cx| {
+                        std::mem::forget(responder);
+                        Ok(())
+                    },
+                    acp::on_receive_request!(),
+                )
+                .on_receive_request(
+                    // Never answer, so the config response stays outstanding when Cancel is sent.
+                    async |_req: SetSessionConfigOptionRequest, responder, _cx| {
+                        std::mem::forget(responder);
+                        Ok(())
+                    },
+                    acp::on_receive_request!(),
+                )
+                .on_receive_notification(
+                    {
+                        let cancelled = Arc::clone(&cancelled);
+                        async move |_n: CancelNotification, _cx| {
+                            cancelled.notify_one();
+                            Ok(())
+                        }
+                    },
+                    acp::on_receive_notification!(),
+                );
+            spawn_local(async move {
+                let _ = agent_builder.connect_to(agent_transport).await;
+            });
+
+            let session = spawn_acp_session(
+                client_transport,
+                InitializeRequest::new(ProtocolVersion::V1),
+                NewSessionRequest::new(PathBuf::from("/tmp")),
+            )
+            .await
+            .expect("session establishes");
+
+            session.prompt_handle.prompt(&session.session_id, "hi", None).expect("prompt queues");
+            session.prompt_handle.set_config_option(&session.session_id, "mode", "Plan").expect("config queues");
+            session.prompt_handle.cancel(&session.session_id).expect("cancel queues");
+
+            cancelled.notified().await;
+        })
+        .await;
+}

--- a/crates/aether-cli/src/acp/session_actor.rs
+++ b/crates/aether-cli/src/acp/session_actor.rs
@@ -304,7 +304,11 @@ async fn on_session_command(
     match cmd {
         SessionCommand::Prompt { content, responder } => {
             let result = handle_prompt(actor, runtime_event_rx, cmd_rx, io, content).await;
+            let turn_ok = result.is_ok();
             respond_prompt(responder, result);
+            if turn_ok {
+                let _ = apply_deferred_agent_switch(actor, io).await;
+            }
         }
         SessionCommand::Cancel => info!("Cancel received while idle, ignoring"),
         SessionCommand::SetConfig { setting, available, responder } => {
@@ -336,7 +340,7 @@ async fn handle_prompt(
     persist_event(actor, io, SessionEvent::User(UserEvent::Message { content: content.clone() }));
     actor.send_active_command(Command::with_content(content)).await?;
 
-    let turn_result: Result<acp::StopReason, SessionError> = loop {
+    loop {
         tokio::select! {
             () = io.cancel.cancelled() => {
                 info!("Cancellation observed during active prompt; forwarding Cancel to agent");
@@ -359,14 +363,24 @@ async fn handle_prompt(
                 handle_in_flight_command(actor, io, cmd).await;
             }
         }
-    };
-
-    if turn_result.is_ok() {
-        let switch = actor.config.take_agent_switch(&actor.modes);
-        apply_switch(actor, io, switch).await?;
     }
+}
 
-    turn_result
+async fn apply_deferred_agent_switch(actor: &mut SessionActor, io: &SessionIo) -> Result<(), SessionError> {
+    let switch = actor.config.take_agent_switch(&actor.modes);
+    apply_switch(actor, io, switch).await.inspect_err(|error| error!("Failed to activate selected mode: {error}"))
+}
+
+async fn apply_idle_config_change(
+    actor: &mut SessionActor,
+    io: &SessionIo,
+    setting: &ConfigSetting,
+    available: &[LlmModel],
+) -> Result<SetSessionConfigOptionResponse, acp::Error> {
+    apply_config_change(actor, io, setting, available)?;
+    apply_deferred_agent_switch(actor, io).await.map_err(|_| acp::Error::internal_error())?;
+    let options = actor.get_config().config_options(available, io.oauth_credential_store.as_ref());
+    Ok(SetSessionConfigOptionResponse::new(options))
 }
 
 fn turn_stop_reason(message: &AgentEvent) -> Option<acp::StopReason> {
@@ -397,31 +411,6 @@ async fn handle_in_flight_command(actor: &mut SessionActor, io: &SessionIo, cmd:
     }
 }
 
-async fn apply_idle_config_change(
-    actor: &mut SessionActor,
-    io: &SessionIo,
-    setting: &ConfigSetting,
-    available: &[LlmModel],
-) -> Result<SetSessionConfigOptionResponse, acp::Error> {
-    actor.config.apply_config_change(&actor.modes, available, setting)?;
-
-    let switch = if matches!(setting, ConfigSetting::Mode(_)) {
-        actor.config.take_agent_switch(&actor.modes)
-    } else {
-        Switch::None
-    };
-    let committed = apply_switch(actor, io, switch).await.map_err(|error| {
-        error!("Failed to activate selected mode: {error}");
-        acp::Error::internal_error()
-    })?;
-    if !committed {
-        publish_snapshot(actor, io);
-    }
-
-    let options = actor.get_config().config_options(available, io.oauth_credential_store.as_ref());
-    Ok(SetSessionConfigOptionResponse::new(options))
-}
-
 fn apply_config_change(
     actor: &mut SessionActor,
     io: &SessionIo,
@@ -435,25 +424,23 @@ fn apply_config_change(
     Ok(SetSessionConfigOptionResponse::new(options))
 }
 
-async fn apply_switch(actor: &mut SessionActor, io: &SessionIo, switch: Switch) -> Result<bool, SessionError> {
+async fn apply_switch(actor: &mut SessionActor, io: &SessionIo, switch: Switch) -> Result<(), SessionError> {
     match switch {
         Switch::Agent(agent_name) => {
             publish_snapshot(actor, io);
             if let Some(event) = actor.select_agent(&agent_name).await? {
                 persist_event(actor, io, event);
             }
-            publish_active_mcps(actor, io).await?;
-            Ok(true)
+            publish_active_mcps(actor, io).await
         }
         Switch::Model(model) => {
             let parser = ModelProviderParser::default()
                 .with_provider_connections(actor.active_provider_connections())
                 .with_codex_provider(Arc::clone(&io.oauth_credential_store));
             let (provider, _) = parser.parse(&model).await.map_err(|e| SessionError::McpOperation(format!("{e}")))?;
-            actor.send_active_command(Command::agent(AgentCommand::SwitchModel(provider))).await?;
-            Ok(true)
+            actor.send_active_command(Command::agent(AgentCommand::SwitchModel(provider))).await
         }
-        Switch::None => Ok(false),
+        Switch::None => Ok(()),
     }
 }
 
@@ -483,7 +470,7 @@ async fn on_runtime_event(actor: &mut SessionActor, io: &SessionIo, event: Runti
         }
         RuntimeEvent::Mcp { event, .. } => {
             let refresh_commands = matches!(event, McpClientEvent::ConnectionReady(_));
-            on_mcp_client_event(&io.connection, event).await;
+            on_mcp_client_event(&io.connection, event);
             if refresh_commands {
                 match actor.list_available_commands().await {
                     Ok(commands) => send_available_commands(&io.connection, io.session_id.clone(), commands),
@@ -566,18 +553,10 @@ fn send_agent_notification(
     }
 }
 
-async fn on_mcp_client_event(connection: &ConnectionTo<Client>, event: McpClientEvent) {
+fn on_mcp_client_event(connection: &ConnectionTo<Client>, event: McpClientEvent) {
     match event {
-        McpClientEvent::Elicitation(
-            elicitation @ ElicitationRequest {
-                request: CreateElicitationRequestParams::UrlElicitationParams { .. },
-                ..
-            },
-        ) => {
-            spawn_url_elicitation_request(connection, elicitation);
-        }
         McpClientEvent::Elicitation(elicitation) => {
-            on_elicitation_request(connection, elicitation).await;
+            spawn_elicitation_request(connection, elicitation);
         }
         McpClientEvent::UrlElicitationComplete(params) => {
             if let Err(e) = connection
@@ -621,13 +600,13 @@ async fn on_elicitation_request(connection: &ConnectionTo<Client>, elicitation: 
     }
 }
 
-fn spawn_url_elicitation_request(connection: &ConnectionTo<Client>, elicitation: ElicitationRequest) {
+fn spawn_elicitation_request(connection: &ConnectionTo<Client>, elicitation: ElicitationRequest) {
     let connection = connection.clone();
     if let Err(e) = connection.clone().spawn(async move {
         on_elicitation_request(&connection, elicitation).await;
         Ok(())
     }) {
-        error!("Failed to spawn URL elicitation request handler: {e:?}");
+        error!("Failed to spawn elicitation request handler: {e:?}");
     }
 }
 
@@ -857,7 +836,7 @@ mod tests {
                             elicitation_id: "el-42".to_string(),
                         });
 
-                    on_mcp_client_event(&cx, event).await;
+                    on_mcp_client_event(&cx, event);
 
                     let received = peer.next_mcp_notification().await;
                     assert!(matches!(received, McpNotification::UrlElicitationComplete(_)));
@@ -875,7 +854,7 @@ mod tests {
                         mcp_utils::client::McpServerStatus::Connected { tool_count: 1 },
                     )];
 
-                    on_mcp_client_event(&cx, McpClientEvent::ServerStatusesChanged(servers)).await;
+                    on_mcp_client_event(&cx, McpClientEvent::ServerStatusesChanged(servers));
 
                     let received = peer.next_mcp_notification().await;
                     assert!(matches!(received, McpNotification::ServerStatus { .. }));
@@ -895,15 +874,14 @@ mod tests {
                         },
                     )];
 
-                    on_mcp_client_event(&cx, McpClientEvent::ServerStatusesChanged(servers)).await;
+                    on_mcp_client_event(&cx, McpClientEvent::ServerStatusesChanged(servers));
                     on_mcp_client_event(
                         &cx,
                         McpClientEvent::AuthenticationFailed {
                             server: "github".to_string(),
                             error: "authentication timed out after 3 minutes".to_string(),
                         },
-                    )
-                    .await;
+                    );
 
                     assert!(matches!(peer.next_mcp_notification().await, McpNotification::ServerStatus { .. }));
                 })
@@ -916,7 +894,7 @@ mod tests {
                 .run_until(async {
                     let (cx, mut peer) = test_connection().await;
 
-                    on_mcp_client_event(&cx, McpClientEvent::ServerStatusesChanged(vec![])).await;
+                    on_mcp_client_event(&cx, McpClientEvent::ServerStatusesChanged(vec![]));
 
                     match peer.next_mcp_notification().await {
                         McpNotification::ServerStatus { servers } => assert!(servers.is_empty()),
@@ -943,7 +921,7 @@ mod tests {
                         server_statuses: servers,
                     };
 
-                    on_mcp_client_event(&cx, McpClientEvent::ConnectionReady(snapshot)).await;
+                    on_mcp_client_event(&cx, McpClientEvent::ConnectionReady(snapshot));
 
                     match peer.next_mcp_notification().await {
                         McpNotification::ServerStatus { servers } => assert_eq!(servers[0].name, "github"),
@@ -1009,7 +987,7 @@ mod tests {
                         response_sender: tx,
                     };
 
-                    on_mcp_client_event(&cx, McpClientEvent::Elicitation(elicitation)).await;
+                    on_mcp_client_event(&cx, McpClientEvent::Elicitation(elicitation));
                     let responder = responder_rx.await.expect("URL elicitation request should reach peer");
 
                     on_mcp_client_event(
@@ -1018,8 +996,7 @@ mod tests {
                             server_name: "github".to_string(),
                             elicitation_id: "el-1".to_string(),
                         }),
-                    )
-                    .await;
+                    );
 
                     match peer.next_mcp_notification().await {
                         McpNotification::UrlElicitationComplete(params) => {
@@ -1036,6 +1013,40 @@ mod tests {
                         content: None,
                     });
                     let result = rx.await.expect("spawned URL request should forward response");
+                    assert_eq!(result.action, rmcp::model::ElicitationAction::Accept);
+                })
+                .await;
+        }
+
+        #[tokio::test(flavor = "current_thread")]
+        async fn form_elicitation_request_does_not_block_the_caller() {
+            LocalSet::new()
+                .run_until(async {
+                    let (cx, peer) = test_connection().await;
+                    let responder_rx = peer.capture_next_elicitation();
+                    let (tx, rx) = oneshot::channel();
+                    let elicitation = ElicitationRequest {
+                        server_name: "test-server".to_string(),
+                        request: CreateElicitationRequestParams::FormElicitationParams {
+                            meta: None,
+                            message: "Pick a color".to_string(),
+                            requested_schema: rmcp::model::ElicitationSchema::builder()
+                                .required_bool("approved")
+                                .build()
+                                .unwrap(),
+                        },
+                        response_sender: tx,
+                    };
+
+                    on_mcp_client_event(&cx, McpClientEvent::Elicitation(elicitation));
+
+                    let responder = responder_rx.await.expect("form elicitation request should reach peer");
+                    let _ = responder.respond(acp_utils::notifications::ElicitationResponse {
+                        action: rmcp::model::ElicitationAction::Accept,
+                        content: Some(serde_json::json!({ "approved": true })),
+                    });
+
+                    let result = rx.await.expect("spawned form request should forward response");
                     assert_eq!(result.action, rmcp::model::ElicitationAction::Accept);
                 })
                 .await;

--- a/crates/aether-core/src/context/compaction.rs
+++ b/crates/aether-core/src/context/compaction.rs
@@ -10,9 +10,7 @@ const SUMMARIZATION_PROMPT: &str = include_str!("prompts/summarization.md");
 /// Result of a compaction operation
 #[derive(Debug, Clone)]
 pub struct CompactionResult {
-    /// The compacted context with summary message
-    pub context: Context,
-    /// The summary text that replaced the compacted messages
+    /// The summary text that replaces the compacted messages
     pub summary: String,
     /// Number of messages that were removed/compacted
     pub messages_removed: usize,
@@ -61,11 +59,12 @@ impl Compactor {
         Self { llm }
     }
 
-    /// Generate a structured summary of the conversation and return a new compacted context.
+    /// Generate a structured summary of the conversation.
     ///
-    /// This is a pure function that takes a reference to the context and returns a new
-    /// context with the compacted messages replaced by a summary.
-    pub async fn compact(&self, context: &Context) -> Result<CompactionResult, CompactionError> {
+    /// Takes the context snapshot by value since the caller applies the summary
+    /// to its live context (which may have changed while the summarization
+    /// request was in flight) via [`Context::with_compacted_summary`].
+    pub async fn compact(&self, mut context: Context) -> Result<CompactionResult, CompactionError> {
         let messages_to_summarize = context.messages_for_summary();
         if messages_to_summarize.is_empty() {
             return Err(CompactionError::NothingToCompact);
@@ -73,15 +72,14 @@ impl Compactor {
 
         let messages_removed = messages_to_summarize.len();
 
-        let mut summary_context = context.clone();
-        summary_context.add_message(ChatMessage::User {
+        context.add_message(ChatMessage::User {
             content: vec![llm::ContentBlock::text(format!(
                 "{SUMMARIZATION_PROMPT}\n\nPlease perform a structured handoff of the conversation above."
             ))],
             timestamp: IsoString::now(),
         });
 
-        let mut stream = self.llm.stream_response(&summary_context);
+        let mut stream = self.llm.stream_response(&context);
         let mut summary = String::new();
         let mut usage = None;
 
@@ -106,9 +104,7 @@ impl Compactor {
             return Err(CompactionError::SummarizationFailed("LLM returned empty summary".to_string()));
         }
 
-        let compacted_context = context.with_compacted_summary(&summary);
-
-        Ok(CompactionResult { context: compacted_context, summary, messages_removed, usage })
+        Ok(CompactionResult { summary, messages_removed, usage })
     }
 }
 
@@ -156,7 +152,7 @@ mod tests {
             vec![],
         );
 
-        let result = compactor.compact(&context).await;
+        let result = compactor.compact(context).await;
         assert!(result.is_ok());
 
         let result = result.unwrap();
@@ -183,7 +179,7 @@ mod tests {
             vec![],
         );
 
-        let result = compactor.compact(&context).await;
+        let result = compactor.compact(context).await;
         assert!(matches!(result, Err(CompactionError::SummarizationFailed(_))));
     }
 
@@ -199,7 +195,7 @@ mod tests {
             vec![],
         );
 
-        let result = compactor.compact(&context).await;
+        let result = compactor.compact(context).await;
         assert!(matches!(result, Err(CompactionError::NothingToCompact)));
     }
 }

--- a/crates/aether-core/src/context/token_tracker.rs
+++ b/crates/aether-core/src/context/token_tracker.rs
@@ -51,16 +51,11 @@ impl TokenTracker {
         self.usage_ratio().is_some_and(|ratio| ratio >= threshold)
     }
 
-    /// Check if context should be compacted based on the given threshold.
-    /// This is a convenience method that combines usage ratio check with
-    /// a minimum context size requirement to avoid unnecessary compaction
-    /// on small conversations.
-    pub fn should_compact(&self, threshold: f64) -> bool {
-        let Some(context_limit) = self.context_limit else {
-            return false;
-        };
-        let min_tokens = std::cmp::max(context_limit / 10, 1000);
-        self.last_usage.input_tokens >= min_tokens && self.exceeds_threshold(threshold)
+    /// Whether the context needs compaction
+    pub fn needs_compaction(&self, estimated_tokens: u32, threshold: f64) -> bool {
+        self.context_limit.is_some_and(|limit| {
+            f64::from(self.last_usage.input_tokens.max(estimated_tokens)) >= f64::from(limit) * threshold
+        })
     }
 
     /// Tokens remaining before hitting limit
@@ -162,7 +157,7 @@ mod tests {
         let tracker = TokenTracker::new(None);
         assert_eq!(tracker.usage_ratio(), None);
         assert_eq!(tracker.tokens_remaining(), None);
-        assert!(!tracker.should_compact(0.85));
+        assert!(!tracker.needs_compaction(1_000_000, 0.85));
     }
 
     #[test]
@@ -179,17 +174,22 @@ mod tests {
     }
 
     #[test]
-    fn test_should_compact() {
+    fn test_needs_compaction_from_recorded_usage() {
         let mut tracker = TokenTracker::new(Some(10000));
 
-        tracker.record_usage(TokenUsage::new(500, 100));
-        assert!(!tracker.should_compact(0.04));
-
         tracker.record_usage(TokenUsage::new(9000, 100));
-        assert!(tracker.should_compact(0.85));
+        assert!(tracker.needs_compaction(0, 0.85));
 
         tracker.record_usage(TokenUsage::new(7000, 100));
-        assert!(!tracker.should_compact(0.85));
+        assert!(!tracker.needs_compaction(0, 0.85));
+    }
+
+    #[test]
+    fn test_needs_compaction_from_estimate_before_usage_recorded() {
+        let tracker = TokenTracker::new(Some(10000));
+
+        assert!(tracker.needs_compaction(9000, 0.85));
+        assert!(!tracker.needs_compaction(1000, 0.85));
     }
 
     #[test]
@@ -217,12 +217,12 @@ mod tests {
         let mut tracker = TokenTracker::new(Some(10000));
         tracker.record_usage(TokenUsage::new(9000, 100));
 
-        assert!(tracker.should_compact(0.85));
+        assert!(tracker.needs_compaction(0, 0.85));
 
         tracker.reset_current_usage();
 
         assert_eq!(tracker.last_input_tokens(), 0);
-        assert!(!tracker.should_compact(0.85));
+        assert!(!tracker.needs_compaction(0, 0.85));
         assert_eq!(tracker.total_input_tokens(), 9000);
         assert_eq!(tracker.total_output_tokens(), 100);
     }

--- a/crates/aether-core/src/core/agent.rs
+++ b/crates/aether-core/src/core/agent.rs
@@ -1,4 +1,4 @@
-use crate::context::{CompactionConfig, Compactor, TokenTracker};
+use crate::context::{CompactionConfig, CompactionError, CompactionResult, Compactor, TokenTracker};
 use crate::core::PromptCache;
 pub use crate::core::retry_config::RetryConfig;
 use crate::events::{
@@ -29,12 +29,20 @@ enum StreamEvent {
     Llm(Result<LlmResponse, LlmError>),
     ToolExecution(ToolExecutionEvent),
     Command(Command),
+    Compaction(Result<CompactionResult, CompactionError>),
 }
 
 type EventStream = Pin<Box<dyn Stream<Item = StreamEvent> + Send>>;
 
-const USER_STREAM_KEY: &str = "user";
-const LLM_STREAM_KEY: &str = "llm";
+/// Keys for the merged stream map. Tool-call ids come from the provider, so a
+/// typed key keeps them from colliding with the reserved streams.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+enum StreamKey {
+    User,
+    Llm,
+    Compaction,
+    Tool(String),
+}
 
 pub(crate) struct AgentConfig {
     pub llm: Arc<dyn StreamingModelProvider>,
@@ -55,7 +63,7 @@ pub struct Agent {
     mcp_command_tx: Option<mpsc::Sender<McpCommand>>,
     message_tx: mpsc::Sender<AgentEvent>,
     observers: Vec<Box<dyn AgentObserver>>,
-    streams: StreamMap<String, EventStream>,
+    streams: StreamMap<StreamKey, EventStream>,
     tool_timeout: Duration,
     token_tracker: TokenTracker,
     compaction_config: Option<CompactionConfig>,
@@ -63,6 +71,7 @@ pub struct Agent {
     retry_config: RetryConfig,
     active_requests: HashMap<String, ToolCallRequest>,
     queued_user_messages: VecDeque<Vec<llm::ContentBlock>>,
+    pending_turn_messages: Vec<Vec<llm::ContentBlock>>,
     context_window: Option<u32>,
     prompt_cache: PromptCache,
     turn_active: bool,
@@ -75,9 +84,8 @@ impl Agent {
         command_rx: mpsc::Receiver<Command>,
         message_tx: mpsc::Sender<AgentEvent>,
     ) -> Self {
-        let mut streams: StreamMap<String, EventStream> = StreamMap::new();
-        streams
-            .insert(USER_STREAM_KEY.to_string(), Box::pin(ReceiverStream::new(command_rx).map(StreamEvent::Command)));
+        let mut streams: StreamMap<StreamKey, EventStream> = StreamMap::new();
+        streams.insert(StreamKey::User, Box::pin(ReceiverStream::new(command_rx).map(StreamEvent::Command)));
 
         let context_limit = config.context_window.or_else(|| config.llm.context_window());
 
@@ -95,6 +103,7 @@ impl Agent {
             retry_config: config.retry_config,
             active_requests: HashMap::new(),
             queued_user_messages: VecDeque::new(),
+            pending_turn_messages: Vec::new(),
             context_window: config.context_window,
             prompt_cache: config.prompt_cache,
             turn_active: false,
@@ -166,6 +175,10 @@ impl Agent {
                 StreamEvent::ToolExecution(tool_event) => {
                     self.on_tool_execution_event(tool_event, &mut state).await;
                 }
+
+                StreamEvent::Compaction(result) => {
+                    self.on_compaction_complete(result).await;
+                }
             }
 
             if state.is_complete() {
@@ -205,11 +218,6 @@ impl Agent {
         }
 
         let has_queued_text = !self.queued_user_messages.is_empty();
-        if has_queued_text {
-            let content: Vec<_> = self.queued_user_messages.drain(..).flatten().collect();
-            self.context.add_message(ChatMessage::User { content, timestamp: IsoString::now() });
-        }
-
         if has_queued_text || has_tool_calls {
             self.auto_continue.reset();
             self.start_next_turn().await;
@@ -238,18 +246,31 @@ impl Agent {
     }
 
     async fn start_next_turn(&mut self) {
-        self.maybe_preflight_compact().await;
+        self.pending_turn_messages.extend(self.queued_user_messages.drain(..));
+        if self.compaction_needed() {
+            self.begin_compaction().await;
+        } else {
+            self.start_chat_turn().await;
+        }
+    }
+
+    async fn start_chat_turn(&mut self) {
+        self.commit_pending_turn_messages();
         self.start_llm_stream(None, 0).await;
     }
 
     async fn on_user_cancel(&mut self, state: &mut IterationState) {
         self.abort_in_flight_work().await;
+        self.commit_pending_turn_messages();
+        self.queued_user_messages.clear();
         *state = IterationState::new();
         self.finish_turn(TurnOutcome::Cancelled).await;
     }
 
     async fn on_user_clear_context(&mut self, state: &mut IterationState) {
         self.abort_in_flight_work().await;
+        self.queued_user_messages.clear();
+        self.pending_turn_messages.clear();
         self.context.clear_conversation();
         self.token_tracker.reset_current_usage();
         self.auto_continue.reset();
@@ -261,6 +282,8 @@ impl Agent {
 
     async fn on_replace_conversation(&mut self, messages: Vec<ChatMessage>, state: &mut IterationState) {
         self.abort_in_flight_work().await;
+        self.queued_user_messages.clear();
+        self.pending_turn_messages.clear();
         self.context.replace_conversation(messages);
         self.auto_continue.reset();
         *state = IterationState::new();
@@ -269,11 +292,11 @@ impl Agent {
     }
 
     async fn on_user_text(&mut self, content: Vec<llm::ContentBlock>) {
-        self.context.add_message(ChatMessage::User { content: content.clone(), timestamp: IsoString::now() });
         self.auto_continue.reset();
         self.turn_active = true;
-        self.emit(AgentEvent::Turn(TurnEvent::Started { content })).await;
-        self.start_llm_stream(None, 0).await;
+        self.emit(AgentEvent::Turn(TurnEvent::Started { content: content.clone() })).await;
+        self.queued_user_messages.push_back(content);
+        self.start_next_turn().await;
     }
 
     async fn on_update_instruction(&mut self, server: String, body: Option<String>) {
@@ -297,7 +320,7 @@ impl Agent {
     }
 
     async fn start_llm_stream(&mut self, delay: Option<Duration>, attempt: u32) {
-        self.streams.remove(LLM_STREAM_KEY);
+        self.streams.remove(&StreamKey::Llm);
         let stream: EventStream = match delay {
             None => {
                 self.begin_chat_call(attempt).await;
@@ -323,7 +346,7 @@ impl Agent {
                 })
             }
         };
-        self.streams.insert(LLM_STREAM_KEY.to_string(), stream);
+        self.streams.insert(StreamKey::Llm, stream);
     }
 
     async fn on_llm_error(&mut self, error: LlmError, state: &mut IterationState) {
@@ -354,19 +377,27 @@ impl Agent {
     }
 
     fn is_busy(&self) -> bool {
-        self.streams.contains_key(LLM_STREAM_KEY) || !self.active_requests.is_empty()
+        self.streams.contains_key(&StreamKey::Llm)
+            || self.streams.contains_key(&StreamKey::Compaction)
+            || !self.active_requests.is_empty()
     }
 
     async fn abort_in_flight_work(&mut self) {
         if self.llm_call_active {
             self.finish_chat_call(LlmCallOutcome::Cancelled).await;
         }
-        self.streams.remove(LLM_STREAM_KEY);
-        for stream_key in self.active_requests.keys().cloned().collect::<Vec<_>>() {
-            self.streams.remove(&stream_key);
+        if self.streams.remove(&StreamKey::Compaction).is_some() {
+            self.emit(AgentEvent::Turn(TurnEvent::LlmCallEnded {
+                purpose: LlmCallPurpose::Compaction,
+                outcome: LlmCallOutcome::Cancelled,
+            }))
+            .await;
+        }
+        self.streams.remove(&StreamKey::Llm);
+        for tool_id in self.active_requests.keys().cloned().collect::<Vec<_>>() {
+            self.streams.remove(&StreamKey::Tool(tool_id));
         }
         self.active_requests.clear();
-        self.queued_user_messages.clear();
     }
 
     /// Inject a continuation prompt when the LLM stops due to a resumable reason.
@@ -493,8 +524,7 @@ impl Agent {
 
         let (tx, rx) = mpsc::channel(100);
         let stream = ReceiverStream::new(rx).map(StreamEvent::ToolExecution);
-        let stream_key = tool_call.id.clone();
-        self.streams.insert(stream_key, Box::pin(stream));
+        self.streams.insert(StreamKey::Tool(tool_call.id.clone()), Box::pin(stream));
 
         if let Some(ref mcp_command_tx) = self.mcp_command_tx {
             let mcp_future =
@@ -513,8 +543,6 @@ impl Agent {
         tracing::debug!(?sample, ?ratio_pct, ?remaining, "Token usage");
 
         self.emit(self.context_usage_message()).await;
-
-        self.maybe_compact_context().await;
     }
 
     fn context_usage_message(&self) -> AgentEvent {
@@ -537,97 +565,47 @@ impl Agent {
         })
     }
 
-    /// Pre-flight check: estimate context size and compact proactively if it would
-    /// overflow before the LLM even sees it. This catches the case where large tool
-    /// results push context past the limit before usage-based compaction can fire.
-    async fn maybe_preflight_compact(&mut self) {
-        let Some(context_limit) = self.token_tracker.context_limit() else {
-            return;
-        };
-        let Some(config) = self.compaction_config.as_ref() else {
-            return;
-        };
-        let estimated = self.context.estimated_token_count();
-        #[allow(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
-        let threshold = (f64::from(context_limit) * config.threshold).ceil() as u32;
-        if estimated >= threshold {
-            tracing::info!(
-                "Pre-flight compaction triggered: estimated {estimated} tokens >= {:.1}% of {context_limit} limit",
-                config.threshold * 100.0
-            );
-            if let CompactionOutcome::Failed(e) = self.compact_context().await {
-                tracing::warn!("Pre-flight compaction failed: {e}");
-            }
-        }
+    fn compaction_needed(&self) -> bool {
+        self.compaction_config.as_ref().is_some_and(|config| {
+            self.token_tracker.needs_compaction(self.context.estimated_token_count(), config.threshold)
+        })
     }
 
-    /// Check if compaction is needed and perform it if so.
-    async fn maybe_compact_context(&mut self) {
-        if !self.compaction_config.as_ref().is_some_and(|config| self.token_tracker.should_compact(config.threshold)) {
-            return;
-        }
-
-        if let CompactionOutcome::Failed(error_message) = self.compact_context().await {
-            tracing::warn!("Context compaction failed: {}", error_message);
-        }
-    }
-
-    async fn compact_context(&mut self) -> CompactionOutcome {
-        let Some(ref _config) = self.compaction_config else {
-            tracing::warn!("Context compaction requested but compaction is disabled");
-            return CompactionOutcome::SkippedDisabled;
-        };
-
-        match self.token_tracker.usage_ratio() {
-            Some(usage_ratio) => {
-                tracing::info!(
-                    "Starting context compaction - {} messages, {:.1}% of context limit",
-                    self.context.message_count(),
-                    usage_ratio * 100.0
-                );
-            }
-            None => {
-                tracing::info!(
-                    "Starting context compaction - {} messages (context limit unknown)",
-                    self.context.message_count(),
-                );
-            }
-        }
-
+    async fn begin_compaction(&mut self) {
+        tracing::info!("Starting context compaction - {} messages", self.context.message_count());
         self.emit(AgentEvent::Context(ContextEvent::CompactionStarted { message_count: self.context.message_count() }))
             .await;
+        self.emit(self.llm_call_started(LlmCallPurpose::Compaction, 0)).await;
 
         let compactor = Compactor::new(self.llm.clone());
+        let context = self.context.clone();
+        let stream: EventStream =
+            Box::pin(futures::stream::once(async move { StreamEvent::Compaction(compactor.compact(context).await) }));
+        self.streams.insert(StreamKey::Compaction, stream);
+    }
 
-        self.emit(self.llm_call_started(LlmCallPurpose::Compaction, 0)).await;
-        match compactor.compact(&self.context).await {
+    async fn on_compaction_complete(&mut self, result: Result<CompactionResult, CompactionError>) {
+        let outcome = match &result {
+            Ok(result) => LlmCallOutcome::Completed { stop_reason: None, usage: result.usage },
+            Err(e) => LlmCallOutcome::Failed { error: e.to_string(), will_retry: false },
+        };
+        self.emit(AgentEvent::Turn(TurnEvent::LlmCallEnded { purpose: LlmCallPurpose::Compaction, outcome })).await;
+
+        match result {
             Ok(result) => {
                 tracing::info!("Context compacted: {} messages removed", result.messages_removed);
-                self.emit(AgentEvent::Turn(TurnEvent::LlmCallEnded {
-                    purpose: LlmCallPurpose::Compaction,
-                    outcome: LlmCallOutcome::Completed { stop_reason: None, usage: result.usage },
-                }))
-                .await;
-
-                self.context = result.context;
+                self.context = self.context.with_compacted_summary(&result.summary);
                 self.token_tracker.reset_current_usage();
-
                 self.emit(AgentEvent::Context(ContextEvent::CompactionResult {
                     summary: result.summary,
                     messages_removed: result.messages_removed,
                 }))
                 .await;
-                CompactionOutcome::Compacted
             }
-            Err(e) => {
-                self.emit(AgentEvent::Turn(TurnEvent::LlmCallEnded {
-                    purpose: LlmCallPurpose::Compaction,
-                    outcome: LlmCallOutcome::Failed { error: e.to_string(), will_retry: false },
-                }))
-                .await;
-                CompactionOutcome::Failed(e.to_string())
-            }
+            Err(e) => tracing::warn!("Context compaction failed: {e}"),
         }
+
+        self.start_chat_turn().await;
     }
 
     async fn on_tool_execution_event(&mut self, event: ToolExecutionEvent, state: &mut IterationState) {
@@ -691,6 +669,13 @@ impl Agent {
         self.context.push_assistant_turn(message_content, reasoning, completed_tools);
     }
 
+    fn commit_pending_turn_messages(&mut self) {
+        let content: Vec<_> = self.pending_turn_messages.drain(..).flatten().collect();
+        if !content.is_empty() {
+            self.context.add_message(ChatMessage::User { content, timestamp: IsoString::now() });
+        }
+    }
+
     async fn emit_tool_definitions(&mut self) {
         let tools = self.context.tools().clone();
         if !tools.is_empty() {
@@ -736,13 +721,6 @@ impl Agent {
             max_attempts: self.retry_config.max_attempts,
         })
     }
-}
-
-#[derive(Debug, Clone, PartialEq, Eq)]
-enum CompactionOutcome {
-    Compacted,
-    SkippedDisabled,
-    Failed(String),
 }
 
 pub(crate) struct AutoContinue {
@@ -823,10 +801,10 @@ impl IterationState {
 #[cfg(test)]
 mod tests {
     use crate::core::{AgentBuilder, Prompt};
+    use crate::testing::drain_until;
 
     use super::*;
     use llm::{ContentBlock, testing::FakeLlmProvider};
-    use tokio::sync::mpsc;
 
     #[tokio::test]
     async fn replace_conversation_preserves_system_prompt_for_next_request() {
@@ -852,11 +830,7 @@ mod tests {
             .await
             .unwrap();
 
-        while let Some(message) = rx.recv().await {
-            if matches!(message, AgentEvent::Turn(TurnEvent::Ended { .. })) {
-                break;
-            }
-        }
+        drain_until(&mut rx, |event| matches!(event, AgentEvent::Turn(TurnEvent::Ended { .. }))).await;
 
         let contexts = captured_contexts.lock().unwrap();
         let messages = contexts.last().expect("provider should receive a context").messages();
@@ -885,11 +859,7 @@ mod tests {
             .await
             .unwrap();
 
-        while let Some(message) = rx.recv().await {
-            if matches!(message, AgentEvent::Turn(TurnEvent::Ended { .. })) {
-                break;
-            }
-        }
+        drain_until(&mut rx, |event| matches!(event, AgentEvent::Turn(TurnEvent::Ended { .. }))).await;
 
         tx.send(Command::AgentCommand(AgentCommand::ReplaceConversation(vec![ChatMessage::User {
             content: vec![ContentBlock::text("replacement user")],
@@ -908,52 +878,129 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_preflight_compaction_uses_configured_threshold() {
-        let llm = Arc::new(
-            FakeLlmProvider::with_single_response(vec![
-                LlmResponse::start("summary"),
-                LlmResponse::text("summary"),
-                LlmResponse::done(),
-            ])
-            .with_context_window(Some(100)),
-        );
-        let context = Context::new(
-            vec![ChatMessage::User {
-                content: vec![llm::ContentBlock::text("x".repeat(344))],
+    async fn oversized_context_is_compacted_before_the_llm_call() {
+        let llm = FakeLlmProvider::new(vec![
+            vec![LlmResponse::start("sum"), LlmResponse::text("summary"), LlmResponse::done()],
+            vec![LlmResponse::start("msg"), LlmResponse::text("hello"), LlmResponse::done()],
+        ])
+        .with_context_window(Some(100));
+        let captured_contexts = llm.captured_contexts();
+
+        let (tx, mut rx, handle) = AgentBuilder::new(Arc::new(llm))
+            .compaction(CompactionConfig::with_threshold(0.85))
+            .messages(vec![ChatMessage::User {
+                content: vec![ContentBlock::text("x".repeat(400))],
                 timestamp: IsoString::now(),
-            }],
-            vec![],
-        );
-        let (user_tx, user_rx) = mpsc::channel(1);
-        let (message_tx, _message_rx) = mpsc::channel(8);
-        drop(user_tx);
+            }])
+            .spawn()
+            .await
+            .unwrap();
 
-        let mut agent = Agent::new(
-            AgentConfig {
-                llm,
-                context,
-                mcp_command_tx: None,
-                tool_timeout: Duration::from_secs(1),
-                compaction_config: Some(CompactionConfig::with_threshold(0.85)),
-                auto_continue: AutoContinue::new(0),
-                retry_config: RetryConfig::disabled(),
-                context_window: None,
-                prompt_cache: PromptCache::new(vec![]),
-                observers: Vec::new(),
-            },
-            user_rx,
-            message_tx,
-        );
+        tx.send(Command::UserCommand(UserCommand::Text { content: vec![ContentBlock::text("go")] })).await.unwrap();
 
-        agent.maybe_preflight_compact().await;
+        drain_until(&mut rx, |event| matches!(event, AgentEvent::Turn(TurnEvent::Ended { .. }))).await;
 
+        let contexts = captured_contexts.lock().unwrap();
+        let chat_messages = contexts.last().expect("chat request should reach the provider").messages();
         assert!(
-            matches!(
-                agent.context.messages().as_slice(),
-                [ChatMessage::Summary { content, .. }] if content == "summary"
-            ),
-            "expected context to be compacted, got {:?}",
-            agent.context.messages()
+            matches!(&chat_messages[0], ChatMessage::Summary { content, .. } if content == "summary"),
+            "expected the prior conversation compacted into a summary, got {chat_messages:?}"
         );
+        assert!(
+            matches!(&chat_messages[1], ChatMessage::User { content, .. } if content == &vec![ContentBlock::text("go")]),
+            "the fresh user message must survive compaction as a real turn, got {chat_messages:?}"
+        );
+        handle.abort();
+    }
+
+    #[tokio::test]
+    async fn cancel_during_compaction_ends_the_turn() {
+        let release = Arc::new(tokio::sync::Notify::new());
+        let llm = FakeLlmProvider::new(vec![vec![
+            LlmResponse::start("sum"),
+            LlmResponse::text("summary"),
+            LlmResponse::done(),
+        ]])
+        .with_context_window(Some(100))
+        .pause_turn_after(0, 0, Arc::clone(&release));
+
+        let (tx, mut rx, handle) = AgentBuilder::new(Arc::new(llm))
+            .compaction(CompactionConfig::with_threshold(0.85))
+            .messages(vec![ChatMessage::User {
+                content: vec![ContentBlock::text("x".repeat(400))],
+                timestamp: IsoString::now(),
+            }])
+            .spawn()
+            .await
+            .unwrap();
+
+        tx.send(Command::UserCommand(UserCommand::Text { content: vec![ContentBlock::text("go")] })).await.unwrap();
+
+        drain_until(&mut rx, |event| matches!(event, AgentEvent::Context(ContextEvent::CompactionStarted { .. })))
+            .await;
+
+        tx.send(Command::UserCommand(UserCommand::Cancel)).await.unwrap();
+
+        let events = drain_until(&mut rx, |event| matches!(event, AgentEvent::Turn(TurnEvent::Ended { .. }))).await;
+        assert!(
+            events.iter().any(|event| matches!(
+                event,
+                AgentEvent::Turn(TurnEvent::LlmCallEnded {
+                    purpose: LlmCallPurpose::Compaction,
+                    outcome: LlmCallOutcome::Cancelled,
+                })
+            )),
+            "cancel should end the in-flight compaction call"
+        );
+        assert!(
+            matches!(events.last(), Some(AgentEvent::Turn(TurnEvent::Ended { outcome: TurnOutcome::Cancelled }))),
+            "the turn must end as cancelled"
+        );
+        handle.abort();
+    }
+
+    #[tokio::test]
+    async fn cancel_during_compaction_preserves_the_initiating_message() {
+        let release = Arc::new(tokio::sync::Notify::new());
+        let llm = FakeLlmProvider::new(vec![
+            vec![LlmResponse::start("sum"), LlmResponse::text("summary"), LlmResponse::done()],
+            vec![LlmResponse::start("sum2"), LlmResponse::text("summary"), LlmResponse::done()],
+            vec![LlmResponse::start("msg"), LlmResponse::text("hello"), LlmResponse::done()],
+        ])
+        .with_context_window(Some(100))
+        .pause_turn_after(0, 0, Arc::clone(&release));
+        let captured_contexts = llm.captured_contexts();
+
+        let (tx, mut rx, handle) = AgentBuilder::new(Arc::new(llm))
+            .compaction(CompactionConfig::with_threshold(0.85))
+            .messages(vec![ChatMessage::User {
+                content: vec![ContentBlock::text("x".repeat(400))],
+                timestamp: IsoString::now(),
+            }])
+            .spawn()
+            .await
+            .unwrap();
+
+        tx.send(Command::UserCommand(UserCommand::Text { content: vec![ContentBlock::text("go")] })).await.unwrap();
+        drain_until(&mut rx, |event| matches!(event, AgentEvent::Context(ContextEvent::CompactionStarted { .. })))
+            .await;
+        tx.send(Command::UserCommand(UserCommand::Cancel)).await.unwrap();
+        drain_until(&mut rx, |event| matches!(event, AgentEvent::Turn(TurnEvent::Ended { .. }))).await;
+
+        tx.send(Command::UserCommand(UserCommand::Text { content: vec![ContentBlock::text("next")] })).await.unwrap();
+        drain_until(&mut rx, |event| matches!(event, AgentEvent::Turn(TurnEvent::Ended { .. }))).await;
+
+        let contexts = captured_contexts.lock().unwrap();
+        let preserved = contexts.iter().any(|context| {
+            context.messages().iter().any(
+                |message| matches!(message, ChatMessage::User { content, .. } if content == &vec![ContentBlock::text("go")]),
+            )
+        });
+        assert!(
+            preserved,
+            "the message that initiated the cancelled turn must stay in the conversation, as it did before \
+             compaction became cancellable"
+        );
+        handle.abort();
     }
 }

--- a/crates/aether-core/tests/agent/trace_tests.rs
+++ b/crates/aether-core/tests/agent/trace_tests.rs
@@ -6,7 +6,7 @@ use aether_core::core::RetryConfig;
 use aether_core::events::{AgentEvent, LlmCallOutcome, LlmCallPurpose, TurnOutcome};
 use aether_core::testing::{AddNumbersRequest, test_agent};
 use llm::testing::llm_response;
-use llm::{LlmError, LlmResponse};
+use llm::{LlmError, LlmResponse, StopReason};
 
 #[tokio::test]
 async fn tool_call_turn_emits_full_trace() -> Result<(), Box<dyn Error>> {
@@ -158,10 +158,11 @@ async fn cancel_during_retry_wait_traces_cancelled_turn_without_starting_call() 
 }
 
 #[tokio::test]
-async fn compaction_call_is_traced_nested_in_the_chat_call() -> Result<(), Box<dyn Error>> {
+async fn usage_triggered_compaction_runs_before_the_next_chat_call() -> Result<(), Box<dyn Error>> {
     let responses = [
-        llm_response("m1").text(&["hi"]).usage(90_000, 10).build(),
+        llm_response("m1").text(&["hi"]).usage(90_000, 10).build_with_stop_reason(StopReason::Length),
         llm_response("summary").text(&["summary"]).usage(50, 5).build(),
+        llm_response("m2").text(&["done"]).build(),
     ];
 
     let trace = test_agent().context_window(100_000).llm_responses(&responses).user_text("go").run_trace().await?;
@@ -170,8 +171,10 @@ async fn compaction_call_is_traced_nested_in_the_chat_call() -> Result<(), Box<d
         "tool_definitions",
         "turn_started",
         "call_started:Chat:0",
+        "call_ended:Chat:completed",
         "call_started:Compaction:0",
         "call_ended:Compaction:completed",
+        "call_started:Chat:0",
         "call_ended:Chat:completed",
         "turn_ended:completed",
     ]);

--- a/crates/aether-telemetry/tests/observer_tests.rs
+++ b/crates/aether-telemetry/tests/observer_tests.rs
@@ -9,7 +9,7 @@ use aether_telemetry::{
     GENAI_SEMCONV_SCHEMA_URL, GenAiMetrics, OtelInstrumentation, OtelObserver, genai_instrumentation_scope,
 };
 use llm::testing::llm_response;
-use llm::{LlmError, LlmResponse};
+use llm::{LlmError, LlmResponse, StopReason};
 use opentelemetry::Value;
 use opentelemetry::metrics::MeterProvider as _;
 use opentelemetry::trace::{Status, TracerProvider as _};
@@ -171,8 +171,9 @@ async fn tool_error_ends_the_tool_span_with_error_status() -> Result<(), Box<dyn
 #[tokio::test]
 async fn compaction_call_is_tagged_and_parented_to_the_turn() -> Result<(), Box<dyn Error>> {
     let responses = [
-        llm_response("m1").text(&["hi"]).usage(90_000, 10).build(),
+        llm_response("m1").text(&["hi"]).usage(90_000, 10).build_with_stop_reason(StopReason::Length),
         llm_response("summary").text(&["summary"]).usage(50, 5).build(),
+        llm_response("m2").text(&["done"]).build(),
     ];
     let trace = test_agent().context_window(100_000).llm_responses(&responses).user_text("go").run_trace().await?;
 
@@ -190,10 +191,10 @@ async fn compaction_call_is_tagged_and_parented_to_the_turn() -> Result<(), Box<
 
     let chats: Vec<_> =
         spans.prefixed("chat").into_iter().filter(|span| span.attr("aether.llm.purpose").is_none()).collect();
-    assert_eq!(chats.len(), 1, "the outer chat call still gets its own span");
+    assert_eq!(chats.len(), 2, "each chat call gets its own span");
     assert!(
-        chats[0].attr("gen_ai.input.messages").is_some(),
-        "the turn input belongs to the chat call, not the compaction call"
+        chats.iter().all(|chat| chat.attr("gen_ai.input.messages").is_some()),
+        "the turn input belongs to the chat calls, not the compaction call"
     );
     Ok(())
 }

--- a/crates/llm/src/testing/llm_response.rs
+++ b/crates/llm/src/testing/llm_response.rs
@@ -1,4 +1,4 @@
-use crate::LlmResponse;
+use crate::{LlmResponse, StopReason};
 
 pub fn llm_response(message_id: &str) -> LlmResponseBuilder {
     LlmResponseBuilder::new(message_id)
@@ -48,5 +48,30 @@ impl LlmResponseBuilder {
     pub fn build(mut self) -> Vec<LlmResponse> {
         self.chunks.push(LlmResponse::done());
         self.chunks
+    }
+
+    pub fn build_with_stop_reason(mut self, stop_reason: StopReason) -> Vec<LlmResponse> {
+        self.chunks.push(LlmResponse::done_with_stop_reason(stop_reason));
+        self.chunks
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn build_with_stop_reason_preserves_response_chunks() {
+        let response = llm_response("message").text(&["hello"]).usage(10, 2).build_with_stop_reason(StopReason::Length);
+
+        assert!(matches!(
+            response.as_slice(),
+            [
+                LlmResponse::Start { .. },
+                LlmResponse::Text { .. },
+                LlmResponse::Usage { .. },
+                LlmResponse::Done { stop_reason: Some(StopReason::Length) },
+            ]
+        ));
     }
 }

--- a/crates/wisp/examples/wisp_gallery.rs
+++ b/crates/wisp/examples/wisp_gallery.rs
@@ -385,7 +385,7 @@ fn stories() -> Vec<(String, WispStory)> {
             "ProgressIndicator".into(),
             WispStory::ProgressIndicator({
                 let mut indicator = ProgressIndicator::default();
-                indicator.update(1, 3, true, WorkspaceProgress::None);
+                indicator.update(true, WorkspaceProgress::None);
                 ProgressIndicatorStory { indicator }
             }),
         ),

--- a/crates/wisp/src/components/app/mod.rs
+++ b/crates/wisp/src/components/app/mod.rs
@@ -199,6 +199,12 @@ impl App {
             AcpEvent::ElicitationRequest { params, responder } => self.on_elicitation_request(params, responder),
             AcpEvent::AuthenticateComplete { method_id } => self.on_authenticate_complete(&method_id),
             AcpEvent::AuthenticateFailed { method_id, error } => self.on_authenticate_failed(&method_id, &error),
+            AcpEvent::ConfigOptionUpdateFailed { error } => {
+                tracing::warn!("set_session_config_option failed: {error}");
+                self.conversation_screen
+                    .conversation
+                    .push_user_message(&format!("[wisp] Failed to update setting: {error}"));
+            }
             AcpEvent::SessionsListed { sessions } => {
                 let current_id = &self.session_id;
                 let filtered: Vec<_> = sessions.into_iter().filter(|s| s.session_id != *current_id).collect();
@@ -350,7 +356,7 @@ impl App {
         for msg in outcome.unwrap_or_default() {
             match msg {
                 ConversationScreenMessage::SendPrompt { user_input, attachments } => {
-                    self.conversation_screen.waiting_for_response = true;
+                    self.conversation_screen.on_prompt_sent();
                     self.submit_prompt(user_input, attachments).await;
                 }
                 ConversationScreenMessage::ClearScreen => {
@@ -428,7 +434,7 @@ impl App {
         }
 
         if self.keybindings.cancel.matches(key_event)
-            && self.conversation_screen.is_waiting()
+            && self.conversation_screen.is_busy()
             && let Err(e) = self.prompt_handle.cancel(&self.session_id)
         {
             tracing::warn!("Failed to send cancel: {e}");
@@ -522,7 +528,7 @@ impl App {
                     return;
                 }
 
-                self.conversation_screen.waiting_for_response = true;
+                self.conversation_screen.on_prompt_sent();
                 self.submit_prompt(user_input, Vec::new()).await;
                 self.screen_router.close_git_diff();
             }
@@ -1267,14 +1273,14 @@ mod tests {
     #[tokio::test]
     async fn esc_in_diff_mode_does_not_cancel() {
         let mut app = make_app();
-        app.conversation_screen.waiting_for_response = true;
+        app.conversation_screen.on_prompt_sent();
         app.screen_router.enter_git_diff_for_test();
 
         send_key(&mut app, KeyCode::Esc, KeyModifiers::NONE).await;
 
         assert!(!app.exit_requested());
         assert!(
-            app.conversation_screen.waiting_for_response,
+            app.conversation_screen.is_waiting(),
             "Esc should NOT cancel a running prompt while git diff mode is active"
         );
     }
@@ -1294,7 +1300,7 @@ mod tests {
         .await;
 
         assert!(!app.screen_router.is_git_diff(), "successful submit should exit git diff mode");
-        assert!(app.conversation_screen.waiting_for_response, "submit should transition into waiting state");
+        assert!(app.conversation_screen.is_waiting(), "submit should transition into waiting state");
 
         let cmd = rx.try_recv().expect("expected Prompt command to be sent");
         match cmd {
@@ -1308,7 +1314,7 @@ mod tests {
     #[tokio::test]
     async fn git_diff_submit_while_waiting_is_ignored_and_keeps_diff_open() {
         let (mut app, mut rx) = make_app_with_config_recording(&[]);
-        app.conversation_screen.waiting_for_response = true;
+        app.conversation_screen.on_prompt_sent();
         app.screen_router.enter_git_diff_for_test();
 
         let mut commands = Vec::new();
@@ -1370,7 +1376,7 @@ mod tests {
         .await;
 
         assert!(rx.try_recv().is_err(), "prompt should be blocked locally");
-        assert!(!app.conversation_screen.waiting_for_response);
+        assert!(!app.conversation_screen.is_waiting());
         let messages: Vec<_> = app
             .conversation_screen
             .conversation
@@ -1434,7 +1440,7 @@ mod tests {
         let mut app = make_app();
         let tool_call = acp::ToolCall::new("tool-1".to_string(), "test_tool");
         app.conversation_screen.tool_call_statuses.on_tool_call(&tool_call);
-        app.conversation_screen.progress_indicator.update(0, 1, true, WorkspaceProgress::default());
+        app.conversation_screen.progress_indicator.update(true, WorkspaceProgress::default());
 
         let ctx = ViewContext::new((80, 24));
         let tool_before = app.conversation_screen.tool_call_statuses.render_tool("tool-1", &ctx);
@@ -1467,7 +1473,7 @@ mod tests {
         }
 
         let mut app = make_app();
-        app.conversation_screen.waiting_for_response = true;
+        app.conversation_screen.on_prompt_sent();
         let outcome = app.on_acp_event(AcpEvent::PromptDone(acp::StopReason::Cancelled));
         match outcome {
             EventOutcome::Render { commands } => assert!(commands.is_empty(), "cancelled prompt should not bell"),
@@ -1478,9 +1484,9 @@ mod tests {
     #[test]
     fn on_prompt_error_clears_waiting_state() {
         let mut app = make_app();
-        app.conversation_screen.waiting_for_response = true;
+        app.conversation_screen.on_prompt_sent();
         app.conversation_screen.on_prompt_error(&acp::Error::internal_error());
-        assert!(!app.conversation_screen.waiting_for_response);
+        assert!(!app.conversation_screen.is_waiting());
         assert!(!app.exit_requested());
     }
 
@@ -1514,7 +1520,7 @@ mod tests {
     #[tokio::test]
     async fn cancel_sends_directly_via_prompt_handle() {
         let mut app = make_app();
-        app.conversation_screen.waiting_for_response = true;
+        app.conversation_screen.on_prompt_sent();
         send_key(&mut app, KeyCode::Esc, KeyModifiers::NONE).await;
         assert!(!app.exit_requested());
     }
@@ -1706,6 +1712,104 @@ mod tests {
         assert!(app.exit_confirmation_active());
         app.on_event(&Event::Tick).await;
         assert!(!app.exit_confirmation_active(), "confirmation should expire after timeout");
+    }
+
+    #[tokio::test]
+    async fn prompt_error_mid_tool_call_finalizes_running_tools() {
+        let (mut app, mut rx) = make_app_with_config_recording(&[]);
+        app.conversation_screen.on_prompt_sent();
+        app.on_session_update(&acp::SessionUpdate::ToolCall(acp::ToolCall::new("tool-1".to_string(), "slow_tool")));
+        assert!(
+            app.conversation_screen.tool_call_statuses.running_any(),
+            "precondition: tool call should be tracked as running"
+        );
+
+        app.on_acp_event(AcpEvent::PromptError(acp::Error::internal_error()));
+
+        assert!(
+            !app.conversation_screen.tool_call_statuses.running_any(),
+            "prompt error should finalize running tool calls like on_prompt_done does"
+        );
+
+        let ctx = ViewContext::new((200, 24));
+        app.conversation_screen.refresh_caches(&ctx);
+        let frame = app.conversation_screen.progress_indicator.render(&ctx);
+        assert!(
+            frame.lines().is_empty(),
+            "progress indicator must go idle after a prompt error; otherwise it renders an animated spinner \
+             with '(esc to interrupt)' while Esc is dead (cancel is gated on waiting_for_response, already false)"
+        );
+
+        send_key(&mut app, KeyCode::Esc, KeyModifiers::NONE).await;
+        assert!(rx.try_recv().is_err(), "no cancel should be needed once the UI is idle");
+    }
+
+    #[tokio::test]
+    async fn esc_hint_renders_when_only_sub_agents_are_running() {
+        use acp_utils::notifications::{SubAgentEvent, SubAgentProgressParams};
+
+        let (mut app, _rx) = make_app_with_config_recording(&[]);
+        app.on_session_update(&acp::SessionUpdate::ToolCall(acp::ToolCall::new(
+            "tool-1".to_string(),
+            "spawn_subagent",
+        )));
+        app.conversation_screen.tool_call_statuses.on_sub_agent_progress(&SubAgentProgressParams {
+            parent_tool_id: "tool-1".to_string(),
+            task_id: "task-1".to_string(),
+            agent_name: "researcher".to_string(),
+            event: SubAgentEvent::Other,
+        });
+        assert!(app.conversation_screen.is_busy(), "precondition: sub-agent work counts as busy");
+
+        let ctx = ViewContext::new((200, 24));
+        app.conversation_screen.refresh_caches(&ctx);
+        let frame = app.conversation_screen.progress_indicator.render(&ctx);
+        let rendered: String = frame.lines().iter().map(tui::Line::plain_text).collect();
+        assert!(
+            rendered.contains("esc to interrupt"),
+            "the indicator must advertise Esc whenever the Esc gate would accept it; deriving indicator state \
+             from top-level tool counts hid sub-agent-only activity"
+        );
+    }
+
+    #[tokio::test]
+    async fn esc_cancels_while_tools_running_even_when_not_waiting() {
+        use acp_utils::client::PromptCommand;
+
+        let (mut app, mut rx) = make_app_with_config_recording(&[]);
+        app.on_session_update(&acp::SessionUpdate::ToolCall(acp::ToolCall::new("tool-1".to_string(), "slow_tool")));
+        assert!(!app.conversation_screen.is_waiting());
+
+        send_key(&mut app, KeyCode::Esc, KeyModifiers::NONE).await;
+
+        let cmd = rx.try_recv().expect("Esc should send cancel whenever the UI advertises '(esc to interrupt)'");
+        assert!(matches!(cmd, PromptCommand::Cancel { .. }));
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn replacing_pending_elicitation_modal_cancels_previous_responder() {
+        LocalSet::new()
+            .run_until(async {
+                let mut app = make_app();
+                let (cx, mut peer) = test_connection().await;
+                let (first_responder, first_rx) = peer.fake_elicitation(&cx).await;
+                let (second_responder, _second_rx) = peer.fake_elicitation(&cx).await;
+
+                app.on_elicitation_request(
+                    elicitation_params("server-a", "first", ElicitationSchema::builder().build().unwrap()),
+                    first_responder,
+                );
+                app.on_elicitation_request(
+                    elicitation_params("server-b", "second", ElicitationSchema::builder().build().unwrap()),
+                    second_responder,
+                );
+
+                // The requesting agent blocks awaiting this response; dropping the
+                // responder without answering would wedge it forever.
+                let first_response = first_rx.await.expect("replaced elicitation must receive a response");
+                assert_eq!(first_response.action, acp_utils::notifications::ElicitationAction::Cancel);
+            })
+            .await;
     }
 
     #[test]

--- a/crates/wisp/src/components/conversation_screen.rs
+++ b/crates/wisp/src/components/conversation_screen.rs
@@ -7,7 +7,7 @@ use crate::components::plan_view::PlanView;
 use crate::components::progress_indicator::{ProgressIndicator, WorkspaceProgress};
 use crate::components::prompt_composer::{PromptComposer, PromptComposerMessage};
 use crate::components::session_picker::{SessionEntry, SessionPicker, SessionPickerMessage};
-use crate::components::tool_call_statuses::ToolCallStatuses;
+use crate::components::tool_call_statuses::{PromptTermination, ToolCallStatuses};
 use crate::components::workspace_picker::{WorkspacePicker, WorkspacePickerMessage};
 use crate::keybindings::Keybindings;
 use acp_utils::CreateElicitationRequestParams;
@@ -73,7 +73,7 @@ pub struct ConversationScreen {
     pub(crate) plan_tracker: PlanTracker,
     pub(crate) progress_indicator: ProgressIndicator,
     pub(crate) workspace_move_state: WorkspaceMoveState,
-    pub(crate) waiting_for_response: bool,
+    waiting_for_response: bool,
     pub(crate) active_modal: Option<Modal>,
     pub(crate) content_padding: usize,
     pub(crate) pending_url_elicitations: HashSet<(String, String)>,
@@ -118,10 +118,17 @@ impl ConversationScreen {
         self.waiting_for_response
     }
 
+    pub fn on_prompt_sent(&mut self) {
+        self.waiting_for_response = true;
+    }
+
+    pub fn is_busy(&self) -> bool {
+        self.waiting_for_response || self.tool_call_statuses.running_any()
+    }
+
     pub fn wants_tick(&self) -> bool {
-        self.waiting_for_response
+        self.is_busy()
             || self.workspace_move_state.progress() != WorkspaceProgress::None
-            || self.tool_call_statuses.progress().running_any
             || self.plan_tracker_has_tick_driven_visibility()
     }
 
@@ -132,13 +139,7 @@ impl ConversationScreen {
     }
 
     pub fn refresh_caches(&mut self, _context: &ViewContext) {
-        let progress = self.tool_call_statuses.progress();
-        self.progress_indicator.update(
-            progress.completed_top_level,
-            progress.total_top_level,
-            self.waiting_for_response,
-            self.workspace_move_state.progress(),
-        );
+        self.progress_indicator.update(self.is_busy(), self.workspace_move_state.progress());
         self.plan_tracker.cached_visible_entries();
     }
 
@@ -267,14 +268,21 @@ impl ConversationScreen {
     }
 
     pub fn on_prompt_done(&mut self, stop_reason: acp::StopReason) {
-        self.waiting_for_response = false;
-        self.tool_call_statuses.finalize_running(matches!(stop_reason, acp::StopReason::Cancelled));
-        self.conversation.close_thought_block();
+        self.on_prompt_terminated(&match stop_reason {
+            acp::StopReason::Cancelled => PromptTermination::Cancelled,
+            _ => PromptTermination::EndTurn,
+        });
     }
 
     pub fn on_prompt_error(&mut self, error: &acp::Error) {
         tracing::error!("Prompt error: {error}");
+        self.on_prompt_terminated(&PromptTermination::Failed(error.to_string()));
+    }
+
+    fn on_prompt_terminated(&mut self, termination: &PromptTermination) {
         self.waiting_for_response = false;
+        self.tool_call_statuses.finalize_running(termination);
+        self.conversation.close_thought_block();
     }
 
     pub fn reject_local_prompt(&mut self, message: &str) {
@@ -400,7 +408,7 @@ impl ConversationScreen {
                     Err(message) => self.conversation.push_user_message(&format!("[wisp] {message}")),
                 },
                 PromptComposerMessage::SubmitRequested { user_input, attachments } => {
-                    self.waiting_for_response = true;
+                    self.on_prompt_sent();
                     out.push(ConversationScreenMessage::SendPrompt { user_input, attachments });
                 }
                 PromptComposerMessage::SearchPrompts(params) => {

--- a/crates/wisp/src/components/elicitation_form.rs
+++ b/crates/wisp/src/components/elicitation_form.rs
@@ -241,14 +241,6 @@ impl ElicitationForm {
         ElicitationResponse { action: ElicitationAction::Cancel, content: None }
     }
 
-    /// Send `Cancel` to the responder if one is still attached. Used when the
-    /// owning container is displacing this form before the user responded.
-    pub fn cancel_pending(&mut self) {
-        if let Some(responder) = self.responder.take() {
-            let _ = responder.respond(Self::cancel());
-        }
-    }
-
     /// If this form is showing the URL prompt that `params` refers to, accept
     /// it and consume the responder. Returns true iff the form was answered.
     pub fn accept_url_complete(&mut self, params: &UrlElicitationCompleteParams) -> bool {
@@ -263,6 +255,16 @@ impl ElicitationForm {
             let _ = responder.respond(response);
         }
         true
+    }
+}
+
+/// A form dropped without being answered (dismissed, replaced, or the app shut
+/// down) still owes the requesting agent a response, or it would block forever.
+impl Drop for ElicitationForm {
+    fn drop(&mut self) {
+        if let Some(responder) = self.responder.take() {
+            let _ = responder.respond(Self::cancel());
+        }
     }
 }
 
@@ -633,6 +635,23 @@ mod tests {
                 assert_eq!(content["name"], "");
                 assert_eq!(content["approved"], true);
                 assert_eq!(content["color"], "green");
+            })
+            .await;
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn dropping_unanswered_form_responds_cancel() {
+        LocalSet::new()
+            .run_until(async {
+                let (cx, mut peer) = test_connection().await;
+                let (responder, rx) = peer.fake_elicitation(&cx).await;
+                let params = elicitation_params("test-server", "Test", ElicitationSchema::builder().build().unwrap());
+
+                drop(ElicitationForm::from_params(params, responder));
+
+                let response = rx.await.expect("dropped form must still answer the requester");
+                assert_eq!(response.action, ElicitationAction::Cancel);
+                assert!(response.content.is_none());
             })
             .await;
     }

--- a/crates/wisp/src/components/progress_indicator.rs
+++ b/crates/wisp/src/components/progress_indicator.rs
@@ -24,8 +24,7 @@ pub enum WorkspaceProgress {
 
 #[derive(Default)]
 pub struct ProgressIndicator {
-    tools_running: bool,
-    waiting_for_response: bool,
+    agent_busy: bool,
     workspace_progress: WorkspaceProgress,
     tick: u16,
     was_active: bool,
@@ -33,16 +32,9 @@ pub struct ProgressIndicator {
 }
 
 impl ProgressIndicator {
-    pub fn update(
-        &mut self,
-        completed: usize,
-        total: usize,
-        waiting_for_response: bool,
-        workspace_progress: WorkspaceProgress,
-    ) {
+    pub fn update(&mut self, agent_busy: bool, workspace_progress: WorkspaceProgress) {
         let previously_active = self.was_active;
-        self.tools_running = total > 0 && completed < total;
-        self.waiting_for_response = waiting_for_response;
+        self.agent_busy = agent_busy;
         self.workspace_progress = workspace_progress;
         let now_active = self.is_active();
         self.was_active = now_active;
@@ -62,7 +54,7 @@ impl ProgressIndicator {
     }
 
     fn is_active(&self) -> bool {
-        self.tools_running || self.waiting_for_response || self.workspace_progress != WorkspaceProgress::None
+        self.agent_busy || self.workspace_progress != WorkspaceProgress::None
     }
 
     fn current_message(&self) -> &'static str {
@@ -73,10 +65,6 @@ impl ProgressIndicator {
                 self.turn_count.checked_sub(1).and_then(|i| MESSAGES.get(i)).copied().unwrap_or("Working...")
             }
         }
-    }
-
-    fn agent_is_busy(&self) -> bool {
-        self.tools_running || self.waiting_for_response
     }
 
     /// Advance the animation state. Call this on tick events.
@@ -97,7 +85,7 @@ impl ProgressIndicator {
         let mut line = Line::default();
         line.push_styled(frame_char.to_string(), context.theme.info());
         line.push_styled(format!(" {}", self.current_message()), context.theme.text_secondary());
-        if self.agent_is_busy() {
+        if self.agent_busy {
             line.push_with_style("  (esc to interrupt)".to_string(), Style::fg(context.theme.muted()).italic());
         }
 
@@ -122,27 +110,17 @@ mod tests {
     }
 
     #[test]
-    fn renders_nothing_when_all_complete_and_not_waiting() {
+    fn renders_nothing_after_busy_clears() {
         let mut indicator = ProgressIndicator::default();
-        indicator.update(3, 3, false, WorkspaceProgress::None);
+        indicator.update(true, WorkspaceProgress::None);
+        indicator.update(false, WorkspaceProgress::None);
         assert!(indicator.render(&ctx()).lines().is_empty());
     }
 
     #[test]
-    fn renders_when_tools_running() {
+    fn renders_esc_hint_when_agent_busy() {
         let mut indicator = ProgressIndicator::default();
-        indicator.update(1, 3, false, WorkspaceProgress::None);
-        let frame = indicator.render(&ctx());
-        let lines = frame.lines();
-        assert_eq!(lines.len(), 3);
-        let text = lines[1].plain_text();
-        assert!(text.contains("esc to interrupt"));
-    }
-
-    #[test]
-    fn renders_when_waiting_for_response_without_tools() {
-        let mut indicator = ProgressIndicator::default();
-        indicator.update(0, 0, true, WorkspaceProgress::None);
+        indicator.update(true, WorkspaceProgress::None);
         let frame = indicator.render(&ctx());
         let lines = frame.lines();
         assert_eq!(lines.len(), 3);
@@ -153,9 +131,9 @@ mod tests {
     #[test]
     fn spinner_animates_with_tick() {
         let mut a = ProgressIndicator::default();
-        a.update(0, 1, false, WorkspaceProgress::None);
+        a.update(true, WorkspaceProgress::None);
         let mut b = ProgressIndicator::default();
-        b.update(0, 1, false, WorkspaceProgress::None);
+        b.update(true, WorkspaceProgress::None);
         b.set_tick(1);
         let text_a = a.render(&ctx()).lines()[1].plain_text();
         let text_b = b.render(&ctx()).lines()[1].plain_text();
@@ -163,27 +141,18 @@ mod tests {
     }
 
     #[test]
-    fn on_tick_advances_when_running() {
+    fn on_tick_advances_when_busy() {
         let mut indicator = ProgressIndicator::default();
-        indicator.update(1, 3, false, WorkspaceProgress::None);
+        indicator.update(true, WorkspaceProgress::None);
+        let tick_before = indicator.tick;
         indicator.on_tick();
-        let frame = indicator.render(&ctx());
-        assert!(!frame.lines().is_empty());
-    }
-
-    #[test]
-    fn on_tick_advances_when_waiting() {
-        let mut indicator = ProgressIndicator::default();
-        indicator.update(0, 0, true, WorkspaceProgress::None);
-        let frame_before = indicator.tick;
-        indicator.on_tick();
-        assert_ne!(indicator.tick, frame_before);
+        assert_ne!(indicator.tick, tick_before);
     }
 
     #[test]
     fn on_tick_noop_when_idle() {
         let mut indicator = ProgressIndicator::default();
-        indicator.update(3, 3, false, WorkspaceProgress::None);
+        indicator.update(false, WorkspaceProgress::None);
         indicator.on_tick();
         assert!(indicator.render(&ctx()).lines().is_empty());
     }
@@ -191,7 +160,7 @@ mod tests {
     #[test]
     fn first_turn_shows_first_tip() {
         let mut indicator = ProgressIndicator::default();
-        indicator.update(0, 0, true, WorkspaceProgress::None);
+        indicator.update(true, WorkspaceProgress::None);
         indicator.set_turn_count(1);
         let frame = indicator.render(&ctx());
         let text = frame.lines()[1].plain_text();
@@ -201,16 +170,13 @@ mod tests {
     #[test]
     fn tip_advances_each_turn() {
         let mut indicator = ProgressIndicator::default();
-        // First turn: inactive → active
-        indicator.update(0, 0, true, WorkspaceProgress::None);
+        indicator.update(true, WorkspaceProgress::None);
         assert_eq!(indicator.turn_count, 1);
         let tip_0 = indicator.render(&ctx()).lines()[1].plain_text();
 
-        // Go inactive
-        indicator.update(0, 0, false, WorkspaceProgress::None);
+        indicator.update(false, WorkspaceProgress::None);
 
-        // Second turn: inactive → active
-        indicator.update(0, 0, true, WorkspaceProgress::None);
+        indicator.update(true, WorkspaceProgress::None);
         assert_eq!(indicator.turn_count, 2);
         let tip_1 = indicator.render(&ctx()).lines()[1].plain_text();
 
@@ -222,7 +188,7 @@ mod tests {
     #[test]
     fn shows_working_after_tips_exhausted() {
         let mut indicator = ProgressIndicator::default();
-        indicator.update(0, 0, true, WorkspaceProgress::None);
+        indicator.update(true, WorkspaceProgress::None);
         indicator.set_turn_count(MESSAGES.len() + 1);
         let text = indicator.render(&ctx()).lines()[1].plain_text();
         assert!(text.contains("Working..."));
@@ -231,7 +197,7 @@ mod tests {
     #[test]
     fn reset_restarts_tips() {
         let mut indicator = ProgressIndicator::default();
-        indicator.update(0, 0, true, WorkspaceProgress::None);
+        indicator.update(true, WorkspaceProgress::None);
         assert_eq!(indicator.turn_count, 1);
 
         let indicator = ProgressIndicator::default();
@@ -241,7 +207,7 @@ mod tests {
     #[test]
     fn renders_workspace_move_without_interrupt_hint() {
         let mut indicator = ProgressIndicator::default();
-        indicator.update(0, 0, false, WorkspaceProgress::Moving);
+        indicator.update(false, WorkspaceProgress::Moving);
         let text = indicator.render(&ctx()).lines()[1].plain_text();
         assert!(text.contains("Moving workspace..."));
         assert!(!text.contains("esc to interrupt"));
@@ -250,7 +216,7 @@ mod tests {
     #[test]
     fn workspace_move_message_takes_precedence_when_agent_is_busy() {
         let mut indicator = ProgressIndicator::default();
-        indicator.update(0, 0, true, WorkspaceProgress::Moving);
+        indicator.update(true, WorkspaceProgress::Moving);
         let text = indicator.render(&ctx()).lines()[1].plain_text();
         assert!(text.contains("Moving workspace..."));
         assert!(text.contains("esc to interrupt"));
@@ -259,7 +225,7 @@ mod tests {
     #[test]
     fn renders_workspace_session_load_without_interrupt_hint() {
         let mut indicator = ProgressIndicator::default();
-        indicator.update(0, 0, false, WorkspaceProgress::LoadingSession);
+        indicator.update(false, WorkspaceProgress::LoadingSession);
         let text = indicator.render(&ctx()).lines()[1].plain_text();
         assert!(text.contains("Loading session in new workspace..."));
         assert!(!text.contains("esc to interrupt"));
@@ -268,14 +234,11 @@ mod tests {
     #[test]
     fn staying_active_does_not_advance_tip() {
         let mut indicator = ProgressIndicator::default();
-        indicator.update(0, 0, true, WorkspaceProgress::None);
+        indicator.update(true, WorkspaceProgress::None);
         assert_eq!(indicator.turn_count, 1);
 
-        // Multiple updates while staying active
-        indicator.update(1, 3, true, WorkspaceProgress::None);
-        indicator.update(2, 3, true, WorkspaceProgress::None);
-        indicator.update(3, 3, true, WorkspaceProgress::None);
-        // Still waiting_for_response so still active
+        indicator.update(true, WorkspaceProgress::None);
+        indicator.update(true, WorkspaceProgress::None);
         assert_eq!(indicator.turn_count, 1);
     }
 }

--- a/crates/wisp/src/components/sub_agent_tracker.rs
+++ b/crates/wisp/src/components/sub_agent_tracker.rs
@@ -3,6 +3,7 @@ use std::collections::HashMap;
 use acp_utils::notifications::{SubAgentEvent, SubAgentProgressParams};
 
 use crate::components::tool_call_status_view::ToolCallStatus;
+use crate::components::tool_call_statuses::PromptTermination;
 use crate::components::tracked_tool_call::{TrackedToolCall, upsert_tracked_tool_call};
 
 pub(crate) const SUB_AGENT_VISIBLE_TOOL_LIMIT: usize = 3;
@@ -105,9 +106,8 @@ impl SubAgentTracker {
         self.agents.values().any(|agents| agents.iter().any(SubAgentState::is_active_for_render))
     }
 
-    pub(crate) fn finalize_running(&mut self, cancelled: bool) {
-        let terminal_status =
-            if cancelled { ToolCallStatus::Error("cancelled".to_string()) } else { ToolCallStatus::Success };
+    pub(crate) fn finalize_running(&mut self, termination: &PromptTermination) {
+        let terminal_status = termination.terminal_status();
 
         for agents in self.agents.values_mut() {
             for agent in agents {

--- a/crates/wisp/src/components/tool_call_statuses.rs
+++ b/crates/wisp/src/components/tool_call_statuses.rs
@@ -8,6 +8,23 @@ use crate::components::tool_call_status_view::{ToolCallStatus, diff_preview_from
 use crate::components::tracked_tool_call::{TrackedToolCall, raw_input_fragment, upsert_tracked_tool_call};
 use tui::{Frame, ViewContext};
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum PromptTermination {
+    EndTurn,
+    Cancelled,
+    Failed(String),
+}
+
+impl PromptTermination {
+    pub(crate) fn terminal_status(&self) -> ToolCallStatus {
+        match self {
+            PromptTermination::EndTurn => ToolCallStatus::Success,
+            PromptTermination::Cancelled => ToolCallStatus::Error("cancelled".to_string()),
+            PromptTermination::Failed(msg) => ToolCallStatus::Error(format!("failed: {msg}")),
+        }
+    }
+}
+
 /// Tracks active tool calls and produces status lines for the frame.
 #[derive(Clone)]
 pub struct ToolCallStatuses {
@@ -21,26 +38,18 @@ pub struct ToolCallStatuses {
     tick: u16,
 }
 
-pub struct ToolProgress {
-    pub running_any: bool,
-    pub completed_top_level: usize,
-    pub total_top_level: usize,
-}
-
 impl ToolCallStatuses {
     pub fn new() -> Self {
         Self { tool_order: Vec::new(), tool_calls: HashMap::new(), sub_agents: SubAgentTracker::default(), tick: 0 }
     }
 
-    pub fn progress(&self) -> ToolProgress {
-        let running_any = self.any_running_including_subagents();
-        let (completed_top_level, total_top_level) = self.top_level_counts();
-        ToolProgress { running_any, completed_top_level, total_top_level }
+    pub fn running_any(&self) -> bool {
+        self.tool_calls.values().any(|tc| matches!(tc.status, ToolCallStatus::Running)) || self.sub_agents.any_running()
     }
 
     /// Advance the animation state. Call this on tick events.
     pub fn on_tick(&mut self, _now: Instant) {
-        if self.progress().running_any {
+        if self.running_any() {
             self.tick = self.tick.wrapping_add(1);
         }
     }
@@ -91,9 +100,8 @@ impl ToolCallStatuses {
         }
     }
 
-    pub fn finalize_running(&mut self, cancelled: bool) {
-        let terminal_status =
-            if cancelled { ToolCallStatus::Error("cancelled".to_string()) } else { ToolCallStatus::Success };
+    pub fn finalize_running(&mut self, termination: &PromptTermination) {
+        let terminal_status = termination.terminal_status();
 
         for tool_call in self.tool_calls.values_mut() {
             if matches!(tool_call.status, ToolCallStatus::Running) {
@@ -101,7 +109,7 @@ impl ToolCallStatuses {
             }
         }
 
-        self.sub_agents.finalize_running(cancelled);
+        self.sub_agents.finalize_running(termination);
     }
 
     pub fn has_tool(&self, id: &str) -> bool {
@@ -134,22 +142,6 @@ impl ToolCallStatuses {
         self.tool_order.clear();
         self.tool_calls.clear();
         self.sub_agents.clear();
-    }
-
-    fn top_level_counts(&self) -> (usize, usize) {
-        let total = self.tool_order.iter().filter(|id| !self.sub_agents.has_sub_agents(id)).count();
-        let completed = self
-            .tool_order
-            .iter()
-            .filter(|id| !self.sub_agents.has_sub_agents(id))
-            .filter_map(|id| self.tool_calls.get(id))
-            .filter(|tc| !matches!(tc.status, ToolCallStatus::Running))
-            .count();
-        (completed, total)
-    }
-
-    fn any_running_including_subagents(&self) -> bool {
-        self.tool_calls.values().any(|tc| matches!(tc.status, ToolCallStatus::Running)) || self.sub_agents.any_running()
     }
 }
 
@@ -208,7 +200,7 @@ mod tests {
             r#"{"ToolCall":{"request":{"id":"c1","name":"grep","arguments":"{}"},"model_name":"m"}}"#,
         ));
 
-        assert!(statuses.progress().running_any);
+        assert!(statuses.running_any());
     }
 
     #[test]
@@ -222,7 +214,7 @@ mod tests {
         ));
 
         statuses.remove_tool("parent-1");
-        assert!(!statuses.progress().running_any);
+        assert!(!statuses.running_any());
         assert!(statuses.render_tool("parent-1", &ctx()).lines().is_empty());
     }
 
@@ -237,7 +229,7 @@ mod tests {
         ));
 
         statuses.clear();
-        assert!(!statuses.progress().running_any);
+        assert!(!statuses.running_any());
     }
 
     #[test]
@@ -335,10 +327,10 @@ mod tests {
         let mut statuses = ToolCallStatuses::new();
         statuses.on_tool_call(&make_tool_call("tool-1", "Read", None));
 
-        statuses.finalize_running(false);
+        statuses.finalize_running(&PromptTermination::EndTurn);
 
         assert!(!statuses.is_tool_running("tool-1"));
-        assert!(!statuses.progress().running_any);
+        assert!(!statuses.running_any());
         let frame = statuses.render_tool("tool-1", &ctx());
         assert!(frame.lines()[0].plain_text().contains('✓'));
     }
@@ -352,10 +344,55 @@ mod tests {
             r#"{"ToolCall":{"request":{"id":"c1","name":"grep","arguments":"{}"},"model_name":"m"}}"#,
         ));
 
-        assert!(statuses.progress().running_any);
+        assert!(statuses.running_any());
 
-        statuses.finalize_running(true);
+        statuses.finalize_running(&PromptTermination::Cancelled);
 
-        assert!(!statuses.progress().running_any);
+        assert!(!statuses.running_any());
+    }
+
+    #[test]
+    fn finalize_running_failed_variant_preserves_cause() {
+        let mut statuses = ToolCallStatuses::new();
+        statuses.on_tool_call(&make_tool_call("tool-1", "Read", None));
+        assert!(statuses.is_tool_running("tool-1"));
+
+        statuses.finalize_running(&PromptTermination::Failed("error".to_string()));
+
+        assert!(!statuses.is_tool_running("tool-1"));
+        assert!(!statuses.running_any());
+    }
+
+    #[test]
+    fn finalize_running_cancelled_vs_failed_both_error() {
+        let mut cancelled = ToolCallStatuses::new();
+        cancelled.on_tool_call(&make_tool_call("t1", "test", None));
+        cancelled.finalize_running(&PromptTermination::Cancelled);
+
+        let mut failed = ToolCallStatuses::new();
+        failed.on_tool_call(&make_tool_call("t1", "test", None));
+        failed.finalize_running(&PromptTermination::Failed("error".to_string()));
+
+        let cancelled_frame = cancelled.render_tool("t1", &ctx());
+        let failed_frame = failed.render_tool("t1", &ctx());
+        assert!(!cancelled_frame.lines()[0].plain_text().contains('\u{2713}'));
+        assert!(!failed_frame.lines()[0].plain_text().contains('\u{2713}'));
+    }
+
+    #[test]
+    fn running_any_false_when_sub_agent_done() {
+        let mut statuses = ToolCallStatuses::new();
+        statuses.on_sub_agent_progress(&make_sub_agent_notification(
+            "parent-1",
+            "explorer",
+            r#"{"ToolCall":{"request":{"id":"c1","name":"grep","arguments":"{}"},"model_name":"m"}}"#,
+        ));
+        assert!(statuses.running_any());
+
+        statuses.on_sub_agent_progress(&make_sub_agent_notification("parent-1", "explorer", r#""Done""#));
+        assert!(statuses.running_any());
+
+        statuses.finalize_running(&PromptTermination::EndTurn);
+        assert!(!statuses.running_any());
     }
 }

--- a/crates/wisp/src/settings/overlay.rs
+++ b/crates/wisp/src/settings/overlay.rs
@@ -141,9 +141,6 @@ impl SettingsOverlay {
     }
 
     pub fn on_elicitation_request(&mut self, params: ElicitationParams, responder: Responder<ElicitationResponse>) {
-        if let Some(mut prior) = self.pending_elicitation.take() {
-            prior.cancel_pending();
-        }
         self.pending_elicitation = Some(ElicitationForm::from_params(params, responder));
     }
 


### PR DESCRIPTION
## Summary
- keep ACP cancellation, configuration, and elicitation handling responsive while requests are outstanding
- run context compaction through the agent event stream and retain queued user input across cancellation
- align Wisp busy, cancellation, tool-finalization, and elicitation lifecycle behavior

## Validation
- `just test` — 3031 passed, 14 skipped
- push hooks: `just fmt-check`, `just lint`, `just test`, and `just doc-check`

## Commits
1. `fix(acp): keep session commands responsive`
2. `fix(agent): compact context without blocking commands`
3. `fix(wisp): synchronize busy state with active work`