### PR TITLE
feat: recover from wedged or crashed language servers in lspd

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -6,6 +6,7 @@ fail-fast = false
 failure-output = "immediate-final"
 success-output = "never"
 retries = 0
+slow-timeout = { period = "60s", terminate-after = 5 }
 
 [profile.ci]
 inherits = "default"
@@ -24,3 +25,7 @@ filter = 'package(internal-evals) and test(/_eval$/)'
 test-group = 'evals'
 slow-timeout = { period = "180s", terminate-after = 3 }
 failure-output = "immediate-final"
+
+[[profile.default.overrides]]
+filter = 'binary(e2e_wedge_recovery)'
+slow-timeout = { period = "30s", terminate-after = 1 }

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,6 +13,7 @@ jobs:
   fmt:
     name: Formatting
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
       - name: Checkout repository
         uses: actions/checkout@v7
@@ -28,6 +29,7 @@ jobs:
   lint:
     name: Clippy
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
       - name: Checkout repository
         uses: actions/checkout@v7
@@ -43,6 +45,7 @@ jobs:
   test:
     name: Test
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout repository
         uses: actions/checkout@v7
@@ -58,6 +61,7 @@ jobs:
   sdk:
     name: TypeScript SDK
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     steps:
       - name: Checkout repository
         uses: actions/checkout@v7
@@ -87,6 +91,7 @@ jobs:
   docs:
     name: Docs
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
       - name: Checkout repository
         uses: actions/checkout@v7
@@ -102,6 +107,7 @@ jobs:
   website:
     name: Website
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
       - name: Checkout repository
         uses: actions/checkout@v7

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,7 +33,7 @@ serde = { version = "1.0.228", features = ["derive"] }
 serde_json = "1.0.150"
 
 # CLI
-clap = { version = "4.6", features = ["derive"] }
+clap = { version = "4.6", features = ["derive", "env"] }
 
 # Logging and tracing
 tracing = "0.1.44"

--- a/crates/aether-lspd/src/client_connection.rs
+++ b/crates/aether-lspd/src/client_connection.rs
@@ -1,23 +1,10 @@
-use crate::protocol::{
-    DaemonRequest, DaemonResponse, LspErrorResponse, ProtocolError, extract_document_uri, read_frame, write_frame,
-};
-use crate::workspace_registry::WorkspaceRegistry;
-use crate::workspace_session::WorkspaceSession;
+use crate::protocol::{DaemonRequest, DaemonResponse, ProtocolError, read_frame, write_frame};
+use crate::workspace_registry::{WorkspaceBinding, WorkspaceRegistry};
 use serde_json::Value;
-use std::sync::Arc;
 use tokio::io::{ReadHalf, WriteHalf, split};
 use tokio::net::UnixStream;
 use tokio::spawn;
 use tokio::sync::mpsc;
-
-const LSP_CONTENT_MODIFIED: i32 = -32801;
-const TRANSIENT_RETRY_LIMIT: u32 = 3;
-const TRANSIENT_RETRY_DELAY: std::time::Duration = std::time::Duration::from_millis(500);
-
-enum ConnectionState {
-    Uninitialized,
-    Bound { session: Arc<WorkspaceSession> },
-}
 
 #[tracing::instrument(skip(stream, registry), fields(%client_id))]
 pub async fn handle_client(stream: UnixStream, registry: WorkspaceRegistry, client_id: uuid::Uuid) {
@@ -26,6 +13,11 @@ pub async fn handle_client(stream: UnixStream, registry: WorkspaceRegistry, clie
     let writer_task = spawn(run_writer(writer, response_rx));
     run_reader(reader, registry, client_id, response_tx).await;
     let _ = writer_task.await;
+}
+
+enum ConnectionState {
+    Uninitialized,
+    Bound { binding: WorkspaceBinding },
 }
 
 async fn run_writer(mut writer: WriteHalf<UnixStream>, mut response_rx: mpsc::Receiver<DaemonResponse>) {
@@ -61,57 +53,41 @@ async fn run_reader(
                 let _ = response_tx.send(DaemonResponse::Pong).await;
             }
             Some(DaemonRequest::Disconnect) => break,
-            Some(DaemonRequest::Initialize(init)) => {
-                match registry.get_or_spawn(&init.workspace_root, init.language).await {
-                    Ok(session) => {
-                        state = ConnectionState::Bound { session };
-                        let _ = response_tx.send(DaemonResponse::Initialized).await;
-                    }
-                    Err(err) => {
-                        let _ = response_tx.send(DaemonResponse::Error(ProtocolError::new(err.to_string()))).await;
-                    }
+            Some(DaemonRequest::Initialize(init)) => match registry.bind(&init.workspace_root, init.language).await {
+                Ok(binding) => {
+                    state = ConnectionState::Bound { binding };
+                    let _ = response_tx.send(DaemonResponse::Initialized).await;
                 }
-            }
+                Err(err) => {
+                    let _ = response_tx.send(DaemonResponse::Error(ProtocolError::new(err.to_string()))).await;
+                }
+            },
             Some(DaemonRequest::LspCall { client_id, method, params }) => {
-                let ConnectionState::Bound { session } = &state else {
+                let ConnectionState::Bound { binding } = &state else {
                     let _ = send_not_initialized(client_id, &response_tx).await;
                     continue;
                 };
 
-                let opened_uri = if let Some(uri) = extract_document_uri(&method, &params) {
-                    let _ = session.ensure_document_open(&uri).await;
-                    Some(uri)
-                } else {
-                    None
-                };
-
-                let result = request_with_retry(session, &method, params, TRANSIENT_RETRY_LIMIT).await;
-
-                if let Some(uri) = opened_uri {
-                    session.close_document(&uri).await;
-                }
-
+                let result = registry.lsp_call(binding, &method, params).await;
                 let _ = response_tx.send(DaemonResponse::LspResult { client_id, result }).await;
             }
             Some(DaemonRequest::GetDiagnostics { client_id, uri }) => {
-                let ConnectionState::Bound { session } = &state else {
+                let ConnectionState::Bound { binding } = &state else {
                     let _ = send_not_initialized(client_id, &response_tx).await;
                     continue;
                 };
 
-                let diagnostics = session.get_diagnostics(uri.as_ref()).await;
-                let result = serde_json::to_value(&diagnostics)
-                    .map_err(|err| LspErrorResponse { code: -1, message: err.to_string() });
+                let result = registry.get_diagnostics(binding, uri.as_ref()).await;
                 let _ = response_tx.send(DaemonResponse::LspResult { client_id, result }).await;
             }
             Some(DaemonRequest::QueueDiagnosticRefresh { client_id, uri }) => {
-                let ConnectionState::Bound { session } = &state else {
+                let ConnectionState::Bound { binding } = &state else {
                     let _ = send_not_initialized(client_id, &response_tx).await;
                     continue;
                 };
 
-                session.queue_diagnostic_refresh(uri).await;
-                let _ = response_tx.send(DaemonResponse::LspResult { client_id, result: Ok(Value::Null) }).await;
+                let result = registry.queue_diagnostic_refresh(binding, uri).await.map(|()| Value::Null);
+                let _ = response_tx.send(DaemonResponse::LspResult { client_id, result }).await;
             }
             None => {}
         }
@@ -123,24 +99,4 @@ async fn send_not_initialized(
     tx: &mpsc::Sender<DaemonResponse>,
 ) -> Result<(), mpsc::error::SendError<DaemonResponse>> {
     tx.send(DaemonResponse::Error(ProtocolError::with_client_id("Not initialized", client_id))).await
-}
-
-async fn request_with_retry(
-    session: &WorkspaceSession,
-    method: &str,
-    params: serde_json::Value,
-    max_retries: u32,
-) -> Result<serde_json::Value, LspErrorResponse> {
-    let mut last_err = None;
-    for attempt in 0..=max_retries {
-        match session.request_raw(method, params.clone()).await {
-            Ok(value) => return Ok(value),
-            Err(err) if err.code == LSP_CONTENT_MODIFIED && attempt < max_retries => {
-                last_err = Some(err);
-                tokio::time::sleep(TRANSIENT_RETRY_DELAY).await;
-            }
-            Err(err) => return Err(err),
-        }
-    }
-    Err(last_err.unwrap())
 }

--- a/crates/aether-lspd/src/daemon.rs
+++ b/crates/aether-lspd/src/daemon.rs
@@ -23,9 +23,9 @@ pub struct LspDaemon {
 }
 
 impl LspDaemon {
-    /// Create a daemon with socket and idle-timeout settings.
-    pub fn new(socket_path: PathBuf, idle_timeout: Option<Duration>) -> Self {
-        Self { socket_path, idle_timeout, workspace_registry: WorkspaceRegistry::new() }
+    /// Create a daemon with socket, idle-timeout, and per-request timeout settings.
+    pub fn new(socket_path: PathBuf, idle_timeout: Option<Duration>, request_timeout: Duration) -> Self {
+        Self { socket_path, idle_timeout, workspace_registry: WorkspaceRegistry::new(request_timeout) }
     }
 
     /// Run the daemon until shutdown.
@@ -104,11 +104,6 @@ impl LspDaemon {
             }
         }
     }
-}
-
-/// Compatibility wrapper for the previous daemon entrypoint.
-pub async fn run_daemon(socket_path: PathBuf, idle_timeout: Option<Duration>) -> DaemonResult<()> {
-    LspDaemon::new(socket_path, idle_timeout).run().await
 }
 
 /// Wait until idle timeout is reached

--- a/crates/aether-lspd/src/lib.rs
+++ b/crates/aether-lspd/src/lib.rs
@@ -28,7 +28,7 @@ use tracing_subscriber::EnvFilter;
 use tracing_subscriber::fmt::writer::MakeWriterExt;
 
 pub use client::{ClientError, ClientResult, LspClient};
-pub use daemon::{LspDaemon, run_daemon};
+pub use daemon::LspDaemon;
 pub use error::{DaemonError, DaemonResult};
 
 #[derive(Debug, thiserror::Error)]
@@ -49,7 +49,8 @@ pub use lsp_utils::symbol_kind_to_string;
 pub use socket_path::{ensure_socket_dir, lockfile_path, log_file_path, socket_path};
 
 pub use protocol::{
-    DaemonRequest, DaemonResponse, InitializeRequest, LspErrorResponse, MAX_MESSAGE_SIZE, ProtocolError,
+    DaemonRequest, DaemonResponse, InitializeRequest, LSP_REQUEST_TIMED_OUT, LSP_TRANSPORT_CLOSED, LspErrorResponse,
+    MAX_MESSAGE_SIZE, ProtocolError,
 };
 pub use uri::{UriError, path_to_uri, uri_to_path};
 
@@ -63,6 +64,14 @@ pub struct LspdArgs {
     #[arg(long, default_value = "300")]
     pub idle_timeout: u64,
 
+    /// Per-request LSP timeout in seconds. When a language server exceeds it,
+    /// the server is killed and replaced on the next request. The env var
+    /// matters because the daemon is usually auto-spawned with fixed arguments,
+    /// so the environment is the only configuration channel available to
+    /// whoever launches the client.
+    #[arg(long, env = "AETHER_LSPD_REQUEST_TIMEOUT", default_value = "120", value_parser = clap::value_parser!(u64).range(1..))]
+    pub request_timeout: u64,
+
     /// Log level (trace, debug, info, warn, error)
     #[arg(long, default_value = "info")]
     pub log_level: String,
@@ -74,6 +83,7 @@ pub struct LspdArgs {
 
 pub fn run_lspd(args: LspdArgs) -> Result<(), LspdRunError> {
     let idle_timeout = if args.idle_timeout == 0 { None } else { Some(Duration::from_secs(args.idle_timeout)) };
+    let request_timeout = Duration::from_secs(args.request_timeout);
 
     let runtime = tokio::runtime::Runtime::new().map_err(LspdRunError::RuntimeCreate)?;
 
@@ -101,6 +111,6 @@ pub fn run_lspd(args: LspdArgs) -> Result<(), LspdRunError> {
         }
 
         tracing::info!("Starting LSP daemon on socket: {:?}", args.socket);
-        run_daemon(args.socket, idle_timeout).await.map_err(LspdRunError::Daemon)
+        LspDaemon::new(args.socket, idle_timeout, request_timeout).run().await.map_err(LspdRunError::Daemon)
     })
 }

--- a/crates/aether-lspd/src/process_transport.rs
+++ b/crates/aether-lspd/src/process_transport.rs
@@ -11,6 +11,10 @@ use lsp_types::{
     WorkspaceClientCapabilities, WorkspaceFolder,
 };
 use lsp_types::{DocumentSymbolClientCapabilities, DynamicRegistrationClientCapabilities};
+#[cfg(unix)]
+use nix::sys::signal::{Signal, kill};
+#[cfg(unix)]
+use nix::unistd::Pid;
 use serde_json::Value;
 use std::collections::HashMap;
 use std::io::ErrorKind;
@@ -25,6 +29,7 @@ const INITIALIZE_REQUEST_ID: i64 = 1;
 #[derive(Clone)]
 pub(crate) struct ProcessTransport {
     command_tx: mpsc::Sender<TransportCommand>,
+    process_id: Option<i32>,
 }
 
 pub(crate) enum TransportEvent {
@@ -33,10 +38,20 @@ pub(crate) enum TransportEvent {
     Closed,
 }
 
+/// Failure of a raw LSP request, typed so callers can react to a dead
+/// transport (replace the server) without inspecting server-defined codes.
+pub(crate) enum TransportError {
+    /// The language server answered with an error response; forwarded verbatim.
+    Lsp(LspErrorResponse),
+    /// The language server process exited or its transport shut down before
+    /// responding.
+    Closed,
+}
+
 struct TransportRequest {
     method: String,
     params: Value,
-    response_tx: oneshot::Sender<Result<Value, LspErrorResponse>>,
+    response_tx: oneshot::Sender<Result<Value, TransportError>>,
 }
 
 enum TransportCommand {
@@ -54,7 +69,7 @@ struct ProcessTransportActor {
     watcher: FileWatcherHandle,
     watcher_rx: mpsc::Receiver<FileWatcherBatch>,
     next_id: i64,
-    pending: HashMap<i64, oneshot::Sender<Result<Value, LspErrorResponse>>>,
+    pending: HashMap<i64, oneshot::Sender<Result<Value, TransportError>>>,
 }
 
 impl ProcessTransport {
@@ -77,6 +92,7 @@ impl ProcessTransport {
             process.stdin.take().ok_or_else(|| DaemonError::LspSpawnFailed("Failed to capture stdin".into()))?;
         let stdout =
             process.stdout.take().ok_or_else(|| DaemonError::LspSpawnFailed("Failed to capture stdout".into()))?;
+        let process_id = process.id().and_then(|id| i32::try_from(id).ok());
 
         let (command_tx, command_rx) = mpsc::channel(100);
         let (event_tx, event_rx) = mpsc::channel(100);
@@ -96,18 +112,15 @@ impl ProcessTransport {
         };
         tokio::spawn(actor.run(root_path.to_path_buf()));
 
-        Ok((Self { command_tx }, event_rx))
+        Ok((Self { command_tx, process_id }, event_rx))
     }
 
-    pub(crate) async fn request_raw(&self, method: &str, params: Value) -> Result<Value, LspErrorResponse> {
+    pub(crate) async fn request_raw(&self, method: &str, params: Value) -> Result<Value, TransportError> {
         let (response_tx, response_rx) = oneshot::channel();
         let request = TransportRequest { method: method.to_string(), params, response_tx };
-        self.command_tx
-            .send(TransportCommand::Request(request))
-            .await
-            .map_err(|_| LspErrorResponse { code: -1, message: "LSP transport closed".into() })?;
+        self.command_tx.send(TransportCommand::Request(request)).await.map_err(|_| TransportError::Closed)?;
 
-        response_rx.await.map_err(|_| LspErrorResponse { code: -1, message: "Response channel closed".into() })?
+        response_rx.await.map_err(|_| TransportError::Closed)?
     }
 
     pub(crate) async fn send_notification(&self, notification: LspNotification) {
@@ -116,6 +129,19 @@ impl ProcessTransport {
 
     pub(crate) async fn shutdown(&self) {
         let _ = self.command_tx.send(TransportCommand::Shutdown).await;
+    }
+
+    /// Forcibly terminate the language server process, bypassing the actor.
+    ///
+    /// Used when the server stops responding: the actor may be blocked on the
+    /// server's pipes, so a cooperative `Shutdown` command would never be
+    /// processed. Killing the process closes its pipes, which unblocks the
+    /// actor and fails all pending requests.
+    pub(crate) fn kill_process(&self) {
+        #[cfg(unix)]
+        if let Some(pid) = self.process_id {
+            let _ = kill(Pid::from_raw(pid), Signal::SIGKILL);
+        }
     }
 }
 
@@ -166,7 +192,8 @@ impl ProcessTransportActor {
                 if let Err(err) = self.send_request(id, &request.method, request.params).await
                     && let Some(tx) = self.pending.remove(&id)
                 {
-                    let _ = tx.send(Err(LspErrorResponse { code: -1, message: err.to_string() }));
+                    tracing::warn!(%err, "Failed to write LSP request");
+                    let _ = tx.send(Err(TransportError::Closed));
                 }
                 true
             }
@@ -287,7 +314,7 @@ impl ProcessTransportActor {
                             .unwrap_or(-1);
                         let message =
                             error.get("message").and_then(Value::as_str).unwrap_or("Unknown error").to_string();
-                        Err(LspErrorResponse { code, message })
+                        Err(TransportError::Lsp(LspErrorResponse { code, message }))
                     } else {
                         Ok(message.get("result").cloned().unwrap_or(Value::Null))
                     };
@@ -352,7 +379,7 @@ impl ProcessTransportActor {
 
     fn cleanup_pending(&mut self) {
         for (_, tx) in self.pending.drain() {
-            let _ = tx.send(Err(LspErrorResponse { code: -1, message: "LSP transport closed".into() }));
+            let _ = tx.send(Err(TransportError::Closed));
         }
     }
 }

--- a/crates/aether-lspd/src/protocol.rs
+++ b/crates/aether-lspd/src/protocol.rs
@@ -90,6 +90,18 @@ pub fn extract_document_uri(method: &str, params: &Value) -> Option<Uri> {
 /// Maximum message size (16 MB)
 pub const MAX_MESSAGE_SIZE: u32 = 16 * 1024 * 1024;
 
+/// Error code for a request that exceeded the daemon's per-request timeout.
+/// The daemon kills and replaces the language server when this fires.
+///
+/// Daemon-synthesized codes live outside the ranges reserved by JSON-RPC
+/// (-32000..=-32768) and LSP (-32800..=-32899), so they can never collide with
+/// a code forwarded verbatim from a real language server.
+pub const LSP_REQUEST_TIMED_OUT: i32 = -33001;
+
+/// Error code for a request that failed because the language server process
+/// exited or its transport shut down before responding.
+pub const LSP_TRANSPORT_CLOSED: i32 = -33002;
+
 /// Read a length-prefixed frame from an async reader
 pub(crate) async fn read_frame<R, T>(reader: &mut R) -> io::Result<Option<T>>
 where

--- a/crates/aether-lspd/src/workspace_registry.rs
+++ b/crates/aether-lspd/src/workspace_registry.rs
@@ -1,11 +1,15 @@
 use crate::error::{DaemonError, DaemonResult};
 use crate::language_catalog::LanguageId;
 use crate::language_catalog::{ServerKind, metadata_for, resolved_config_for_language, server_kind_for_language};
+use crate::process_transport::TransportError;
+use crate::protocol::{LSP_REQUEST_TIMED_OUT, LSP_TRANSPORT_CLOSED, LspErrorResponse, extract_document_uri};
 use crate::workspace_session::WorkspaceSession;
+use serde_json::Value;
 use std::collections::HashMap;
 use std::collections::HashSet;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
+use std::time::Duration;
 use tokio::sync::RwLock;
 
 #[derive(Debug, Clone, Eq, PartialEq, Hash)]
@@ -14,43 +18,78 @@ pub(crate) struct WorkspaceKey {
     pub(crate) server_kind: ServerKind,
 }
 
-#[derive(Clone, Default)]
+/// A client's resolved attachment to one workspace/language-server pair.
+/// Carries everything needed to (re)spawn the server, so per-request lookups
+/// never re-canonicalize paths or re-derive server configuration.
+#[derive(Clone)]
+pub(crate) struct WorkspaceBinding {
+    key: WorkspaceKey,
+    language: LanguageId,
+}
+
+#[derive(Clone)]
 pub(crate) struct WorkspaceRegistry {
     sessions: Arc<RwLock<HashMap<WorkspaceKey, Arc<WorkspaceSession>>>>,
+    request_timeout: Duration,
 }
 
 impl WorkspaceRegistry {
-    pub(crate) fn new() -> Self {
-        Self::default()
+    pub(crate) fn new(request_timeout: Duration) -> Self {
+        Self { sessions: Arc::new(RwLock::new(HashMap::new())), request_timeout }
     }
 
-    pub(crate) async fn get_or_spawn(
-        &self,
-        workspace_root: &Path,
-        language: LanguageId,
-    ) -> DaemonResult<Arc<WorkspaceSession>> {
+    /// Resolve a workspace/language pair and spawn its language server if needed.
+    pub(crate) async fn bind(&self, workspace_root: &Path, language: LanguageId) -> DaemonResult<WorkspaceBinding> {
         let key = WorkspaceKey::new(workspace_root, language)?;
+        let binding = WorkspaceBinding { key, language };
+        self.get_or_spawn(&binding).await?;
+        Ok(binding)
+    }
 
-        if let Some(session) = self.sessions.read().await.get(&key) {
-            return Ok(Arc::clone(session));
-        }
+    /// Run an LSP call against the binding's current session. If the session's
+    /// transport turns out to be closed (the language server exited), replace
+    /// the session and retry once against the fresh server. On timeout the
+    /// session is declared wedged: its server process is killed so the next
+    /// request gets a fresh one.
+    pub(crate) async fn lsp_call(
+        &self,
+        binding: &WorkspaceBinding,
+        method: &str,
+        params: Value,
+    ) -> Result<Value, LspErrorResponse> {
+        let session = self.session(binding).await?;
+        let result = match self.call_session(&session, method, &params).await {
+            Err(SessionCallError::TransportClosed) => {
+                session.mark_dead();
+                let session = self.session(binding).await?;
+                self.call_session(&session, method, &params).await
+            }
+            result => result,
+        };
+        result.map_err(|err| err.into_response(method, self.request_timeout))
+    }
 
-        let config = resolved_config_for_language(language)
-            .ok_or_else(|| DaemonError::LspSpawnFailed(format!("No LSP configured for language: {language:?}")))?;
+    pub(crate) async fn get_diagnostics(
+        &self,
+        binding: &WorkspaceBinding,
+        uri: Option<&lsp_types::Uri>,
+    ) -> Result<Value, LspErrorResponse> {
+        let session = self.session(binding).await?;
+        let Ok(diagnostics) = tokio::time::timeout(self.request_timeout, session.get_diagnostics(uri)).await else {
+            session.declare_wedged();
+            return Err(SessionCallError::TimedOut.into_response("diagnostics", self.request_timeout));
+        };
+        serde_json::to_value(&diagnostics).map_err(|e| LspErrorResponse { code: -1, message: e.to_string() })
+    }
 
-        let mut sessions = self.sessions.write().await;
-        if let Some(session) = sessions.get(&key) {
-            return Ok(Arc::clone(session));
-        }
-
-        let session = Arc::new(WorkspaceSession::spawn(
-            &key.workspace_root,
-            &config.command,
-            &config.args,
-            supported_extensions(&config),
-        )?);
-        sessions.insert(key, Arc::clone(&session));
-        Ok(session)
+    pub(crate) async fn queue_diagnostic_refresh(
+        &self,
+        binding: &WorkspaceBinding,
+        uri: lsp_types::Uri,
+    ) -> Result<(), LspErrorResponse> {
+        let session = self.session(binding).await?;
+        session.queue_diagnostic_refresh(uri).await;
+        Ok(())
     }
 
     pub(crate) async fn workspace_roots(&self) -> Vec<PathBuf> {
@@ -62,6 +101,135 @@ impl WorkspaceRegistry {
         futures::future::join_all(sessions.iter().map(|s| s.shutdown())).await;
         self.sessions.write().await.clear();
     }
+
+    async fn session(&self, binding: &WorkspaceBinding) -> Result<Arc<WorkspaceSession>, LspErrorResponse> {
+        self.get_or_spawn(binding).await.map_err(|e| LspErrorResponse { code: -1, message: e.to_string() })
+    }
+
+    async fn get_or_spawn(&self, binding: &WorkspaceBinding) -> DaemonResult<Arc<WorkspaceSession>> {
+        if let Some(session) = self.sessions.read().await.get(&binding.key)
+            && session.is_alive()
+        {
+            return Ok(Arc::clone(session));
+        }
+
+        let config = resolved_config_for_language(binding.language).ok_or_else(|| {
+            DaemonError::LspSpawnFailed(format!("No LSP configured for language: {:?}", binding.language))
+        })?;
+
+        let mut sessions = self.sessions.write().await;
+        if let Some(session) = sessions.get(&binding.key) {
+            if session.is_alive() {
+                return Ok(Arc::clone(session));
+            }
+            sessions.remove(&binding.key);
+        }
+
+        let session = Arc::new(WorkspaceSession::spawn(
+            &binding.key.workspace_root,
+            &config.command,
+            &config.args,
+            supported_extensions(&config),
+        )?);
+        sessions.insert(binding.key.clone(), Arc::clone(&session));
+        Ok(session)
+    }
+
+    /// Run a single LSP call against one session, bounded by the request timeout.
+    async fn call_session(
+        &self,
+        session: &WorkspaceSession,
+        method: &str,
+        params: &Value,
+    ) -> Result<Value, SessionCallError> {
+        let call = async {
+            let opened_uri = if let Some(uri) = extract_document_uri(method, params) {
+                let _ = session.ensure_document_open(&uri).await;
+                Some(uri)
+            } else {
+                None
+            };
+
+            let result = request_with_retry(session, method, params, TRANSIENT_RETRY_LIMIT).await;
+
+            if let Some(uri) = opened_uri {
+                session.close_document(&uri).await;
+            }
+            result
+        };
+
+        let Ok(result) = tokio::time::timeout(self.request_timeout, call).await else {
+            session.declare_wedged();
+            return Err(SessionCallError::TimedOut);
+        };
+        result.map_err(SessionCallError::from)
+    }
+}
+
+impl WorkspaceKey {
+    pub(crate) fn new(workspace_root: &Path, language: LanguageId) -> DaemonResult<Self> {
+        let workspace_root = workspace_root.canonicalize().unwrap_or_else(|_| workspace_root.to_path_buf());
+        let server_kind = server_kind_for_language(language)
+            .ok_or_else(|| DaemonError::LspSpawnFailed(format!("No LSP configured for language: {language:?}")))?;
+        Ok(Self { workspace_root, server_kind })
+    }
+}
+
+const LSP_CONTENT_MODIFIED: i32 = -32801;
+const TRANSIENT_RETRY_LIMIT: u32 = 3;
+const TRANSIENT_RETRY_DELAY: Duration = Duration::from_millis(500);
+
+enum SessionCallError {
+    Lsp(LspErrorResponse),
+    TransportClosed,
+    TimedOut,
+}
+
+impl SessionCallError {
+    fn into_response(self, what: &str, request_timeout: Duration) -> LspErrorResponse {
+        match self {
+            Self::Lsp(err) => err,
+            Self::TransportClosed => {
+                LspErrorResponse { code: LSP_TRANSPORT_CLOSED, message: "LSP transport closed".into() }
+            }
+            Self::TimedOut => LspErrorResponse {
+                code: LSP_REQUEST_TIMED_OUT,
+                message: format!(
+                    "LSP request '{what}' timed out after {}s; the language server was killed and will be replaced on the next request",
+                    request_timeout.as_secs()
+                ),
+            },
+        }
+    }
+}
+
+impl From<TransportError> for SessionCallError {
+    fn from(err: TransportError) -> Self {
+        match err {
+            TransportError::Lsp(err) => Self::Lsp(err),
+            TransportError::Closed => Self::TransportClosed,
+        }
+    }
+}
+
+async fn request_with_retry(
+    session: &WorkspaceSession,
+    method: &str,
+    params: &Value,
+    max_retries: u32,
+) -> Result<Value, TransportError> {
+    let mut last_err = None;
+    for attempt in 0..=max_retries {
+        match session.request_raw(method, params.clone()).await {
+            Ok(value) => return Ok(value),
+            Err(TransportError::Lsp(err)) if err.code == LSP_CONTENT_MODIFIED && attempt < max_retries => {
+                last_err = Some(TransportError::Lsp(err));
+                tokio::time::sleep(TRANSIENT_RETRY_DELAY).await;
+            }
+            Err(err) => return Err(err),
+        }
+    }
+    Err(last_err.unwrap())
 }
 
 fn supported_extensions(config: &crate::language_catalog::LspConfig) -> HashSet<String> {
@@ -72,15 +240,6 @@ fn supported_extensions(config: &crate::language_catalog::LspConfig) -> HashSet<
         .flat_map(|metadata| metadata.extensions.iter().copied())
         .map(ToOwned::to_owned)
         .collect()
-}
-
-impl WorkspaceKey {
-    pub(crate) fn new(workspace_root: &Path, language: LanguageId) -> DaemonResult<Self> {
-        let workspace_root = workspace_root.canonicalize().unwrap_or_else(|_| workspace_root.to_path_buf());
-        let server_kind = server_kind_for_language(language)
-            .ok_or_else(|| DaemonError::LspSpawnFailed(format!("No LSP configured for language: {language:?}")))?;
-        Ok(Self { workspace_root, server_kind })
-    }
 }
 
 #[cfg(test)]

--- a/crates/aether-lspd/src/workspace_session.rs
+++ b/crates/aether-lspd/src/workspace_session.rs
@@ -1,7 +1,7 @@
 use crate::diagnostics_store::DiagnosticsStore;
 use crate::document_lifecycle::{AcquireAction, DocumentLifecycle, ReleaseAction};
 use crate::language_catalog::LanguageId;
-use crate::process_transport::{ProcessTransport, TransportEvent};
+use crate::process_transport::{ProcessTransport, TransportError, TransportEvent};
 use crate::protocol::LspNotification;
 use crate::refresh_queue::RefreshQueue;
 use ignore::WalkBuilder;
@@ -17,6 +17,7 @@ use std::collections::HashSet;
 use std::ffi::OsStr;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::time::Duration;
 use tokio::sync::mpsc;
 
@@ -28,6 +29,7 @@ pub(crate) struct WorkspaceSession {
     documents: DocumentLifecycle,
     diagnostics: DiagnosticsStore,
     refresh: RefreshQueue,
+    alive: Arc<AtomicBool>,
 }
 
 impl WorkspaceSession {
@@ -41,8 +43,9 @@ impl WorkspaceSession {
         let documents = DocumentLifecycle::new();
         let diagnostics = DiagnosticsStore::new();
         let refresh = RefreshQueue::new();
+        let alive = Arc::new(AtomicBool::new(true));
 
-        let session = Self { transport, documents, diagnostics, refresh };
+        let session = Self { transport, documents, diagnostics, refresh, alive: Arc::clone(&alive) };
         let supported_extensions = Arc::new(supported_extensions);
 
         tokio::spawn(run_session_events(
@@ -52,6 +55,7 @@ impl WorkspaceSession {
             session.refresh.clone(),
             Arc::clone(&supported_extensions),
             event_rx,
+            alive,
         ));
 
         tokio::spawn(run_background_refresh_worker(
@@ -70,7 +74,7 @@ impl WorkspaceSession {
         Ok(session)
     }
 
-    pub(crate) async fn request_raw(&self, method: &str, params: Value) -> Result<Value, crate::LspErrorResponse> {
+    pub(crate) async fn request_raw(&self, method: &str, params: Value) -> Result<Value, TransportError> {
         self.transport.request_raw(method, params).await
     }
 
@@ -94,6 +98,24 @@ impl WorkspaceSession {
     pub(crate) async fn shutdown(&self) {
         self.refresh.shutdown().await;
         self.transport.shutdown().await;
+    }
+
+    /// Whether the language server behind this session is still usable.
+    pub(crate) fn is_alive(&self) -> bool {
+        self.alive.load(Ordering::SeqCst)
+    }
+
+    /// Mark this session dead so the registry replaces it on the next request.
+    pub(crate) fn mark_dead(&self) {
+        self.alive.store(false, Ordering::SeqCst);
+    }
+
+    /// Declare the language server wedged: mark the session dead and kill the
+    /// server process so blocked pipes unwind and pending requests fail.
+    pub(crate) fn declare_wedged(&self) {
+        if self.alive.swap(false, Ordering::SeqCst) {
+            self.transport.kill_process();
+        }
     }
 
     async fn sync_documents_for_diagnostics(&self, uri: Option<&Uri>) {
@@ -226,6 +248,7 @@ async fn run_session_events(
     refresh: RefreshQueue,
     supported_extensions: Arc<HashSet<String>>,
     mut event_rx: mpsc::Receiver<TransportEvent>,
+    alive: Arc<AtomicBool>,
 ) {
     while let Some(event) = event_rx.recv().await {
         match event {
@@ -260,6 +283,9 @@ async fn run_session_events(
             TransportEvent::Closed => break,
         }
     }
+
+    alive.store(false, Ordering::SeqCst);
+    refresh.shutdown().await;
 }
 
 fn filter_supported_uris(uris: Vec<Uri>, supported_extensions: &HashSet<String>) -> Vec<Uri> {

--- a/crates/aether-lspd/tests/common/fake_lsp_server.py
+++ b/crates/aether-lspd/tests/common/fake_lsp_server.py
@@ -1,7 +1,15 @@
 import json
+import argparse
 import sys
 
 docs = {}
+
+parser = argparse.ArgumentParser()
+parser.add_argument("--wedge-on", action="append", default=[])
+parser.add_argument("--crash-on", action="append", default=[])
+cli_args = parser.parse_args()
+wedge_methods = set(cli_args.wedge_on)
+crash_methods = set(cli_args.crash_on)
 
 
 def write_message(msg):
@@ -111,6 +119,12 @@ while True:
 
     method = message.get("method")
     params = message.get("params", {})
+
+    if method in crash_methods:
+        sys.exit(1)
+
+    if method in wedge_methods:
+        continue
 
     if method == "initialize":
         write_message(

--- a/crates/aether-lspd/tests/common/mod.rs
+++ b/crates/aether-lspd/tests/common/mod.rs
@@ -13,14 +13,23 @@ static FAKE_SERVER_ENV: Once = Once::new();
 
 #[allow(dead_code)]
 pub fn use_fake_rust_server() {
+    use_fake_rust_server_with_args(&[]);
+}
+
+/// Point the daemon at the fake Python LSP server for this test binary.
+///
+/// The configuration is process-wide and applied exactly once: the first
+/// caller's `extra_args` win and later calls with different args are silently
+/// ignored. Don't mix differently-configured fake servers in one test binary.
+#[allow(dead_code)]
+pub fn use_fake_rust_server_with_args(extra_args: &[&str]) {
     FAKE_SERVER_ENV.call_once(|| {
         let script = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("tests").join("common").join("fake_lsp_server.py");
+        let mut args = vec![script.to_string_lossy().to_string()];
+        args.extend(extra_args.iter().map(ToString::to_string));
         unsafe {
             std::env::set_var("AETHER_LSPD_SERVER_COMMAND_RUST_ANALYZER", "python3");
-            std::env::set_var(
-                "AETHER_LSPD_SERVER_ARGS_RUST_ANALYZER",
-                serde_json::to_string(&vec![script.to_string_lossy().to_string()]).unwrap(),
-            );
+            std::env::set_var("AETHER_LSPD_SERVER_ARGS_RUST_ANALYZER", serde_json::to_string(&args).unwrap());
         }
     });
 }

--- a/crates/aether-lspd/tests/e2e_wedge_recovery.rs
+++ b/crates/aether-lspd/tests/e2e_wedge_recovery.rs
@@ -1,0 +1,80 @@
+//! Recovery tests for unresponsive or crashed language servers.
+//!
+//! A language server that stops responding (or exits) must not leave a zombie
+//! session behind: in-flight requests must fail with a bounded error, and the
+//! next request must be served by a freshly spawned server.
+
+mod common;
+
+use aether_lspd::{ClientError, LSP_REQUEST_TIMED_OUT, LanguageId};
+use common::{CargoProject, DaemonHarness, TestProject, hover_text, use_fake_rust_server_with_args};
+use std::sync::Once;
+
+static SETUP: Once = Once::new();
+
+/// Fake server that never answers `workspace/symbol` and exits on
+/// `textDocument/references`, with a short daemon request timeout so wedge
+/// detection fires quickly.
+fn use_misbehaving_fake_server() {
+    SETUP.call_once(|| {
+        unsafe { std::env::set_var("AETHER_LSPD_REQUEST_TIMEOUT", "2") };
+        use_fake_rust_server_with_args(&["--wedge-on", "workspace/symbol", "--crash-on", "textDocument/references"]);
+    });
+}
+
+#[tokio::test]
+async fn wedged_request_fails_with_timeout_instead_of_hanging() {
+    use_misbehaving_fake_server();
+
+    let project = CargoProject::new("wedge_timeout").expect("Failed to create project");
+    let harness = DaemonHarness::spawn(project.root(), LanguageId::Rust).await.expect("Failed to spawn daemon");
+    let client = harness.connect().await.expect("Failed to connect");
+
+    let result = client.workspace_symbol("example".to_string()).await;
+    match result {
+        Err(ClientError::LspError { code, message }) => {
+            assert_eq!(code, LSP_REQUEST_TIMED_OUT, "unexpected error: {message}");
+        }
+        other => panic!("Expected timeout error for wedged request, got {other:?}"),
+    }
+
+    harness.kill().await.expect("Failed to kill daemon");
+}
+
+#[tokio::test]
+async fn wedged_server_is_replaced_on_next_request() {
+    use_misbehaving_fake_server();
+
+    let project = CargoProject::new("wedge_recovery").expect("Failed to create project");
+    project.add_file("src/main.rs", "fn main() {}\n").expect("Failed to add file");
+    let harness = DaemonHarness::spawn(project.root(), LanguageId::Rust).await.expect("Failed to spawn daemon");
+    let client = harness.connect().await.expect("Failed to connect");
+    let uri = project.file_uri("src/main.rs");
+
+    let wedged = client.workspace_symbol("example".to_string()).await;
+    assert!(wedged.is_err(), "wedged request should fail, got {wedged:?}");
+
+    let hover = hover_text(client.hover(uri, 0, 0).await.expect("Hover after wedge should succeed"));
+    assert!(hover.contains("open_count=1"), "unexpected hover from replacement server: {hover}");
+
+    harness.kill().await.expect("Failed to kill daemon");
+}
+
+#[tokio::test]
+async fn crashed_server_is_replaced_on_next_request() {
+    use_misbehaving_fake_server();
+
+    let project = CargoProject::new("crash_recovery").expect("Failed to create project");
+    project.add_file("src/main.rs", "fn main() {}\n").expect("Failed to add file");
+    let harness = DaemonHarness::spawn(project.root(), LanguageId::Rust).await.expect("Failed to spawn daemon");
+    let client = harness.connect().await.expect("Failed to connect");
+    let uri = project.file_uri("src/main.rs");
+
+    let crashed = client.find_references(uri.clone(), 0, 0, true).await;
+    assert!(crashed.is_err(), "request to crashing server should fail, got {crashed:?}");
+
+    let hover = hover_text(client.hover(uri, 0, 0).await.expect("Hover after crash should succeed"));
+    assert!(hover.contains("open_count=1"), "unexpected hover from replacement server: {hover}");
+
+    harness.kill().await.expect("Failed to kill daemon");
+}

--- a/crates/mcp-servers/tests/lsp_diagnostics_e2e.rs
+++ b/crates/mcp-servers/tests/lsp_diagnostics_e2e.rs
@@ -269,7 +269,7 @@ async fn test_workspace_diagnostics_clear_after_fix_without_file_check() {
     let (_server_handle, client) = connect_lsp(&project).await;
 
     let initial =
-        poll_workspace_diagnostics(&client, |result| file_error_count(result, &main_rs) > 0, Duration::from_secs(15))
+        poll_workspace_diagnostics(&client, |result| file_error_count(result, &main_rs) > 0, Duration::from_secs(60))
             .await;
     assert!(
         file_error_count(&initial, &main_rs) > 0,
@@ -289,7 +289,7 @@ async fn test_workspace_diagnostics_clear_after_fix_without_file_check() {
     .await;
 
     let result =
-        poll_workspace_diagnostics(&client, |r| file_error_count(r, &main_rs) == 0, Duration::from_secs(15)).await;
+        poll_workspace_diagnostics(&client, |r| file_error_count(r, &main_rs) == 0, Duration::from_secs(60)).await;
     assert_eq!(
         file_error_count(&result, &main_rs),
         0,

--- a/crates/mcp-servers/tests/lsp_diagnostics_e2e.rs
+++ b/crates/mcp-servers/tests/lsp_diagnostics_e2e.rs
@@ -269,7 +269,7 @@ async fn test_workspace_diagnostics_clear_after_fix_without_file_check() {
     let (_server_handle, client) = connect_lsp(&project).await;
 
     let initial =
-        poll_workspace_diagnostics(&client, |result| file_error_count(result, &main_rs) > 0, Duration::from_secs(60))
+        poll_workspace_diagnostics(&client, |result| file_error_count(result, &main_rs) > 0, Duration::from_mins(1))
             .await;
     assert!(
         file_error_count(&initial, &main_rs) > 0,
@@ -289,7 +289,7 @@ async fn test_workspace_diagnostics_clear_after_fix_without_file_check() {
     .await;
 
     let result =
-        poll_workspace_diagnostics(&client, |r| file_error_count(r, &main_rs) == 0, Duration::from_secs(60)).await;
+        poll_workspace_diagnostics(&client, |r| file_error_count(r, &main_rs) == 0, Duration::from_mins(1)).await;
     assert_eq!(
         file_error_count(&result, &main_rs),
         0,


### PR DESCRIPTION
## Summary

CI test jobs could hang until GitHub's 6-hour kill when a language server (typically typescript-language-server) stopped responding to a single request: no layer had a deadline, and a wedged-but-alive server left a permanent zombie session behind for real users.

- **Per-request timeout in the daemon** — the workspace registry bounds every LSP call and diagnostics request (`--request-timeout`, `AETHER_LSPD_REQUEST_TIMEOUT` env, default 120s). On timeout the server process is SIGKILLed by pid (bypassing the transport actor, which may be stuck in `initialize` or blocked on a full stdin pipe) and the session is replaced on the next request.
- **Crash recovery** — a request that fails because the transport closed is retried once against a freshly spawned server.
- **Recovery policy lives in one place** — `WorkspaceRegistry` owns bind/timeout/kill/replace; `client_connection.rs` is a pure protocol translator. Sessions clean themselves up when their transport closes.
- **Typed transport errors** — `TransportError::{Lsp, Closed}` replaces error-code sniffing; daemon-synthesized wire codes (−33001/−33002) sit outside the JSON-RPC and LSP reserved ranges so they can't collide with codes forwarded from a real server.
- **Backstops** — `timeout-minutes` on all CI jobs and a default nextest `slow-timeout` so a hang terminates the test rather than the 6-hour job.

## Test plan

- New `e2e_wedge_recovery.rs` suite drives a fake LSP server with `--wedge-on` / `--crash-on` seams: a wedged request fails with `LSP_REQUEST_TIMED_OUT` instead of hanging, and both wedged and crashed servers are replaced transparently on the next request.
- `cargo nextest run -p aether-lspd`: 90/90 pass; clippy and `cargo check --workspace` clean.
- Full local suite passes except `lsp_ts_operations_e2e::test_ts_incoming_calls_omit_context_by_default`, which fails identically on `main` (pre-existing local Node-v25 flake, unrelated to this change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01G3h5CP5SPnabqnGjGkY4p2