### PR TITLE
feat: support trace IDs without parent spans

### DIFF
--- a/crates/aether-telemetry/src/telemetry_runtime.rs
+++ b/crates/aether-telemetry/src/telemetry_runtime.rs
@@ -5,7 +5,7 @@ use crate::genai_constants;
 use crate::otel_observer::OtelInstrumentation;
 use opentelemetry::metrics::MeterProvider as _;
 use opentelemetry::propagation::TextMapPropagator;
-use opentelemetry::trace::{TraceContextExt, TraceState, TracerProvider as _};
+use opentelemetry::trace::{TraceContextExt, TraceId, TraceState, TracerProvider as _};
 use opentelemetry::{Context, KeyValue};
 use opentelemetry_otlp::{MetricExporter, SpanExporter, WithExportConfig, WithHttpConfig};
 use opentelemetry_sdk::Resource;
@@ -14,7 +14,7 @@ use opentelemetry_sdk::metrics::periodic_reader_with_async_runtime::PeriodicRead
 use opentelemetry_sdk::propagation::TraceContextPropagator;
 use opentelemetry_sdk::runtime::Tokio;
 use opentelemetry_sdk::trace::span_processor_with_async_runtime::BatchSpanProcessor;
-use opentelemetry_sdk::trace::{Sampler, SdkTracerProvider};
+use opentelemetry_sdk::trace::{IdGenerator, RandomIdGenerator, Sampler, SdkTracerProvider};
 use std::collections::HashMap;
 use std::str::FromStr;
 
@@ -52,20 +52,21 @@ impl TelemetryRuntime {
             return Err(TelemetryInitError::InvalidSampleRatio(config.sample_ratio));
         }
 
-        let root_parent = extract_root_parent(config.trace_context.as_ref())?;
+        let trace_root = resolve_trace_root(config.trace_context.as_ref())?;
         let http_client = build_http_client(&config.headers)?;
         let resource = Resource::builder()
             .with_service_name(config.service_name.clone())
             .with_attribute(KeyValue::new(genai_constants::SERVICE_VERSION, config.service_version.clone()))
             .build();
         let scope = genai_constants::genai_instrumentation_scope(config.service_version.clone());
-        let tracer_provider = build_tracer_provider(config, resource.clone(), http_client.clone())?;
+        let tracer_provider =
+            build_tracer_provider(config, resource.clone(), http_client.clone(), trace_root.trace_id)?;
         let meter_provider = build_meter_provider(config, resource, http_client)?;
         let instrumentation = OtelInstrumentation {
             tracer: tracer_provider.tracer_with_scope(scope.clone()),
             metrics: GenAiMetrics::new(&meter_provider.meter_with_scope(scope)),
             capture_content: config.capture_content,
-            root_parent,
+            root_parent: trace_root.parent,
         };
 
         Ok(Self { tracer_provider, meter_provider, instrumentation })
@@ -112,29 +113,81 @@ impl TelemetryConfig {
     }
 }
 
-fn extract_root_parent(trace_context: Option<&AgentTraceContext>) -> Result<Option<Context>, TelemetryInitError> {
+#[derive(Default)]
+struct TraceRoot {
+    parent: Option<Context>,
+    trace_id: Option<TraceId>,
+}
+
+#[derive(Debug)]
+struct TraceIdGenerator {
+    trace_id: TraceId,
+    random: RandomIdGenerator,
+}
+
+impl IdGenerator for TraceIdGenerator {
+    fn new_trace_id(&self) -> TraceId {
+        self.trace_id
+    }
+
+    fn new_span_id(&self) -> opentelemetry::trace::SpanId {
+        self.random.new_span_id()
+    }
+}
+
+fn resolve_trace_root(trace_context: Option<&AgentTraceContext>) -> Result<TraceRoot, TelemetryInitError> {
     let Some(trace_context) = trace_context else {
-        return Ok(None);
+        return Ok(TraceRoot::default());
     };
 
-    if let Some(tracestate) = &trace_context.tracestate {
-        TraceState::from_str(tracestate).map_err(|_| TelemetryInitError::InvalidTraceContext("tracestate"))?;
+    match trace_context {
+        AgentTraceContext::Parent { tracestate, .. } => {
+            if let Some(tracestate) = tracestate {
+                TraceState::from_str(tracestate).map_err(|_| TelemetryInitError::InvalidTraceContext("tracestate"))?;
+            }
+
+            let context = TraceContextPropagator::new().extract(trace_context);
+            if !context.span().span_context().is_valid() {
+                return Err(TelemetryInitError::InvalidTraceContext("traceparent"));
+            }
+
+            Ok(TraceRoot { parent: Some(context), trace_id: None })
+        }
+        AgentTraceContext::Root { trace_id } => {
+            let trace_id = parse_trace_id(trace_id)?;
+            Ok(TraceRoot { parent: None, trace_id: Some(trace_id) })
+        }
+    }
+}
+
+fn parse_trace_id(value: &str) -> Result<TraceId, TelemetryInitError> {
+    let valid_hex =
+        value.len() == 32 && value.bytes().all(|byte| byte.is_ascii_digit() || (b'a'..=b'f').contains(&byte));
+    if !valid_hex {
+        return Err(TelemetryInitError::InvalidTraceContext("traceId"));
     }
 
-    let context = TraceContextPropagator::new().extract(trace_context);
-    if !context.span().span_context().is_valid() {
-        return Err(TelemetryInitError::InvalidTraceContext("traceparent"));
+    let trace_id = TraceId::from_hex(value).map_err(|_| TelemetryInitError::InvalidTraceContext("traceId"))?;
+    if trace_id == TraceId::INVALID {
+        return Err(TelemetryInitError::InvalidTraceContext("traceId"));
     }
 
-    Ok(Some(context))
+    Ok(trace_id)
 }
 
 fn build_tracer_provider(
     config: &TelemetryConfig,
     resource: Resource,
     http_client: reqwest::Client,
+    trace_id: Option<TraceId>,
 ) -> Result<SdkTracerProvider, TelemetryInitError> {
     let builder = SdkTracerProvider::builder().with_resource(resource);
+    let builder = match trace_id {
+        Some(trace_id) => {
+            builder.with_id_generator(TraceIdGenerator { trace_id, random: RandomIdGenerator::default() })
+        }
+        None => builder,
+    };
     if !config.traces_enabled {
         return Ok(builder.with_sampler(Sampler::AlwaysOff).build());
     }

--- a/crates/aether-telemetry/src/trace_context.rs
+++ b/crates/aether-telemetry/src/trace_context.rs
@@ -3,29 +3,39 @@ use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
 #[derive(Clone, Debug, Deserialize, Eq, JsonSchema, PartialEq, Serialize)]
-#[serde(deny_unknown_fields)]
-pub struct AgentTraceContext {
-    /// W3C traceparent header: version, trace ID, parent span ID, and trace flags.
-    pub traceparent: String,
-    /// Optional W3C tracestate header carrying vendor-specific trace state.
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub tracestate: Option<String>,
+#[serde(untagged, rename_all = "camelCase", deny_unknown_fields)]
+pub enum AgentTraceContext {
+    /// Continue the trace beneath a remote W3C parent span.
+    Parent {
+        /// W3C traceparent header: version, trace ID, parent span ID, and trace flags.
+        traceparent: String,
+        /// Optional W3C tracestate header carrying vendor-specific trace state.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        tracestate: Option<String>,
+    },
+    /// Start root spans in the supplied trace without attaching a parent span.
+    Root {
+        /// W3C trace ID: 32 lowercase hexadecimal characters and not all zeros.
+        #[serde(rename = "traceId")]
+        #[schemars(rename = "traceId")]
+        trace_id: String,
+    },
 }
 
 impl Extractor for AgentTraceContext {
     fn get(&self, key: &str) -> Option<&str> {
-        match key {
-            "traceparent" => Some(&self.traceparent),
-            "tracestate" => self.tracestate.as_deref(),
+        match (self, key) {
+            (Self::Parent { traceparent, .. }, "traceparent") => Some(traceparent),
+            (Self::Parent { tracestate, .. }, "tracestate") => tracestate.as_deref(),
             _ => None,
         }
     }
 
     fn keys(&self) -> Vec<&str> {
-        let mut keys = vec!["traceparent"];
-        if self.tracestate.is_some() {
-            keys.push("tracestate");
+        match self {
+            Self::Parent { tracestate: Some(_), .. } => vec!["traceparent", "tracestate"],
+            Self::Parent { tracestate: None, .. } => vec!["traceparent"],
+            Self::Root { .. } => Vec::new(),
         }
-        keys
     }
 }

--- a/crates/aether-telemetry/tests/otlp_collector_tests.rs
+++ b/crates/aether-telemetry/tests/otlp_collector_tests.rs
@@ -101,6 +101,42 @@ async fn runtime_parents_every_turn_to_the_supplied_trace_context() {
 }
 
 #[tokio::test(flavor = "multi_thread")]
+async fn runtime_starts_root_spans_with_the_supplied_trace_id() {
+    let collector = FakeOtlpCollector::start().await;
+    let trace_context = serde_json::from_str::<AgentTraceContext>(r#"{"traceId":"00112233445566778899aabbccddeeff"}"#)
+        .expect("valid trace ID context");
+    let expected_trace_id =
+        vec![0x00, 0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x88, 0x99, 0xaa, 0xbb, 0xcc, 0xdd, 0xee, 0xff];
+    let runtime = TelemetryRuntime::new(&TelemetryConfig {
+        headers: test_headers("fixed-trace-root"),
+        trace_context: Some(trace_context),
+        ..collector_config(&collector)
+    })
+    .expect("runtime initializes against collector");
+
+    for _ in 0..2 {
+        let factory = runtime.observer_factory();
+        let mut observer = factory();
+        for event in events() {
+            observer.on_event(&event);
+        }
+    }
+
+    runtime.shutdown().expect("runtime flushes traces");
+    let exports = collector.exports();
+    let spans = trace_spans(&exports);
+
+    assert_eq!(spans.len(), 4);
+    assert!(spans.iter().all(|span| span.trace_id == expected_trace_id));
+    let roots = spans.iter().filter(|span| span.name == "invoke_agent").copied().collect::<Vec<_>>();
+    assert_eq!(roots.len(), 2);
+    assert!(roots.iter().all(|span| span.parent_span_id.is_empty()));
+    for child in spans.iter().filter(|span| span.name != "invoke_agent") {
+        assert!(roots.iter().any(|root| child.parent_span_id == root.span_id));
+    }
+}
+
+#[tokio::test(flavor = "multi_thread")]
 async fn runtime_exports_genai_spans_and_metrics_to_an_otlp_collector() {
     let collector = FakeOtlpCollector::start().await;
     let runtime = TelemetryRuntime::new(&TelemetryConfig {

--- a/crates/aether-telemetry/tests/runtime_tests.rs
+++ b/crates/aether-telemetry/tests/runtime_tests.rs
@@ -15,12 +15,27 @@ fn round_trips_agent_trace_context_carriers() {
 }
 
 #[test]
+fn round_trips_trace_id_only_contexts() {
+    let context: AgentTraceContext =
+        serde_json::from_str(r#"{"traceId":"00112233445566778899aabbccddeeff"}"#).expect("valid trace ID context");
+
+    assert_eq!(
+        serde_json::to_string(&context).expect("serializes trace ID context"),
+        r#"{"traceId":"00112233445566778899aabbccddeeff"}"#
+    );
+}
+
+#[test]
 fn rejects_invalid_agent_trace_contexts_when_initializing_runtime() {
     for (value, header) in [
         (r#"{"traceparent":"INVALID"}"#, "traceparent"),
         (r#"{"traceparent":"00-00000000000000000000000000000000-0123456789abcdef-01"}"#, "traceparent"),
         (r#"{"traceparent":"00-00112233445566778899aabbccddeeff-0000000000000000-01"}"#, "traceparent"),
         (r#"{"traceparent":"00-00112233445566778899AABBCCDDEEFF-0123456789abcdef-01"}"#, "traceparent"),
+        (r#"{"traceId":"00000000000000000000000000000000"}"#, "traceId"),
+        (r#"{"traceId":"00112233445566778899aabbccddee"}"#, "traceId"),
+        (r#"{"traceId":"00112233445566778899AABBCCDDEEFF"}"#, "traceId"),
+        (r#"{"traceId":"00112233445566778899aabbccddeezz"}"#, "traceId"),
         (
             r#"{"traceparent":"00-00112233445566778899aabbccddeeff-0123456789abcdef-01","tracestate":"invalid"}"#,
             "tracestate",
@@ -39,6 +54,15 @@ fn rejects_invalid_agent_trace_contexts_when_initializing_runtime() {
             "expected an invalid {header} for {value}"
         );
     }
+}
+
+#[test]
+fn rejects_mixed_trace_context_forms() {
+    let result = serde_json::from_str::<AgentTraceContext>(
+        r#"{"traceId":"00112233445566778899aabbccddeeff","traceparent":"00-00112233445566778899aabbccddeeff-0123456789abcdef-01"}"#,
+    );
+
+    assert!(result.is_err());
 }
 
 #[test]

--- a/packages/aether-sdk/README.md
+++ b/packages/aether-sdk/README.md
@@ -70,7 +70,7 @@ yourself in a `finally` block.
 | `cwd`                | Working directory for the spawned `aether acp` process.                                                                       |
 | `binaryPath`         | Override the bundled `@aether-agent/cli` binary (absolute path or name on `PATH`).                                            |
 | `providers`          | Provider connection overrides, keyed by provider (for example `{ bedrock: { url: "http://127.0.0.1:8787", auth: "none" } }`). |
-| `traceContext`       | Remote W3C `traceparent` and optional `tracestate` used as the parent of every turn in the launched session.                    |
+| `traceContext`       | A remote W3C `traceparent` with optional `tracestate`, or a standalone `traceId` for root spans without a parent.                 |
 | `abortSignal`        | Cancel the active session and tear the subprocess down.                                                                       |
 
 `agent` and `model` are mutually exclusive. `settings` and `settingsFile` are
@@ -107,16 +107,22 @@ await AetherSession.start({
 ## Correlating telemetry traces
 
 ```ts
-await using session = await AetherSession.start({
+await using continuedSession = await AetherSession.start({
   traceContext: {
     traceparent:
       "00-00112233445566778899aabbccddeeff-0123456789abcdef-01",
     tracestate: "vendor=value",
   },
 });
+
+await using rootSession = await AetherSession.start({
+  traceContext: {
+    traceId: "00112233445566778899aabbccddeeff",
+  },
+});
 ```
 
-`traceContext` is also accepted by `runHeadless` and the lower-level ACP process options. Aether treats the supplied W3C `traceparent` as a remote parent, so every turn is a child of the propagated span and every descendant remains in the same trace. Telemetry must still be enabled in Aether settings. See the [telemetry documentation](https://aether-agent.io/aether/settings/telemetry/) for validation and sampling semantics.
+`traceContext` is also accepted by `runHeadless` and the lower-level ACP process options. A `traceparent` makes every turn a child of the propagated span. A standalone `traceId` instead creates root turn spans with that trace ID and no parent span. Telemetry must still be enabled in Aether settings. See the [telemetry documentation](https://aether-agent.io/aether/settings/telemetry/) for validation and sampling semantics.
 
 ## Multi-turn usage
 

--- a/packages/aether-sdk/package.json
+++ b/packages/aether-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aether-agent/sdk",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "description": "TypeScript SDK for the Aether agent CLI",
   "repository": {
     "type": "git",

--- a/packages/aether-sdk/test/agentProcess.test.ts
+++ b/packages/aether-sdk/test/agentProcess.test.ts
@@ -4,7 +4,7 @@ import path from "node:path";
 import { describe, expect, it } from "vitest";
 
 import { buildAetherAcpCommand } from "../src/agentProcess.js";
-import { TRACE_CONTEXT } from "./traceContext.js";
+import { TRACE_CONTEXT, TRACE_ID_CONTEXT } from "./traceContext.js";
 
 const FAKE_AETHER = path.resolve(
   path.dirname(fileURLToPath(import.meta.url)),
@@ -55,6 +55,17 @@ describe("buildAetherAcpCommand()", () => {
       model: "anthropic:claude-sonnet-4-5",
       reasoningEffort: "high",
       traceContext: TRACE_CONTEXT,
+    });
+  });
+
+  it("adds a trace-only context to ACP options JSON", () => {
+    const command = buildAetherAcpCommand({
+      binaryPath: FAKE_AETHER,
+      traceContext: TRACE_ID_CONTEXT,
+    });
+
+    expect(JSON.parse(command.args[2]!)).toEqual({
+      traceContext: TRACE_ID_CONTEXT,
     });
   });
 

--- a/packages/aether-sdk/test/headless.test.ts
+++ b/packages/aether-sdk/test/headless.test.ts
@@ -9,7 +9,7 @@ import { z } from "zod";
 import { runHeadless } from "../src/headless.js";
 import { mcp } from "../src/mcp/index.js";
 import { tool } from "../src/tool.js";
-import { TRACE_CONTEXT } from "./traceContext.js";
+import { TRACE_ID_CONTEXT } from "./traceContext.js";
 
 const FAKE_AETHER = path.resolve(
   path.dirname(fileURLToPath(import.meta.url)),
@@ -53,7 +53,7 @@ describe("runAetherHeadless()", () => {
       },
       output: "json",
       events: ["tool_call", "turn_ended"],
-      traceContext: TRACE_CONTEXT,
+      traceContext: TRACE_ID_CONTEXT,
       env: { ...process.env, FAKE_AETHER_LOG_FILE: logFile },
     });
 
@@ -71,7 +71,7 @@ describe("runAetherHeadless()", () => {
       model: "anthropic:claude-sonnet-4-5",
       output: "json",
       events: ["tool_call", "turn_ended"],
-      traceContext: TRACE_CONTEXT,
+      traceContext: TRACE_ID_CONTEXT,
       providers: {
         bedrock: {
           url: "http://127.0.0.1:8787",

--- a/packages/aether-sdk/test/traceContext.ts
+++ b/packages/aether-sdk/test/traceContext.ts
@@ -2,3 +2,7 @@ export const TRACE_CONTEXT = {
   traceparent: "00-00112233445566778899aabbccddeeff-0123456789abcdef-01",
   tracestate: "vendor=value",
 } as const;
+
+export const TRACE_ID_CONTEXT = {
+  traceId: "00112233445566778899aabbccddeeff",
+} as const;

--- a/packages/website/src/content/docs/aether/settings/telemetry.mdx
+++ b/packages/website/src/content/docs/aether/settings/telemetry.mdx
@@ -45,21 +45,29 @@ Set both `traces.enabled` and `metrics.enabled` to `false` to keep a telemetry s
 
 ## Correlating SDK runs
 
-SDK callers can correlate every turn in a launched session or headless run with an existing OpenTelemetry trace:
+SDK callers can either continue beneath an existing OpenTelemetry parent span or start root spans with a caller-supplied trace ID:
 
 ```ts
-await using session = await AetherSession.start({
+await using continuedSession = await AetherSession.start({
   traceContext: {
     traceparent:
       "00-00112233445566778899aabbccddeeff-0123456789abcdef-01",
     tracestate: "vendor=value",
   },
 });
+
+await using rootSession = await AetherSession.start({
+  traceContext: {
+    traceId: "00112233445566778899aabbccddeeff",
+  },
+});
 ```
 
-`traceContext` is a run/session launch option for `AetherSession.start`, `runHeadless`, and the lower-level ACP process API; it is not a persistent telemetry setting. Telemetry still has to be enabled above — without a telemetry section the trace context is ignored. Aether treats the supplied W3C `traceparent` as a remote parent, making every `invoke_agent` turn span its child and preserving the causal hierarchy across the process boundary. Optional `tracestate` is propagated to those spans.
+`traceContext` is a run/session launch option for `AetherSession.start`, `runHeadless`, and the lower-level ACP process API; it is not a persistent telemetry setting. Telemetry still has to be enabled above — without a telemetry section the trace context is ignored.
 
-Both headers are validated when telemetry starts: `traceparent` must follow the W3C Trace Context format with a non-zero trace ID and parent span ID, and `tracestate` must be a valid W3C header. An invalid value fails Aether startup with an error rather than being silently dropped. The parent's sampled flag is authoritative: sampled parents remain sampled and unsampled parents remain unsampled. `sampleRatio` is used only for traces without a propagated parent.
+With `traceparent`, Aether treats the supplied context as a remote parent, making every `invoke_agent` turn span its child and preserving `tracestate`. The parent's sampled flag is authoritative. With `traceId`, each `invoke_agent` span is a root span with no parent span ID, and `sampleRatio` controls sampling.
+
+Values are validated when telemetry starts. `traceparent` must follow the W3C Trace Context format with non-zero trace and parent span IDs. `traceId` must contain exactly 32 lowercase hexadecimal characters and cannot be all zeros. `tracestate` must be a valid W3C header and is only accepted with `traceparent`. Invalid or mixed forms fail Aether startup rather than being silently dropped.
 
 ## Privacy
 

--- a/packages/website/src/content/docs/libraries/typescript-sdk.mdx
+++ b/packages/website/src/content/docs/libraries/typescript-sdk.mdx
@@ -67,7 +67,7 @@ await AetherSession.start({
 | `env`                 | Environment variables for the spawned `aether acp` process.                            |
 | `logDir`              | Custom directory for ACP logs.                                                         |
 | `providers`           | Provider connection overrides, such as custom Bedrock endpoints or auth behavior.     |
-| `traceContext`        | Remote W3C `traceparent` and optional `tracestate` used as the parent of every turn in the launched session. See [Telemetry](/aether/settings/telemetry/#correlating-sdk-runs) for validation and sampling semantics. |
+| `traceContext`        | A remote W3C `traceparent` with optional `tracestate`, or a standalone `traceId` for root spans without a parent. See [Telemetry](/aether/settings/telemetry/#correlating-sdk-runs) for validation and sampling semantics. |
 | `abortSignal`         | Cancel the active session and tear down the subprocess.                               |
 | `onPermissionRequest` | Custom policy for ACP permission requests. Defaults to `autoApprovePermissions`.      |
 | `onElicitation`       | Handler for Aether's `_aether/elicitation` extension request.                         |


### PR DESCRIPTION
## Summary
- add a trace-only OpenTelemetry context form using `traceId`
- create root spans with the supplied trace ID and no parent span
- expose the generated TypeScript union and bump `@aether-agent/sdk` to 0.4.1
- document validation and sampling behavior

## Testing
- `cargo test -p aether-telemetry`
- `cargo test -p aether-agent-cli --test trace_context`
- `pnpm --filter @aether-agent/sdk typecheck`
- `pnpm --filter @aether-agent/sdk exec vitest run test/agentProcess.test.ts test/headless.test.ts test/session.integration.test.ts`
- `just lint`