### PR TITLE
feat(mcp): support pre-registered OAuth clients

### DIFF
--- a/crates/aether-auth/src/mcp/credential_store.rs
+++ b/crates/aether-auth/src/mcp/credential_store.rs
@@ -14,12 +14,20 @@ use crate::{OAuthCredential, OAuthCredentialStorage};
 pub struct McpCredentialStore {
     server_id: String,
     store: Arc<dyn OAuthCredentialStorage>,
+    expected_client_id: Option<String>,
     now_fn: fn() -> SystemTime,
 }
 
 impl McpCredentialStore {
     pub fn new(store: Arc<dyn OAuthCredentialStorage>, server_id: String) -> Self {
-        Self { server_id, store, now_fn: SystemTime::now }
+        Self { server_id, store, expected_client_id: None, now_fn: SystemTime::now }
+    }
+
+    /// Only serve stored credentials issued to this client id; credentials for any
+    /// other client are ignored on load (and replaced on the next successful flow).
+    pub fn with_expected_client_id(mut self, client_id: Option<&str>) -> Self {
+        self.expected_client_id = client_id.map(String::from);
+        self
     }
 
     pub fn with_now_fn(mut self, f: fn() -> SystemTime) -> Self {
@@ -35,8 +43,12 @@ impl McpCredentialStore {
 #[async_trait]
 impl CredentialStore for McpCredentialStore {
     async fn load(&self) -> Result<Option<StoredCredentials>, AuthError> {
-        let cred =
-            self.store.load_credential(&self.server_id).await.map_err(|e| AuthError::InternalError(e.to_string()))?;
+        let cred = self
+            .store
+            .load_credential(&self.server_id)
+            .await
+            .map_err(|e| AuthError::InternalError(e.to_string()))?
+            .filter(|c| self.expected_client_id.as_deref().is_none_or(|expected| c.client_id == expected));
 
         let now = self.now();
         Ok(cred.map(|c| {
@@ -164,6 +176,28 @@ mod tests {
         let token = loaded.token_response.unwrap();
         assert_eq!(token.access_token().secret(), "token");
         assert_eq!(token.refresh_token().map(|t| t.secret().as_str()), Some("refresh"));
+    }
+
+    #[tokio::test]
+    async fn load_filters_credentials_for_unexpected_client() {
+        let store = Arc::new(FakeOAuthCredentialStore::new());
+        store.save_credential("server", credential_expiring_at(fake_now())).await.unwrap();
+
+        let mcp_store = mcp_store(store.clone()).with_expected_client_id(Some("other-client"));
+
+        assert!(CredentialStore::load(&mcp_store).await.unwrap().is_none());
+        assert!(store.load_credential("server").await.unwrap().is_some());
+    }
+
+    #[tokio::test]
+    async fn load_serves_credentials_for_expected_client() {
+        let store = Arc::new(FakeOAuthCredentialStore::new());
+        store.save_credential("server", credential_expiring_at(fake_now())).await.unwrap();
+
+        let mcp_store = mcp_store(store).with_expected_client_id(Some("client"));
+
+        let loaded = CredentialStore::load(&mcp_store).await.unwrap().unwrap();
+        assert_eq!(loaded.client_id, "client");
     }
 
     #[tokio::test]

--- a/crates/aether-auth/src/mcp/integration.rs
+++ b/crates/aether-auth/src/mcp/integration.rs
@@ -1,23 +1,28 @@
 use super::credential_store::McpCredentialStore;
 use crate::{OAuthCredentialStorage, OAuthError, OAuthHandler};
-use rmcp::transport::auth::{AuthClient, AuthorizationManager, OAuthState};
+use rmcp::transport::auth::{AuthClient, AuthError, AuthorizationManager, OAuthClientConfig};
 use std::sync::Arc;
 
 const OAUTH_CLIENT_NAME: &str = "Aether MCP Client";
 
 /// Returns `Ok(Some(manager))` if credentials were found and initialized successfully,
 /// `Ok(None)` if no stored credentials exist, or `Err` on failure.
+///
+/// When `expected_client_id` is given, stored credentials issued to a different client
+/// are ignored, forcing a fresh authorization flow.
 pub async fn create_auth_manager_from_store(
     server_id: &str,
     base_url: &str,
+    expected_client_id: Option<&str>,
     store: Arc<dyn OAuthCredentialStorage>,
 ) -> Result<Option<AuthorizationManager>, OAuthError> {
-    let credential_store = McpCredentialStore::new(store, server_id.to_string());
+    let credential_store =
+        McpCredentialStore::new(store, server_id.to_string()).with_expected_client_id(expected_client_id);
 
-    let mut auth_manager = AuthorizationManager::new(base_url).await.map_err(|e| OAuthError::Rmcp(e.to_string()))?;
+    let mut auth_manager = AuthorizationManager::new(base_url).await.map_err(rmcp_err("OAuth init failed"))?;
     auth_manager.set_credential_store(credential_store);
 
-    if auth_manager.initialize_from_store().await.map_err(|e| OAuthError::Rmcp(e.to_string()))? {
+    if auth_manager.initialize_from_store().await.map_err(rmcp_err("credential store load failed"))? {
         Ok(Some(auth_manager))
     } else {
         Ok(None)
@@ -26,54 +31,58 @@ pub async fn create_auth_manager_from_store(
 
 /// Run a full OAuth authorization flow against an MCP server.
 ///
-/// Creates the `OAuthState`, starts authorization using the handler's redirect URI,
-/// opens the browser (via the handler), handles the callback, and returns an `AuthClient`
-/// ready for authenticated HTTP transport. When `store` is `Some`, the resulting tokens
-/// are persisted via the store; when `None`, tokens live only for the lifetime of the
-/// returned `AuthClient`.
+/// Discovers the server's authorization metadata, obtains a client (the pre-registered
+/// `client_id` when given, dynamic registration otherwise), opens the browser (via the
+/// handler), handles the callback, and returns an `AuthClient` ready for authenticated
+/// HTTP transport. When `store` is `Some`, the resulting tokens are persisted via the
+/// store; when `None`, tokens live only for the lifetime of the returned `AuthClient`.
 pub async fn perform_oauth_flow(
     server_id: &str,
     base_url: &str,
     handler: &dyn OAuthHandler,
+    client_id: Option<&str>,
     store: Option<Arc<dyn OAuthCredentialStorage>>,
 ) -> Result<AuthClient<reqwest::Client>, OAuthError> {
-    let mut oauth_state =
-        OAuthState::new(base_url, None).await.map_err(|e| OAuthError::Rmcp(format!("OAuth init failed: {e}")))?;
+    let mut manager = AuthorizationManager::new(base_url).await.map_err(rmcp_err("OAuth init failed"))?;
 
     if let Some(store) = store {
-        let credential_store = McpCredentialStore::new(store, server_id.to_string());
-        if let OAuthState::Unauthorized(ref mut manager) = oauth_state {
-            manager.set_credential_store(credential_store);
-        }
+        manager.set_credential_store(
+            McpCredentialStore::new(store, server_id.to_string()).with_expected_client_id(client_id),
+        );
     }
 
-    oauth_state
-        .start_authorization(&[], handler.redirect_uri(), Some(OAUTH_CLIENT_NAME))
-        .await
-        .map_err(|e| OAuthError::Rmcp(format!("start_authorization failed: {e}")))?;
+    let metadata = manager.discover_metadata().await.map_err(rmcp_err("OAuth metadata discovery failed"))?;
+    manager.set_metadata(metadata);
 
-    let auth_url = oauth_state
-        .get_authorization_url()
-        .await
-        .map_err(|e| OAuthError::Rmcp(format!("get_authorization_url failed: {e}")))?;
+    let scopes = manager.select_scopes(None, &[]);
+    let scope_refs = scopes.iter().map(String::as_str).collect::<Vec<_>>();
+    let client_config = match client_id {
+        Some(client_id) => OAuthClientConfig::new(client_id, handler.redirect_uri()),
+        None => manager
+            .register_client(OAUTH_CLIENT_NAME, handler.redirect_uri(), &scope_refs)
+            .await
+            .map_err(rmcp_err("dynamic client registration failed"))?,
+    };
+    manager.configure_client(client_config).map_err(rmcp_err("OAuth client configuration failed"))?;
+
+    let auth_url =
+        manager.get_authorization_url(&scope_refs).await.map_err(rmcp_err("get_authorization_url failed"))?;
 
     // Some authorization servers (e.g. Sentry) bake `resource` into their
     // authorization_endpoint metadata. rmcp then adds its own `resource` param,
     // producing a duplicate that the server rejects with "invalid_target".
-    let auth_url = dedupe_query_params(&auth_url);
+    let callback = handler.authorize(&dedupe_query_params(&auth_url)).await?;
 
-    let callback = handler.authorize(&auth_url).await?;
-
-    oauth_state
-        .handle_callback(&callback.code, &callback.state)
+    manager
+        .exchange_code_for_token(&callback.code, &callback.state)
         .await
-        .map_err(|e| OAuthError::Rmcp(format!("handle_callback failed: {e}")))?;
+        .map_err(rmcp_err("token exchange failed"))?;
 
-    let auth_manager = oauth_state
-        .into_authorization_manager()
-        .ok_or_else(|| OAuthError::Rmcp("OAuth flow did not produce an AuthorizationManager".into()))?;
+    Ok(AuthClient::new(reqwest::Client::default(), manager))
+}
 
-    Ok(AuthClient::new(reqwest::Client::default(), auth_manager))
+fn rmcp_err(context: &'static str) -> impl Fn(AuthError) -> OAuthError {
+    move |e| OAuthError::Rmcp(format!("{context}: {e}"))
 }
 
 fn dedupe_query_params(url_str: &str) -> String {

--- a/crates/aether-auth/tests/mcp_oauth.rs
+++ b/crates/aether-auth/tests/mcp_oauth.rs
@@ -1,0 +1,146 @@
+#![cfg(feature = "mcp")]
+
+use aether_auth::{
+    FakeOAuthCredentialStore, OAuthCallback, OAuthCredential, OAuthCredentialStorage, OAuthError, OAuthHandler,
+    create_auth_manager_from_store, perform_oauth_flow,
+};
+use futures::future::BoxFuture;
+use std::sync::{Arc, Mutex};
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
+
+#[tokio::test]
+async fn configured_client_id_ignores_credentials_for_another_client() {
+    let store = Arc::new(FakeOAuthCredentialStore::new().with_credential(
+        "slack",
+        OAuthCredential {
+            client_id: "old-client".to_string(),
+            access_token: "old-token".to_string(),
+            refresh_token: None,
+            expires_at: None,
+            granted_scopes: Vec::new(),
+        },
+    ));
+
+    let manager =
+        create_auth_manager_from_store("slack", "https://mcp.slack.com/mcp", Some("configured-client"), store.clone())
+            .await
+            .unwrap();
+
+    assert!(manager.is_none());
+    let preserved = store.load_credential("slack").await.unwrap().expect("mismatched credential should be preserved");
+    assert_eq!(preserved.client_id, "old-client");
+}
+
+struct FakeHandler {
+    auth_url: Arc<Mutex<Option<String>>>,
+}
+
+impl OAuthHandler for FakeHandler {
+    fn redirect_uri(&self) -> &'static str {
+        "http://localhost:3118/"
+    }
+
+    fn authorize(&self, auth_url: &str) -> BoxFuture<'_, Result<OAuthCallback, OAuthError>> {
+        *self.auth_url.lock().unwrap() = Some(auth_url.to_string());
+        let state =
+            url::Url::parse(auth_url).unwrap().query_pairs().find(|(name, _)| name == "state").unwrap().1.into_owned();
+        Box::pin(async move { Ok(OAuthCallback { code: "test-code".to_string(), state }) })
+    }
+}
+
+struct OAuthServer {
+    base_url: String,
+    requests: Arc<Mutex<Vec<String>>>,
+    task: tokio::task::JoinHandle<()>,
+}
+
+impl OAuthServer {
+    async fn bind() -> Self {
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let origin = format!("http://{}", listener.local_addr().unwrap());
+        let base_url = format!("{origin}/mcp");
+        let requests = Arc::new(Mutex::new(Vec::new()));
+        let captured_requests = Arc::clone(&requests);
+        let task = tokio::spawn(async move {
+            while let Ok((mut stream, _)) = listener.accept().await {
+                let mut buffer = vec![0; 8192];
+                let read = stream.read(&mut buffer).await.unwrap();
+                let request = String::from_utf8_lossy(&buffer[..read]);
+                let request_line = request.lines().next().unwrap().to_string();
+                captured_requests.lock().unwrap().push(request_line.clone());
+                let path = request_line.split_whitespace().nth(1).unwrap();
+
+                let body = if path.contains("oauth-protected-resource") {
+                    serde_json::json!({
+                        "resource": format!("{origin}/mcp"),
+                        "authorization_servers": [&origin]
+                    })
+                } else if path == "/token" {
+                    serde_json::json!({
+                        "access_token": "access-token",
+                        "token_type": "Bearer",
+                        "expires_in": 3600
+                    })
+                } else if path == "/register" {
+                    serde_json::json!({
+                        "client_id": "registered-client",
+                        "redirect_uris": ["http://localhost:3118/"]
+                    })
+                } else {
+                    serde_json::json!({
+                        "issuer": origin,
+                        "authorization_endpoint": format!("{origin}/authorize"),
+                        "token_endpoint": format!("{origin}/token"),
+                        "registration_endpoint": format!("{origin}/register"),
+                        "response_types_supported": ["code"],
+                        "code_challenge_methods_supported": ["S256"],
+                        "scopes_supported": ["openid"]
+                    })
+                }
+                .to_string();
+                let response = format!(
+                    "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{}",
+                    body.len(),
+                    body
+                );
+                stream.write_all(response.as_bytes()).await.unwrap();
+            }
+        });
+        Self { base_url, requests, task }
+    }
+}
+
+impl Drop for OAuthServer {
+    fn drop(&mut self) {
+        self.task.abort();
+    }
+}
+
+#[tokio::test]
+async fn no_client_id_uses_dynamic_registration() {
+    let server = OAuthServer::bind().await;
+    let auth_url = Arc::new(Mutex::new(None));
+    let handler = FakeHandler { auth_url: Arc::clone(&auth_url) };
+
+    perform_oauth_flow("slack", &server.base_url, &handler, None, None).await.unwrap();
+
+    let auth_url = auth_url.lock().unwrap().clone().unwrap();
+    let auth_url = url::Url::parse(&auth_url).unwrap();
+    assert!(auth_url.query_pairs().any(|(name, value)| name == "client_id" && value == "registered-client"));
+    assert!(server.requests.lock().unwrap().iter().any(|request| request.starts_with("POST /register")));
+}
+
+#[tokio::test]
+async fn configured_client_id_skips_dynamic_registration() {
+    let server = OAuthServer::bind().await;
+    let auth_url = Arc::new(Mutex::new(None));
+    let handler = FakeHandler { auth_url: Arc::clone(&auth_url) };
+
+    perform_oauth_flow("slack", &server.base_url, &handler, Some("static-client"), None).await.unwrap();
+
+    let auth_url = auth_url.lock().unwrap().clone().unwrap();
+    let auth_url = url::Url::parse(&auth_url).unwrap();
+    assert!(auth_url.query_pairs().any(|(name, value)| name == "client_id" && value == "static-client"));
+    assert!(auth_url.query_pairs().any(|(name, value)| name == "redirect_uri" && value == "http://localhost:3118/"));
+    assert!(!server.requests.lock().unwrap().iter().any(|request| request.starts_with("POST /register")));
+}

--- a/crates/aether-cli/src/acp/protocol/mcp.rs
+++ b/crates/aether-cli/src/acp/protocol/mcp.rs
@@ -30,15 +30,13 @@ fn try_map_mcp_server(server: McpServer) -> Option<RuntimeMcpServer> {
 
         Http(http) => Some(RuntimeMcpServer::new(
             http.name,
-            McpTransport::Http { config: http_config(http.url, &http.headers) },
+            McpTransport::Http(http_config(http.url, &http.headers).into()),
             false,
         )),
 
-        Sse(sse) => Some(RuntimeMcpServer::new(
-            sse.name,
-            McpTransport::Http { config: http_config(sse.url, &sse.headers) },
-            false,
-        )),
+        Sse(sse) => {
+            Some(RuntimeMcpServer::new(sse.name, McpTransport::Http(http_config(sse.url, &sse.headers).into()), false))
+        }
 
         _ => None,
     }
@@ -97,10 +95,10 @@ mod tests {
         assert_eq!(configs.len(), 1);
 
         match &configs[0].transport {
-            McpTransport::Http { config } => {
+            McpTransport::Http(config) => {
                 assert_eq!(configs[0].name, "http-server");
-                assert_eq!(config.uri.as_ref(), "https://example.com/mcp");
-                assert_eq!(config.auth_header.as_deref(), Some("token123"));
+                assert_eq!(config.transport.uri.as_ref(), "https://example.com/mcp");
+                assert_eq!(config.transport.auth_header.as_deref(), Some("token123"));
             }
             other => panic!("Expected Http, got {other:?}"),
         }
@@ -126,8 +124,8 @@ mod tests {
             );
             let configs = map_acp_mcp_servers(vec![server]);
             match &configs[0].transport {
-                McpTransport::Http { config } => {
-                    assert_eq!(config.auth_header.as_deref(), Some(expected), "input was {input:?}");
+                McpTransport::Http(config) => {
+                    assert_eq!(config.transport.auth_header.as_deref(), Some(expected), "input was {input:?}");
                 }
                 other => panic!("Expected Http, got {other:?}"),
             }
@@ -142,10 +140,10 @@ mod tests {
         assert_eq!(configs.len(), 1);
 
         match &configs[0].transport {
-            McpTransport::Http { config } => {
+            McpTransport::Http(config) => {
                 assert_eq!(configs[0].name, "sse-server");
-                assert_eq!(config.uri.as_ref(), "https://example.com/sse");
-                assert_eq!(config.auth_header, None);
+                assert_eq!(config.transport.uri.as_ref(), "https://example.com/sse");
+                assert_eq!(config.transport.auth_header, None);
             }
             other => panic!("Expected Http, got {other:?}"),
         }

--- a/crates/aether-core/tests/mcp/config_parser_tests.rs
+++ b/crates/aether-core/tests/mcp/config_parser_tests.rs
@@ -1,4 +1,4 @@
-use mcp_utils::client::{McpConfig, McpServer, McpTransport, ParseError};
+use mcp_utils::client::{McpConfig, McpHttpConfig, McpServer, McpTransport, ParseError};
 use std::collections::HashMap;
 use std::env;
 use utils::variables::Vars;
@@ -28,9 +28,9 @@ macro_rules! with_env {
 
 fn assert_http(server: McpServer, expected_name: &str, expected_url: &str) -> McpServer {
     match &server.transport {
-        McpTransport::Http { config: c } => {
+        McpTransport::Http(c) => {
             assert_eq!(server.name, expected_name);
-            assert_eq!(c.uri.to_string(), expected_url);
+            assert_eq!(c.transport.uri.to_string(), expected_url);
         }
         other => panic!("Expected Http config, got {other:?}"),
     }
@@ -64,6 +64,44 @@ async fn test_parse_stdio_config() {
 }
 
 #[tokio::test]
+async fn test_parse_http_oauth_config() {
+    let json = server_json(
+        "slack",
+        r#"{
+            "type": "http",
+            "url": "https://mcp.slack.com/mcp",
+            "oauth": {
+                "clientId": "1601185624273.8899143856786",
+                "callbackPort": 3118
+            }
+        }"#,
+    );
+
+    let server = parse_one(&json).await;
+    match server.transport {
+        McpTransport::Http(McpHttpConfig { oauth: Some(oauth), .. }) => {
+            assert_eq!(oauth.client_id, "1601185624273.8899143856786");
+            assert_eq!(oauth.callback_port.get(), 3118);
+        }
+        other => panic!("Expected HTTP OAuth config, got {other:?}"),
+    }
+}
+
+#[test]
+fn test_rejects_zero_oauth_callback_port() {
+    let json = server_json(
+        "bad",
+        r#"{
+            "type": "http",
+            "url": "https://example.com/mcp",
+            "oauth": { "clientId": "client", "callbackPort": 0 }
+        }"#,
+    );
+
+    assert!(McpConfig::from_json(&json).is_err());
+}
+
+#[tokio::test]
 async fn test_parse_http_and_sse_configs() {
     let json = server_json(
         "mcpMesh",
@@ -77,8 +115,8 @@ async fn test_parse_http_and_sse_configs() {
         [("API_TOKEN", "secret_token")],
         assert_http(parse_one(&json).await, "mcpMesh", "http://localhost:3000/mcp")
     );
-    if let McpTransport::Http { config: c } = cfg.transport {
-        assert_eq!(c.auth_header.as_ref().unwrap(), "secret_token");
+    if let McpTransport::Http(c) = cfg.transport {
+        assert_eq!(c.transport.auth_header.as_ref().unwrap(), "secret_token");
     }
 
     let json = server_json("sseServer", r#"{ "type": "sse", "url": "http://localhost:4000/sse", "headers": {} }"#);

--- a/crates/aether-core/tests/mcp/oauth_tests.rs
+++ b/crates/aether-core/tests/mcp/oauth_tests.rs
@@ -29,7 +29,7 @@ impl FailingHttpEndpoint {
     fn server(&self, name: &str, proxied: bool) -> McpServer {
         McpServer::new(
             name,
-            McpTransport::Http { config: StreamableHttpClientTransportConfig::with_uri(self.uri.as_str()) },
+            McpTransport::Http(StreamableHttpClientTransportConfig::with_uri(self.uri.as_str()).into()),
             proxied,
         )
     }

--- a/crates/mcp-utils/Cargo.toml
+++ b/crates/mcp-utils/Cargo.toml
@@ -54,5 +54,6 @@ thiserror = { workspace = true, optional = true }
 
 [dev-dependencies]
 aether-doctest = { path = "../doctest" }
+rmcp = { workspace = true, features = ["macros"] }
 tempfile = { workspace = true }
 tracing-subscriber = { workspace = true }

--- a/crates/mcp-utils/src/client/config.rs
+++ b/crates/mcp-utils/src/client/config.rs
@@ -5,6 +5,7 @@ use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use std::collections::{BTreeMap, HashMap};
 use std::fmt::{Debug, Formatter};
+use std::num::NonZeroU16;
 use std::path::Path;
 use utils::is_false;
 use utils::variables::{VarError, Vars};
@@ -20,8 +21,7 @@ pub struct McpConfig {
 #[serde(untagged)]
 pub enum McpServerConfig {
     Stdio(StdioServerConfig),
-    Http(HttpServerConfig),
-    Sse(SseServerConfig),
+    Remote(RemoteServerConfig),
     InMemory(InMemoryServerConfig),
 }
 
@@ -49,37 +49,29 @@ pub struct StdioServerConfig {
 }
 
 #[derive(Debug, Clone, Deserialize, Serialize, JsonSchema, PartialEq)]
-#[serde(deny_unknown_fields)]
-pub struct HttpServerConfig {
-    /// Transport discriminant; always `http`.
-    #[serde(rename = "type")]
-    pub type_: HttpType,
-
-    /// Base URL of the streamable HTTP MCP server.
-    pub url: String,
-
-    /// Extra HTTP headers sent with every request.
-    #[serde(default)]
-    pub headers: HashMap<String, String>,
-
-    /// Expose this server's tools through Aether's tool proxy.
-    #[serde(default, skip_serializing_if = "is_false")]
-    pub proxy: bool,
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct McpOAuthConfig {
+    pub client_id: String,
+    pub callback_port: NonZeroU16,
 }
 
 #[derive(Debug, Clone, Deserialize, Serialize, JsonSchema, PartialEq)]
 #[serde(deny_unknown_fields)]
-pub struct SseServerConfig {
-    /// Transport discriminant; always `sse`.
+pub struct RemoteServerConfig {
+    /// Transport discriminant; `http` (streamable HTTP) or `sse` (Server-Sent Events).
     #[serde(rename = "type")]
-    pub type_: SseType,
+    pub type_: RemoteType,
 
-    /// Base URL of the Server-Sent Events MCP server.
+    /// Base URL of the remote MCP server.
     pub url: String,
 
     /// Extra HTTP headers sent with every request.
     #[serde(default)]
     pub headers: HashMap<String, String>,
+
+    /// OAuth settings for a pre-registered public client.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub oauth: Option<McpOAuthConfig>,
 
     /// Expose this server's tools through Aether's tool proxy.
     #[serde(default, skip_serializing_if = "is_false")]
@@ -114,13 +106,9 @@ pub enum StdioType {
 }
 
 #[derive(Debug, Clone, Copy, Deserialize, Serialize, JsonSchema, PartialEq)]
-pub enum HttpType {
+pub enum RemoteType {
     #[serde(rename = "http")]
     Http,
-}
-
-#[derive(Debug, Clone, Copy, Deserialize, Serialize, JsonSchema, PartialEq)]
-pub enum SseType {
     #[serde(rename = "sse")]
     Sse,
 }
@@ -139,8 +127,30 @@ pub struct McpServer {
 
 pub enum McpTransport {
     Stdio { command: String, args: Vec<String>, env: HashMap<String, String> },
-    Http { config: StreamableHttpClientTransportConfig },
+    Http(McpHttpConfig),
     InMemory { server: Box<dyn DynService<RoleServer>> },
+}
+
+#[derive(Debug, Clone)]
+pub struct McpHttpConfig {
+    pub transport: StreamableHttpClientTransportConfig,
+    pub oauth: Option<McpOAuthConfig>,
+}
+
+impl McpHttpConfig {
+    pub fn oauth_client_id(&self) -> Option<&str> {
+        self.oauth.as_ref().map(|oauth| oauth.client_id.as_str())
+    }
+
+    pub fn callback_port(&self) -> Option<NonZeroU16> {
+        self.oauth.as_ref().map(|oauth| oauth.callback_port)
+    }
+}
+
+impl From<StreamableHttpClientTransportConfig> for McpHttpConfig {
+    fn from(transport: StreamableHttpClientTransportConfig) -> Self {
+        Self { transport, oauth: None }
+    }
 }
 
 impl McpServer {
@@ -156,7 +166,7 @@ impl McpServer {
             McpTransport::Stdio { command, args, env } => {
                 McpTransport::Stdio { command: command.clone(), args: args.clone(), env: env.clone() }
             }
-            McpTransport::Http { config } => McpTransport::Http { config: config.clone() },
+            McpTransport::Http(config) => McpTransport::Http(config.clone()),
             McpTransport::InMemory { .. } => return Err(McpServerCloneError(self.name.clone())),
         };
         Ok(Self { name: self.name.clone(), transport, proxy: self.proxy })
@@ -183,7 +193,7 @@ impl Debug for McpTransport {
             McpTransport::Stdio { command, args, env } => {
                 f.debug_struct("Stdio").field("command", command).field("args", args).field("env", env).finish()
             }
-            McpTransport::Http { config } => f.debug_struct("Http").field("config", config).finish(),
+            McpTransport::Http(config) => f.debug_tuple("Http").field(config).finish(),
             McpTransport::InMemory { .. } => f.debug_struct("InMemory").field("server", &"<DynService>").finish(),
         }
     }
@@ -265,8 +275,7 @@ impl McpServerConfig {
     pub fn proxy(&self) -> bool {
         match self {
             McpServerConfig::Stdio(config) => config.proxy,
-            McpServerConfig::Http(config) => config.proxy,
-            McpServerConfig::Sse(config) => config.proxy,
+            McpServerConfig::Remote(config) => config.proxy,
             McpServerConfig::InMemory(config) => config.proxy,
         }
     }
@@ -274,8 +283,7 @@ impl McpServerConfig {
     pub fn set_proxy(&mut self, value: bool) {
         match self {
             McpServerConfig::Stdio(config) => config.proxy = value,
-            McpServerConfig::Http(config) => config.proxy = value,
-            McpServerConfig::Sse(config) => config.proxy = value,
+            McpServerConfig::Remote(config) => config.proxy = value,
             McpServerConfig::InMemory(config) => config.proxy = value,
         }
     }
@@ -308,8 +316,7 @@ impl McpServerConfig {
                     .collect::<Result<HashMap<_, _>, VarError>>()?,
             }),
 
-            McpServerConfig::Http(HttpServerConfig { url, headers, .. })
-            | McpServerConfig::Sse(SseServerConfig { url, headers, .. }) => {
+            McpServerConfig::Remote(RemoteServerConfig { url, headers, oauth, .. }) => {
                 let auth_header = headers.get("Authorization").map(|v| vars.expand(v)).transpose()?.map(|auth| {
                     // rmcp adds `Bearer`  to the auth header.
                     auth.split_once(' ')
@@ -318,12 +325,18 @@ impl McpServerConfig {
                         .to_string()
                 });
 
-                let mut config = StreamableHttpClientTransportConfig::with_uri(vars.expand(&url)?);
+                let mut transport = StreamableHttpClientTransportConfig::with_uri(vars.expand(&url)?);
                 if let Some(auth) = auth_header {
-                    config = config.auth_header(auth);
+                    transport = transport.auth_header(auth);
                 }
 
-                Ok(McpTransport::Http { config })
+                let oauth = oauth
+                    .map(|oauth| -> Result<McpOAuthConfig, VarError> {
+                        Ok(McpOAuthConfig { client_id: vars.expand(&oauth.client_id)?, ..oauth })
+                    })
+                    .transpose()?;
+
+                Ok(McpTransport::Http(McpHttpConfig { transport, oauth }))
             }
 
             McpServerConfig::InMemory(InMemoryServerConfig { args, input, .. }) => {
@@ -547,11 +560,11 @@ mod tests {
         .map_err(|e| e.to_string())?;
 
         let servers = config.into_servers(&HashMap::new(), &Vars::new()).await.map_err(|e| e.to_string())?;
-        let McpTransport::Http { config } = &servers[0].transport else {
+        let McpTransport::Http(config) = &servers[0].transport else {
             return Err(format!("expected Http transport, got {:?}", servers[0].transport));
         };
 
-        assert_eq!(config.auth_header.as_deref(), Some("secret-token"));
+        assert_eq!(config.transport.auth_header.as_deref(), Some("secret-token"));
         Ok(())
     }
 
@@ -563,10 +576,10 @@ mod tests {
         .map_err(|e| e.to_string())?;
         let servers = config.into_servers(&HashMap::new(), &Vars::new()).await.map_err(|e| e.to_string())?;
 
-        let McpTransport::Http { config } = &servers[0].transport else {
+        let McpTransport::Http(config) = &servers[0].transport else {
             return Err(format!("expected Http transport, got {:?}", servers[0].transport));
         };
-        assert_eq!(config.auth_header.as_deref(), Some("Basic dXNlcjpwYXNz"));
+        assert_eq!(config.transport.auth_header.as_deref(), Some("Basic dXNlcjpwYXNz"));
         Ok(())
     }
 
@@ -579,10 +592,10 @@ mod tests {
         let vars = Vars::new().with("TOKEN", "expanded-token");
         let servers = config.into_servers(&HashMap::new(), &vars).await.map_err(|e| e.to_string())?;
 
-        let McpTransport::Http { config } = &servers[0].transport else {
+        let McpTransport::Http(config) = &servers[0].transport else {
             return Err(format!("expected Http transport, got {:?}", servers[0].transport));
         };
-        assert_eq!(config.auth_header.as_deref(), Some("expanded-token"));
+        assert_eq!(config.transport.auth_header.as_deref(), Some("expanded-token"));
         Ok(())
     }
 }

--- a/crates/mcp-utils/src/client/connection.rs
+++ b/crates/mcp-utils/src/client/connection.rs
@@ -1,6 +1,6 @@
 use super::{
     McpClientEvent, McpError, OAuthHandlerFactory, Result,
-    config::{McpServer, McpTransport},
+    config::{McpHttpConfig, McpServer, McpTransport},
     mcp_client::McpClient,
 };
 use crate::{client::OAuthHandlerContext, transport::create_in_memory_transport};
@@ -79,8 +79,8 @@ pub struct McpConnectAttempt {
 }
 
 pub enum McpConnectOutcome {
-    Connected { conn: McpServerConnection, reauth_config: Option<StreamableHttpClientTransportConfig> },
-    NeedsOAuth { config: StreamableHttpClientTransportConfig, error: McpError },
+    Connected { conn: McpServerConnection, reauth_config: Option<McpHttpConfig> },
+    NeedsOAuth { config: McpHttpConfig, error: McpError },
     Failed { error: McpError },
 }
 
@@ -135,7 +135,7 @@ pub(super) async fn connect_server(server: McpServer, ctx: &ConnectConfig) -> Mc
             connect_stdio(&name, command, args, env, mcp_client, ctx.root_dir.clone()).await
         }
         McpTransport::InMemory { server } => connect_in_memory(&name, server, mcp_client).await,
-        McpTransport::Http { config } => {
+        McpTransport::Http(config) => {
             connect_http(
                 &name,
                 config,
@@ -152,7 +152,7 @@ pub(super) async fn connect_server(server: McpServer, ctx: &ConnectConfig) -> Mc
 
 pub async fn authenticate_http(
     name: String,
-    config: StreamableHttpClientTransportConfig,
+    config: McpHttpConfig,
     ctx: Arc<ConnectConfig>,
     proxied: bool,
 ) -> McpConnectAttempt {
@@ -161,14 +161,24 @@ pub async fn authenticate_http(
             .oauth_handler_factory
             .as_ref()
             .ok_or_else(|| McpError::ConnectionFailed(format!("No OAuth handler factory available for '{name}'")))?;
-        let handler = factory(OAuthHandlerContext { server_name: name.clone(), tx: ctx.event_sender.clone() })?;
+        let handler = factory(OAuthHandlerContext {
+            server_name: name.clone(),
+            callback_port: config.callback_port(),
+            tx: ctx.event_sender.clone(),
+        })?;
 
-        let auth_client = perform_oauth_flow(&name, &config.uri, handler.as_ref(), ctx.oauth_credential_store.clone())
-            .await
-            .map_err(|e| McpError::ConnectionFailed(format!("OAuth failed for '{name}': {e}")))?;
+        let auth_client = perform_oauth_flow(
+            &name,
+            &config.transport.uri,
+            handler.as_ref(),
+            config.oauth_client_id(),
+            ctx.oauth_credential_store.clone(),
+        )
+        .await
+        .map_err(|e| McpError::ConnectionFailed(format!("OAuth failed for '{name}': {e}")))?;
 
         let mcp_client = McpClient::new(ctx.client_info.clone(), name.clone(), ctx.event_sender.clone());
-        McpServerConnection::reconnect_with_auth(&name, config.clone(), auth_client, mcp_client).await
+        McpServerConnection::reconnect_with_auth(&name, config.transport.clone(), auth_client, mcp_client).await
     }
     .await
     {
@@ -180,7 +190,7 @@ pub async fn authenticate_http(
 }
 
 impl McpConnectOutcome {
-    fn with_reauth(self, reauth_config: Option<StreamableHttpClientTransportConfig>) -> Self {
+    fn with_reauth(self, reauth_config: Option<McpHttpConfig>) -> Self {
         match self {
             Self::Connected { conn, .. } => Self::Connected { conn, reauth_config },
             other => other,
@@ -251,16 +261,18 @@ async fn connect_in_memory(
 
 async fn connect_http(
     name: &str,
-    config: StreamableHttpClientTransportConfig,
+    config: McpHttpConfig,
     mcp_client: McpClient,
     oauth_handler_factory: Option<&OAuthHandlerFactory>,
     oauth_credential_store: Option<&Arc<dyn OAuthCredentialStorage>>,
 ) -> McpConnectOutcome {
     let conn_err = |e| McpError::ConnectionFailed(format!("HTTP MCP server {name}: {e}"));
     let stored_auth_manager = if let Some(store) = oauth_credential_store
-        && config.auth_header.is_none()
+        && config.transport.auth_header.is_none()
     {
-        match create_auth_manager_from_store(name, &config.uri, Arc::clone(store)).await {
+        match create_auth_manager_from_store(name, &config.transport.uri, config.oauth_client_id(), Arc::clone(store))
+            .await
+        {
             Ok(manager) => manager,
             Err(e) => {
                 tracing::warn!(
@@ -277,10 +289,10 @@ async fn connect_http(
     let result = if let Some(auth_manager) = stored_auth_manager {
         tracing::debug!("Using OAuth for server '{name}'");
         let auth_client = AuthClient::new(reqwest::Client::default(), auth_manager);
-        let transport = StreamableHttpClientTransport::with_client(auth_client, config.clone());
+        let transport = StreamableHttpClientTransport::with_client(auth_client, config.transport.clone());
         serve_client(mcp_client, transport).await.map_err(conn_err)
     } else {
-        let transport = StreamableHttpClientTransport::from_config(config.clone());
+        let transport = StreamableHttpClientTransport::from_config(config.transport.clone());
         serve_client(mcp_client, transport).await.map_err(conn_err)
     };
 
@@ -290,7 +302,7 @@ async fn connect_http(
         }
         Err(error) => {
             tracing::warn!("Failed to connect to MCP server '{name}': {error}");
-            if oauth_handler_factory.is_some() && config.auth_header.is_none() {
+            if oauth_handler_factory.is_some() && config.transport.auth_header.is_none() {
                 McpConnectOutcome::NeedsOAuth { config, error }
             } else {
                 McpConnectOutcome::Failed { error }
@@ -302,9 +314,9 @@ async fn connect_http(
 fn reauth_config_for(
     transport: &McpTransport,
     oauth_handler_factory: Option<&OAuthHandlerFactory>,
-) -> Option<StreamableHttpClientTransportConfig> {
+) -> Option<McpHttpConfig> {
     match transport {
-        McpTransport::Http { config } if oauth_handler_factory.is_some() && config.auth_header.is_none() => {
+        McpTransport::Http(config) if oauth_handler_factory.is_some() && config.transport.auth_header.is_none() => {
             Some(config.clone())
         }
         _ => None,

--- a/crates/mcp-utils/src/client/manager.rs
+++ b/crates/mcp-utils/src/client/manager.rs
@@ -2,7 +2,7 @@ use llm::ToolDefinition;
 
 use super::{
     McpError, Result,
-    config::McpServer,
+    config::{McpHttpConfig, McpServer},
     connection::{
         ConnectConfig, McpConnectAttempt, McpConnectOutcome, McpServerConnection, Tool, authenticate_http,
         connect_server,
@@ -20,12 +20,12 @@ use rmcp::{
         ElicitationAction, FormElicitationCapability, Implementation, Tool as RmcpTool, UrlElicitationCapability,
     },
     service::RunningService,
-    transport::streamable_http_client::StreamableHttpClientTransportConfig,
 };
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use std::collections::{BTreeMap, HashMap, HashSet};
 use std::future::Future;
+use std::num::NonZeroU16;
 use std::path::PathBuf;
 use std::sync::Arc;
 use tokio::sync::{mpsc, oneshot};
@@ -41,6 +41,7 @@ pub type OAuthHandlerFactory = Arc<dyn Fn(OAuthHandlerContext) -> Result<Arc<dyn
 #[derive(Clone)]
 pub struct OAuthHandlerContext {
     pub server_name: String,
+    pub callback_port: Option<NonZeroU16>,
     pub tx: mpsc::Sender<McpClientEvent>,
 }
 
@@ -503,7 +504,7 @@ impl McpManager {
         &mut self,
         name: &str,
         conn: McpServerConnection,
-        reauth_config: Option<StreamableHttpClientTransportConfig>,
+        reauth_config: Option<McpHttpConfig>,
         proxied: bool,
     ) -> Result<Vec<RmcpTool>> {
         let tools = conn
@@ -519,7 +520,7 @@ impl McpManager {
         name: &str,
         conn: McpServerConnection,
         tools: &[RmcpTool],
-        reauth_config: Option<StreamableHttpClientTransportConfig>,
+        reauth_config: Option<McpHttpConfig>,
         proxied: bool,
     ) {
         let existing_reauth = self.servers.get(name).and_then(|r| r.reauth_config.clone());
@@ -572,13 +573,7 @@ impl McpManager {
         }
     }
 
-    fn register_record(
-        &mut self,
-        name: &str,
-        state: ServerState,
-        reauth_config: Option<StreamableHttpClientTransportConfig>,
-        proxied: bool,
-    ) {
+    fn register_record(&mut self, name: &str, state: ServerState, reauth_config: Option<McpHttpConfig>, proxied: bool) {
         self.remember_server_order(name);
         self.servers.insert(name.to_string(), ServerRecord::new(state, reauth_config, proxied));
     }
@@ -621,7 +616,7 @@ impl Drop for McpManager {
 /// Internal record holding all mutable state for a single MCP server.
 struct ServerRecord {
     state: ServerState,
-    reauth_config: Option<StreamableHttpClientTransportConfig>,
+    reauth_config: Option<McpHttpConfig>,
     proxied: bool,
 }
 
@@ -646,14 +641,14 @@ impl From<&ServerState> for McpServerStatus {
 }
 
 impl ServerRecord {
-    fn new(state: ServerState, reauth_config: Option<StreamableHttpClientTransportConfig>, proxied: bool) -> Self {
+    fn new(state: ServerState, reauth_config: Option<McpHttpConfig>, proxied: bool) -> Self {
         Self { state, reauth_config, proxied }
     }
 
     fn connected(
         connection: McpServerConnection,
         tools: Vec<Tool>,
-        reauth_config: Option<StreamableHttpClientTransportConfig>,
+        reauth_config: Option<McpHttpConfig>,
         proxied: bool,
     ) -> Self {
         Self::new(ServerState::Connected { connection, tools }, reauth_config, proxied)
@@ -716,7 +711,7 @@ impl ServerRecord {
 mod tests {
     use super::{DEFAULT_PROXY_NAME, McpClientEvent, McpManager, McpServerStatus, ServerState};
     use crate::client::OAuthHandlerFactory;
-    use crate::client::config::{McpServer, McpTransport};
+    use crate::client::config::{McpHttpConfig, McpServer, McpTransport};
     use crate::client::connection::{McpConnectAttempt, McpConnectOutcome};
     use crate::status::McpServerAuthCapability;
     use aether_auth::{OAuthCallback, OAuthError, OAuthHandler};
@@ -810,6 +805,10 @@ mod tests {
         Arc::new(|_ctx| Ok(Arc::new(TestOAuthHandler)))
     }
 
+    fn http_config(uri: &str) -> McpHttpConfig {
+        StreamableHttpClientTransportConfig::with_uri(uri).into()
+    }
+
     #[tokio::test]
     async fn authenticate_server_task_rejects_record_without_reauth_config() {
         let (event_sender, _event_receiver) = mpsc::channel(1);
@@ -830,7 +829,7 @@ mod tests {
         manager.register_record(
             "remote",
             ServerState::NeedsOAuth,
-            Some(StreamableHttpClientTransportConfig::with_uri("http://localhost:19999/mcp")),
+            Some(http_config("http://localhost:19999/mcp")),
             false,
         );
 
@@ -853,7 +852,7 @@ mod tests {
         manager.register_record(
             "remote",
             ServerState::NeedsOAuth,
-            Some(StreamableHttpClientTransportConfig::with_uri("http://localhost:19999/mcp")),
+            Some(http_config("http://localhost:19999/mcp")),
             false,
         );
         let _task = manager.authenticate_server_task("remote").await.expect("auth should start");
@@ -894,14 +893,14 @@ mod tests {
         manager.register_record(
             "with-oauth",
             ServerState::Connecting,
-            Some(StreamableHttpClientTransportConfig::with_uri("http://localhost/mcp")),
+            Some(http_config("http://localhost/mcp")),
             false,
         );
         manager.register_record("without-oauth", ServerState::Connecting, None, false);
         manager.register_record(
             "needs-oauth",
             ServerState::NeedsOAuth,
-            Some(StreamableHttpClientTransportConfig::with_uri("http://localhost/mcp2")),
+            Some(http_config("http://localhost/mcp2")),
             false,
         );
 

--- a/crates/mcp-utils/src/client/mod.rs
+++ b/crates/mcp-utils/src/client/mod.rs
@@ -10,8 +10,9 @@ mod naming;
 mod tool_proxy;
 
 pub use config::{
-    HttpServerConfig, HttpType, InMemoryServerConfig, InMemoryType, McpConfig, McpServer, McpServerCloneError,
-    McpServerConfig, McpTransport, ParseError, ServerFactory, SseServerConfig, SseType, StdioServerConfig, StdioType,
+    InMemoryServerConfig, InMemoryType, McpConfig, McpHttpConfig, McpOAuthConfig, McpServer, McpServerCloneError,
+    McpServerConfig, McpTransport, ParseError, RemoteServerConfig, RemoteType, ServerFactory, StdioServerConfig,
+    StdioType,
 };
 pub use connection::{McpConnectAttempt, McpConnectOutcome, McpServerConnection};
 pub use connection_attempt_manager::McpConnectionAttemptManager;

--- a/crates/mcp-utils/src/client/oauth_handler.rs
+++ b/crates/mcp-utils/src/client/oauth_handler.rs
@@ -2,6 +2,7 @@ use crate::client::manager::{ElicitationRequest, McpClientEvent, OAuthHandlerCon
 use aether_auth::{OAuthCallback, OAuthError, OAuthHandler, accept_oauth_callback};
 use futures::future::BoxFuture;
 use rmcp::model::{CreateElicitationRequestParams, ElicitationAction};
+use std::num::NonZeroU16;
 use tokio::net::TcpListener;
 use tokio::sync::{mpsc, oneshot};
 
@@ -18,7 +19,8 @@ pub struct ElicitingOAuthHandler {
 impl ElicitingOAuthHandler {
     pub fn new(ctx: OAuthHandlerContext) -> Result<Self, std::io::Error> {
         let (port, listener) = {
-            let std_listener = std::net::TcpListener::bind("127.0.0.1:0")?;
+            let port = ctx.callback_port.map_or(0, NonZeroU16::get);
+            let std_listener = std::net::TcpListener::bind(("127.0.0.1", port))?;
             let port = std_listener.local_addr()?.port();
             std_listener.set_nonblocking(true)?;
             (port, TcpListener::from_std(std_listener)?)
@@ -26,7 +28,7 @@ impl ElicitingOAuthHandler {
 
         Ok(Self {
             listener,
-            redirect_uri: format!("http://127.0.0.1:{port}/oauth2callback"),
+            redirect_uri: format!("http://localhost:{port}/"),
             server_name: ctx.server_name,
             event_sender: ctx.tx,
         })
@@ -79,5 +81,44 @@ impl OAuthHandler for ElicitingOAuthHandler {
 
             Ok(callback)
         })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn configured_callback_port_uses_registered_localhost_redirect() {
+        let probe = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
+        let port = probe.local_addr().unwrap().port();
+        drop(probe);
+        let (tx, _) = mpsc::channel(1);
+
+        let handler = ElicitingOAuthHandler::new(OAuthHandlerContext {
+            server_name: "slack".to_string(),
+            callback_port: NonZeroU16::new(port),
+            tx,
+        })
+        .unwrap();
+
+        assert_eq!(handler.redirect_uri(), format!("http://localhost:{port}/"));
+    }
+
+    #[tokio::test]
+    async fn configured_callback_port_fails_when_already_in_use() {
+        let listener = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
+        let port = listener.local_addr().unwrap().port();
+        let (tx, _) = mpsc::channel(1);
+
+        let error = ElicitingOAuthHandler::new(OAuthHandlerContext {
+            server_name: "slack".to_string(),
+            callback_port: NonZeroU16::new(port),
+            tx,
+        })
+        .err()
+        .expect("occupied callback port should fail");
+
+        assert_eq!(error.kind(), std::io::ErrorKind::AddrInUse);
     }
 }

--- a/crates/mcp-utils/src/docs/mcp_server_config.md
+++ b/crates/mcp-utils/src/docs/mcp_server_config.md
@@ -12,7 +12,25 @@ A local stdio server launched as a subprocess:
 }
 ```
 
-A remote streamable-HTTP server:
+A remote streamable-HTTP server using a pre-registered public OAuth client:
+
+```json
+{
+  "type": "http",
+  "url": "https://mcp.slack.com/mcp",
+  "oauth": {
+    "clientId": "1601185624273.8899143856786",
+    "callbackPort": 3118
+  }
+}
+```
+
+When `oauth` is omitted, Aether uses dynamic client registration and a random
+loopback callback port. When present, Aether binds the configured callback port
+and advertises `http://localhost:<callbackPort>/`, which must match the redirect
+URI registered for the OAuth client.
+
+A remote server using a bearer token:
 
 ```json
 {


### PR DESCRIPTION
## Summary

- add optional MCP OAuth configuration for a pre-registered public client ID and fixed callback port
- preserve dynamic client registration when OAuth configuration is omitted
- ignore stored credentials issued to a different configured client
- unify remote HTTP and SSE configuration handling and document the new settings

## Testing

- `just fmt`
- `just test` (3092 tests passed)
- workspace LSP diagnostics (no errors or warnings)
- `git diff --check`