### PR TITLE
feat: expose semantic context compaction lifecycle

### DIFF
--- a/crates/acp-utils/src/client/event.rs
+++ b/crates/acp-utils/src/client/event.rs
@@ -5,15 +5,16 @@ use agent_client_protocol as acp;
 use agent_client_protocol::schema::{SessionConfigOption, SessionId, SessionInfo};
 
 use crate::notifications::{
-    AuthMethodsUpdatedParams, ContextClearedParams, ContextUsageParams, ElicitationParams, ElicitationResponse,
-    McpNotification, PromptSearchResponse, SessionPreviewResponse, SubAgentProgressParams, WorkspaceListResponse,
-    WorkspaceMoveResponse,
+    AuthMethodsUpdatedParams, ContextClearedParams, ContextCompactionParams, ContextUsageParams, ElicitationParams,
+    ElicitationResponse, McpNotification, PromptSearchResponse, SessionPreviewResponse, SubAgentProgressParams,
+    WorkspaceListResponse, WorkspaceMoveResponse,
 };
 
 /// Events forwarded from the ACP connection to the main event loop.
 pub enum AcpEvent {
     SessionUpdate { session_id: SessionId, update: Box<SessionUpdate> },
     ContextCleared(ContextClearedParams),
+    ContextCompaction(ContextCompactionParams),
     ContextUsage(ContextUsageParams),
     SubAgentProgress(SubAgentProgressParams),
     AuthMethodsUpdated(AuthMethodsUpdatedParams),

--- a/crates/acp-utils/src/client/session.rs
+++ b/crates/acp-utils/src/client/session.rs
@@ -2,8 +2,8 @@ use super::error::AcpClientError;
 use super::event::AcpEvent;
 use super::prompt_handle::{AcpPromptHandle, PromptCommand};
 use crate::notifications::{
-    AuthMethodsUpdatedParams, ContextClearedParams, ContextUsageParams, ElicitationParams, McpNotification, McpRequest,
-    SubAgentProgressParams,
+    AuthMethodsUpdatedParams, ContextClearedParams, ContextCompactionParams, ContextUsageParams, ElicitationParams,
+    McpNotification, McpRequest, SubAgentProgressParams,
 };
 use agent_client_protocol::schema::{
     AuthMethod, AuthenticateRequest, CancelNotification, ConfigOptionUpdate, ContentBlock, InitializeRequest,
@@ -114,8 +114,8 @@ async fn run_client_connection(
         .on_receive_notification(
             {
                 let event_tx = event_tx.clone();
-                async move |p: ContextUsageParams, _cx| {
-                    let _ = event_tx.send(AcpEvent::ContextUsage(p));
+                async move |params: ContextUsageParams, _cx| {
+                    let _ = event_tx.send(AcpEvent::ContextUsage(params));
                     Ok(())
                 }
             },
@@ -124,8 +124,8 @@ async fn run_client_connection(
         .on_receive_notification(
             {
                 let event_tx = event_tx.clone();
-                async move |p: ContextClearedParams, _cx| {
-                    let _ = event_tx.send(AcpEvent::ContextCleared(p));
+                async move |params: ContextCompactionParams, _cx| {
+                    let _ = event_tx.send(AcpEvent::ContextCompaction(params));
                     Ok(())
                 }
             },
@@ -134,8 +134,8 @@ async fn run_client_connection(
         .on_receive_notification(
             {
                 let event_tx = event_tx.clone();
-                async move |p: SubAgentProgressParams, _cx| {
-                    let _ = event_tx.send(AcpEvent::SubAgentProgress(p));
+                async move |params: ContextClearedParams, _cx| {
+                    let _ = event_tx.send(AcpEvent::ContextCleared(params));
                     Ok(())
                 }
             },
@@ -144,8 +144,8 @@ async fn run_client_connection(
         .on_receive_notification(
             {
                 let event_tx = event_tx.clone();
-                async move |p: AuthMethodsUpdatedParams, _cx| {
-                    let _ = event_tx.send(AcpEvent::AuthMethodsUpdated(p));
+                async move |params: SubAgentProgressParams, _cx| {
+                    let _ = event_tx.send(AcpEvent::SubAgentProgress(params));
                     Ok(())
                 }
             },
@@ -154,8 +154,18 @@ async fn run_client_connection(
         .on_receive_notification(
             {
                 let event_tx = event_tx.clone();
-                async move |n: McpNotification, _cx| {
-                    let _ = event_tx.send(AcpEvent::McpNotification(n));
+                async move |params: AuthMethodsUpdatedParams, _cx| {
+                    let _ = event_tx.send(AcpEvent::AuthMethodsUpdated(params));
+                    Ok(())
+                }
+            },
+            acp::on_receive_notification!(),
+        )
+        .on_receive_notification(
+            {
+                let event_tx = event_tx.clone();
+                async move |params: McpNotification, _cx| {
+                    let _ = event_tx.send(AcpEvent::McpNotification(params));
                     Ok(())
                 }
             },

--- a/crates/acp-utils/src/notifications.rs
+++ b/crates/acp-utils/src/notifications.rs
@@ -71,6 +71,13 @@ pub struct ContextUsageParams {
     pub usage: ContextUsage,
 }
 
+/// Parameters for `_aether/context_compaction` notifications.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, JsonRpcNotification)]
+#[notification(method = "_aether/context_compaction")]
+pub struct ContextCompactionParams {
+    pub active: bool,
+}
+
 /// Parameters for `_aether/context_cleared` notifications.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Default, JsonRpcNotification)]
 #[notification(method = "_aether/context_cleared")]
@@ -414,6 +421,17 @@ mod tests {
         assert!(!raw.contains("\"cache_read_tokens\""));
         assert!(!raw.contains("\"cache_creation_tokens\""));
         assert!(!raw.contains("\"reasoning_tokens\""));
+    }
+
+    #[test]
+    fn context_compaction_params_roundtrip() {
+        for active in [true, false] {
+            let params = ContextCompactionParams { active };
+            let untyped = params.to_untyped_message().expect("serializable");
+            assert_eq!(untyped.method(), "_aether/context_compaction");
+            let parsed = ContextCompactionParams::parse_message(untyped.method(), untyped.params()).expect("roundtrip");
+            assert_eq!(parsed, params);
+        }
     }
 
     #[test]

--- a/crates/acp-utils/src/server/error.rs
+++ b/crates/acp-utils/src/server/error.rs
@@ -10,7 +10,7 @@ pub enum AcpServerError {
 }
 
 impl AcpServerError {
-    pub fn protocol(operation: &'static str, source: agent_client_protocol::Error) -> Self {
-        Self::Protocol { operation: operation.to_string(), source }
+    pub fn protocol(operation: impl Into<String>, source: agent_client_protocol::Error) -> Self {
+        Self::Protocol { operation: operation.into(), source }
     }
 }

--- a/crates/aether-cli/src/acp/protocol/events.rs
+++ b/crates/aether-cli/src/acp/protocol/events.rs
@@ -1,6 +1,6 @@
 use acp_utils::notifications::{
-    ContextClearedParams, ContextUsageParams, SubAgentEvent, SubAgentProgressParams, SubAgentToolCallUpdate,
-    SubAgentToolError, SubAgentToolRequest, SubAgentToolResult,
+    ContextClearedParams, ContextCompactionParams, ContextUsageParams, SubAgentEvent, SubAgentProgressParams,
+    SubAgentToolCallUpdate, SubAgentToolError, SubAgentToolRequest, SubAgentToolResult,
 };
 use aether_core::events::{
     AgentEvent, ContextEvent, MessageEvent, ModelEvent, SubAgentProgressPayload, ToolEvent, TurnEvent, TurnOutcome,
@@ -24,6 +24,7 @@ pub fn map_agent_event_to_session_notification(session_id: SessionId, msg: &Agen
 /// and is sent via [`ConnectionTo<Client>::send_notification`].
 pub enum AgentExtNotification {
     ContextUsage(ContextUsageParams),
+    ContextCompaction(ContextCompactionParams),
     ContextCleared(ContextClearedParams),
     SubAgentProgress(SubAgentProgressParams),
 }
@@ -32,6 +33,12 @@ pub fn try_into_agent_notification(msg: &AgentEvent) -> Option<AgentExtNotificat
     match msg {
         AgentEvent::Context(ContextEvent::UsageUpdated { usage }) => {
             Some(AgentExtNotification::ContextUsage(ContextUsageParams { usage: usage.clone() }))
+        }
+        AgentEvent::Context(ContextEvent::CompactionStarted { .. }) => {
+            Some(AgentExtNotification::ContextCompaction(ContextCompactionParams { active: true }))
+        }
+        AgentEvent::Context(ContextEvent::CompactionEnded { .. }) => {
+            Some(AgentExtNotification::ContextCompaction(ContextCompactionParams { active: false }))
         }
         AgentEvent::Tool(ToolEvent::Progress { request, message, .. }) => {
             let msg_str = message.as_ref()?;
@@ -118,6 +125,7 @@ pub(crate) fn map_agent_event_to_notification(
             ContextEvent::UsageUpdated { .. }
             | ContextEvent::Cleared
             | ContextEvent::CompactionStarted { .. }
+            | ContextEvent::CompactionEnded { .. }
             | ContextEvent::CompactionResult { .. },
         )
         | AgentEvent::Turn(
@@ -327,6 +335,7 @@ fn to_sub_agent_event(event: &AgentEvent) -> SubAgentEvent {
 mod tests {
     use super::*;
     use acp_utils::notifications::SubAgentEvent;
+    use aether_core::events::CompactionOutcome;
     use llm::ToolCallRequest;
 
     #[test]
@@ -545,6 +554,31 @@ mod tests {
             };
             assert_eq!(text.text, expected_text);
         }
+        Ok(())
+    }
+
+    #[test]
+    fn test_compaction_lifecycle_maps_to_agent_notifications() -> Result<(), String> {
+        let started = AgentEvent::Context(ContextEvent::CompactionStarted { message_count: 12 });
+        let started = try_into_agent_notification(&started).ok_or("compaction start notification")?;
+        let AgentExtNotification::ContextCompaction(started) = started else {
+            return Err("expected ContextCompaction".to_string());
+        };
+        assert!(started.active);
+
+        for outcome in [
+            CompactionOutcome::Completed,
+            CompactionOutcome::Failed { error: "failed".to_string() },
+            CompactionOutcome::Cancelled,
+        ] {
+            let ended = AgentEvent::Context(ContextEvent::CompactionEnded { outcome });
+            let ended = try_into_agent_notification(&ended).ok_or("compaction end notification")?;
+            let AgentExtNotification::ContextCompaction(ended) = ended else {
+                return Err("expected ContextCompaction".to_string());
+            };
+            assert!(!ended.active);
+        }
+
         Ok(())
     }
 

--- a/crates/aether-cli/src/acp/session_actor.rs
+++ b/crates/aether-cli/src/acp/session_actor.rs
@@ -5,7 +5,7 @@ use aether_core::agent_spec::AgentSpec;
 use aether_core::context::ext::{SessionControlEvent, SessionEvent, UserEvent, conversation_messages_from_events};
 use aether_core::events::{AgentCommand, AgentEvent, Command, ToolEvent, TurnOutcome};
 use agent_client_protocol::schema::{self as acp, PromptResponse, SessionId, SetSessionConfigOptionResponse};
-use agent_client_protocol::{Client, ConnectionTo, Responder};
+use agent_client_protocol::{Client, ConnectionTo, JsonRpcNotification, Responder};
 use llm::catalog::LlmModel;
 use llm::parser::ModelProviderParser;
 use llm::{ChatMessage, ContentBlock, ProviderConnectionOverrides, ReasoningEffort};
@@ -541,16 +541,19 @@ fn send_agent_notification(
     notification: AgentExtNotification,
 ) -> Result<(), AcpServerError> {
     match notification {
-        AgentExtNotification::ContextUsage(p) => {
-            connection.send_notification(p).map_err(|e| AcpServerError::protocol("_aether/context_usage", e))
-        }
-        AgentExtNotification::ContextCleared(p) => {
-            connection.send_notification(p).map_err(|e| AcpServerError::protocol("_aether/context_cleared", e))
-        }
-        AgentExtNotification::SubAgentProgress(p) => {
-            connection.send_notification(p).map_err(|e| AcpServerError::protocol("_aether/sub_agent_progress", e))
-        }
+        AgentExtNotification::ContextUsage(params) => send_extension_notification(connection, params),
+        AgentExtNotification::ContextCompaction(params) => send_extension_notification(connection, params),
+        AgentExtNotification::ContextCleared(params) => send_extension_notification(connection, params),
+        AgentExtNotification::SubAgentProgress(params) => send_extension_notification(connection, params),
     }
+}
+
+fn send_extension_notification<N: JsonRpcNotification>(
+    connection: &ConnectionTo<Client>,
+    notification: N,
+) -> Result<(), AcpServerError> {
+    let method = notification.method().to_string();
+    connection.send_notification(notification).map_err(|error| AcpServerError::protocol(method, error))
 }
 
 fn on_mcp_client_event(connection: &ConnectionTo<Client>, event: McpClientEvent) {

--- a/crates/aether-cli/src/acp/session_store.rs
+++ b/crates/aether-cli/src/acp/session_store.rs
@@ -348,6 +348,7 @@ pub(crate) fn should_persist_session_event(event: &SessionEvent) -> bool {
             )
             | AgentEvent::Context(
                 ContextEvent::CompactionStarted { .. }
+                | ContextEvent::CompactionEnded { .. }
                 | ContextEvent::CompactionResult { .. }
                 | ContextEvent::UsageUpdated { .. }
                 | ContextEvent::Cleared,

--- a/crates/aether-cli/src/headless/mod.rs
+++ b/crates/aether-cli/src/headless/mod.rs
@@ -35,6 +35,7 @@ pub enum CliEventKind {
     ModelSwitched,
     ToolProgress,
     ContextCompactionStarted,
+    ContextCompactionEnded,
     ContextCompactionResult,
     ContextUsage,
     ContextCleared,

--- a/crates/aether-cli/src/headless/run.rs
+++ b/crates/aether-cli/src/headless/run.rs
@@ -1,6 +1,7 @@
 use aether_core::core::{AgentDeps, Prompt};
 use aether_core::events::{
-    AgentEvent, Command, ContextEvent, LlmCallOutcome, MessageEvent, ModelEvent, ToolEvent, TurnEvent, TurnOutcome,
+    AgentEvent, Command, CompactionOutcome, ContextEvent, LlmCallOutcome, MessageEvent, ModelEvent, ToolEvent,
+    TurnEvent, TurnOutcome,
 };
 use aether_core::mcp::run_mcp_task::McpCommand;
 use aether_telemetry::TelemetryRuntime;
@@ -127,6 +128,7 @@ fn event_kind(msg: &AgentEvent) -> Option<CliEventKind> {
         AgentEvent::Model(ModelEvent::Switched { .. }) => Some(CliEventKind::ModelSwitched),
         AgentEvent::Tool(ToolEvent::Progress { .. }) => Some(CliEventKind::ToolProgress),
         AgentEvent::Context(ContextEvent::CompactionStarted { .. }) => Some(CliEventKind::ContextCompactionStarted),
+        AgentEvent::Context(ContextEvent::CompactionEnded { .. }) => Some(CliEventKind::ContextCompactionEnded),
         AgentEvent::Context(ContextEvent::CompactionResult { .. }) => Some(CliEventKind::ContextCompactionResult),
         AgentEvent::Context(ContextEvent::UsageUpdated { .. }) => Some(CliEventKind::ContextUsage),
         AgentEvent::Context(ContextEvent::Cleared) => Some(CliEventKind::ContextCleared),
@@ -199,6 +201,12 @@ fn format_text(msg: &AgentEvent) -> Option<String> {
         AgentEvent::Context(ContextEvent::CompactionStarted { message_count }) => {
             Some(format!("Context compaction started ({message_count} messages)"))
         }
+
+        AgentEvent::Context(ContextEvent::CompactionEnded { outcome }) => Some(match outcome {
+            CompactionOutcome::Completed => "Context compaction completed".to_string(),
+            CompactionOutcome::Failed { error } => format!("Context compaction failed: {error}"),
+            CompactionOutcome::Cancelled => "Context compaction cancelled".to_string(),
+        }),
 
         AgentEvent::Context(ContextEvent::CompactionResult { summary, messages_removed }) => {
             Some(format!("Context compacted: {messages_removed} messages removed. {summary}"))
@@ -492,6 +500,10 @@ mod tests {
             (
                 AgentEvent::Context(ContextEvent::CompactionStarted { message_count: 1 }),
                 CliEventKind::ContextCompactionStarted,
+            ),
+            (
+                AgentEvent::Context(ContextEvent::CompactionEnded { outcome: CompactionOutcome::Completed }),
+                CliEventKind::ContextCompactionEnded,
             ),
             (
                 AgentEvent::Context(ContextEvent::CompactionResult { summary: "s".to_string(), messages_removed: 1 }),

--- a/crates/aether-core/examples/basic_agent.rs
+++ b/crates/aether-core/examples/basic_agent.rs
@@ -55,6 +55,9 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             Some(AgentEvent::Context(ContextEvent::CompactionStarted { message_count })) => {
                 println!("Context compaction started: {message_count} messages");
             }
+            Some(AgentEvent::Context(ContextEvent::CompactionEnded { outcome })) => {
+                println!("Context compaction ended: {outcome:?}");
+            }
             Some(AgentEvent::Context(ContextEvent::CompactionResult { messages_removed, .. })) => {
                 println!("Context compacted: {messages_removed} messages removed");
             }

--- a/crates/aether-core/examples/mcp_agent.rs
+++ b/crates/aether-core/examples/mcp_agent.rs
@@ -64,6 +64,9 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             Some(AgentEvent::Context(ContextEvent::CompactionStarted { message_count })) => {
                 println!("Context compaction started: {message_count} messages");
             }
+            Some(AgentEvent::Context(ContextEvent::CompactionEnded { outcome })) => {
+                println!("Context compaction ended: {outcome:?}");
+            }
             Some(AgentEvent::Context(ContextEvent::CompactionResult { messages_removed, .. })) => {
                 println!("Context compacted: {messages_removed} messages removed");
             }

--- a/crates/aether-core/src/core/agent.rs
+++ b/crates/aether-core/src/core/agent.rs
@@ -2,8 +2,8 @@ use crate::context::{CompactionConfig, CompactionError, CompactionResult, Compac
 use crate::core::PromptCache;
 pub use crate::core::retry_config::RetryConfig;
 use crate::events::{
-    AgentCommand, AgentEvent, AgentObserver, Command, ContextEvent, ContextUsage, LlmCallOutcome, LlmCallPurpose,
-    ModelEvent, ToolEvent, TurnEvent, TurnOutcome, UserCommand,
+    AgentCommand, AgentEvent, AgentObserver, Command, CompactionOutcome, ContextEvent, ContextUsage, LlmCallOutcome,
+    LlmCallPurpose, ModelEvent, ToolEvent, TurnEvent, TurnOutcome, UserCommand,
 };
 use crate::mcp::run_mcp_task::{McpCommand, ToolExecutionEvent};
 use futures::Stream;
@@ -392,6 +392,8 @@ impl Agent {
                 outcome: LlmCallOutcome::Cancelled,
             }))
             .await;
+            self.emit(AgentEvent::Context(ContextEvent::CompactionEnded { outcome: CompactionOutcome::Cancelled }))
+                .await;
         }
         self.streams.remove(&StreamKey::Llm);
         for tool_id in self.active_requests.keys().cloned().collect::<Vec<_>>() {
@@ -601,8 +603,16 @@ impl Agent {
                     messages_removed: result.messages_removed,
                 }))
                 .await;
+                self.emit(AgentEvent::Context(ContextEvent::CompactionEnded { outcome: CompactionOutcome::Completed }))
+                    .await;
             }
-            Err(e) => tracing::warn!("Context compaction failed: {e}"),
+            Err(e) => {
+                tracing::warn!("Context compaction failed: {e}");
+                self.emit(AgentEvent::Context(ContextEvent::CompactionEnded {
+                    outcome: CompactionOutcome::Failed { error: e.to_string() },
+                }))
+                .await;
+            }
         }
 
         self.start_chat_turn().await;

--- a/crates/aether-core/src/events/agent_event.rs
+++ b/crates/aether-core/src/events/agent_event.rs
@@ -39,7 +39,7 @@ impl AgentEvent {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::events::{ContextUsage, LlmCallOutcome, LlmCallPurpose};
+    use crate::events::{CompactionOutcome, ContextUsage, LlmCallOutcome, LlmCallPurpose};
 
     #[test]
     fn serializes_nested_event_contract() {
@@ -60,6 +60,7 @@ mod tests {
                 outcome: LlmCallOutcome::Cancelled,
             }),
             AgentEvent::Context(ContextEvent::UsageUpdated { usage: ContextUsage::default() }),
+            AgentEvent::Context(ContextEvent::CompactionEnded { outcome: CompactionOutcome::Completed }),
             AgentEvent::Model(ModelEvent::Switched { previous: "a".into(), new: "b".into() }),
         ];
         for event in events {

--- a/crates/aether-core/src/events/context_event.rs
+++ b/crates/aether-core/src/events/context_event.rs
@@ -3,12 +3,23 @@ use serde::{Deserialize, Serialize};
 
 pub use acp_utils::notifications::ContextUsage;
 
+/// Terminal result of a context compaction operation.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+#[serde(tag = "status", rename_all = "snake_case")]
+pub enum CompactionOutcome {
+    Completed,
+    Failed { error: String },
+    Cancelled,
+}
+
 /// Context lifecycle events.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize, JsonSchema)]
 #[serde(tag = "type", rename_all = "snake_case")]
 pub enum ContextEvent {
     /// Context compaction has been triggered.
     CompactionStarted { message_count: usize },
+    /// Context compaction reached a terminal state.
+    CompactionEnded { outcome: CompactionOutcome },
     /// Context was compacted to reduce token usage.
     CompactionResult { summary: String, messages_removed: usize },
     /// Context usage update for UI display.

--- a/crates/aether-core/src/events/mod.rs
+++ b/crates/aether-core/src/events/mod.rs
@@ -17,7 +17,7 @@ mod user_message;
 
 pub use acp::{aether_tool_name_meta, humanize_tool_name, parse_tool_call_chunk};
 pub use agent_event::AgentEvent;
-pub use context_event::{ContextEvent, ContextUsage};
+pub use context_event::{CompactionOutcome, ContextEvent, ContextUsage};
 pub use message_event::MessageEvent;
 pub use model_event::ModelEvent;
 pub use observer::{AgentObserver, ObserverFactory};

--- a/crates/aether-core/src/testing/utils.rs
+++ b/crates/aether-core/src/testing/utils.rs
@@ -1,4 +1,3 @@
-use crate::events::{ToolEvent, TurnEvent};
 use std::collections::BTreeMap;
 use std::error::Error;
 use std::sync::{Arc, Mutex};
@@ -7,11 +6,13 @@ use tokio::sync::{Notify, mpsc};
 
 use crate::context::CompactionConfig;
 use crate::core::{Prompt, RetryConfig, agent};
-use crate::events::{AgentEvent, AgentObserver, Command, UserCommand};
+use crate::events::{
+    AgentCommand, AgentEvent, AgentObserver, Command, ContextEvent, ToolEvent, TurnEvent, UserCommand,
+};
 use crate::mcp::mcp;
 use crate::testing::fake_mcp::fake_mcp;
 use crate::testing::{AgentTrace, FakeAgentObserver, FakeMcpServer};
-use llm::{ChatMessage, Context, LlmError, LlmModel, LlmResponse, ModelSettings};
+use llm::{ChatMessage, Context, LlmError, LlmModel, LlmResponse, ModelSettings, StreamingModelProvider};
 
 use llm::testing::FakeLlmProvider;
 
@@ -63,8 +64,101 @@ impl TestAgentStep {
         Self::Send(command)
     }
 
+    pub fn user_text(text: impl Into<String>) -> Self {
+        Self::send(Command::UserCommand(UserCommand::Text { content: vec![llm::ContentBlock::text(text.into())] }))
+    }
+
+    pub fn cancel() -> Self {
+        Self::send(Command::UserCommand(UserCommand::Cancel))
+    }
+
+    pub fn switch_model(provider: impl StreamingModelProvider + 'static) -> Self {
+        Self::send(Command::AgentCommand(AgentCommand::SwitchModel(Box::new(provider))))
+    }
+
+    pub fn replace_conversation(messages: Vec<ChatMessage>) -> Self {
+        Self::send(Command::AgentCommand(AgentCommand::ReplaceConversation(messages)))
+    }
+
     pub fn wait_for(predicate: impl Fn(&AgentEvent) -> bool + Send + 'static) -> Self {
         Self::WaitFor(Box::new(predicate))
+    }
+
+    pub fn wait_for_turn_end() -> Self {
+        Self::wait_for(|event| matches!(event, AgentEvent::Turn(TurnEvent::Ended { .. })))
+    }
+
+    pub fn wait_for_compaction_start() -> Self {
+        Self::wait_for(|event| matches!(event, AgentEvent::Context(ContextEvent::CompactionStarted { .. })))
+    }
+
+    pub fn wait_for_retry(attempt: u32) -> Self {
+        Self::wait_for(
+            move |event| matches!(event, AgentEvent::Turn(TurnEvent::RetryScheduled { attempt: actual, .. }) if *actual == attempt),
+        )
+    }
+}
+
+/// A fluent sequence of commands and synchronization points for a test agent.
+#[derive(Default)]
+pub struct TestScenario {
+    steps: Vec<TestAgentStep>,
+}
+
+impl TestScenario {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    pub fn send(mut self, command: Command) -> Self {
+        self.steps.push(TestAgentStep::send(command));
+        self
+    }
+
+    pub fn user_text(mut self, text: impl Into<String>) -> Self {
+        self.steps.push(TestAgentStep::user_text(text));
+        self
+    }
+
+    pub fn cancel(mut self) -> Self {
+        self.steps.push(TestAgentStep::cancel());
+        self
+    }
+
+    pub fn switch_model(mut self, provider: impl StreamingModelProvider + 'static) -> Self {
+        self.steps.push(TestAgentStep::switch_model(provider));
+        self
+    }
+
+    pub fn replace_conversation(mut self, messages: Vec<ChatMessage>) -> Self {
+        self.steps.push(TestAgentStep::replace_conversation(messages));
+        self
+    }
+
+    pub fn wait_for(mut self, predicate: impl Fn(&AgentEvent) -> bool + Send + 'static) -> Self {
+        self.steps.push(TestAgentStep::wait_for(predicate));
+        self
+    }
+
+    pub fn wait_for_turn_end(mut self) -> Self {
+        self.steps.push(TestAgentStep::wait_for_turn_end());
+        self
+    }
+
+    pub fn wait_for_compaction_start(mut self) -> Self {
+        self.steps.push(TestAgentStep::wait_for_compaction_start());
+        self
+    }
+
+    pub fn wait_for_retry(mut self, attempt: u32) -> Self {
+        self.steps.push(TestAgentStep::wait_for_retry(attempt));
+        self
+    }
+}
+
+impl From<Vec<TestAgentStep>> for TestScenario {
+    fn from(steps: Vec<TestAgentStep>) -> Self {
+        Self { steps }
     }
 }
 
@@ -74,12 +168,14 @@ pub struct TestAgentResult {
     pub captured_contexts: Arc<Mutex<Vec<Context>>>,
 }
 
-pub struct TestAgentBuilder {
-    commands: Vec<Command>,
-    scenario: Option<Vec<TestAgentStep>>,
+struct ProviderTestConfig {
     responses: Vec<Vec<Result<LlmResponse, LlmError>>>,
     model: Option<LlmModel>,
-    provider_context_window: Option<u32>,
+    context_window: Option<u32>,
+    pause: Option<(usize, usize, Arc<Notify>)>,
+}
+
+struct AgentTestConfig {
     context_window_override: Option<u32>,
     timeout: Option<Duration>,
     max_auto_continues: Option<u32>,
@@ -88,9 +184,19 @@ pub struct TestAgentBuilder {
     include_fake_mcp: bool,
     initial_messages: Vec<ChatMessage>,
     system_prompt: Option<Prompt>,
-    compaction_config: Option<CompactionConfig>,
+    compaction: Option<CompactionConfig>,
     model_settings: Option<ModelSettings>,
-    pause: Option<(usize, usize, Arc<Notify>)>,
+}
+
+enum TestExecution {
+    CommandsUntilTurnEnd(Vec<Command>),
+    Scenario(TestScenario),
+}
+
+pub struct TestAgentBuilder {
+    provider: ProviderTestConfig,
+    agent: AgentTestConfig,
+    execution: Option<TestExecution>,
 }
 
 impl Default for TestAgentBuilder {
@@ -102,33 +208,29 @@ impl Default for TestAgentBuilder {
 impl TestAgentBuilder {
     pub fn new() -> Self {
         Self {
-            commands: Vec::new(),
-            scenario: None,
-            responses: Vec::new(),
-            model: None,
-            provider_context_window: None,
-            context_window_override: None,
-            timeout: None,
-            max_auto_continues: None,
-            retry_config: None,
-            observers: Vec::new(),
-            include_fake_mcp: true,
-            initial_messages: Vec::new(),
-            system_prompt: None,
-            compaction_config: None,
-            model_settings: None,
-            pause: None,
+            provider: ProviderTestConfig { responses: Vec::new(), model: None, context_window: None, pause: None },
+            agent: AgentTestConfig {
+                context_window_override: None,
+                timeout: None,
+                max_auto_continues: None,
+                retry_config: None,
+                observers: Vec::new(),
+                include_fake_mcp: true,
+                initial_messages: Vec::new(),
+                system_prompt: None,
+                compaction: None,
+                model_settings: None,
+            },
+            execution: None,
         }
     }
 
-    pub fn commands(mut self, commands: Vec<Command>) -> Self {
-        self.commands = commands;
-        self
+    pub fn commands(self, commands: Vec<Command>) -> Self {
+        self.with_execution(TestExecution::CommandsUntilTurnEnd(commands))
     }
 
-    pub fn scenario(mut self, steps: Vec<TestAgentStep>) -> Self {
-        self.scenario = Some(steps);
-        self
+    pub fn scenario(self, scenario: impl Into<TestScenario>) -> Self {
+        self.with_execution(TestExecution::Scenario(scenario.into()))
     }
 
     pub fn user_text(self, text: &str) -> Self {
@@ -136,85 +238,85 @@ impl TestAgentBuilder {
     }
 
     pub fn llm_responses(mut self, llm_responses: &[Vec<LlmResponse>]) -> Self {
-        self.responses = llm_responses.iter().map(|turn| turn.iter().cloned().map(Ok).collect()).collect();
+        self.provider.responses = llm_responses.iter().map(|turn| turn.iter().cloned().map(Ok).collect()).collect();
         self
     }
 
     pub fn llm_result_responses(mut self, llm_responses: &[Vec<Result<LlmResponse, LlmError>>]) -> Self {
-        self.responses = Vec::from(llm_responses);
+        self.provider.responses = Vec::from(llm_responses);
         self
     }
 
     pub fn model(mut self, model: LlmModel) -> Self {
-        self.model = Some(model);
+        self.provider.model = Some(model);
         self
     }
 
     pub fn provider_context_window(mut self, window: Option<u32>) -> Self {
-        self.provider_context_window = window;
+        self.provider.context_window = window;
         self
     }
 
     pub fn context_window_override(mut self, window: u32) -> Self {
-        self.context_window_override = Some(window);
+        self.agent.context_window_override = Some(window);
         self
     }
 
     pub fn tool_timeout(mut self, timeout: Duration) -> Self {
-        self.timeout = Some(timeout);
+        self.agent.timeout = Some(timeout);
         self
     }
 
     pub fn max_auto_continues(mut self, max: u32) -> Self {
-        self.max_auto_continues = Some(max);
+        self.agent.max_auto_continues = Some(max);
         self
     }
 
     pub fn retry_config(mut self, config: RetryConfig) -> Self {
-        self.retry_config = Some(config);
+        self.agent.retry_config = Some(config);
         self
     }
 
     /// Run without the default fake MCP server when the scenario does not exercise tools.
     pub fn without_mcp(mut self) -> Self {
-        self.include_fake_mcp = false;
+        self.agent.include_fake_mcp = false;
         self
     }
 
     /// Pre-populate the context with conversation history.
     pub fn messages(mut self, messages: Vec<ChatMessage>) -> Self {
-        self.initial_messages = messages;
+        self.agent.initial_messages = messages;
         self
     }
 
     /// Set the system prompt.
     pub fn system_prompt(mut self, prompt: Prompt) -> Self {
-        self.system_prompt = Some(prompt);
+        self.agent.system_prompt = Some(prompt);
         self
     }
 
     /// Configure context compaction settings.
     pub fn compaction_config(mut self, config: CompactionConfig) -> Self {
-        self.compaction_config = Some(config);
+        self.agent.compaction = Some(config);
         self
     }
 
     /// Set the model settings applied to every LLM call.
     pub fn model_settings(mut self, settings: ModelSettings) -> Self {
-        self.model_settings = Some(settings);
+        self.agent.model_settings = Some(settings);
         self
     }
 
     /// Pause the fake LLM stream at `turn_index` / `chunk_index` until
     /// `release.notify_one()` is called. Used for deterministic timing tests.
     pub fn pause_turn_after(mut self, turn_index: usize, chunk_index: usize, release: Arc<Notify>) -> Self {
-        self.pause = Some((turn_index, chunk_index, release));
+        self.provider.pause = Some((turn_index, chunk_index, release));
         self
     }
 
     /// Attach an observer of the test agent's event stream.
     pub fn observer(mut self, observer: Box<dyn AgentObserver>) -> Self {
-        self.observers.push(observer);
+        self.agent.observers.push(observer);
         self
     }
 
@@ -237,16 +339,17 @@ impl TestAgentBuilder {
     /// Use this when you need to verify what context was passed to the LLM,
     /// for example when testing that file attachments are properly formatted.
     pub async fn run_with_context(self) -> Result<TestAgentResult, Box<dyn Error>> {
-        let mut llm = FakeLlmProvider::from_results(self.responses).with_context_window(self.provider_context_window);
-        if let Some(model) = self.model {
+        let Self { provider, agent: config, execution } = self;
+        let mut llm = FakeLlmProvider::from_results(provider.responses).with_context_window(provider.context_window);
+        if let Some(model) = provider.model {
             llm = llm.with_model(model);
         }
-        if let Some((turn_index, chunk_index, release)) = self.pause {
+        if let Some((turn_index, chunk_index, release)) = provider.pause {
             llm = llm.pause_turn_after(turn_index, chunk_index, release);
         }
         let captured_contexts = llm.captured_contexts();
 
-        let mut mcp_spawn = if self.include_fake_mcp {
+        let mut mcp_spawn = if config.include_fake_mcp {
             Some(mcp("/workspace").with_servers(vec![fake_mcp("test", FakeMcpServer::new())]).spawn().await?)
         } else {
             None
@@ -257,40 +360,47 @@ impl TestAgentBuilder {
             let snapshot = spawn.block_until_ready().await.expect("bootstrap completes");
             builder = builder.tools(spawn.command_tx.clone(), snapshot.tool_definitions);
         }
-        if let Some(timeout) = self.timeout {
+        if let Some(timeout) = config.timeout {
             builder = builder.tool_timeout(timeout);
         }
-        if let Some(max) = self.max_auto_continues {
+        if let Some(max) = config.max_auto_continues {
             builder = builder.max_auto_continues(max);
         }
-        if let Some(retry) = self.retry_config {
+        if let Some(retry) = config.retry_config {
             builder = builder.retry(retry);
         } else {
             builder = builder.retry(RetryConfig::disabled());
         }
-        if let Some(prompt) = self.system_prompt {
+        if let Some(prompt) = config.system_prompt {
             builder = builder.system_prompt(prompt);
         }
-        if let Some(compaction) = self.compaction_config {
+        if let Some(compaction) = config.compaction {
             builder = builder.compaction(compaction);
         }
-        if let Some(settings) = self.model_settings {
+        if let Some(settings) = config.model_settings {
             builder = builder.model_settings(settings);
         }
-        builder = builder.context_window(self.context_window_override);
-        if !self.initial_messages.is_empty() {
-            builder = builder.messages(self.initial_messages);
+        builder = builder.context_window(config.context_window_override);
+        if !config.initial_messages.is_empty() {
+            builder = builder.messages(config.initial_messages);
         }
-        for observer in self.observers {
+        for observer in config.observers {
             builder = builder.observer(observer);
         }
 
+        let steps = match execution.expect("test agent requires commands(), user_text(), or scenario()") {
+            TestExecution::CommandsUntilTurnEnd(commands) => {
+                assert!(!commands.is_empty(), "commands() requires at least one command");
+                let mut steps = commands.into_iter().map(TestAgentStep::send).collect::<Vec<_>>();
+                steps.push(TestAgentStep::wait_for_turn_end());
+                steps
+            }
+            TestExecution::Scenario(scenario) => {
+                assert!(!scenario.steps.is_empty(), "scenario() requires at least one step");
+                scenario.steps
+            }
+        };
         let (tx, mut rx, handle) = builder.spawn().await?;
-        let steps = self.scenario.unwrap_or_else(|| {
-            let mut steps = self.commands.into_iter().map(TestAgentStep::send).collect::<Vec<_>>();
-            steps.push(TestAgentStep::wait_for(|event| matches!(event, AgentEvent::Turn(TurnEvent::Ended { .. }))));
-            steps
-        });
         let mut messages = Vec::new();
 
         for step in steps {
@@ -311,5 +421,11 @@ impl TestAgentBuilder {
         handle.await_completion().await;
 
         Ok(TestAgentResult { messages, captured_contexts })
+    }
+
+    fn with_execution(mut self, execution: TestExecution) -> Self {
+        assert!(self.execution.is_none(), "commands(), user_text(), and scenario() are mutually exclusive");
+        self.execution = Some(execution);
+        self
     }
 }

--- a/crates/aether-core/tests/agent.rs
+++ b/crates/aether-core/tests/agent.rs
@@ -5,6 +5,7 @@ mod agent {
     mod compaction_tests;
     mod context_window_tests;
     mod error_recovery_tests;
+    mod harness_tests;
     mod model_switch_tests;
     mod queued_message_tests;
     mod replace_conversation_tests;

--- a/crates/aether-core/tests/agent/agent_tests.rs
+++ b/crates/aether-core/tests/agent/agent_tests.rs
@@ -134,8 +134,10 @@ async fn test_tool_request_arg_emits_tool_call_update() -> Result<(), Box<dyn Er
     let tool_request = AddNumbersRequest::new(3, 5);
     let request_json = tool_request.json()?;
     let (arg_chunk_1, arg_chunk_2) = split_json_in_half(&request_json);
-    let llm_responses =
-        [llm_response("message_1").tool_call("call_1", "test__add_numbers", &[arg_chunk_1, arg_chunk_2]).build()];
+    let llm_responses = [
+        llm_response("message_1").tool_call("call_1", "test__add_numbers", &[arg_chunk_1, arg_chunk_2]).build(),
+        llm_response("message_2").text(&["done"]).build(),
+    ];
 
     let messages = test_agent()
         .llm_responses(&llm_responses)
@@ -268,7 +270,10 @@ async fn test_tool_timeout() -> Result<(), Box<dyn Error>> {
     let tool_request = SlowToolRequest::new(tool_duration);
     let (m1_id, t1_id, t1_name) = ("message_1", "call_1", "test__slow_tool");
 
-    let llm_responses = [llm_response(m1_id).tool_call(t1_id, t1_name, &[&tool_request.json()?]).build()];
+    let llm_responses = [
+        llm_response(m1_id).tool_call(t1_id, t1_name, &[&tool_request.json()?]).build(),
+        llm_response("message_2").text(&["done"]).build(),
+    ];
 
     let messages = test_agent()
         .llm_responses(&llm_responses)

--- a/crates/aether-core/tests/agent/cancel_tests.rs
+++ b/crates/aether-core/tests/agent/cancel_tests.rs
@@ -1,5 +1,5 @@
-use aether_core::events::{AgentEvent, Command, MessageEvent, TurnEvent, UserCommand};
-use aether_core::testing::{TestAgentStep, test_agent};
+use aether_core::events::{AgentEvent, MessageEvent, TurnEvent};
+use aether_core::testing::{TestScenario, test_agent};
 use llm::testing::llm_response;
 
 /// After cancelling, a new prompt should produce a normal response.
@@ -12,17 +12,14 @@ async fn test_prompt_after_cancel_produces_response() {
             llm_response("msg_1").text(&["Hello", " world", " this", " is", " a", " long", " response"]).build(),
             llm_response("msg_2").text(&["Second response"]).build(),
         ])
-        .scenario(vec![
-            TestAgentStep::send(Command::UserCommand(UserCommand::Text {
-                content: vec![llm::ContentBlock::text("first question")],
-            })),
-            TestAgentStep::send(Command::UserCommand(UserCommand::Cancel)),
-            TestAgentStep::wait_for(|event| matches!(event, AgentEvent::Turn(TurnEvent::Ended { .. }))),
-            TestAgentStep::send(Command::UserCommand(UserCommand::Text {
-                content: vec![llm::ContentBlock::text("second question")],
-            })),
-            TestAgentStep::wait_for(|event| matches!(event, AgentEvent::Turn(TurnEvent::Ended { .. }))),
-        ])
+        .scenario(
+            TestScenario::new()
+                .user_text("first question")
+                .cancel()
+                .wait_for_turn_end()
+                .user_text("second question")
+                .wait_for_turn_end(),
+        )
         .run()
         .await
         .unwrap();

--- a/crates/aether-core/tests/agent/compaction_tests.rs
+++ b/crates/aether-core/tests/agent/compaction_tests.rs
@@ -2,9 +2,9 @@ use std::sync::Arc;
 
 use aether_core::context::CompactionConfig;
 use aether_core::events::{
-    AgentEvent, Command, ContextEvent, LlmCallOutcome, LlmCallPurpose, TurnEvent, TurnOutcome, UserCommand,
+    AgentEvent, CompactionOutcome, ContextEvent, LlmCallOutcome, LlmCallPurpose, TurnEvent, TurnOutcome,
 };
-use aether_core::testing::{TestAgentStep, test_agent};
+use aether_core::testing::{TestScenario, test_agent};
 use llm::testing::llm_response;
 use llm::types::IsoString;
 use llm::{ChatMessage, ContentBlock};
@@ -47,14 +47,7 @@ async fn cancel_during_compaction_ends_the_turn() {
         .compaction_config(CompactionConfig::with_threshold(0.85))
         .messages(vec![user_message(&"x".repeat(400))])
         .pause_turn_after(0, 0, release)
-        .scenario(vec![
-            TestAgentStep::send(Command::UserCommand(UserCommand::Text { content: vec![ContentBlock::text("go")] })),
-            TestAgentStep::wait_for(|event| {
-                matches!(event, AgentEvent::Context(ContextEvent::CompactionStarted { .. }))
-            }),
-            TestAgentStep::send(Command::UserCommand(UserCommand::Cancel)),
-            TestAgentStep::wait_for(|event| matches!(event, AgentEvent::Turn(TurnEvent::Ended { .. }))),
-        ])
+        .scenario(TestScenario::new().user_text("go").wait_for_compaction_start().cancel().wait_for_turn_end())
         .run_trace()
         .await
         .unwrap();
@@ -69,6 +62,13 @@ async fn cancel_during_compaction_ends_the_turn() {
             })
         )),
         "cancel should end the in-flight compaction call"
+    );
+    assert!(
+        events.iter().any(|event| matches!(
+            event,
+            AgentEvent::Context(ContextEvent::CompactionEnded { outcome: CompactionOutcome::Cancelled })
+        )),
+        "cancel should end the semantic compaction lifecycle"
     );
     assert!(
         matches!(events.last(), Some(AgentEvent::Turn(TurnEvent::Ended { outcome: TurnOutcome::Cancelled }))),
@@ -91,16 +91,15 @@ async fn cancel_during_compaction_preserves_the_initiating_message() {
         .compaction_config(CompactionConfig::with_threshold(0.85))
         .messages(vec![user_message(&"x".repeat(400))])
         .pause_turn_after(0, 0, release)
-        .scenario(vec![
-            TestAgentStep::send(Command::UserCommand(UserCommand::Text { content: vec![ContentBlock::text("go")] })),
-            TestAgentStep::wait_for(|event| {
-                matches!(event, AgentEvent::Context(ContextEvent::CompactionStarted { .. }))
-            }),
-            TestAgentStep::send(Command::UserCommand(UserCommand::Cancel)),
-            TestAgentStep::wait_for(|event| matches!(event, AgentEvent::Turn(TurnEvent::Ended { .. }))),
-            TestAgentStep::send(Command::UserCommand(UserCommand::Text { content: vec![ContentBlock::text("next")] })),
-            TestAgentStep::wait_for(|event| matches!(event, AgentEvent::Turn(TurnEvent::Ended { .. }))),
-        ])
+        .scenario(
+            TestScenario::new()
+                .user_text("go")
+                .wait_for_compaction_start()
+                .cancel()
+                .wait_for_turn_end()
+                .user_text("next")
+                .wait_for_turn_end(),
+        )
         .run_with_context()
         .await
         .unwrap();

--- a/crates/aether-core/tests/agent/context_window_tests.rs
+++ b/crates/aether-core/tests/agent/context_window_tests.rs
@@ -1,5 +1,5 @@
-use aether_core::events::{AgentCommand, AgentEvent, Command, ContextEvent, ContextUsage};
-use aether_core::testing::{TestAgentStep, test_agent};
+use aether_core::events::{AgentEvent, ContextEvent, ContextUsage};
+use aether_core::testing::{TestScenario, test_agent};
 use llm::ModelSettings;
 use llm::testing::{FakeLlmProvider, llm_response};
 
@@ -55,12 +55,13 @@ async fn context_window_override_survives_model_switch() {
         .without_mcp()
         .provider_context_window(Some(128_000))
         .context_window_override(200_000)
-        .scenario(vec![
-            TestAgentStep::send(Command::AgentCommand(AgentCommand::SwitchModel(Box::new(
-                FakeLlmProvider::new(vec![]).with_display_name("new fake").with_context_window(Some(32_000)),
-            )))),
-            TestAgentStep::wait_for(|event| matches!(event, AgentEvent::Context(ContextEvent::UsageUpdated { .. }))),
-        ])
+        .scenario(
+            TestScenario::new()
+                .switch_model(
+                    FakeLlmProvider::new(vec![]).with_display_name("new fake").with_context_window(Some(32_000)),
+                )
+                .wait_for(|event| matches!(event, AgentEvent::Context(ContextEvent::UsageUpdated { .. }))),
+        )
         .run()
         .await
         .unwrap();

--- a/crates/aether-core/tests/agent/harness_tests.rs
+++ b/crates/aether-core/tests/agent/harness_tests.rs
@@ -1,0 +1,19 @@
+use aether_core::events::{Command, UserCommand};
+use aether_core::testing::{TestAgentStep, TestScenario, test_agent};
+
+#[test]
+fn scenario_steps_build_common_user_commands() {
+    let TestAgentStep::Send(Command::UserCommand(UserCommand::Text { content })) = TestAgentStep::user_text("hello")
+    else {
+        panic!("expected user text command");
+    };
+    assert_eq!(content, vec![llm::ContentBlock::text("hello")]);
+
+    assert!(matches!(TestAgentStep::cancel(), TestAgentStep::Send(Command::UserCommand(UserCommand::Cancel))));
+}
+
+#[test]
+#[should_panic(expected = "mutually exclusive")]
+fn builder_rejects_conflicting_execution_policies() {
+    let _ = test_agent().user_text("hello").scenario(TestScenario::new().wait_for_turn_end());
+}

--- a/crates/aether-core/tests/agent/replace_conversation_tests.rs
+++ b/crates/aether-core/tests/agent/replace_conversation_tests.rs
@@ -1,6 +1,6 @@
 use aether_core::core::Prompt;
-use aether_core::events::{AgentCommand, AgentEvent, Command, ContextEvent, TurnEvent, UserCommand};
-use aether_core::testing::{TestAgentStep, test_agent};
+use aether_core::events::{AgentEvent, ContextEvent};
+use aether_core::testing::{TestScenario, test_agent};
 use llm::testing::llm_response;
 use llm::types::IsoString;
 use llm::{AssistantReasoning, ChatMessage, ContentBlock};
@@ -10,18 +10,20 @@ async fn replace_conversation_preserves_system_prompt_for_next_request() {
     let result = test_agent()
         .system_prompt(Prompt::text("original system"))
         .llm_responses(&[llm_response("msg").build()])
-        .commands(vec![
-            Command::AgentCommand(AgentCommand::ReplaceConversation(vec![
-                ChatMessage::User { content: vec![ContentBlock::text("old user")], timestamp: IsoString::now() },
-                ChatMessage::Assistant {
-                    content: "old assistant".to_string(),
-                    reasoning: AssistantReasoning::default(),
-                    timestamp: IsoString::now(),
-                    tool_calls: vec![],
-                },
-            ])),
-            Command::UserCommand(UserCommand::Text { content: vec![ContentBlock::text("new user")] }),
-        ])
+        .scenario(
+            TestScenario::new()
+                .replace_conversation(vec![
+                    ChatMessage::User { content: vec![ContentBlock::text("old user")], timestamp: IsoString::now() },
+                    ChatMessage::Assistant {
+                        content: "old assistant".to_string(),
+                        reasoning: AssistantReasoning::default(),
+                        timestamp: IsoString::now(),
+                        tool_calls: vec![],
+                    },
+                ])
+                .user_text("new user")
+                .wait_for_turn_end(),
+        )
         .run_with_context()
         .await
         .unwrap();
@@ -44,17 +46,16 @@ async fn replace_conversation_preserves_token_usage() {
     let events = test_agent()
         .llm_responses(&[llm_response("msg").usage(800, 10).build()])
         .provider_context_window(Some(1000))
-        .scenario(vec![
-            TestAgentStep::send(Command::UserCommand(UserCommand::Text {
-                content: vec![ContentBlock::text("first user")],
-            })),
-            TestAgentStep::wait_for(|event| matches!(event, AgentEvent::Turn(TurnEvent::Ended { .. }))),
-            TestAgentStep::send(Command::AgentCommand(AgentCommand::ReplaceConversation(vec![ChatMessage::User {
-                content: vec![ContentBlock::text("replacement user")],
-                timestamp: IsoString::now(),
-            }]))),
-            TestAgentStep::wait_for(|event| matches!(event, AgentEvent::Context(ContextEvent::UsageUpdated { .. }))),
-        ])
+        .scenario(
+            TestScenario::new()
+                .user_text("first user")
+                .wait_for_turn_end()
+                .replace_conversation(vec![ChatMessage::User {
+                    content: vec![ContentBlock::text("replacement user")],
+                    timestamp: IsoString::now(),
+                }])
+                .wait_for(|event| matches!(event, AgentEvent::Context(ContextEvent::UsageUpdated { .. }))),
+        )
         .run()
         .await
         .unwrap();

--- a/crates/aether-core/tests/agent/trace_tests.rs
+++ b/crates/aether-core/tests/agent/trace_tests.rs
@@ -4,7 +4,7 @@ use std::time::Duration;
 
 use aether_core::core::RetryConfig;
 use aether_core::events::{AgentEvent, LlmCallOutcome, LlmCallPurpose, TurnOutcome};
-use aether_core::testing::{AddNumbersRequest, TestAgentStep, test_agent};
+use aether_core::testing::{AddNumbersRequest, TestScenario, test_agent};
 use llm::testing::llm_response;
 use llm::{LlmError, LlmResponse, StopReason};
 
@@ -140,16 +140,7 @@ async fn cancel_during_retry_wait_traces_cancelled_turn_without_starting_call() 
     let trace = test_agent()
         .retry_config(retry)
         .llm_result_responses(&attempts)
-        .scenario(vec![
-            TestAgentStep::send(aether_core::events::Command::UserCommand(aether_core::events::UserCommand::Text {
-                content: vec![llm::ContentBlock::text("go")],
-            })),
-            TestAgentStep::wait_for(|event| {
-                matches!(event, AgentEvent::Turn(TurnEvent::RetryScheduled { attempt: 1, .. }))
-            }),
-            TestAgentStep::send(aether_core::events::Command::UserCommand(aether_core::events::UserCommand::Cancel)),
-            TestAgentStep::wait_for(|event| matches!(event, AgentEvent::Turn(TurnEvent::Ended { .. }))),
-        ])
+        .scenario(TestScenario::new().user_text("go").wait_for_retry(1).cancel().wait_for_turn_end())
         .run_trace()
         .await?;
 

--- a/crates/aether-core/tests/mcp/oauth_tests.rs
+++ b/crates/aether-core/tests/mcp/oauth_tests.rs
@@ -7,21 +7,38 @@ use mcp_utils::status::{McpServerAuthCapability, McpServerStatus};
 use rmcp::transport::streamable_http_client::StreamableHttpClientTransportConfig;
 use std::sync::Arc;
 use tokio::sync::mpsc;
+use tokio::task::JoinHandle;
 
-fn http_mcp(name: &str, uri: &str) -> McpServer {
-    McpServer::new(name, McpTransport::Http { config: StreamableHttpClientTransportConfig::with_uri(uri) }, false)
+struct FailingHttpEndpoint {
+    uri: String,
+    task: JoinHandle<()>,
 }
 
-fn failing_http_mcp(name: &str) -> McpServer {
-    http_mcp(name, "http://localhost:19999/mcp")
+impl FailingHttpEndpoint {
+    async fn bind() -> Self {
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let uri = format!("http://{}/mcp", listener.local_addr().unwrap());
+        let task = tokio::spawn(async move {
+            while let Ok((stream, _)) = listener.accept().await {
+                drop(stream);
+            }
+        });
+        Self { uri, task }
+    }
+
+    fn server(&self, name: &str, proxied: bool) -> McpServer {
+        McpServer::new(
+            name,
+            McpTransport::Http { config: StreamableHttpClientTransportConfig::with_uri(self.uri.as_str()) },
+            proxied,
+        )
+    }
 }
 
-fn failing_http_mcp_proxied(name: &str) -> McpServer {
-    McpServer::new(
-        name,
-        McpTransport::Http { config: StreamableHttpClientTransportConfig::with_uri("http://localhost:19999/mcp") },
-        true,
-    )
+impl Drop for FailingHttpEndpoint {
+    fn drop(&mut self) {
+        self.task.abort();
+    }
 }
 
 fn test_manager(with_oauth: bool) -> McpManager {
@@ -113,15 +130,17 @@ async fn builder_with_oauth_handler_factory_spawns_successfully() {
 
 #[tokio::test]
 async fn http_server_without_handler_stashes_failed_status() {
+    let endpoint = FailingHttpEndpoint::bind().await;
     let mut manager = test_manager(false);
-    assert!(manager.add_mcps(vec![failing_http_mcp("test_server")]).await.is_ok());
+    assert!(manager.add_mcps(vec![endpoint.server("test_server", false)]).await.is_ok());
 }
 
 #[tokio::test]
 async fn http_server_with_handler_stashes_needs_oauth_on_failure() {
+    let endpoint = FailingHttpEndpoint::bind().await;
     let mut manager = test_manager(true);
 
-    assert!(manager.add_mcps(vec![failing_http_mcp("test_oauth_server")]).await.is_ok());
+    assert!(manager.add_mcps(vec![endpoint.server("test_oauth_server", false)]).await.is_ok());
 
     let statuses = manager.server_statuses();
     assert_eq!(statuses.len(), 1);
@@ -136,11 +155,12 @@ async fn http_server_with_handler_stashes_needs_oauth_on_failure() {
 
 #[tokio::test]
 async fn add_mcps_continues_on_oauth_failure() {
+    let endpoint = FailingHttpEndpoint::bind().await;
     let mut manager = test_manager(true);
 
     assert!(
         manager
-            .add_mcps(vec![failing_http_mcp("failing_server_1"), failing_http_mcp("failing_server_2")])
+            .add_mcps(vec![endpoint.server("failing_server_1", false), endpoint.server("failing_server_2", false)])
             .await
             .is_ok()
     );
@@ -177,9 +197,10 @@ async fn oauth_handler_is_dyn_compatible() {
 
 #[tokio::test]
 async fn tool_proxy_with_failing_http_surfaces_needs_oauth() {
+    let endpoint = FailingHttpEndpoint::bind().await;
     let (_home, mut manager) = test_manager_with_home(true);
 
-    let servers = vec![fake_mcp_with_proxy("local", FakeMcpServer::new(), true), failing_http_mcp_proxied("remote")];
+    let servers = vec![fake_mcp_with_proxy("local", FakeMcpServer::new(), true), endpoint.server("remote", true)];
 
     let _ = manager.add_mcps(servers).await;
     let statuses = manager.server_statuses();
@@ -206,9 +227,10 @@ async fn tool_proxy_with_failing_http_surfaces_needs_oauth() {
 
 #[tokio::test]
 async fn tool_proxy_partial_connection_works() {
+    let endpoint = FailingHttpEndpoint::bind().await;
     let (_home, mut manager) = test_manager_with_home(false);
 
-    let servers = vec![fake_mcp_with_proxy("working", FakeMcpServer::new(), true), failing_http_mcp_proxied("broken")];
+    let servers = vec![fake_mcp_with_proxy("working", FakeMcpServer::new(), true), endpoint.server("broken", true)];
 
     let _ = manager.add_mcps(servers).await;
 

--- a/crates/aether-core/tests/mcp/tool_proxy_tests.rs
+++ b/crates/aether-core/tests/mcp/tool_proxy_tests.rs
@@ -5,13 +5,17 @@ use mcp_utils::client::McpConnectionDetails;
 use std::time::Duration;
 use tokio::sync::mpsc;
 
-type ProxyEnv = (tempfile::TempDir, McpSpawnResult, McpConnectionDetails);
+struct ProxyFixture {
+    _home: tempfile::TempDir,
+    spawn: McpSpawnResult,
+    snapshot: McpConnectionDetails,
+}
 
-async fn spawn_proxy(servers: Vec<mcp_utils::client::McpServer>) -> ProxyEnv {
+async fn spawn_proxy(servers: Vec<mcp_utils::client::McpServer>) -> ProxyFixture {
     let aether_home = tempfile::tempdir().unwrap();
     let mut spawn = mcp("/workspace").with_aether_home(aether_home.path()).with_servers(servers).spawn().await.unwrap();
     let snapshot = spawn.block_until_ready().await.expect("bootstrap completes");
-    (aether_home, spawn, snapshot)
+    ProxyFixture { _home: aether_home, spawn, snapshot }
 }
 
 async fn call_proxy_tool(
@@ -47,17 +51,10 @@ fn extract_tool_dir(instructions: &str) -> Option<String> {
     Some(instructions[start..end].to_string())
 }
 
-fn cleanup_tool_dir(instructions: &std::collections::BTreeMap<String, String>, proxy_name: &str) {
-    if let Some(instr) = instructions.get(proxy_name)
-        && let Some(tool_dir) = extract_tool_dir(instr)
-    {
-        let _ = std::fs::remove_dir_all(tool_dir);
-    }
-}
-
 #[tokio::test]
 async fn test_tool_proxy_exposes_only_call_tool() {
-    let (_home, _spawn, snapshot) = spawn_proxy(vec![fake_mcp_with_proxy("math", FakeMcpServer::new(), true)]).await;
+    let ProxyFixture { _home, snapshot, .. } =
+        spawn_proxy(vec![fake_mcp_with_proxy("math", FakeMcpServer::new(), true)]).await;
 
     assert_eq!(snapshot.tool_definitions.len(), 1);
     assert_eq!(snapshot.tool_definitions[0].name, "proxy__call_tool");
@@ -66,7 +63,8 @@ async fn test_tool_proxy_exposes_only_call_tool() {
 
 #[tokio::test]
 async fn test_tool_proxy_instructions_mention_tool_directory() {
-    let (_home, _spawn, snapshot) = spawn_proxy(vec![fake_mcp_with_proxy("math", FakeMcpServer::new(), true)]).await;
+    let ProxyFixture { _home, snapshot, .. } =
+        spawn_proxy(vec![fake_mcp_with_proxy("math", FakeMcpServer::new(), true)]).await;
     let proxy_instr = proxy_instructions(&snapshot);
 
     assert!(proxy_instr.contains("tool-proxy"), "Instructions should mention tool-proxy directory: {proxy_instr}");
@@ -80,7 +78,8 @@ async fn test_tool_proxy_instructions_mention_tool_directory() {
 
 #[tokio::test]
 async fn test_tool_proxy_does_not_expose_nested_server_tools() {
-    let (_home, _spawn, snapshot) = spawn_proxy(vec![fake_mcp_with_proxy("math", FakeMcpServer::new(), true)]).await;
+    let ProxyFixture { _home, snapshot, .. } =
+        spawn_proxy(vec![fake_mcp_with_proxy("math", FakeMcpServer::new(), true)]).await;
 
     for td in &snapshot.tool_definitions {
         assert!(!td.name.contains("add_numbers"), "Nested tool should not be exposed: {}", td.name);
@@ -92,7 +91,8 @@ async fn test_tool_proxy_does_not_expose_nested_server_tools() {
 
 #[tokio::test]
 async fn test_tool_proxy_does_not_leak_nested_instructions() {
-    let (_home, _spawn, snapshot) = spawn_proxy(vec![fake_mcp_with_proxy("math", FakeMcpServer::new(), true)]).await;
+    let ProxyFixture { _home, snapshot, .. } =
+        spawn_proxy(vec![fake_mcp_with_proxy("math", FakeMcpServer::new(), true)]).await;
 
     assert!(
         !snapshot.instructions.contains_key("math"),
@@ -103,7 +103,8 @@ async fn test_tool_proxy_does_not_leak_nested_instructions() {
 
 #[tokio::test]
 async fn test_tool_proxy_writes_tool_files_to_disk() {
-    let (_home, _spawn, snapshot) = spawn_proxy(vec![fake_mcp_with_proxy("math", FakeMcpServer::new(), true)]).await;
+    let ProxyFixture { _home, snapshot, .. } =
+        spawn_proxy(vec![fake_mcp_with_proxy("math", FakeMcpServer::new(), true)]).await;
 
     let tool_dir = extract_tool_dir(proxy_instructions(&snapshot)).expect("Should find tool directory");
     let tool_dir = std::path::Path::new(&tool_dir);
@@ -120,23 +121,21 @@ async fn test_tool_proxy_writes_tool_files_to_disk() {
     assert_eq!(parsed["name"], "add_numbers");
     assert_eq!(parsed["server"], "math");
     assert!(parsed["description"].as_str().unwrap().contains("Adds two numbers"));
-
-    let _ = std::fs::remove_dir_all(tool_dir);
 }
 
 #[tokio::test]
 async fn test_tool_proxy_call_tool_routes_to_nested_server() {
-    let (_home, spawn, snapshot) = spawn_proxy(vec![fake_mcp_with_proxy("math", FakeMcpServer::new(), true)]).await;
+    let ProxyFixture { _home, spawn, snapshot: _snapshot } =
+        spawn_proxy(vec![fake_mcp_with_proxy("math", FakeMcpServer::new(), true)]).await;
 
     let result = call_proxy_tool(&spawn, "math", "add_numbers", serde_json::json!({"a": 3, "b": 4})).await;
     assert!(result.unwrap().contains('7'), "Expected result to contain sum of 3+4=7");
-
-    cleanup_tool_dir(&snapshot.instructions, "proxy");
 }
 
 #[tokio::test]
 async fn test_tool_proxy_call_tool_unknown_server_returns_error() {
-    let (_home, spawn, snapshot) = spawn_proxy(vec![fake_mcp_with_proxy("math", FakeMcpServer::new(), true)]).await;
+    let ProxyFixture { _home, spawn, snapshot: _snapshot } =
+        spawn_proxy(vec![fake_mcp_with_proxy("math", FakeMcpServer::new(), true)]).await;
 
     let err = call_proxy_tool(&spawn, "nonexistent", "some_tool", serde_json::json!({}))
         .await
@@ -145,13 +144,11 @@ async fn test_tool_proxy_call_tool_unknown_server_returns_error() {
         err.contains("nonexistent") || err.contains("not part of proxy") || err.contains("not connected"),
         "Expected error mentioning unknown server, got: {err}"
     );
-
-    cleanup_tool_dir(&snapshot.instructions, "proxy");
 }
 
 #[tokio::test]
 async fn test_tool_proxy_multiple_nested_servers() {
-    let (_home, _spawn, snapshot) = spawn_proxy(vec![
+    let ProxyFixture { _home, snapshot, .. } = spawn_proxy(vec![
         fake_mcp_with_proxy("server_a", FakeMcpServer::new(), true),
         fake_mcp_with_proxy("server_b", FakeMcpServer::new(), true),
     ])
@@ -167,19 +164,16 @@ async fn test_tool_proxy_multiple_nested_servers() {
     assert!(tool_dir.join("server_b").exists());
     assert!(tool_dir.join("server_a/add_numbers.json").exists());
     assert!(tool_dir.join("server_b/add_numbers.json").exists());
-
-    let _ = std::fs::remove_dir_all(tool_dir);
 }
 
 #[tokio::test]
 async fn test_tool_proxy_member_server_status_shows_connected_and_proxied() {
-    let (_home, _spawn, snapshot) = spawn_proxy(vec![fake_mcp_with_proxy("math", FakeMcpServer::new(), true)]).await;
+    let ProxyFixture { _home, snapshot, .. } =
+        spawn_proxy(vec![fake_mcp_with_proxy("math", FakeMcpServer::new(), true)]).await;
 
     assert!(!snapshot.server_statuses.iter().any(|s| s.name == "proxy"));
 
     let math_status = snapshot.server_statuses.iter().find(|s| s.name == "math").expect("Expected 'math' status entry");
     assert!(matches!(math_status.status, mcp_utils::status::McpServerStatus::Connected { .. }));
     assert!(math_status.proxied);
-
-    cleanup_tool_dir(&snapshot.instructions, "proxy");
 }

--- a/crates/aether-telemetry/tests/observer_tests.rs
+++ b/crates/aether-telemetry/tests/observer_tests.rs
@@ -3,10 +3,8 @@ use std::error::Error;
 use std::time::Duration;
 
 use aether_core::core::RetryConfig;
-use aether_core::events::{
-    AgentEvent, AgentObserver, Command, LlmCallOutcome, LlmCallPurpose, TurnEvent, TurnOutcome, UserCommand,
-};
-use aether_core::testing::{AddNumbersRequest, AgentTrace, DivideNumbersRequest, TestAgentStep, test_agent};
+use aether_core::events::{AgentEvent, AgentObserver, LlmCallOutcome, LlmCallPurpose, TurnEvent, TurnOutcome};
+use aether_core::testing::{AddNumbersRequest, AgentTrace, DivideNumbersRequest, TestScenario, test_agent};
 use aether_telemetry::{
     GENAI_SEMCONV_SCHEMA_URL, GenAiMetrics, OtelInstrumentation, OtelObserver, genai_instrumentation_scope,
 };
@@ -61,16 +59,7 @@ async fn failed_and_cancelled_calls_carry_error_attributes() -> Result<(), Box<d
     let trace = test_agent()
         .retry_config(retry)
         .llm_result_responses(&attempts)
-        .scenario(vec![
-            TestAgentStep::send(Command::UserCommand(UserCommand::Text {
-                content: vec![llm::ContentBlock::text("go")],
-            })),
-            TestAgentStep::wait_for(|event| {
-                matches!(event, AgentEvent::Turn(TurnEvent::RetryScheduled { attempt: 1, .. }))
-            }),
-            TestAgentStep::send(Command::UserCommand(UserCommand::Cancel)),
-            TestAgentStep::wait_for(|event| matches!(event, AgentEvent::Turn(TurnEvent::Ended { .. }))),
-        ])
+        .scenario(TestScenario::new().user_text("go").wait_for_retry(1).cancel().wait_for_turn_end())
         .run_trace()
         .await?;
 

--- a/crates/wisp/examples/wisp_gallery.rs
+++ b/crates/wisp/examples/wisp_gallery.rs
@@ -10,7 +10,7 @@ use wisp::components::command_picker::{CommandEntry, CommandPicker};
 use wisp::components::file_picker::{FileMatch, FilePicker};
 use wisp::components::plan_review::PlanDocument;
 use wisp::components::plan_view::PlanView;
-use wisp::components::progress_indicator::{ProgressIndicator, WorkspaceProgress};
+use wisp::components::progress_indicator::{ProgressActivity, ProgressIndicator, WorkspaceProgress};
 use wisp::components::status_line::{ContextUsageDisplay, StatusLine};
 use wisp::components::text_input::TextInput;
 use wisp::components::thought_message::ThoughtMessage;
@@ -385,7 +385,7 @@ fn stories() -> Vec<(String, WispStory)> {
             "ProgressIndicator".into(),
             WispStory::ProgressIndicator({
                 let mut indicator = ProgressIndicator::default();
-                indicator.update(true, WorkspaceProgress::None);
+                indicator.update(ProgressActivity::new(true, WorkspaceProgress::None, false));
                 ProgressIndicatorStory { indicator }
             }),
         ),

--- a/crates/wisp/src/components/app/mod.rs
+++ b/crates/wisp/src/components/app/mod.rs
@@ -181,6 +181,9 @@ impl App {
                 self.conversation_screen.reset_after_context_cleared();
                 self.context_usage = None;
             }
+            AcpEvent::ContextCompaction(params) => {
+                self.conversation_screen.set_compaction_active(params.active);
+            }
             AcpEvent::ContextUsage(params) => {
                 self.context_usage = params
                     .usage
@@ -852,7 +855,7 @@ mod tests {
     use crate::components::conversation_screen::Modal;
     use crate::components::conversation_window::SegmentContent;
     use crate::components::elicitation_form::ElicitationForm;
-    use crate::components::progress_indicator::WorkspaceProgress;
+    use crate::components::progress_indicator::{ProgressActivity, WorkspaceProgress};
     use crate::settings::{DEFAULT_CONTENT_PADDING, save_settings};
     use crate::settings::{ThemeSettings, WispSettings};
     use crate::test_helpers::{elicitation_params, modified_key, url_elicitation_params, with_wisp_home};
@@ -1440,7 +1443,11 @@ mod tests {
         let mut app = make_app();
         let tool_call = acp::ToolCall::new("tool-1".to_string(), "test_tool");
         app.conversation_screen.tool_call_statuses.on_tool_call(&tool_call);
-        app.conversation_screen.progress_indicator.update(true, WorkspaceProgress::default());
+        app.conversation_screen.progress_indicator.update(ProgressActivity::new(
+            true,
+            WorkspaceProgress::default(),
+            false,
+        ));
 
         let ctx = ViewContext::new((80, 24));
         let tool_before = app.conversation_screen.tool_call_statuses.render_tool("tool-1", &ctx);

--- a/crates/wisp/src/components/conversation_screen.rs
+++ b/crates/wisp/src/components/conversation_screen.rs
@@ -4,7 +4,7 @@ use crate::components::conversation_window::{ConversationBuffer, ConversationWin
 use crate::components::elicitation_form::{ElicitationForm, ElicitationMessage};
 use crate::components::plan_tracker::PlanTracker;
 use crate::components::plan_view::PlanView;
-use crate::components::progress_indicator::{ProgressIndicator, WorkspaceProgress};
+use crate::components::progress_indicator::{ProgressActivity, ProgressIndicator, WorkspaceProgress};
 use crate::components::prompt_composer::{PromptComposer, PromptComposerMessage};
 use crate::components::session_picker::{SessionEntry, SessionPicker, SessionPickerMessage};
 use crate::components::tool_call_statuses::{PromptTermination, ToolCallStatuses};
@@ -73,6 +73,7 @@ pub struct ConversationScreen {
     pub(crate) plan_tracker: PlanTracker,
     pub(crate) progress_indicator: ProgressIndicator,
     pub(crate) workspace_move_state: WorkspaceMoveState,
+    compaction_active: bool,
     waiting_for_response: bool,
     pub(crate) active_modal: Option<Modal>,
     pub(crate) content_padding: usize,
@@ -94,6 +95,7 @@ impl ConversationScreen {
             plan_tracker: PlanTracker::default(),
             progress_indicator: ProgressIndicator::default(),
             workspace_move_state: WorkspaceMoveState::Idle,
+            compaction_active: false,
             waiting_for_response: false,
             active_modal: None,
             content_padding,
@@ -122,12 +124,17 @@ impl ConversationScreen {
         self.waiting_for_response = true;
     }
 
+    pub fn set_compaction_active(&mut self, active: bool) {
+        self.compaction_active = active;
+    }
+
     pub fn is_busy(&self) -> bool {
         self.waiting_for_response || self.tool_call_statuses.running_any()
     }
 
     pub fn wants_tick(&self) -> bool {
         self.is_busy()
+            || self.compaction_active
             || self.workspace_move_state.progress() != WorkspaceProgress::None
             || self.plan_tracker_has_tick_driven_visibility()
     }
@@ -139,7 +146,11 @@ impl ConversationScreen {
     }
 
     pub fn refresh_caches(&mut self, _context: &ViewContext) {
-        self.progress_indicator.update(self.is_busy(), self.workspace_move_state.progress());
+        self.progress_indicator.update(ProgressActivity::new(
+            self.is_busy(),
+            self.workspace_move_state.progress(),
+            self.compaction_active,
+        ));
         self.plan_tracker.cached_visible_entries();
     }
 
@@ -148,6 +159,7 @@ impl ConversationScreen {
         self.tool_call_statuses.clear();
         self.waiting_for_response = false;
         self.workspace_move_state = WorkspaceMoveState::Idle;
+        self.compaction_active = false;
         self.plan_tracker.clear();
         self.progress_indicator = ProgressIndicator::default();
         self.pending_url_elicitations.clear();
@@ -281,12 +293,14 @@ impl ConversationScreen {
 
     fn on_prompt_terminated(&mut self, termination: &PromptTermination) {
         self.waiting_for_response = false;
+        self.compaction_active = false;
         self.tool_call_statuses.finalize_running(termination);
         self.conversation.close_thought_block();
     }
 
     pub fn reject_local_prompt(&mut self, message: &str) {
         self.waiting_for_response = false;
+        self.compaction_active = false;
         self.conversation.push_user_message(&format!("[wisp] {message}"));
     }
 

--- a/crates/wisp/src/components/progress_indicator.rs
+++ b/crates/wisp/src/components/progress_indicator.rs
@@ -22,25 +22,78 @@ pub enum WorkspaceProgress {
     LoadingSession,
 }
 
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
+pub struct ProgressActivity {
+    pub agent_busy: bool,
+    pub workspace: WorkspaceProgress,
+    pub compaction_active: bool,
+}
+
+impl ProgressActivity {
+    pub fn new(agent_busy: bool, workspace: WorkspaceProgress, compaction_active: bool) -> Self {
+        Self { agent_busy, workspace, compaction_active }
+    }
+
+    fn display(self) -> ProgressDisplay {
+        match self.workspace {
+            WorkspaceProgress::Moving => ProgressDisplay::MovingWorkspace { interruptible: self.agent_busy },
+            WorkspaceProgress::LoadingSession => ProgressDisplay::LoadingSession { interruptible: self.agent_busy },
+            WorkspaceProgress::None if self.compaction_active => {
+                ProgressDisplay::Compacting { interruptible: self.agent_busy }
+            }
+            WorkspaceProgress::None if self.agent_busy => ProgressDisplay::AgentWorking,
+            WorkspaceProgress::None => ProgressDisplay::Idle,
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
+enum ProgressDisplay {
+    #[default]
+    Idle,
+    AgentWorking,
+    Compacting {
+        interruptible: bool,
+    },
+    MovingWorkspace {
+        interruptible: bool,
+    },
+    LoadingSession {
+        interruptible: bool,
+    },
+}
+
+impl ProgressDisplay {
+    fn is_active(self) -> bool {
+        self != Self::Idle
+    }
+
+    fn is_interruptible(self) -> bool {
+        match self {
+            Self::AgentWorking => true,
+            Self::Compacting { interruptible }
+            | Self::MovingWorkspace { interruptible }
+            | Self::LoadingSession { interruptible } => interruptible,
+            Self::Idle => false,
+        }
+    }
+}
+
 #[derive(Default)]
 pub struct ProgressIndicator {
-    agent_busy: bool,
-    workspace_progress: WorkspaceProgress,
+    display: ProgressDisplay,
     tick: u16,
-    was_active: bool,
+    agent_was_busy: bool,
     turn_count: usize,
 }
 
 impl ProgressIndicator {
-    pub fn update(&mut self, agent_busy: bool, workspace_progress: WorkspaceProgress) {
-        let previously_active = self.was_active;
-        self.agent_busy = agent_busy;
-        self.workspace_progress = workspace_progress;
-        let now_active = self.is_active();
-        self.was_active = now_active;
-        if !previously_active && now_active {
+    pub fn update(&mut self, activity: ProgressActivity) {
+        if !self.agent_was_busy && activity.agent_busy {
             self.turn_count += 1;
         }
+        self.agent_was_busy = activity.agent_busy;
+        self.display = activity.display();
     }
 
     #[cfg(test)]
@@ -54,16 +107,18 @@ impl ProgressIndicator {
     }
 
     fn is_active(&self) -> bool {
-        self.agent_busy || self.workspace_progress != WorkspaceProgress::None
+        self.display.is_active()
     }
 
     fn current_message(&self) -> &'static str {
-        match self.workspace_progress {
-            WorkspaceProgress::Moving => "Moving workspace...",
-            WorkspaceProgress::LoadingSession => "Loading session in new workspace...",
-            WorkspaceProgress::None => {
+        match self.display {
+            ProgressDisplay::MovingWorkspace { .. } => "Moving workspace...",
+            ProgressDisplay::LoadingSession { .. } => "Loading session in new workspace...",
+            ProgressDisplay::Compacting { .. } => "Compacting context...",
+            ProgressDisplay::AgentWorking => {
                 self.turn_count.checked_sub(1).and_then(|i| MESSAGES.get(i)).copied().unwrap_or("Working...")
             }
+            ProgressDisplay::Idle => "",
         }
     }
 
@@ -83,9 +138,14 @@ impl ProgressIndicator {
 
         let frame_char = FRAMES[self.tick as usize % FRAMES.len()];
         let mut line = Line::default();
-        line.push_styled(frame_char.to_string(), context.theme.info());
+        let spinner_color = if matches!(self.display, ProgressDisplay::Compacting { .. }) {
+            context.theme.warning()
+        } else {
+            context.theme.info()
+        };
+        line.push_styled(frame_char.to_string(), spinner_color);
         line.push_styled(format!(" {}", self.current_message()), context.theme.text_secondary());
-        if self.agent_busy {
+        if self.display.is_interruptible() {
             line.push_with_style("  (esc to interrupt)".to_string(), Style::fg(context.theme.muted()).italic());
         }
 
@@ -112,15 +172,15 @@ mod tests {
     #[test]
     fn renders_nothing_after_busy_clears() {
         let mut indicator = ProgressIndicator::default();
-        indicator.update(true, WorkspaceProgress::None);
-        indicator.update(false, WorkspaceProgress::None);
+        indicator.update(ProgressActivity::new(true, WorkspaceProgress::None, false));
+        indicator.update(ProgressActivity::new(false, WorkspaceProgress::None, false));
         assert!(indicator.render(&ctx()).lines().is_empty());
     }
 
     #[test]
     fn renders_esc_hint_when_agent_busy() {
         let mut indicator = ProgressIndicator::default();
-        indicator.update(true, WorkspaceProgress::None);
+        indicator.update(ProgressActivity::new(true, WorkspaceProgress::None, false));
         let frame = indicator.render(&ctx());
         let lines = frame.lines();
         assert_eq!(lines.len(), 3);
@@ -131,9 +191,9 @@ mod tests {
     #[test]
     fn spinner_animates_with_tick() {
         let mut a = ProgressIndicator::default();
-        a.update(true, WorkspaceProgress::None);
+        a.update(ProgressActivity::new(true, WorkspaceProgress::None, false));
         let mut b = ProgressIndicator::default();
-        b.update(true, WorkspaceProgress::None);
+        b.update(ProgressActivity::new(true, WorkspaceProgress::None, false));
         b.set_tick(1);
         let text_a = a.render(&ctx()).lines()[1].plain_text();
         let text_b = b.render(&ctx()).lines()[1].plain_text();
@@ -143,7 +203,7 @@ mod tests {
     #[test]
     fn on_tick_advances_when_busy() {
         let mut indicator = ProgressIndicator::default();
-        indicator.update(true, WorkspaceProgress::None);
+        indicator.update(ProgressActivity::new(true, WorkspaceProgress::None, false));
         let tick_before = indicator.tick;
         indicator.on_tick();
         assert_ne!(indicator.tick, tick_before);
@@ -152,7 +212,7 @@ mod tests {
     #[test]
     fn on_tick_noop_when_idle() {
         let mut indicator = ProgressIndicator::default();
-        indicator.update(false, WorkspaceProgress::None);
+        indicator.update(ProgressActivity::new(false, WorkspaceProgress::None, false));
         indicator.on_tick();
         assert!(indicator.render(&ctx()).lines().is_empty());
     }
@@ -160,7 +220,7 @@ mod tests {
     #[test]
     fn first_turn_shows_first_tip() {
         let mut indicator = ProgressIndicator::default();
-        indicator.update(true, WorkspaceProgress::None);
+        indicator.update(ProgressActivity::new(true, WorkspaceProgress::None, false));
         indicator.set_turn_count(1);
         let frame = indicator.render(&ctx());
         let text = frame.lines()[1].plain_text();
@@ -170,13 +230,13 @@ mod tests {
     #[test]
     fn tip_advances_each_turn() {
         let mut indicator = ProgressIndicator::default();
-        indicator.update(true, WorkspaceProgress::None);
+        indicator.update(ProgressActivity::new(true, WorkspaceProgress::None, false));
         assert_eq!(indicator.turn_count, 1);
         let tip_0 = indicator.render(&ctx()).lines()[1].plain_text();
 
-        indicator.update(false, WorkspaceProgress::None);
+        indicator.update(ProgressActivity::new(false, WorkspaceProgress::None, false));
 
-        indicator.update(true, WorkspaceProgress::None);
+        indicator.update(ProgressActivity::new(true, WorkspaceProgress::None, false));
         assert_eq!(indicator.turn_count, 2);
         let tip_1 = indicator.render(&ctx()).lines()[1].plain_text();
 
@@ -188,7 +248,7 @@ mod tests {
     #[test]
     fn shows_working_after_tips_exhausted() {
         let mut indicator = ProgressIndicator::default();
-        indicator.update(true, WorkspaceProgress::None);
+        indicator.update(ProgressActivity::new(true, WorkspaceProgress::None, false));
         indicator.set_turn_count(MESSAGES.len() + 1);
         let text = indicator.render(&ctx()).lines()[1].plain_text();
         assert!(text.contains("Working..."));
@@ -197,7 +257,7 @@ mod tests {
     #[test]
     fn reset_restarts_tips() {
         let mut indicator = ProgressIndicator::default();
-        indicator.update(true, WorkspaceProgress::None);
+        indicator.update(ProgressActivity::new(true, WorkspaceProgress::None, false));
         assert_eq!(indicator.turn_count, 1);
 
         let indicator = ProgressIndicator::default();
@@ -207,7 +267,7 @@ mod tests {
     #[test]
     fn renders_workspace_move_without_interrupt_hint() {
         let mut indicator = ProgressIndicator::default();
-        indicator.update(false, WorkspaceProgress::Moving);
+        indicator.update(ProgressActivity::new(false, WorkspaceProgress::Moving, false));
         let text = indicator.render(&ctx()).lines()[1].plain_text();
         assert!(text.contains("Moving workspace..."));
         assert!(!text.contains("esc to interrupt"));
@@ -216,7 +276,7 @@ mod tests {
     #[test]
     fn workspace_move_message_takes_precedence_when_agent_is_busy() {
         let mut indicator = ProgressIndicator::default();
-        indicator.update(true, WorkspaceProgress::Moving);
+        indicator.update(ProgressActivity::new(true, WorkspaceProgress::Moving, false));
         let text = indicator.render(&ctx()).lines()[1].plain_text();
         assert!(text.contains("Moving workspace..."));
         assert!(text.contains("esc to interrupt"));
@@ -225,20 +285,33 @@ mod tests {
     #[test]
     fn renders_workspace_session_load_without_interrupt_hint() {
         let mut indicator = ProgressIndicator::default();
-        indicator.update(false, WorkspaceProgress::LoadingSession);
+        indicator.update(ProgressActivity::new(false, WorkspaceProgress::LoadingSession, false));
         let text = indicator.render(&ctx()).lines()[1].plain_text();
         assert!(text.contains("Loading session in new workspace..."));
         assert!(!text.contains("esc to interrupt"));
     }
 
     #[test]
+    fn non_agent_activity_does_not_advance_turn_tips() {
+        let mut indicator = ProgressIndicator::default();
+        indicator.update(ProgressActivity::new(false, WorkspaceProgress::Moving, false));
+        indicator.update(ProgressActivity::new(false, WorkspaceProgress::None, false));
+        indicator.update(ProgressActivity::new(false, WorkspaceProgress::None, true));
+        indicator.update(ProgressActivity::new(false, WorkspaceProgress::None, false));
+        indicator.update(ProgressActivity::new(true, WorkspaceProgress::None, false));
+
+        let text = indicator.render(&ctx()).lines()[1].plain_text();
+        assert!(text.contains(MESSAGES[0]));
+    }
+
+    #[test]
     fn staying_active_does_not_advance_tip() {
         let mut indicator = ProgressIndicator::default();
-        indicator.update(true, WorkspaceProgress::None);
+        indicator.update(ProgressActivity::new(true, WorkspaceProgress::None, false));
         assert_eq!(indicator.turn_count, 1);
 
-        indicator.update(true, WorkspaceProgress::None);
-        indicator.update(true, WorkspaceProgress::None);
+        indicator.update(ProgressActivity::new(true, WorkspaceProgress::None, false));
+        indicator.update(ProgressActivity::new(true, WorkspaceProgress::None, false));
         assert_eq!(indicator.turn_count, 1);
     }
 }

--- a/crates/wisp/tests/app_tests/common.rs
+++ b/crates/wisp/tests/app_tests/common.rs
@@ -307,6 +307,13 @@ impl Renderer {
         Ok(())
     }
 
+    pub(super) fn on_context_compaction(&mut self, active: bool) -> Result<(), Box<dyn std::error::Error>> {
+        self.handle_acp_event(AcpEvent::ContextCompaction(acp_utils::notifications::ContextCompactionParams {
+            active,
+        }))?;
+        Ok(())
+    }
+
     pub(super) fn on_context_cleared(&mut self) -> Result<(), Box<dyn std::error::Error>> {
         self.handle_acp_event(AcpEvent::ContextCleared(acp_utils::notifications::ContextClearedParams::default()))?;
         Ok(())

--- a/crates/wisp/tests/app_tests/progress_indicator_tests.rs
+++ b/crates/wisp/tests/app_tests/progress_indicator_tests.rs
@@ -1,6 +1,66 @@
 use tui::testing::assert_buffer_eq;
+use tui::{BRAILLE_FRAMES, ViewContext};
 
 use super::common::*;
+
+fn spinner_on_row(lines: &[String], row: usize) -> char {
+    lines[row].chars().find(|character| BRAILLE_FRAMES.contains(character)).expect("spinner")
+}
+
+#[tokio::test]
+async fn test_compaction_overrides_progress_indicator_and_restores_it_afterward() -> TestResult {
+    let mut renderer = RendererTest::new().size((TEST_WIDTH, 40)).build()?;
+
+    type_string(&mut renderer, "Hello").await?;
+    press(&mut renderer, Enter).await?;
+    renderer.on_context_compaction(true)?;
+
+    let lines = renderer.writer().get_lines();
+    let row = lines.iter().position(|line| line.contains("Compacting context...")).expect("compaction message");
+    assert!(lines[row].contains("esc to interrupt"));
+    let spinner = spinner_on_row(&lines, row);
+    let spinner_style = renderer.writer().style_of_text(row, &spinner.to_string()).expect("spinner style");
+    assert_eq!(spinner_style.fg, Some(ViewContext::new((TEST_WIDTH, 40)).theme.warning()));
+
+    renderer.on_context_compaction(false)?;
+    let lines = renderer.writer().get_lines();
+    assert!(!lines.iter().any(|line| line.contains("Compacting context...")));
+    let row = lines
+        .iter()
+        .position(|line| line.contains("esc to interrupt") && !line.contains("Compacting context..."))
+        .expect("normal progress message");
+    let spinner = spinner_on_row(&lines, row);
+    let spinner_style = renderer.writer().style_of_text(row, &spinner.to_string()).expect("spinner style");
+    assert_eq!(spinner_style.fg, Some(ViewContext::new((TEST_WIDTH, 40)).theme.info()));
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_prompt_done_clears_compaction_indicator() -> TestResult {
+    let mut renderer = RendererTest::new().size((TEST_WIDTH, 40)).build()?;
+
+    type_string(&mut renderer, "Hello").await?;
+    press(&mut renderer, Enter).await?;
+    renderer.on_context_compaction(true)?;
+    renderer.on_prompt_done()?;
+
+    assert!(!renderer.writer().get_lines().iter().any(|line| line.contains("Compacting context...")));
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_context_clear_resets_compaction_indicator() -> TestResult {
+    let mut renderer = RendererTest::new().size((TEST_WIDTH, 40)).build()?;
+
+    type_string(&mut renderer, "Hello").await?;
+    press(&mut renderer, Enter).await?;
+    renderer.on_context_compaction(true)?;
+    renderer.on_context_cleared()?;
+
+    assert!(!renderer.writer().get_lines().iter().any(|line| line.contains("Compacting context...")));
+    Ok(())
+}
 
 #[tokio::test]
 async fn test_spinner_visible_after_prompt_submit() -> TestResult {


### PR DESCRIPTION
## Summary

- emit explicit completed, failed, and cancelled context compaction outcomes
- forward semantic compaction lifecycle notifications through ACP and render them in Wisp
- model progress display precedence explicitly without consuming agent-turn tips
- separate test-agent configuration from execution and add a fluent scenario API
- make MCP integration fixtures own cleanup and avoid fixed failure ports

## Test plan

- `just test -p aether-agent-core` (203 passed)
- `just test -p aether-wisp` (828 passed)
- `just test -p aether-agent-cli -p aether-acp-utils -p aether-telemetry` (329 passed)
- `just test -p aether-acp-utils` (55 passed after removing the notification macro)
- `just lint`