### PR TITLE
fix: keep file picker open when pasting

### DIFF
--- a/crates/tui/src/combobox.rs
+++ b/crates/tui/src/combobox.rs
@@ -189,10 +189,17 @@ impl<T: Searchable + Send + Sync + 'static> Combobox<T> {
 
     /// Standard event dispatch for picker-style components.
     ///
-    /// Handles Escape, Up/Down, Tab/Enter (confirm), Char (query + whitespace-close),
+    /// Handles paste, Escape, Up/Down, Tab/Enter (confirm), Char (query + whitespace-close),
     /// Backspace, and `BackspaceOnEmpty`. Returns `PickerMessage<T>` for each action.
     pub fn handle_picker_event(&mut self, event: &crate::components::Event) -> Option<Vec<PickerMessage<T>>> {
         let crate::components::Event::Key(key_event) = event else {
+            if let crate::components::Event::Paste(text) = event {
+                let sanitized: String = text.chars().filter(|c| !c.is_control()).collect();
+                for c in sanitized.chars() {
+                    self.push_query_char(c);
+                }
+                return Some(if sanitized.is_empty() { vec![] } else { vec![PickerMessage::TextTyped(sanitized)] });
+            }
             return None;
         };
         match classify_key(*key_event, self.fuzzy.query().is_empty()) {

--- a/crates/tui/src/components/component.rs
+++ b/crates/tui/src/components/component.rs
@@ -65,6 +65,7 @@ pub enum PickerMessage<T> {
     CloseWithChar(char),
     Confirm(T),
     CharTyped(char),
+    TextTyped(String),
     PopChar,
 }
 

--- a/crates/tui/tests/combobox.rs
+++ b/crates/tui/tests/combobox.rs
@@ -313,6 +313,17 @@ fn move_down_where_noop_when_all_filtered() {
 }
 
 #[test]
+fn handle_picker_event_paste_appends_sanitized_text() {
+    let mut combobox = combo(&["fix login", "add tests"]);
+    let event = Event::Paste("fix \nlogin".into());
+
+    let outcome = combobox.handle_picker_event(&event).expect("paste consumed");
+
+    assert!(matches!(outcome.as_slice(), [PickerMessage::TextTyped(text)] if text == "fix login"));
+    assert_eq!(combobox.query(), "fix login");
+}
+
+#[test]
 fn handle_picker_event_whitespace_closes_by_default() {
     let mut combobox = combo(&["alpha", "beta"]);
     let event = Event::Key(key(KeyCode::Char(' ')));

--- a/crates/wisp/src/components/prompt_composer.rs
+++ b/crates/wisp/src/components/prompt_composer.rs
@@ -252,6 +252,10 @@ impl PromptComposer {
                 self.text_input.insert_char_at_cursor(c);
                 (false, None)
             }
+            PickerMessage::TextTyped(text) => {
+                self.text_input.insert_paste(&text);
+                (false, None)
+            }
             PickerMessage::PopChar => {
                 self.text_input.delete_char_before_cursor();
                 (false, None)
@@ -383,6 +387,10 @@ impl Component for PromptComposer {
                 if let Some(Overlay::PromptSearch { picker, .. }) = self.active_overlay.as_mut() {
                     let outcome = picker.on_event(event).await;
                     return Some(self.handle_prompt_search_outcome(outcome));
+                }
+                if let Some(Overlay::File(picker)) = self.active_overlay.as_mut() {
+                    let outcome = picker.on_event(event).await;
+                    return Some(self.handle_file_picker_outcome(outcome));
                 }
                 self.close_all();
                 let added = parse_dropped_file_paths(text).is_some_and(|paths| self.add_dropped_media(paths));
@@ -665,14 +673,14 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn paste_closes_picker_and_inserts_text() {
+    async fn paste_keeps_file_picker_open_and_filters() {
         let mut composer = PromptComposer::default();
         type_chars(&mut composer, "@").await;
         assert!(composer.has_file_picker());
 
-        let msgs = composer.on_event(&Event::Paste("pasted text".into())).await.unwrap();
+        let msgs = composer.on_event(&Event::Paste("pasted \ntext".into())).await.unwrap();
         assert!(msgs.is_empty());
-        assert!(!composer.has_active_picker());
+        assert!(composer.has_file_picker());
         assert_eq!(composer.buffer(), "@pasted text");
     }
 
@@ -751,7 +759,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn paste_closes_file_picker_before_processing_drop() {
+    async fn paste_media_path_filters_file_picker_instead_of_adding_attachment() {
         let tmp = TempDir::new().unwrap();
         let img = create_temp_media(&tmp, "screen.png");
 
@@ -761,8 +769,9 @@ mod tests {
 
         composer.on_event(&Event::Paste(img.to_str().unwrap().into())).await;
 
-        assert!(!composer.has_active_picker());
-        assert_eq!(composer.pending_media().len(), 1);
+        assert!(composer.has_file_picker());
+        assert_eq!(composer.pending_media().len(), 0);
+        assert_eq!(composer.buffer(), format!("@{}", img.display()));
     }
 
     #[tokio::test]

--- a/crates/wisp/tests/app_tests/input_prompt_tests.rs
+++ b/crates/wisp/tests/app_tests/input_prompt_tests.rs
@@ -149,7 +149,7 @@ async fn test_paste_strips_control_characters() -> TestResult {
 }
 
 #[tokio::test]
-async fn test_paste_closes_file_picker() -> TestResult {
+async fn test_paste_keeps_file_picker_open() -> TestResult {
     let mut renderer = RendererTest::new().size((80, 24)).build()?;
 
     // Open file picker with @
@@ -163,12 +163,11 @@ async fn test_paste_closes_file_picker() -> TestResult {
         .await?;
     assert!(has_file_picker(renderer.writer()), "File picker should be open");
 
-    // Paste should close the picker and append text
+    // Paste should keep the picker open and append filter text
     renderer.on_paste("pasted text").await?;
 
-    assert!(!has_file_picker(renderer.writer()), "File picker should be closed");
-    let expected = expected_prompt(80, "@pasted text", TEST_AGENT);
-    assert_buffer_eq(renderer.writer(), &expected);
+    assert!(has_file_picker(renderer.writer()), "File picker should remain open");
+    assert_buffer_contains(renderer.writer(), "> @pasted text");
     Ok(())
 }
 


### PR DESCRIPTION
## Summary
- route paste events through the active `@` file picker
- keep the prompt input and fuzzy-search query synchronized
- sanitize pasted control characters while preserving spaces
- treat pasted file paths as picker queries while the picker is active
- replace close-on-paste expectations with regression coverage

## Validation
- `cargo test -p aether-tui -p aether-wisp`
- `just lint`
- `just fmt`