### PR TITLE
fix: publish evals with canonical agent events

### DIFF
--- a/packages/aether-evals/package.json
+++ b/packages/aether-evals/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aether-agent/evals",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "description": "Evaluation harness for the Aether agent SDK",
   "repository": {
     "type": "git",
@@ -25,7 +25,7 @@
     "test": "vitest run"
   },
   "dependencies": {
-    "@aether-agent/sdk": "workspace:^",
+    "@aether-agent/sdk": "^0.4.1",
     "testcontainers": "^12.0.3",
     "zod": "^4.4.3"
   },

--- a/packages/aether-evals/test/DockerAgent.test.ts
+++ b/packages/aether-evals/test/DockerAgent.test.ts
@@ -1,0 +1,89 @@
+import { describe, expect, it } from "vitest";
+
+import type { AgentEvent } from "@aether-agent/sdk";
+import { DockerAgent, Task, Transcript } from "../src/index.js";
+import type { Container, ContainerStreamingOptions } from "../src/index.js";
+
+describe("DockerAgent", () => {
+  it("streams canonical events including tool definition updates", async () => {
+    const definitionsUpdated: AgentEvent = {
+      category: "tool",
+      event: {
+        type: "definitions_updated",
+        tools: [
+          {
+            name: "weather",
+            description: "Get the weather",
+            parameters: { type: "object" },
+          },
+        ],
+      },
+    };
+    const ended: AgentEvent = {
+      category: "turn",
+      event: { type: "ended", outcome: { status: "completed" } },
+    };
+    const agent = agentEmitting(definitionsUpdated, ended);
+
+    const transcript = await Transcript.fromStream(agent.run(new Task("test")));
+
+    expect(transcript.events).toEqual([definitionsUpdated, ended]);
+  });
+
+  it.each([
+    { status: "completed" } as const,
+    { status: "failed", error: "boom" } as const,
+    { status: "cancelled" } as const,
+  ])("stops at a $status turn outcome", async (outcome) => {
+    const ended: AgentEvent = {
+      category: "turn",
+      event: { type: "ended", outcome },
+    };
+    const trailing: AgentEvent = {
+      category: "message",
+      event: {
+        type: "text",
+        chunk: "not emitted",
+        is_complete: true,
+        message_id: "message-1",
+      },
+    };
+    const agent = agentEmitting(ended, trailing);
+
+    const transcript = await Transcript.fromStream(agent.run(new Task("test")));
+
+    expect(transcript.events).toEqual([ended]);
+  });
+
+  it("rejects malformed NDJSON", async () => {
+    const agent = agentEmittingLines("not JSON");
+
+    await expect(collect(agent.run(new Task("test")))).rejects.toMatchObject({
+      name: "AetherEvalError",
+      code: "agent_event_json_line",
+    });
+  });
+});
+
+function agentEmitting(...events: AgentEvent[]): DockerAgent {
+  return agentEmittingLines(...events.map((event) => JSON.stringify(event)));
+}
+
+function agentEmittingLines(...lines: string[]): DockerAgent {
+  const container = {
+    workspaceRoot: "/workspace",
+    cwd: "/workspace",
+    async *execStreaming(_options: ContainerStreamingOptions) {
+      yield* lines;
+    },
+  } as unknown as Container;
+  return new DockerAgent({ container, command: ["fake-agent"] });
+}
+
+async function collect(
+  stream: AsyncIterable<AgentEvent>,
+): Promise<AgentEvent[]> {
+  const events: AgentEvent[] = [];
+  for await (const event of stream) events.push(event);
+  return events;
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -18,8 +18,8 @@ importers:
   packages/aether-evals:
     dependencies:
       '@aether-agent/sdk':
-        specifier: workspace:^
-        version: link:../aether-sdk
+        specifier: ^0.4.1
+        version: 0.4.1
       testcontainers:
         specifier: ^12.0.3
         version: 12.0.3
@@ -150,6 +150,10 @@ packages:
     resolution: {integrity: sha512-/TOSPbVNXsdSB8LPJFPq+qvtN227EyzYYYrwPvPsS1J79oTmDKxTCrGQpSgOG/z+2fdqXcQu+WKlEN4FSkcMcg==}
     engines: {node: '>=14', npm: '>=6'}
     hasBin: true
+
+  '@aether-agent/sdk@0.4.1':
+    resolution: {integrity: sha512-SqQrMxBTV3mD6eMzJmCYO/ZW1FsZ7x58glGvMXqGFTPyVfv8Evt/0dcpaLolBOdutQLdXGLHV6H5fKL7ebxzQg==}
+    engines: {node: '>=24'}
 
   '@agentclientprotocol/sdk@0.25.1':
     resolution: {integrity: sha512-jx2rF3bdpGwZ75Q/meyEDLLbYmbtxk82Uh9hDCdxDvcEedBnNSF5hZAnL/kJR5VNz56JqwOmqnAqasC84MwwkQ==}
@@ -4424,6 +4428,18 @@ snapshots:
       detect-libc: 2.1.2
       rimraf: 6.1.3
     transitivePeerDependencies:
+      - debug
+      - supports-color
+
+  '@aether-agent/sdk@0.4.1':
+    dependencies:
+      '@aether-agent/cli': 0.7.22
+      '@agentclientprotocol/sdk': 0.25.1(zod@4.4.3)
+      '@modelcontextprotocol/sdk': 1.29.0(zod@4.4.3)
+      express: 5.2.1
+      zod: 4.4.3
+    transitivePeerDependencies:
+      - '@cfworker/json-schema'
       - debug
       - supports-color
 


### PR DESCRIPTION
## Summary
- prepare `@aether-agent/evals@0.3.0` for the canonical `AgentEvent` protocol
- depend on the published `@aether-agent/sdk@^0.4.1`
- cover tool definition updates, terminal turn outcomes, and malformed NDJSON

## Testing
- `pnpm --filter @aether-agent/evals typecheck`
- `pnpm --filter @aether-agent/evals test`
- `pnpm --filter @aether-agent/evals build`
- `npm pack --dry-run`