### PR TITLE
feat: stage and unstage directories in the git diff file tree

### DIFF
--- a/crates/wisp/src/components/app/git_diff_mode.rs
+++ b/crates/wisp/src/components/app/git_diff_mode.rs
@@ -5,7 +5,7 @@ use crate::components::git_diff::{DiffAnchor, PatchAnchor};
 use crate::components::review_comments::{CommentAnchor, ReviewComment};
 use crate::git_diff::{
     DiffScope, FileDiff, FileStatus, GitDiffDocument, GitDiffError, PatchLineKind, StageState, commit, load_git_diff,
-    stage_all, stage_file, unstage_all, unstage_file,
+    stage_all, stage_files, unstage_all, unstage_files,
 };
 use std::collections::HashMap;
 use std::path::{Path, PathBuf};
@@ -49,7 +49,7 @@ pub struct GitDiffMode {
     pub load_state: GitDiffLoadState,
     split: SplitPanel<FileListPanel, GitDiffPanel>,
     comments: ReviewQueue,
-    pending_restore: Option<RefreshState>,
+    pending_focus: Option<FocusSide>,
     bottom: BottomBar,
 }
 
@@ -65,7 +65,7 @@ impl GitDiffMode {
                 .with_separator("│", Style::default())
                 .with_resize_keys(),
             comments: ReviewQueue::default(),
-            pending_restore: None,
+            pending_focus: None,
             bottom: BottomBar::Help,
         }
     }
@@ -75,10 +75,7 @@ impl GitDiffMode {
     }
 
     pub(crate) fn begin_refresh(&mut self) {
-        self.pending_restore = Some(RefreshState {
-            selected_path: self.selected_file_path().map(ToOwned::to_owned),
-            was_right_focused: !self.split.is_left_focused(),
-        });
+        self.pending_focus = Some(if self.split.is_left_focused() { FocusSide::Left } else { FocusSide::Right });
         self.load_state = GitDiffLoadState::Loading;
         self.split.right_mut().clear_rendered_patches();
     }
@@ -89,11 +86,11 @@ impl GitDiffMode {
                 if self.cached_repo_root.is_none() {
                     self.cached_repo_root = Some(doc.repo_root.clone());
                 }
-                let restore = self.pending_restore.take();
+                let restore = self.pending_focus.take();
                 self.apply_loaded_document(doc, restore);
             }
             Err(error) => {
-                self.pending_restore = None;
+                self.pending_focus = None;
                 self.load_state = GitDiffLoadState::Error { message: error.to_string() };
                 self.split.right_mut().clear_rendered_patches();
             }
@@ -105,7 +102,7 @@ impl GitDiffMode {
     }
 
     fn reset(&mut self, load_state: GitDiffLoadState) {
-        self.pending_restore = None;
+        self.pending_focus = None;
         self.bottom = BottomBar::Help;
         self.load_state = load_state;
         *self.split.left_mut() = FileListPanel::new();
@@ -319,14 +316,6 @@ impl GitDiffMode {
         vec![GitDiffViewMessage::SubmitPrompt(self.comments.format_prompt())]
     }
 
-    fn selected_file_path(&self) -> Option<&str> {
-        let GitDiffLoadState::Ready(doc) = &self.load_state else {
-            return None;
-        };
-        let idx = self.split.left().selected_file_index()?;
-        doc.files.get(idx).map(|f| f.path.as_str())
-    }
-
     fn repo_root(&self) -> Option<&Path> {
         match &self.load_state {
             GitDiffLoadState::Ready(doc) => Some(&doc.repo_root),
@@ -352,16 +341,19 @@ impl GitDiffMode {
     }
 
     async fn toggle_stage_selected(&mut self) -> Vec<GitDiffViewMessage> {
-        let Some(file) = self.selected_file() else {
+        let (Some(root), GitDiffLoadState::Ready(doc)) = (self.repo_root_buf(), &self.load_state) else {
             return vec![];
         };
-        let (path, staged) = (file.path.clone(), file.staged);
-        let Some(root) = self.repo_root_buf() else {
+        let files: Vec<&FileDiff> =
+            self.split.left().selected_file_indices().into_iter().filter_map(|index| doc.files.get(index)).collect();
+        if files.is_empty() {
             return vec![];
-        };
-        let result = match staged {
-            StageState::Staged => unstage_file(&root, &path).await,
-            StageState::Unstaged | StageState::PartiallyStaged => stage_file(&root, &path).await,
+        }
+        let paths: Vec<&str> = files.iter().map(|file| file.path.as_str()).collect();
+        let result = if files.iter().all(|file| file.staged == StageState::Staged) {
+            unstage_files(&root, &paths).await
+        } else {
+            stage_files(&root, &paths).await
         };
         self.apply_action_result(result)
     }
@@ -504,7 +496,7 @@ impl GitDiffMode {
         }
     }
 
-    fn apply_loaded_document(&mut self, doc: GitDiffDocument, restore: Option<RefreshState>) {
+    fn apply_loaded_document(&mut self, doc: GitDiffDocument, restore: Option<FocusSide>) {
         self.document_revision = self.document_revision.saturating_add(1);
 
         if doc.files.is_empty() {
@@ -518,18 +510,12 @@ impl GitDiffMode {
         self.split.right_mut().clear_rendered_patches();
         self.split.right_mut().set_repo_root(doc.repo_root.clone());
 
-        if let Some(restore) = restore {
-            if restore.was_right_focused {
-                self.split.focus_right();
-            } else {
-                self.split.focus_left();
+        if let Some(focus) = restore {
+            match focus {
+                FocusSide::Left => self.split.focus_left(),
+                FocusSide::Right => self.split.focus_right(),
             }
             self.split.right_mut().reset_scroll();
-            if let Some(path) = &restore.selected_path
-                && let Some(idx) = doc.files.iter().position(|file| file.path == *path)
-            {
-                self.split.left_mut().select_file_index(idx);
-            }
         }
 
         self.load_state = GitDiffLoadState::Ready(doc);
@@ -649,7 +635,7 @@ impl ReviewQueue {
     }
 }
 
-struct RefreshState {
-    selected_path: Option<String>,
-    was_right_focused: bool,
+enum FocusSide {
+    Left,
+    Right,
 }

--- a/crates/wisp/src/components/file_list_panel.rs
+++ b/crates/wisp/src/components/file_list_panel.rs
@@ -50,13 +50,16 @@ impl FileListPanel {
         self.file_count = files.len();
         self.additions = files.iter().map(FileDiff::additions).sum();
         self.deletions = files.iter().map(FileDiff::deletions).sum();
-        self.tree = FileTree::from_files(files);
-        self.cursor = VerticalCursor::new();
+        self.tree.rebuild_from_files(files);
         self.file_comment_counts = vec![0; files.len()];
     }
 
     pub fn selected_file_index(&self) -> Option<usize> {
         self.tree.selected_file_index()
+    }
+
+    pub fn selected_file_indices(&self) -> Vec<usize> {
+        self.tree.selected_file_indices()
     }
 
     pub fn select_file_index(&mut self, file_index: usize) {
@@ -95,10 +98,6 @@ impl FileListPanel {
     pub(crate) fn tree_expand_or_enter(&mut self) -> Option<usize> {
         let is_file = self.tree.expand_or_enter();
         if is_file { self.tree.selected_file_index() } else { None }
-    }
-
-    pub fn tree_mut(&mut self) -> &mut FileTree {
-        &mut self.tree
     }
 
     fn header_row(&self, width: usize, theme: &tui::Theme) -> Line {
@@ -200,11 +199,11 @@ impl Component for FileListPanel {
                 let is_selected = entry_index == tree_selected;
                 let comments =
                     entry_file_index(entry).and_then(|index| self.file_comment_counts.get(index).copied()).unwrap_or(0);
-                let indent = tree_indent(visible_entries, entry_index);
+                let indent = tree_indent(&visible_entries, entry_index);
                 let flags = EntryFlags { is_selected, indent: &indent, width, comments };
                 match &entry.kind {
-                    FileTreeEntryKind::Directory { name, expanded, .. } => {
-                        render_directory_entry(&mut content, name, *expanded, entry.depth, flags, theme);
+                    FileTreeEntryKind::Directory { name, expanded, staged, .. } => {
+                        render_directory_entry(&mut content, name, *expanded, *staged, entry.depth, flags, theme);
                     }
                     FileTreeEntryKind::File { name, status, staged, additions, deletions, .. } => {
                         let row = FileRow {
@@ -247,6 +246,7 @@ fn render_directory_entry(
     line: &mut Line,
     name: &str,
     expanded: bool,
+    staged: StageState,
     depth: usize,
     flags: EntryFlags<'_>,
     theme: &tui::Theme,
@@ -257,16 +257,21 @@ fn render_directory_entry(
     let icon_gap = if depth == 0 { "  " } else { " " };
     let dir_style = row_fg_style(theme.info(), is_selected, theme);
     let indicator = if is_selected { "▎" } else { " " };
+    let (checkbox, checkbox_color) = stage_checkbox(staged, theme);
     let prefix_width = format!("{indicator}{indent}{connector}{icon}{icon_gap}").chars().count();
-    let name_budget = width.saturating_sub(prefix_width);
-    let display_name = format!("{name}/");
-    let truncated = truncate_text(&display_name, name_budget);
 
     line.push_with_style(indicator, row_fg_style(theme.accent(), is_selected, theme));
     line.push_with_style(format!("{indent}{connector}"), row_fg_style(theme.muted(), is_selected, theme));
     line.push_with_style(format!("{icon}{icon_gap}"), dir_style);
-    line.push_with_style(truncated.as_ref(), dir_style.bold());
-    line.extend_bg_to_width(width);
+    push_name_padded_to_suffix(
+        line,
+        &format!("{name}/"),
+        dir_style.bold(),
+        dir_style,
+        prefix_width,
+        vec![(format!(" {checkbox}"), row_fg_style(checkbox_color, is_selected, theme))],
+        width,
+    );
 }
 
 #[derive(Clone, Copy)]
@@ -286,36 +291,41 @@ fn render_file_entry(line: &mut Line, row: FileRow<'_>, flags: EntryFlags<'_>, t
     let indicator = if is_selected { "▎" } else { " " };
     let (checkbox, checkbox_color) = stage_checkbox(staged, theme);
 
-    let badge = (comments > 0).then(|| format!("◆{comments} "));
-    let badge_width = badge.as_deref().map_or(0, |b| b.chars().count());
-    let add_str = format!("+{additions}");
-    let del_str = format!(" -{deletions}");
-    let marker_str = format!(" {}", status.marker());
-    let checkbox_str = format!(" {checkbox}");
-    let suffix_width = badge_width
-        + add_str.chars().count()
-        + del_str.chars().count()
-        + marker_str.chars().count()
-        + checkbox_str.chars().count();
-    let prefix = format!("{indicator}{indent}── ");
-    let prefix_width = prefix.chars().count();
-    let name_budget = width.saturating_sub(prefix_width + suffix_width + 1);
-    let truncated = truncate_text(name, name_budget);
+    let mut suffix = vec![(" ".to_string(), style)];
+    if comments > 0 {
+        suffix.push((format!("◆{comments} "), row_fg_style(theme.accent(), is_selected, theme)));
+    }
+    suffix.push((format!("+{additions}"), row_fg_style(theme.diff_added_fg(), is_selected, theme)));
+    suffix.push((format!(" -{deletions}"), row_fg_style(theme.diff_removed_fg(), is_selected, theme)));
+    suffix.push((format!(" {}", status.marker()), row_fg_style(file_status_color(status, theme), is_selected, theme)));
+    suffix.push((format!(" {checkbox}"), row_fg_style(checkbox_color, is_selected, theme)));
+    let prefix_width = format!("{indicator}{indent}── ").chars().count();
 
     line.push_with_style(indicator, row_fg_style(theme.accent(), is_selected, theme));
     line.push_with_style(format!("{indent}── "), guide_style);
-    line.push_with_style(truncated.as_ref(), style);
+    push_name_padded_to_suffix(line, name, style, style, prefix_width, suffix, width);
+}
+
+fn push_name_padded_to_suffix(
+    line: &mut Line,
+    name: &str,
+    name_style: Style,
+    pad_style: Style,
+    prefix_width: usize,
+    suffix: Vec<(String, Style)>,
+    width: usize,
+) {
+    let suffix_width: usize = suffix.iter().map(|(text, _)| text.chars().count()).sum();
+    let truncated = truncate_text(name, width.saturating_sub(prefix_width + suffix_width));
+    line.push_with_style(truncated.as_ref(), name_style);
     let padding = width.saturating_sub(prefix_width + truncated.chars().count() + suffix_width);
     if padding > 0 {
-        line.push_with_style(" ".repeat(padding), style);
+        line.push_with_style(" ".repeat(padding), pad_style);
     }
-    if let Some(badge) = badge {
-        line.push_with_style(badge, row_fg_style(theme.accent(), is_selected, theme));
+    for (text, style) in suffix {
+        line.push_with_style(text, style);
     }
-    line.push_with_style(add_str, row_fg_style(theme.diff_added_fg(), is_selected, theme));
-    line.push_with_style(del_str, row_fg_style(theme.diff_removed_fg(), is_selected, theme));
-    line.push_with_style(marker_str, row_fg_style(file_status_color(status, theme), is_selected, theme));
-    line.push_with_style(checkbox_str, row_fg_style(checkbox_color, is_selected, theme));
+    line.extend_bg_to_width(width);
 }
 
 fn stage_checkbox(staged: StageState, theme: &tui::Theme) -> (&'static str, tui::Color) {
@@ -334,7 +344,7 @@ fn row_fg_style(fg: tui::Color, is_selected: bool, theme: &tui::Theme) -> Style 
     if is_selected { theme.selected_row_style_with_fg(fg) } else { Style::fg(fg) }
 }
 
-fn tree_indent(entries: &[FileTreeEntry], index: usize) -> String {
+fn tree_indent(entries: &[&FileTreeEntry], index: usize) -> String {
     let Some(entry) = entries.get(index) else {
         return String::new();
     };
@@ -349,7 +359,7 @@ fn tree_indent(entries: &[FileTreeEntry], index: usize) -> String {
     indent
 }
 
-fn level_continues(entries: &[FileTreeEntry], index: usize, level: usize) -> bool {
+fn level_continues(entries: &[&FileTreeEntry], index: usize, level: usize) -> bool {
     for next in &entries[index + 1..] {
         if next.depth < level {
             return false;

--- a/crates/wisp/src/components/file_tree.rs
+++ b/crates/wisp/src/components/file_tree.rs
@@ -1,9 +1,5 @@
 use crate::git_diff::{FileDiff, FileStatus, StageState};
-
-pub enum FileTreeNode {
-    Directory { name: String, children: Vec<FileTreeNode>, expanded: bool },
-    File { file_index: usize, name: String, status: FileStatus, staged: StageState, additions: usize, deletions: usize },
-}
+use std::collections::HashSet;
 
 #[derive(Debug, Clone)]
 pub struct FileTreeEntry {
@@ -13,49 +9,68 @@ pub struct FileTreeEntry {
 
 #[derive(Debug, Clone)]
 pub enum FileTreeEntryKind {
-    Directory { name: String, expanded: bool },
-    File { file_index: usize, name: String, status: FileStatus, staged: StageState, additions: usize, deletions: usize },
+    Directory {
+        path: String,
+        name: String,
+        expanded: bool,
+        staged: StageState,
+        file_indices: Vec<usize>,
+    },
+    File {
+        path: String,
+        file_index: usize,
+        name: String,
+        status: FileStatus,
+        staged: StageState,
+        additions: usize,
+        deletions: usize,
+    },
 }
 
 pub struct FileTree {
-    roots: Vec<FileTreeNode>,
+    entries: Vec<FileTreeEntry>,
+    visible: Vec<usize>,
     selected_visible: usize,
-    cached_entries: Vec<FileTreeEntry>,
 }
 
 impl FileTree {
     pub fn empty() -> Self {
-        Self { roots: Vec::new(), selected_visible: 0, cached_entries: Vec::new() }
+        Self { entries: Vec::new(), visible: Vec::new(), selected_visible: 0 }
     }
 
     pub fn from_files(files: &[FileDiff]) -> Self {
-        let mut roots: Vec<FileTreeNode> = Vec::new();
-
-        for (idx, file) in files.iter().enumerate() {
-            let parts: Vec<&str> = file.path.split('/').collect();
-            insert_into_tree(&mut roots, &parts, idx, file);
-        }
-
-        sort_tree(&mut roots);
-        compress_paths(&mut roots);
-
-        let mut tree = Self { roots, selected_visible: 0, cached_entries: Vec::new() };
-        tree.rebuild_visible_entries();
+        let mut tree = Self::empty();
+        tree.rebuild_from_files(files);
         tree
     }
 
-    pub fn select_file_index(&mut self, file_index: usize) {
-        if let Some(pos) = self
-            .cached_entries
+    pub fn rebuild_from_files(&mut self, files: &[FileDiff]) {
+        let selected_path = self.selected_entry().map(|entry| entry_path(entry).to_owned());
+        let collapsed: HashSet<String> = self
+            .entries
             .iter()
-            .position(|e| matches!(&e.kind, FileTreeEntryKind::File { file_index: fi, .. } if *fi == file_index))
+            .filter_map(|entry| match &entry.kind {
+                FileTreeEntryKind::Directory { path, expanded: false, .. } => Some(path.clone()),
+                _ => None,
+            })
+            .collect();
+
+        self.entries = build_entries(files);
+        for entry in &mut self.entries {
+            if let FileTreeEntryKind::Directory { path, expanded, .. } = &mut entry.kind {
+                *expanded = !collapsed.contains(path);
+            }
+        }
+        self.rebuild_visible();
+        if let Some(path) = selected_path
+            && let Some(position) = self.visible.iter().position(|&index| entry_path(&self.entries[index]) == path)
         {
-            self.selected_visible = pos;
+            self.selected_visible = position;
         }
     }
 
-    pub fn visible_entries(&self) -> &[FileTreeEntry] {
-        &self.cached_entries
+    pub fn visible_entries(&self) -> Vec<&FileTreeEntry> {
+        self.visible.iter().map(|&index| &self.entries[index]).collect()
     }
 
     pub fn selected_visible(&self) -> usize {
@@ -63,209 +78,246 @@ impl FileTree {
     }
 
     pub fn selected_file_index(&self) -> Option<usize> {
-        self.cached_entries.get(self.selected_visible).and_then(|e| match &e.kind {
+        self.selected_entry().and_then(|entry| match &entry.kind {
             FileTreeEntryKind::File { file_index, .. } => Some(*file_index),
             FileTreeEntryKind::Directory { .. } => None,
         })
     }
 
+    pub fn selected_file_indices(&self) -> Vec<usize> {
+        match self.selected_entry().map(|entry| &entry.kind) {
+            Some(FileTreeEntryKind::File { file_index, .. }) => vec![*file_index],
+            Some(FileTreeEntryKind::Directory { file_indices, .. }) => file_indices.clone(),
+            None => Vec::new(),
+        }
+    }
+
+    pub fn select_file_index(&mut self, file_index: usize) {
+        if let Some(position) = self.visible.iter().position(|&index| {
+            matches!(&self.entries[index].kind, FileTreeEntryKind::File { file_index: fi, .. } if *fi == file_index)
+        }) {
+            self.selected_visible = position;
+        }
+    }
+
     pub fn navigate(&mut self, delta: isize) {
-        if self.cached_entries.is_empty() {
+        if self.visible.is_empty() {
             return;
         }
-        self.selected_visible = self.selected_visible.saturating_add_signed(delta).min(self.cached_entries.len() - 1);
+        self.selected_visible = self.selected_visible.saturating_add_signed(delta).min(self.visible.len() - 1);
     }
 
     pub fn collapse_or_parent(&mut self) {
-        let Some(entry) = self.cached_entries.get(self.selected_visible) else {
+        let Some(&index) = self.visible.get(self.selected_visible) else {
             return;
         };
-
-        match &entry.kind {
-            FileTreeEntryKind::Directory { expanded: true, .. } => {
-                toggle_at(&mut self.roots, self.selected_visible);
-                self.rebuild_visible_entries();
-            }
-            _ => {
-                if let Some(parent_idx) = find_parent_dir(&self.cached_entries, self.selected_visible) {
-                    self.selected_visible = parent_idx;
-                }
-            }
+        if let FileTreeEntryKind::Directory { expanded, .. } = &mut self.entries[index].kind
+            && *expanded
+        {
+            *expanded = false;
+            self.rebuild_visible();
+            return;
+        }
+        if let Some(parent) = self.parent_position(self.selected_visible) {
+            self.selected_visible = parent;
         }
     }
 
     pub fn expand_or_enter(&mut self) -> bool {
-        let Some(entry) = self.cached_entries.get(self.selected_visible) else {
+        let Some(&index) = self.visible.get(self.selected_visible) else {
             return false;
         };
-
-        match &entry.kind {
-            FileTreeEntryKind::Directory { expanded: false, .. } => {
-                toggle_at(&mut self.roots, self.selected_visible);
-                self.rebuild_visible_entries();
-                false
-            }
-            FileTreeEntryKind::Directory { expanded: true, .. } => {
-                if self.selected_visible + 1 < self.cached_entries.len() {
-                    self.selected_visible += 1;
+        match &mut self.entries[index].kind {
+            FileTreeEntryKind::File { .. } => true,
+            FileTreeEntryKind::Directory { expanded, .. } => {
+                if *expanded {
+                    if self.selected_visible + 1 < self.visible.len() {
+                        self.selected_visible += 1;
+                    }
+                } else {
+                    *expanded = true;
+                    self.rebuild_visible();
                 }
                 false
             }
-            FileTreeEntryKind::File { .. } => true,
         }
     }
 
-    fn rebuild_visible_entries(&mut self) {
-        let mut entries = Vec::new();
-        for node in &self.roots {
-            collect_visible(node, 0, &mut entries);
+    fn selected_entry(&self) -> Option<&FileTreeEntry> {
+        self.visible.get(self.selected_visible).map(|&index| &self.entries[index])
+    }
+
+    fn parent_position(&self, position: usize) -> Option<usize> {
+        let current_depth = self.entries[*self.visible.get(position)?].depth;
+        if current_depth == 0 {
+            return None;
         }
-        self.cached_entries = entries;
-        if self.cached_entries.is_empty() {
-            self.selected_visible = 0;
-        } else {
-            self.selected_visible = self.selected_visible.min(self.cached_entries.len() - 1);
+        (0..position).rev().find(|&candidate| {
+            let entry = &self.entries[self.visible[candidate]];
+            entry.depth < current_depth && matches!(entry.kind, FileTreeEntryKind::Directory { .. })
+        })
+    }
+
+    fn rebuild_visible(&mut self) {
+        self.visible.clear();
+        let mut hidden_below: Option<usize> = None;
+        for (index, entry) in self.entries.iter().enumerate() {
+            if let Some(depth) = hidden_below {
+                if entry.depth > depth {
+                    continue;
+                }
+                hidden_below = None;
+            }
+            self.visible.push(index);
+            if matches!(entry.kind, FileTreeEntryKind::Directory { expanded: false, .. }) {
+                hidden_below = Some(entry.depth);
+            }
         }
+        self.selected_visible = self.selected_visible.min(self.visible.len().saturating_sub(1));
     }
 }
 
-fn insert_into_tree(nodes: &mut Vec<FileTreeNode>, parts: &[&str], file_index: usize, file: &FileDiff) {
+enum BuildNode {
+    Directory { name: String, children: Vec<BuildNode> },
+    File { file_index: usize, name: String },
+}
+
+fn build_entries(files: &[FileDiff]) -> Vec<FileTreeEntry> {
+    let mut roots: Vec<BuildNode> = Vec::new();
+    for (index, file) in files.iter().enumerate() {
+        let parts: Vec<&str> = file.path.split('/').collect();
+        insert_into_tree(&mut roots, &parts, index);
+    }
+    sort_tree(&mut roots);
+    compress_paths(&mut roots);
+
+    let mut entries = Vec::new();
+    flatten_into(&roots, 0, "", files, &mut entries);
+    entries
+}
+
+fn insert_into_tree(nodes: &mut Vec<BuildNode>, parts: &[&str], file_index: usize) {
     if parts.len() == 1 {
-        nodes.push(FileTreeNode::File {
-            file_index,
-            name: parts[0].to_string(),
-            status: file.status,
-            staged: file.staged,
-            additions: file.additions(),
-            deletions: file.deletions(),
-        });
+        nodes.push(BuildNode::File { file_index, name: parts[0].to_string() });
         return;
     }
 
     let dir_name = parts[0];
-    let existing = nodes.iter_mut().find(|n| matches!(n, FileTreeNode::Directory { name, .. } if name == dir_name));
+    let existing = nodes.iter_mut().find(|node| matches!(node, BuildNode::Directory { name, .. } if name == dir_name));
 
-    if let Some(FileTreeNode::Directory { children, .. }) = existing {
-        insert_into_tree(children, &parts[1..], file_index, file);
+    if let Some(BuildNode::Directory { children, .. }) = existing {
+        insert_into_tree(children, &parts[1..], file_index);
     } else {
         let mut children = Vec::new();
-        insert_into_tree(&mut children, &parts[1..], file_index, file);
-        nodes.push(FileTreeNode::Directory { name: dir_name.to_string(), children, expanded: true });
+        insert_into_tree(&mut children, &parts[1..], file_index);
+        nodes.push(BuildNode::Directory { name: dir_name.to_string(), children });
     }
 }
 
-fn sort_tree(nodes: &mut [FileTreeNode]) {
+fn sort_tree(nodes: &mut [BuildNode]) {
     nodes.sort_by(|a, b| {
-        let a_is_dir = matches!(a, FileTreeNode::Directory { .. });
-        let b_is_dir = matches!(b, FileTreeNode::Directory { .. });
+        let a_is_dir = matches!(a, BuildNode::Directory { .. });
+        let b_is_dir = matches!(b, BuildNode::Directory { .. });
         b_is_dir.cmp(&a_is_dir).then_with(|| node_name(a).cmp(node_name(b)))
     });
     for node in nodes.iter_mut() {
-        if let FileTreeNode::Directory { children, .. } = node {
+        if let BuildNode::Directory { children, .. } = node {
             sort_tree(children);
         }
     }
 }
 
-fn compress_paths(nodes: &mut [FileTreeNode]) {
+fn compress_paths(nodes: &mut [BuildNode]) {
     for node in nodes.iter_mut() {
-        loop {
-            let should_compress = matches!(
-                node,
-                FileTreeNode::Directory { children, .. }
-                if children.len() == 1 && matches!(children[0], FileTreeNode::Directory { .. })
-            );
-            if !should_compress {
+        while let BuildNode::Directory { name, children } = node {
+            if children.len() != 1 || !matches!(children[0], BuildNode::Directory { .. }) {
                 break;
             }
-            if let FileTreeNode::Directory { name, children, .. } = node {
-                let child = children.remove(0);
-                if let FileTreeNode::Directory {
-                    name: child_name,
-                    children: child_children,
-                    expanded: child_expanded,
-                } = child
-                {
-                    *name = format!("{name}/{child_name}");
-                    *children = child_children;
-                    if let FileTreeNode::Directory { expanded, .. } = node {
-                        *expanded = child_expanded;
-                    }
-                }
-            }
+            let BuildNode::Directory { name: child_name, children: grandchildren } = children.remove(0) else {
+                unreachable!("checked above that the only child is a directory");
+            };
+            *name = format!("{name}/{child_name}");
+            *children = grandchildren;
         }
-        if let FileTreeNode::Directory { children, .. } = node {
+        if let BuildNode::Directory { children, .. } = node {
             compress_paths(children);
         }
     }
 }
 
-fn node_name(node: &FileTreeNode) -> &str {
+fn node_name(node: &BuildNode) -> &str {
     match node {
-        FileTreeNode::Directory { name, .. } | FileTreeNode::File { name, .. } => name,
+        BuildNode::Directory { name, .. } | BuildNode::File { name, .. } => name,
     }
 }
 
-fn collect_visible(node: &FileTreeNode, depth: usize, entries: &mut Vec<FileTreeEntry>) {
-    match node {
-        FileTreeNode::Directory { name, children, expanded } => {
-            entries.push(FileTreeEntry {
-                depth,
-                kind: FileTreeEntryKind::Directory { name: name.clone(), expanded: *expanded },
-            });
-            if *expanded {
-                for child in children {
-                    collect_visible(child, depth + 1, entries);
+fn flatten_into(
+    nodes: &[BuildNode],
+    depth: usize,
+    parent_path: &str,
+    files: &[FileDiff],
+    entries: &mut Vec<FileTreeEntry>,
+) -> Vec<usize> {
+    let mut collected = Vec::new();
+    for node in nodes {
+        match node {
+            BuildNode::Directory { name, children } => {
+                let path = join_path(parent_path, name);
+                let slot = entries.len();
+                entries.push(FileTreeEntry {
+                    depth,
+                    kind: FileTreeEntryKind::Directory {
+                        path: path.clone(),
+                        name: name.clone(),
+                        expanded: true,
+                        staged: StageState::Unstaged,
+                        file_indices: Vec::new(),
+                    },
+                });
+                let descendants = flatten_into(children, depth + 1, &path, files, entries);
+                if let FileTreeEntryKind::Directory { staged, file_indices, .. } = &mut entries[slot].kind {
+                    *staged = aggregate_stage_state(&descendants, files);
+                    file_indices.clone_from(&descendants);
                 }
+                collected.extend(descendants);
+            }
+            BuildNode::File { file_index, name } => {
+                let file = &files[*file_index];
+                entries.push(FileTreeEntry {
+                    depth,
+                    kind: FileTreeEntryKind::File {
+                        path: join_path(parent_path, name),
+                        file_index: *file_index,
+                        name: name.clone(),
+                        status: file.status,
+                        staged: file.staged,
+                        additions: file.additions(),
+                        deletions: file.deletions(),
+                    },
+                });
+                collected.push(*file_index);
             }
         }
-        FileTreeNode::File { file_index, name, status, staged, additions, deletions } => {
-            entries.push(FileTreeEntry {
-                depth,
-                kind: FileTreeEntryKind::File {
-                    file_index: *file_index,
-                    name: name.clone(),
-                    status: *status,
-                    staged: *staged,
-                    additions: *additions,
-                    deletions: *deletions,
-                },
-            });
-        }
+    }
+    collected
+}
+
+fn aggregate_stage_state(file_indices: &[usize], files: &[FileDiff]) -> StageState {
+    let mut states = file_indices.iter().map(|&index| files[index].staged);
+    let Some(first) = states.next() else {
+        return StageState::Unstaged;
+    };
+    if states.all(|state| state == first) { first } else { StageState::PartiallyStaged }
+}
+
+fn entry_path(entry: &FileTreeEntry) -> &str {
+    match &entry.kind {
+        FileTreeEntryKind::Directory { path, .. } | FileTreeEntryKind::File { path, .. } => path,
     }
 }
 
-fn toggle_at(nodes: &mut [FileTreeNode], target_visible_idx: usize) {
-    let mut counter = 0;
-    toggle_at_inner(nodes, target_visible_idx, &mut counter);
-}
-
-fn toggle_at_inner(nodes: &mut [FileTreeNode], target: usize, counter: &mut usize) -> bool {
-    for node in nodes.iter_mut() {
-        if *counter == target {
-            if let FileTreeNode::Directory { expanded, .. } = node {
-                *expanded = !*expanded;
-            }
-            return true;
-        }
-        *counter += 1;
-        if let FileTreeNode::Directory { children, expanded: true, .. } = node
-            && toggle_at_inner(children, target, counter)
-        {
-            return true;
-        }
-    }
-    false
-}
-
-fn find_parent_dir(entries: &[FileTreeEntry], idx: usize) -> Option<usize> {
-    let current_depth = entries.get(idx)?.depth;
-    if current_depth == 0 {
-        return None;
-    }
-    (0..idx)
-        .rev()
-        .find(|&i| entries[i].depth < current_depth && matches!(entries[i].kind, FileTreeEntryKind::Directory { .. }))
+fn join_path(parent: &str, name: &str) -> String {
+    if parent.is_empty() { name.to_string() } else { format!("{parent}/{name}") }
 }
 
 #[cfg(test)]
@@ -440,6 +492,80 @@ mod tests {
         tree.selected_visible = 2;
         tree.collapse_or_parent();
         assert!(tree.selected_visible < tree.visible_entries().len());
+    }
+
+    #[test]
+    fn rebuild_preserves_selected_directory() {
+        let files = vec![modified("lib/a.rs"), modified("src/b.rs")];
+        let mut tree = FileTree::from_files(&files);
+        tree.navigate(2);
+
+        tree.rebuild_from_files(&files);
+
+        assert!(
+            matches!(&tree.visible_entries()[tree.selected_visible()].kind, FileTreeEntryKind::Directory { name, .. } if name == "src")
+        );
+    }
+
+    #[test]
+    fn rebuild_preserves_collapsed_directories() {
+        let files = vec![modified("lib/a.rs"), modified("src/b.rs")];
+        let mut tree = FileTree::from_files(&files);
+        tree.collapse_or_parent();
+
+        tree.rebuild_from_files(&files);
+
+        assert!(
+            matches!(&tree.visible_entries()[0].kind, FileTreeEntryKind::Directory { name, expanded: false, .. } if name == "lib")
+        );
+        assert!(
+            !tree
+                .visible_entries()
+                .iter()
+                .any(|entry| matches!(&entry.kind, FileTreeEntryKind::File { name, .. } if name == "a.rs"))
+        );
+    }
+
+    #[test]
+    fn rebuild_preserves_collapsed_directory_hidden_under_collapsed_parent() {
+        let files = vec![modified("src/inner/a.rs"), modified("src/b.rs"), modified("src/inner/other/c.rs")];
+        let mut tree = FileTree::from_files(&files);
+        tree.navigate(1);
+        tree.collapse_or_parent();
+        tree.collapse_or_parent();
+        tree.collapse_or_parent();
+        assert_eq!(tree.visible_entries().len(), 1);
+
+        tree.rebuild_from_files(&files);
+        tree.expand_or_enter();
+
+        assert!(
+            matches!(&tree.visible_entries()[1].kind, FileTreeEntryKind::Directory { name, expanded: false, .. } if name == "inner"),
+            "nested collapsed directory should stay collapsed after rebuild"
+        );
+    }
+
+    #[test]
+    fn directory_stage_state_aggregates_descendant_files() {
+        let mut files = vec![modified("src/a.rs"), modified("src/b.rs")];
+        files[1].staged = StageState::Staged;
+        let tree = FileTree::from_files(&files);
+
+        assert!(matches!(
+            &tree.visible_entries()[0].kind,
+            FileTreeEntryKind::Directory { staged: StageState::PartiallyStaged, .. }
+        ));
+    }
+
+    #[test]
+    fn selected_file_indices_for_directory_includes_hidden_descendants() {
+        let files = vec![modified("src/nested/a.rs"), modified("src/b.rs"), modified("top.rs")];
+        let mut tree = FileTree::from_files(&files);
+        tree.collapse_or_parent();
+
+        let mut indices = tree.selected_file_indices();
+        indices.sort_unstable();
+        assert_eq!(indices, vec![0, 1]);
     }
 
     #[test]

--- a/crates/wisp/src/git_diff.rs
+++ b/crates/wisp/src/git_diff.rs
@@ -185,12 +185,16 @@ pub(crate) async fn load_git_diff(
     Ok(GitDiffDocument { repo_root, files })
 }
 
-pub(crate) async fn stage_file(repo_root: &Path, path: &str) -> Result<(), GitDiffError> {
-    git(repo_root, &["add", "--", path]).await.map(drop)
+pub(crate) async fn stage_files(repo_root: &Path, paths: &[&str]) -> Result<(), GitDiffError> {
+    let mut args = vec!["add", "--"];
+    args.extend_from_slice(paths);
+    git(repo_root, &args).await.map(drop)
 }
 
-pub(crate) async fn unstage_file(repo_root: &Path, path: &str) -> Result<(), GitDiffError> {
-    git(repo_root, &["reset", "--quiet", "--", path]).await.map(drop)
+pub(crate) async fn unstage_files(repo_root: &Path, paths: &[&str]) -> Result<(), GitDiffError> {
+    let mut args = vec!["reset", "--quiet", "--"];
+    args.extend_from_slice(paths);
+    git(repo_root, &args).await.map(drop)
 }
 
 pub(crate) async fn stage_all(repo_root: &Path) -> Result<(), GitDiffError> {
@@ -909,11 +913,11 @@ index abc..def 100644
         let doc = load_git_diff(dir, None, DiffScope::Both).await.unwrap();
         assert_eq!(staged_of(&doc, "a.txt"), StageState::Unstaged);
 
-        stage_file(dir, "a.txt").await.unwrap();
+        stage_files(dir, &["a.txt"]).await.unwrap();
         let doc = load_git_diff(dir, None, DiffScope::Both).await.unwrap();
         assert_eq!(staged_of(&doc, "a.txt"), StageState::Staged);
 
-        unstage_file(dir, "a.txt").await.unwrap();
+        unstage_files(dir, &["a.txt"]).await.unwrap();
         let doc = load_git_diff(dir, None, DiffScope::Both).await.unwrap();
         assert_eq!(staged_of(&doc, "a.txt"), StageState::Unstaged);
     }
@@ -941,7 +945,7 @@ index abc..def 100644
         let dir = repo.path();
         commit_file(dir, "a.txt", "one\n", "init").await;
         write_file(dir, "a.txt", "one\ntwo\n").await;
-        stage_file(dir, "a.txt").await.unwrap();
+        stage_files(dir, &["a.txt"]).await.unwrap();
         commit(dir, "second commit").await.unwrap();
         let log = git(dir, &["log", "--oneline", "-1"]).await.unwrap();
         assert!(log.contains("second commit"), "log was: {log}");
@@ -983,7 +987,7 @@ index abc..def 100644
         let dir = repo.path();
         write_file(dir, "a.txt", "hi\n").await;
         git(dir, &["add", "a.txt"]).await.unwrap();
-        unstage_file(dir, "a.txt").await.unwrap();
+        unstage_files(dir, &["a.txt"]).await.unwrap();
         let status = git(dir, &["status", "--porcelain"]).await.unwrap();
         assert!(status.contains("?? a.txt"), "status was: {status}");
     }
@@ -995,7 +999,7 @@ index abc..def 100644
         commit_file(dir, "a.txt", "one\n", "init").await;
 
         write_file(dir, "a.txt", "two\n").await;
-        stage_file(dir, "a.txt").await.unwrap();
+        stage_files(dir, &["a.txt"]).await.unwrap();
         write_file(dir, "a.txt", "three\n").await;
         write_file(dir, "untracked.txt", "scratch\n").await;
 

--- a/crates/wisp/tests/app_tests/git_diff_tests.rs
+++ b/crates/wisp/tests/app_tests/git_diff_tests.rs
@@ -1,11 +1,13 @@
+use std::fs::{create_dir_all, read_to_string, write};
 use std::path::Path;
+use std::process::Command;
 
 use tui::{KeyCode, KeyModifiers};
 
 use super::common::*;
 
 fn run_git(dir: &Path, args: &[&str]) -> String {
-    let output = std::process::Command::new("git").args(args).current_dir(dir).output().unwrap();
+    let output = Command::new("git").args(args).current_dir(dir).output().unwrap();
     assert!(output.status.success(), "git {args:?} failed: {}", String::from_utf8_lossy(&output.stderr));
     String::from_utf8_lossy(&output.stdout).into_owned()
 }
@@ -28,13 +30,13 @@ async fn open_git_diff(renderer: &mut Renderer) -> TestResult {
 async fn git_diff_scope_cycles_between_both_unstaged_and_staged() -> TestResult {
     let repo = init_temp_repo();
     let dir = repo.path().to_path_buf();
-    std::fs::write(dir.join("a.txt"), "one\n").unwrap();
+    write(dir.join("a.txt"), "one\n").unwrap();
     run_git(&dir, &["add", "-A"]);
     run_git(&dir, &["commit", "--quiet", "-m", "init"]);
-    std::fs::write(dir.join("a.txt"), "two\n").unwrap();
+    write(dir.join("a.txt"), "two\n").unwrap();
     run_git(&dir, &["add", "a.txt"]);
-    std::fs::write(dir.join("a.txt"), "three\n").unwrap();
-    std::fs::write(dir.join("untracked.txt"), "scratch\n").unwrap();
+    write(dir.join("a.txt"), "three\n").unwrap();
+    write(dir.join("untracked.txt"), "scratch\n").unwrap();
 
     let mut renderer = RendererTest::new().size((TEST_WIDTH, 40)).working_dir(dir).build()?;
     open_git_diff(&mut renderer).await?;
@@ -55,10 +57,10 @@ async fn git_diff_scope_cycles_between_both_unstaged_and_staged() -> TestResult 
 async fn typing_long_commit_message_keeps_diff_rows_visible() -> TestResult {
     let repo = init_temp_repo();
     let dir = repo.path().to_path_buf();
-    std::fs::write(dir.join("a.txt"), "one\n").unwrap();
+    write(dir.join("a.txt"), "one\n").unwrap();
     run_git(&dir, &["add", "-A"]);
     run_git(&dir, &["commit", "--quiet", "-m", "init"]);
-    std::fs::write(dir.join("a.txt"), "one\ntwo\n").unwrap();
+    write(dir.join("a.txt"), "one\ntwo\n").unwrap();
 
     let mut renderer = RendererTest::new().size((50, 12)).working_dir(dir.clone()).build()?;
     open_git_diff(&mut renderer).await?;
@@ -76,11 +78,11 @@ async fn typing_short_chars_in_commit_box_does_not_scroll_tall_diff() -> TestRes
     let repo = init_temp_repo();
     let dir = repo.path().to_path_buf();
     let initial = (0..40).map(|i| format!("line {i}")).collect::<Vec<_>>().join("\n") + "\n";
-    std::fs::write(dir.join("a.txt"), &initial).unwrap();
+    write(dir.join("a.txt"), &initial).unwrap();
     run_git(&dir, &["add", "-A"]);
     run_git(&dir, &["commit", "--quiet", "-m", "init"]);
     let modified = (0..40).map(|i| format!("line {i} edited")).collect::<Vec<_>>().join("\n") + "\n";
-    std::fs::write(dir.join("a.txt"), &modified).unwrap();
+    write(dir.join("a.txt"), &modified).unwrap();
 
     let mut renderer = RendererTest::new().size((80, 10)).working_dir(dir.clone()).build()?;
     open_git_diff(&mut renderer).await?;
@@ -100,10 +102,10 @@ async fn typing_short_chars_in_commit_box_does_not_scroll_tall_diff() -> TestRes
 async fn space_stages_selected_file() -> TestResult {
     let repo = init_temp_repo();
     let dir = repo.path().to_path_buf();
-    std::fs::write(dir.join("a.txt"), "one\n").unwrap();
+    write(dir.join("a.txt"), "one\n").unwrap();
     run_git(&dir, &["add", "-A"]);
     run_git(&dir, &["commit", "--quiet", "-m", "init"]);
-    std::fs::write(dir.join("a.txt"), "one\ntwo\n").unwrap();
+    write(dir.join("a.txt"), "one\ntwo\n").unwrap();
 
     let mut renderer = RendererTest::new().size((TEST_WIDTH, 40)).working_dir(dir.clone()).build()?;
     open_git_diff(&mut renderer).await?;
@@ -117,13 +119,55 @@ async fn space_stages_selected_file() -> TestResult {
 }
 
 #[tokio::test]
+async fn space_toggles_staging_for_selected_directory() -> TestResult {
+    let repo = init_temp_repo();
+    let dir = repo.path().to_path_buf();
+    create_dir_all(dir.join("src/nested")).unwrap();
+    write(dir.join("src/a.txt"), "one\n").unwrap();
+    write(dir.join("src/b.txt"), "one\n").unwrap();
+    write(dir.join("src/nested/c.txt"), "one\n").unwrap();
+    run_git(&dir, &["add", "-A"]);
+    run_git(&dir, &["commit", "--quiet", "-m", "init"]);
+    write(dir.join("src/a.txt"), "two\n").unwrap();
+    write(dir.join("src/b.txt"), "two\n").unwrap();
+    write(dir.join("src/nested/c.txt"), "two\n").unwrap();
+
+    let mut renderer = RendererTest::new().size((TEST_WIDTH, 40)).working_dir(dir.clone()).build()?;
+    open_git_diff(&mut renderer).await?;
+
+    assert!(
+        renderer.writer().get_lines().iter().any(|line| {
+            let line = line.trim_end();
+            line.contains("src/") && line.contains("☐")
+        }),
+        "directory should show its unstaged checkbox"
+    );
+
+    press(&mut renderer, KeyCode::Char(' ')).await?;
+
+    assert!(
+        renderer.writer().get_lines().iter().any(|line| {
+            let line = line.trim_end();
+            line.contains("src/") && line.contains("☑")
+        }),
+        "directory should show its staged checkbox"
+    );
+    assert_eq!(run_git(&dir, &["status", "--porcelain"]), "M  src/a.txt\nM  src/b.txt\nM  src/nested/c.txt\n");
+
+    press(&mut renderer, KeyCode::Char(' ')).await?;
+
+    assert_eq!(run_git(&dir, &["status", "--porcelain"]), " M src/a.txt\n M src/b.txt\n M src/nested/c.txt\n");
+    Ok(())
+}
+
+#[tokio::test]
 async fn commit_via_composer_creates_commit_and_clears_changes() -> TestResult {
     let repo = init_temp_repo();
     let dir = repo.path().to_path_buf();
-    std::fs::write(dir.join("a.txt"), "one\n").unwrap();
+    write(dir.join("a.txt"), "one\n").unwrap();
     run_git(&dir, &["add", "-A"]);
     run_git(&dir, &["commit", "--quiet", "-m", "init"]);
-    std::fs::write(dir.join("a.txt"), "one\ntwo\n").unwrap();
+    write(dir.join("a.txt"), "one\ntwo\n").unwrap();
 
     let mut renderer = RendererTest::new().size((TEST_WIDTH, 40)).working_dir(dir.clone()).build()?;
     open_git_diff(&mut renderer).await?;
@@ -143,10 +187,10 @@ async fn commit_via_composer_creates_commit_and_clears_changes() -> TestResult {
 async fn commit_with_nothing_staged_shows_hint() -> TestResult {
     let repo = init_temp_repo();
     let dir = repo.path().to_path_buf();
-    std::fs::write(dir.join("a.txt"), "one\n").unwrap();
+    write(dir.join("a.txt"), "one\n").unwrap();
     run_git(&dir, &["add", "-A"]);
     run_git(&dir, &["commit", "--quiet", "-m", "init"]);
-    std::fs::write(dir.join("a.txt"), "one\ntwo\n").unwrap();
+    write(dir.join("a.txt"), "one\ntwo\n").unwrap();
 
     let mut renderer = RendererTest::new().size((TEST_WIDTH, 40)).working_dir(dir.clone()).build()?;
     open_git_diff(&mut renderer).await?;
@@ -161,10 +205,10 @@ async fn commit_with_nothing_staged_shows_hint() -> TestResult {
 async fn discard_confirm_reverts_file() -> TestResult {
     let repo = init_temp_repo();
     let dir = repo.path().to_path_buf();
-    std::fs::write(dir.join("a.txt"), "v1\n").unwrap();
+    write(dir.join("a.txt"), "v1\n").unwrap();
     run_git(&dir, &["add", "-A"]);
     run_git(&dir, &["commit", "--quiet", "-m", "init"]);
-    std::fs::write(dir.join("a.txt"), "v2\n").unwrap();
+    write(dir.join("a.txt"), "v2\n").unwrap();
 
     let mut renderer = RendererTest::new().size((TEST_WIDTH, 40)).working_dir(dir.clone()).build()?;
     open_git_diff(&mut renderer).await?;
@@ -174,7 +218,7 @@ async fn discard_confirm_reverts_file() -> TestResult {
 
     press(&mut renderer, KeyCode::Char('y')).await?;
 
-    assert_eq!(std::fs::read_to_string(dir.join("a.txt")).unwrap(), "v1\n", "file should be reverted");
+    assert_eq!(read_to_string(dir.join("a.txt")).unwrap(), "v1\n", "file should be reverted");
     assert_buffer_contains(renderer.writer(), "No changes");
     Ok(())
 }

--- a/crates/wisp/tests/component_tests/file_list_panel.rs
+++ b/crates/wisp/tests/component_tests/file_list_panel.rs
@@ -184,7 +184,7 @@ fn renders_directory_tree() {
         &[
             " Git Diff · Both  2 files  +6 -1".to_string(),
             rule(),
-            "▎▾  src/".to_string(),
+            cols(&[("▎▾  src/", 39), ("☐", 0)]),
             cols(&[(" ├── main.rs", 31), ("+2 -1 M ☐", 0)]),
             cols(&[(" └── util.rs", 31), ("+4 -0 A ☐", 0)]),
         ],
@@ -335,7 +335,13 @@ async fn collapse_directory_hides_children() {
 
     assert_buffer_eq(
         &term,
-        &[" Git Diff · Both  2 files  +6 -1".to_string(), rule(), "▎▸  src/".to_string(), String::new(), String::new()],
+        &[
+            " Git Diff · Both  2 files  +6 -1".to_string(),
+            rule(),
+            cols(&[("▎▸  src/", 39), ("☐", 0)]),
+            String::new(),
+            String::new(),
+        ],
     );
 }
 


### PR DESCRIPTION
## Summary
- Space on a directory row in the git diff view now stages/unstages every file beneath it, and directory rows render an aggregate stage checkbox (`☐` / `▣` / `☑`).
- Selection and collapsed directories survive the refresh that follows staging actions, handled inside `FileTree` instead of `GitDiffMode`.
- Refactor `FileTree` to use a flat entry list as its model: the nested tree now exists only transiently during construction, directory entries carry precomputed stage state and descendant file indices, and the recursive counter-/path-threading walkers are gone.
- Drop the single-file `stage_file`/`unstage_file` wrappers for slice-based `stage_files`/`unstage_files` taking `&[&str]`, and replace the one-field `RefreshState` struct with a `FocusSide` enum.

## Test plan
- `just lint` clean workspace-wide, `cargo test -p aether-wisp` green (836 tests).
- New app-level test drives directory staging end-to-end against a real git repo (`space_toggles_staging_for_selected_directory`).
- New unit tests cover collapse preservation for directories hidden under collapsed parents and `selected_file_indices` including hidden descendants.
- Updated two golden component tests to expect the new directory checkbox.