### PR TITLE
feat(telemetry): interpolate OTLP header variables

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -64,6 +64,7 @@ dependencies = [
  "aether-project",
  "aether-telemetry",
  "aether-tui",
+ "aether-utils",
  "aether-wisp",
  "agent-client-protocol",
  "async-trait",
@@ -345,6 +346,7 @@ version = "0.1.2"
 dependencies = [
  "aether-agent-core",
  "aether-llm",
+ "aether-utils",
  "axum",
  "opentelemetry",
  "opentelemetry-otlp",

--- a/crates/aether-cli/Cargo.toml
+++ b/crates/aether-cli/Cargo.toml
@@ -56,6 +56,7 @@ tracing-appender = { workspace = true }
 futures = { workspace = true }
 dirs = { workspace = true }
 uuid = { workspace = true }
+utils = { package = "aether-utils", path = "../utils", version = "0.2.10" }
 tempfile = { workspace = true }
 crossterm = { workspace = true }
 url = { workspace = true }

--- a/crates/aether-cli/src/telemetry.rs
+++ b/crates/aether-cli/src/telemetry.rs
@@ -1,6 +1,7 @@
 use aether_project::TelemetrySettings;
 use aether_telemetry::{TelemetryConfig, TelemetryInitError, TelemetryRuntime};
 use std::sync::Arc;
+use utils::variables::Vars;
 
 pub(crate) fn build_telemetry_runtime(
     settings: Option<&TelemetrySettings>,
@@ -17,7 +18,7 @@ pub(crate) fn build_telemetry_runtime(
         endpoint: settings.otlp.endpoint.clone(),
         traces_endpoint: settings.otlp.traces_endpoint.clone(),
         metrics_endpoint: settings.otlp.metrics_endpoint.clone(),
-        headers: settings.otlp.headers.clone().into_iter().collect(),
+        headers: settings.otlp.resolved_headers(&Vars::new())?.into_iter().collect(),
         service_name: settings.service_name().to_string(),
         service_version: env!("CARGO_PKG_VERSION").to_string(),
         sample_ratio: settings.sample_ratio(),

--- a/crates/aether-project/src/aether_settings.rs
+++ b/crates/aether-project/src/aether_settings.rs
@@ -11,7 +11,7 @@ use serde::{Deserialize, Serialize};
 use std::collections::BTreeMap;
 use std::fs::read_to_string;
 use std::path::{Path, PathBuf};
-use utils::variables::VarError;
+use utils::variables::{VarError, Vars};
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
 #[serde(tag = "type", rename_all = "camelCase", deny_unknown_fields)]
@@ -201,6 +201,10 @@ impl TelemetrySignalSettings {
 }
 
 impl OtlpTelemetrySettings {
+    pub fn resolved_headers(&self, vars: &Vars) -> Result<BTreeMap<String, String>, VarError> {
+        self.headers.iter().map(|(name, value)| Ok((name.clone(), vars.expand(value)?))).collect()
+    }
+
     fn is_unset(&self) -> bool {
         self.endpoint.is_none()
             && self.traces_endpoint.is_none()
@@ -1417,6 +1421,41 @@ mod tests {
         .unwrap();
 
         assert_eq!(config.credentials_store, Some(CredentialsStoreConfig::Memory));
+    }
+
+    #[test]
+    fn expands_otlp_header_environment_variables() {
+        let settings = OtlpTelemetrySettings {
+            headers: BTreeMap::from([
+                ("authorization".to_string(), "Bearer $POSTHOG_PROJECT_TOKEN".to_string()),
+                ("x-project".to_string(), "${POSTHOG_PROJECT_TOKEN}".to_string()),
+                ("x-literal".to_string(), "$$POSTHOG_PROJECT_TOKEN".to_string()),
+            ]),
+            ..OtlpTelemetrySettings::default()
+        };
+        let vars = Vars::new().with_env_lookup(|name| (name == "POSTHOG_PROJECT_TOKEN").then(|| "token-value".into()));
+
+        assert_eq!(
+            settings.resolved_headers(&vars).unwrap(),
+            BTreeMap::from([
+                ("authorization".to_string(), "Bearer token-value".to_string()),
+                ("x-project".to_string(), "token-value".to_string()),
+                ("x-literal".to_string(), "$POSTHOG_PROJECT_TOKEN".to_string()),
+            ])
+        );
+    }
+
+    #[test]
+    fn reports_missing_otlp_header_environment_variables() {
+        let settings = OtlpTelemetrySettings {
+            headers: BTreeMap::from([("authorization".to_string(), "Bearer $POSTHOG_PROJECT_TOKEN".to_string())]),
+            ..OtlpTelemetrySettings::default()
+        };
+
+        assert!(matches!(
+            settings.resolved_headers(&Vars::new().with_env_lookup(|_| None)),
+            Err(VarError::NotFound(variable)) if variable == "POSTHOG_PROJECT_TOKEN"
+        ));
     }
 
     #[test]

--- a/crates/aether-telemetry/Cargo.toml
+++ b/crates/aether-telemetry/Cargo.toml
@@ -22,6 +22,7 @@ opentelemetry-semantic-conventions = { version = "0.32.1", features = ["semconv_
 reqwest = { workspace = true }
 serde_json = { workspace = true }
 thiserror = { workspace = true }
+utils = { package = "aether-utils", path = "../utils", version = "0.2.10" }
 tracing = { workspace = true }
 
 [dev-dependencies]

--- a/crates/aether-telemetry/src/error.rs
+++ b/crates/aether-telemetry/src/error.rs
@@ -1,9 +1,13 @@
+use utils::variables::VarError;
+
 use opentelemetry_otlp::ExporterBuildError;
 use opentelemetry_sdk::error::OTelSdkError;
 use thiserror::Error;
 
 #[derive(Debug, Error)]
 pub enum TelemetryInitError {
+    #[error("failed to resolve telemetry configuration: {0}")]
+    Variable(#[from] VarError),
     #[error("telemetry OTLP endpoint is required")]
     MissingOtlpEndpoint,
     #[error("telemetry sample ratio must be between 0.0 and 1.0, got {0}")]


### PR DESCRIPTION
## Summary
- expand OTLP telemetry header values with the existing `$VAR` / `${VAR}` variable utility
- surface missing environment variables as telemetry initialization errors
- cover interpolation, literal dollar escaping, and missing variables

## Validation
- `cargo test -p aether-project otlp_header_environment_variables`
- `cargo test -p aether-agent-cli --lib`
- `cargo test -p aether-telemetry --lib`
- workspace LSP diagnostics