### PR TITLE
feat(wisp): add staged/unstaged/both scope toggle to git diff mode

### DIFF
--- a/crates/wisp/src/components/app/git_diff_mode.rs
+++ b/crates/wisp/src/components/app/git_diff_mode.rs
@@ -4,8 +4,8 @@ use crate::components::git_diff::git_diff_panel::{GitDiffPanel, GitDiffPanelMess
 use crate::components::git_diff::{DiffAnchor, PatchAnchor};
 use crate::components::review_comments::{CommentAnchor, ReviewComment};
 use crate::git_diff::{
-    FileDiff, FileStatus, GitDiffDocument, GitDiffError, PatchLineKind, StageState, commit, load_git_diff, stage_all,
-    stage_file, unstage_all, unstage_file,
+    DiffScope, FileDiff, FileStatus, GitDiffDocument, GitDiffError, PatchLineKind, StageState, commit, load_git_diff,
+    stage_all, stage_file, unstage_all, unstage_file,
 };
 use std::collections::HashMap;
 use std::path::{Path, PathBuf};
@@ -45,6 +45,7 @@ pub struct GitDiffMode {
     working_dir: PathBuf,
     cached_repo_root: Option<PathBuf>,
     document_revision: usize,
+    diff_scope: DiffScope,
     pub load_state: GitDiffLoadState,
     split: SplitPanel<FileListPanel, GitDiffPanel>,
     comments: ReviewQueue,
@@ -58,6 +59,7 @@ impl GitDiffMode {
             working_dir,
             cached_repo_root: None,
             document_revision: 0,
+            diff_scope: DiffScope::default(),
             load_state: GitDiffLoadState::Empty,
             split: SplitPanel::new(FileListPanel::new(), GitDiffPanel::new(), SplitLayout::fraction(1, 3, 20, 28))
                 .with_separator("│", Style::default())
@@ -82,7 +84,7 @@ impl GitDiffMode {
     }
 
     pub(crate) async fn complete_load(&mut self) {
-        match load_git_diff(&self.working_dir, self.cached_repo_root.as_deref()).await {
+        match load_git_diff(&self.working_dir, self.cached_repo_root.as_deref(), self.diff_scope).await {
             Ok(doc) => {
                 if self.cached_repo_root.is_none() {
                     self.cached_repo_root = Some(doc.repo_root.clone());
@@ -145,6 +147,10 @@ impl Component for GitDiffMode {
                 KeyCode::Char('C') => return Some(self.begin_commit()),
                 KeyCode::Char('d') => return Some(self.request_discard()),
                 KeyCode::Char('r') => return Some(vec![GitDiffViewMessage::Refresh]),
+                KeyCode::Char('t') => {
+                    self.diff_scope = self.diff_scope.next();
+                    return Some(vec![GitDiffViewMessage::Refresh]);
+                }
                 KeyCode::Char('u') => {
                     self.comments.pop();
                     self.sync_comment_state();
@@ -507,6 +513,7 @@ impl GitDiffMode {
             return;
         }
 
+        self.split.left_mut().set_diff_scope(self.diff_scope);
         self.split.left_mut().rebuild_from_files(&doc.files);
         self.split.right_mut().clear_rendered_patches();
         self.split.right_mut().set_repo_root(doc.repo_root.clone());
@@ -530,13 +537,21 @@ impl GitDiffMode {
     }
 }
 
-const LEFT_HELP_KEYS: [(&str, &str); 6] =
-    [("j/k", "move"), ("space", "stage"), ("A", "stage all"), ("C", "commit"), ("d", "discard"), ("Esc", "close")];
+const LEFT_HELP_KEYS: [(&str, &str); 7] = [
+    ("j/k", "move"),
+    ("space", "stage"),
+    ("t", "scope"),
+    ("A", "stage all"),
+    ("C", "commit"),
+    ("d", "discard"),
+    ("Esc", "close"),
+];
 
 const COMMIT_HELP_KEYS: [(&str, &str); 2] = [("enter", "commit"), ("esc", "cancel")];
 
-const RIGHT_HELP_KEYS: [(&str, &str); 7] = [
+const RIGHT_HELP_KEYS: [(&str, &str); 8] = [
     ("space", "stage"),
+    ("t", "scope"),
     ("c", "comment"),
     ("C", "commit"),
     ("d", "discard"),

--- a/crates/wisp/src/components/file_list_panel.rs
+++ b/crates/wisp/src/components/file_list_panel.rs
@@ -1,7 +1,7 @@
 use crate::components::common::VerticalCursor;
 use crate::components::file_tree::{FileTree, FileTreeEntry, FileTreeEntryKind};
 use crate::components::git_diff::{file_status_color, header_rule, push_diff_stats};
-use crate::git_diff::{FileDiff, FileStatus, StageState};
+use crate::git_diff::{DiffScope, FileDiff, FileStatus, StageState};
 use tui::{Component, Event, Frame, KeyCode, Line, MouseEventKind, Style, ViewContext, truncate_line, truncate_text};
 
 const CHROME_HEIGHT: usize = 2;
@@ -15,6 +15,7 @@ pub struct FileListPanel {
     deletions: usize,
     focused: bool,
     file_comment_counts: Vec<usize>,
+    diff_scope: DiffScope,
     scroll_consumed_this_frame: bool,
 }
 
@@ -34,6 +35,7 @@ impl Default for FileListPanel {
             deletions: 0,
             focused: false,
             file_comment_counts: Vec::new(),
+            diff_scope: DiffScope::default(),
             scroll_consumed_this_frame: false,
         }
     }
@@ -64,6 +66,10 @@ impl FileListPanel {
     pub fn sync_view_state(&mut self, queued_comment_count: usize, file_comment_counts: Vec<usize>) {
         self.queued_comment_count = queued_comment_count;
         self.file_comment_counts = file_comment_counts;
+    }
+
+    pub fn set_diff_scope(&mut self, diff_scope: DiffScope) {
+        self.diff_scope = diff_scope;
     }
 
     pub fn set_focused(&mut self, focused: bool) {
@@ -99,7 +105,7 @@ impl FileListPanel {
         let title_fg = if self.focused { theme.accent() } else { theme.text_primary() };
         let mut row = Line::default();
         row.push_text(" ");
-        row.push_with_style("Git Diff", Style::fg(title_fg).bold());
+        row.push_with_style(format!("Git Diff · {}", self.diff_scope.label()), Style::fg(title_fg).bold());
         row.push_text("  ");
         row.push_with_style(
             format!("{} file{}", self.file_count, if self.file_count == 1 { "" } else { "s" }),

--- a/crates/wisp/src/git_diff.rs
+++ b/crates/wisp/src/git_diff.rs
@@ -18,6 +18,14 @@ pub struct FileDiff {
     pub binary: bool,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum DiffScope {
+    Unstaged,
+    Staged,
+    #[default]
+    Both,
+}
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum FileStatus {
     Modified,
@@ -69,6 +77,28 @@ pub enum GitDiffError {
     CommandFailed { stderr: String },
     #[error("Failed to parse diff: {0}")]
     ParseError(String),
+}
+
+impl DiffScope {
+    pub fn label(self) -> &'static str {
+        match self {
+            Self::Unstaged => "Unstaged",
+            Self::Staged => "Staged",
+            Self::Both => "Both",
+        }
+    }
+
+    pub(crate) fn next(self) -> Self {
+        match self {
+            Self::Both => Self::Unstaged,
+            Self::Unstaged => Self::Staged,
+            Self::Staged => Self::Both,
+        }
+    }
+
+    fn includes_untracked(self) -> bool {
+        !matches!(self, Self::Staged)
+    }
 }
 
 impl FileStatus {
@@ -125,18 +155,26 @@ impl Hunk {
 pub(crate) async fn load_git_diff(
     working_dir: &Path,
     cached_repo_root: Option<&Path>,
+    scope: DiffScope,
 ) -> Result<GitDiffDocument, GitDiffError> {
     let repo_root = match cached_repo_root {
         Some(root) => root.to_path_buf(),
         None => resolve_repo_root(working_dir).await?,
     };
-    let diff_output = git(&repo_root, &["diff", "--no-ext-diff", "--find-renames", "HEAD"]).await?;
+    let diff_args = match scope {
+        DiffScope::Unstaged => &["diff", "--no-ext-diff", "--find-renames"][..],
+        DiffScope::Staged => &["diff", "--cached", "--no-ext-diff", "--find-renames"][..],
+        DiffScope::Both => &["diff", "--no-ext-diff", "--find-renames", "HEAD"][..],
+    };
+    let diff_output = git(&repo_root, diff_args).await?;
 
     let mut files = if diff_output.trim().is_empty() { Vec::new() } else { parse_unified_diff(&diff_output)? };
 
-    let untracked_stdout = git(&repo_root, &["ls-files", "--others", "--exclude-standard"]).await?;
-    for path in untracked_stdout.lines().filter(|l| !l.is_empty()).map(String::from) {
-        files.push(build_untracked_file_diff(&repo_root, path).await);
+    if scope.includes_untracked() {
+        let untracked_stdout = git(&repo_root, &["ls-files", "--others", "--exclude-standard"]).await?;
+        for path in untracked_stdout.lines().filter(|l| !l.is_empty()).map(String::from) {
+            files.push(build_untracked_file_diff(&repo_root, path).await);
+        }
     }
 
     let status_map = load_status_map(&repo_root).await?;
@@ -868,15 +906,15 @@ index abc..def 100644
         commit_file(dir, "a.txt", "one\n", "init").await;
         write_file(dir, "a.txt", "one\ntwo\n").await;
 
-        let doc = load_git_diff(dir, None).await.unwrap();
+        let doc = load_git_diff(dir, None, DiffScope::Both).await.unwrap();
         assert_eq!(staged_of(&doc, "a.txt"), StageState::Unstaged);
 
         stage_file(dir, "a.txt").await.unwrap();
-        let doc = load_git_diff(dir, None).await.unwrap();
+        let doc = load_git_diff(dir, None, DiffScope::Both).await.unwrap();
         assert_eq!(staged_of(&doc, "a.txt"), StageState::Staged);
 
         unstage_file(dir, "a.txt").await.unwrap();
-        let doc = load_git_diff(dir, None).await.unwrap();
+        let doc = load_git_diff(dir, None, DiffScope::Both).await.unwrap();
         assert_eq!(staged_of(&doc, "a.txt"), StageState::Unstaged);
     }
 
@@ -891,7 +929,7 @@ index abc..def 100644
         write_file(dir, "c.txt", "c1\n").await;
 
         stage_all(dir).await.unwrap();
-        let doc = load_git_diff(dir, None).await.unwrap();
+        let doc = load_git_diff(dir, None, DiffScope::Both).await.unwrap();
         assert_eq!(staged_of(&doc, "a.txt"), StageState::Staged);
         assert_eq!(staged_of(&doc, "b.txt"), StageState::Staged);
         assert_eq!(staged_of(&doc, "c.txt"), StageState::Staged);
@@ -908,7 +946,7 @@ index abc..def 100644
         let log = git(dir, &["log", "--oneline", "-1"]).await.unwrap();
         assert!(log.contains("second commit"), "log was: {log}");
 
-        let doc = load_git_diff(dir, None).await.unwrap();
+        let doc = load_git_diff(dir, None, DiffScope::Both).await.unwrap();
         assert!(doc.files.is_empty(), "expected clean tree, got {} files", doc.files.len());
     }
 
@@ -948,6 +986,45 @@ index abc..def 100644
         unstage_file(dir, "a.txt").await.unwrap();
         let status = git(dir, &["status", "--porcelain"]).await.unwrap();
         assert!(status.contains("?? a.txt"), "status was: {status}");
+    }
+
+    #[tokio::test]
+    async fn load_git_diff_filters_changes_by_scope() {
+        let repo = init_repo().await;
+        let dir = repo.path();
+        commit_file(dir, "a.txt", "one\n", "init").await;
+
+        write_file(dir, "a.txt", "two\n").await;
+        stage_file(dir, "a.txt").await.unwrap();
+        write_file(dir, "a.txt", "three\n").await;
+        write_file(dir, "untracked.txt", "scratch\n").await;
+
+        let unstaged = load_git_diff(dir, None, DiffScope::Unstaged).await.unwrap();
+        assert_eq!(
+            unstaged.files.iter().map(|file| file.path.as_str()).collect::<Vec<_>>(),
+            vec!["a.txt", "untracked.txt"]
+        );
+        assert!(
+            unstaged
+                .files
+                .iter()
+                .any(|file| file.path == "a.txt" && file.hunks[0].lines.iter().any(|line| line.text == "three"))
+        );
+
+        let staged = load_git_diff(dir, None, DiffScope::Staged).await.unwrap();
+        assert_eq!(staged.files.iter().map(|file| file.path.as_str()).collect::<Vec<_>>(), vec!["a.txt"]);
+        assert!(staged.files[0].hunks[0].lines.iter().any(|line| line.text == "two"));
+
+        let both = load_git_diff(dir, None, DiffScope::Both).await.unwrap();
+        assert_eq!(
+            both.files.iter().map(|file| file.path.as_str()).collect::<Vec<_>>(),
+            vec!["a.txt", "untracked.txt"]
+        );
+        assert!(
+            both.files
+                .iter()
+                .any(|file| file.path == "a.txt" && file.hunks[0].lines.iter().any(|line| line.text == "three"))
+        );
     }
 
     #[test]

--- a/crates/wisp/tests/app_tests/git_diff_tests.rs
+++ b/crates/wisp/tests/app_tests/git_diff_tests.rs
@@ -25,6 +25,33 @@ async fn open_git_diff(renderer: &mut Renderer) -> TestResult {
 }
 
 #[tokio::test]
+async fn git_diff_scope_cycles_between_both_unstaged_and_staged() -> TestResult {
+    let repo = init_temp_repo();
+    let dir = repo.path().to_path_buf();
+    std::fs::write(dir.join("a.txt"), "one\n").unwrap();
+    run_git(&dir, &["add", "-A"]);
+    run_git(&dir, &["commit", "--quiet", "-m", "init"]);
+    std::fs::write(dir.join("a.txt"), "two\n").unwrap();
+    run_git(&dir, &["add", "a.txt"]);
+    std::fs::write(dir.join("a.txt"), "three\n").unwrap();
+    std::fs::write(dir.join("untracked.txt"), "scratch\n").unwrap();
+
+    let mut renderer = RendererTest::new().size((TEST_WIDTH, 40)).working_dir(dir).build()?;
+    open_git_diff(&mut renderer).await?;
+    assert_buffer_contains(renderer.writer(), "Git Diff · Both");
+    assert_buffer_contains(renderer.writer(), "untracked.txt");
+
+    press(&mut renderer, KeyCode::Char('t')).await?;
+    assert_buffer_contains(renderer.writer(), "Git Diff · Unstaged");
+    assert_buffer_contains(renderer.writer(), "untracked.txt");
+
+    press(&mut renderer, KeyCode::Char('t')).await?;
+    assert_buffer_contains(renderer.writer(), "Git Diff · Staged");
+    assert_buffer_not_contains(renderer.writer(), "untracked.txt");
+    Ok(())
+}
+
+#[tokio::test]
 async fn typing_long_commit_message_keeps_diff_rows_visible() -> TestResult {
     let repo = init_temp_repo();
     let dir = repo.path().to_path_buf();

--- a/crates/wisp/tests/component_tests/file_list_panel.rs
+++ b/crates/wisp/tests/component_tests/file_list_panel.rs
@@ -80,7 +80,7 @@ fn flat_rows(selected: usize) -> [String; 4] {
     let app_indicator = if selected == 0 { "▎" } else { " " };
     let lib_indicator = if selected == 1 { "▎" } else { " " };
     [
-        " Git Diff  2 files  +8 -1".to_string(),
+        " Git Diff · Both  2 files  +8 -1".to_string(),
         rule(),
         cols(&[(format!("{app_indicator}── app.rs").as_str(), 31), ("+3 -1 M ☐", 0)]),
         cols(&[(format!("{lib_indicator}── lib.rs").as_str(), 31), ("+5 -0 A ☐", 0)]),
@@ -182,7 +182,7 @@ fn renders_directory_tree() {
     assert_buffer_eq(
         &term,
         &[
-            " Git Diff  2 files  +6 -1".to_string(),
+            " Git Diff · Both  2 files  +6 -1".to_string(),
             rule(),
             "▎▾  src/".to_string(),
             cols(&[(" ├── main.rs", 31), ("+2 -1 M ☐", 0)]),
@@ -335,7 +335,7 @@ async fn collapse_directory_hides_children() {
 
     assert_buffer_eq(
         &term,
-        &[" Git Diff  2 files  +6 -1".to_string(), rule(), "▎▸  src/".to_string(), String::new(), String::new()],
+        &[" Git Diff · Both  2 files  +6 -1".to_string(), rule(), "▎▸  src/".to_string(), String::new(), String::new()],
     );
 }
 
@@ -349,7 +349,7 @@ fn renders_queued_comment_indicator() {
 
     assert_buffer_eq(
         &term,
-        &[" Git Diff  1 file  +1 -1  ◆3".to_string(), rule(), cols(&[("▎── a.rs", 31), ("+1 -1 M ☐", 0)])],
+        &[" Git Diff · Both  1 file  +1 -1  ◆3".to_string(), rule(), cols(&[("▎── a.rs", 31), ("+1 -1 M ☐", 0)])],
     );
 }
 
@@ -370,7 +370,7 @@ fn empty_panel_renders_chrome_only() {
     let mut panel = FileListPanel::new();
     let term = render_component(|ctx| panel.render(ctx), 30, 2);
 
-    assert_buffer_eq(&term, &[" Git Diff  0 files  +0 -0", &"─".repeat(30)]);
+    assert_buffer_eq(&term, &[" Git Diff · Both  0 files  +0", &"─".repeat(30)]);
 }
 
 #[test]
@@ -387,7 +387,7 @@ fn file_status_markers_render_correctly() {
     assert_buffer_eq(
         &term,
         &[
-            " Git Diff  3 files  +2 -2".to_string(),
+            " Git Diff · Both  3 files  +2 -2".to_string(),
             rule(),
             cols(&[("▎── added.rs", 31), ("+1 -0 A ☐", 0)]),
             cols(&[(" ── deleted.rs", 31), ("+0 -1 D ☐", 0)]),
@@ -451,7 +451,7 @@ async fn renders_only_viewport_rows_after_scrolling_many_files() {
     assert_buffer_eq(
         &term,
         &[
-            " Git Diff  20 files  +20 -20".to_string(),
+            " Git Diff · Both  20 files  +20 -20".to_string(),
             rule(),
             cols(&[(" ── file-02.rs", 31), ("+1 -1 M ☐", 0)]),
             cols(&[(" ── file-03.rs", 31), ("+1 -1 M ☐", 0)]),

--- a/crates/wisp/tests/component_tests/git_diff_view.rs
+++ b/crates/wisp/tests/component_tests/git_diff_view.rs
@@ -8,8 +8,8 @@ use tui::{Component, Event, KeyCode, MIN_GUTTER_WIDTH, SEPARATOR_WIDTH, ViewCont
 use wisp::components::app::{GitDiffLoadState, GitDiffMode};
 use wisp::git_diff::GitDiffDocument;
 
-const LEFT_HINT_LINE: &str = "j/k move  space stage  A stage all  C commit  d discard  Esc close";
-const RIGHT_HINT_LINE: &str = "space stage  c comment  C commit  d discard  s submit  o full file  Esc close";
+const LEFT_HINT_LINE: &str = "j/k move  space stage  t scope  A stage all  C commit  d discard  Esc close";
+const RIGHT_HINT_LINE: &str = "space stage  t scope  c comment  C commit  d discard  s submit  o full file  Esc close";
 
 fn make_mode(doc: GitDiffDocument) -> GitDiffMode {
     let mut mode = GitDiffMode::new(PathBuf::from("."));
@@ -115,7 +115,7 @@ fn git_diff_view_keeps_wrapped_code_out_of_the_line_number_gutter() {
     assert_buffer_eq(
         &term,
         &[
-            cols(&[(" Git Diff  1 file  +1 -1", 28), ("│", 1), (" x.rs  modified  +1 -1", 0)]),
+            cols(&[(" Git Diff · Both  1 file  +1", 28), ("│", 1), (" x.rs  modified  +1 -1", 0)]),
             cols(&[(&"─".repeat(28), 28), ("│", 1), (&"─".repeat(111), 0)]),
             cols(&[("▎── x.rs", 19), ("+1 -1 M ☐", 9), ("│", 1), (" 1 LEFT_MARK", 55), ("", 1), (" 1 RIGHT_HEAD", 55)]),
             cols(&[("", 28), ("│", 1), ("", 55), ("", 1), (" ↪ ", 3), (filler.as_str(), 0)]),
@@ -260,7 +260,7 @@ fn render_shows_file_list_and_patch() {
     assert_buffer_eq(
         &term,
         &[
-            cols(&[(" Git Diff  2 files  +2 -1", sb), ("│", 1), ("a.rs  modified  +1 -1", 0)]),
+            cols(&[(" Git Diff · Both  2 files  +", sb), ("│", 1), ("a.rs  modified  +1 -1", 0)]),
             cols(&[(&"─".repeat(sb), sb), ("│", 1), (&"─".repeat(71), 0)]),
             cols(&[("▎── a.rs", 19), ("+1 -1 M ☐", 9), ("│", 1), ("1   fn main() {", 0)]),
             cols(&[(" ── b.rs", 19), ("+1 -0 A ☐", 9), ("│", 1), ("2 -     old();", 0)]),


### PR DESCRIPTION
## Summary

Adds a `DiffScope` toggle to Git Diff mode, letting you cycle between viewing **unstaged** changes, **staged** changes, or **both** (the existing default).

## Changes

- **`DiffScope` enum** (`Unstaged`, `Staged`, `Both`) in `git_diff.rs` with `Both` as default to preserve existing behavior
- **`load_git_diff()`** now accepts a scope parameter and runs the appropriate git comparison:
  - `Unstaged` → `git diff` (index → worktree)
  - `Staged` → `git diff --cached` (HEAD → index)
  - `Both` → `git diff HEAD` (HEAD → worktree, unchanged)
- Untracked files are only included in `Unstaged` and `Both` scopes
- **`t` key** cycles scope: Both → Unstaged → Staged → Both
- File-list header shows the active scope: `Git Diff · Both`, `Git Diff · Unstaged`, `Git Diff · Staged`
- Help bar updated with `t scope` hint on both left and right panels

## Tests

- Integration test verifying each scope returns the correct hunks for a partially-staged file
- App test verifying `t` cycles the scope and updates the header/file list
- Updated existing component test expectations for the wider header text