### PR TITLE
chore: Prefer connecting with new 7-28-2026 mcp protocol

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,7 +47,7 @@ tracing-appender = "0.2"
 agent-client-protocol = "0.14.0"
 
 # MCP and API clients
-rmcp = { version = "^3.0.0", default-features = false }
+rmcp = { version = "^3.1.0", default-features = false }
 async-openai = { version = "^0.41.0", features = ["byot", "chat-completion", "responses"] }
 reqwest = { version = "^0.13.4", default-features = false, features = ["json", "query", "rustls", "http2", "stream"] }
 oauth2 = "5.0"

--- a/crates/mcp-utils/src/client/connection.rs
+++ b/crates/mcp-utils/src/client/connection.rs
@@ -3,13 +3,13 @@ use super::{
     config::{McpHttpConfig, McpServer, McpTransport},
     mcp_client::McpClient,
 };
-use crate::{client::OAuthHandlerContext, transport::create_in_memory_transport};
+use crate::{client::OAuthHandlerContext, protocol::client_lifecycle_mode, transport::create_in_memory_transport};
 use aether_auth::{OAuthCredentialStorage, create_auth_manager_from_store, perform_oauth_flow};
 use llm::ToolAnnotations;
 use rmcp::{
     RoleClient, RoleServer, ServiceExt,
     model::{ClientInfo, Tool as RmcpTool},
-    serve_client,
+    serve_client_with_lifecycle,
     service::{DynService, RunningService},
     transport::{
         StreamableHttpClientTransport, TokioChildProcess, auth::AuthClient,
@@ -104,7 +104,7 @@ impl McpServerConnection {
         mcp_client: McpClient,
     ) -> Result<Self> {
         let transport = StreamableHttpClientTransport::with_client(auth_client, config);
-        let client = serve_client(mcp_client, transport)
+        let client = serve_client_with_lifecycle(mcp_client, transport, client_lifecycle_mode())
             .await
             .map_err(|e| McpError::ConnectionFailed(format!("reconnect failed for '{name}': {e}")))?;
         Ok(Self::from_parts(client, None))
@@ -215,7 +215,7 @@ async fn connect_stdio(
     };
     let stderr_task = stderr.map(|stderr| spawn_stderr_logger(server_name.to_string(), stderr));
 
-    match serve_client(mcp_client, proc).await {
+    match serve_client_with_lifecycle(mcp_client, proc, client_lifecycle_mode()).await {
         Ok(client) => McpConnectOutcome::Connected {
             conn: McpServerConnection::from_parts(client, stderr_task),
             reauth_config: None,
@@ -290,10 +290,10 @@ async fn connect_http(
         tracing::debug!("Using OAuth for server '{name}'");
         let auth_client = AuthClient::new(reqwest::Client::default(), auth_manager);
         let transport = StreamableHttpClientTransport::with_client(auth_client, config.transport.clone());
-        serve_client(mcp_client, transport).await.map_err(conn_err)
+        serve_client_with_lifecycle(mcp_client, transport, client_lifecycle_mode()).await.map_err(conn_err)
     } else {
         let transport = StreamableHttpClientTransport::from_config(config.transport.clone());
-        serve_client(mcp_client, transport).await.map_err(conn_err)
+        serve_client_with_lifecycle(mcp_client, transport, client_lifecycle_mode()).await.map_err(conn_err)
     };
 
     match result {
@@ -341,7 +341,7 @@ async fn serve_in_memory(
         }
     });
 
-    let client = serve_client(mcp_client, client_transport)
+    let client = serve_client_with_lifecycle(mcp_client, client_transport, client_lifecycle_mode())
         .await
         .map_err(|e| McpError::ConnectionFailed(format!("Failed to connect to in-memory server '{label}': {e}")))?;
 

--- a/crates/mcp-utils/src/lib.rs
+++ b/crates/mcp-utils/src/lib.rs
@@ -1,6 +1,7 @@
 #![doc = include_str!("../README.md")]
 
 pub mod display_meta;
+mod protocol;
 pub mod status;
 pub mod testing;
 pub mod transport;

--- a/crates/mcp-utils/src/protocol.rs
+++ b/crates/mcp-utils/src/protocol.rs
@@ -1,0 +1,14 @@
+use rmcp::{ClientLifecycleMode, model::ProtocolVersion};
+
+pub(crate) fn client_lifecycle_mode() -> ClientLifecycleMode {
+    ClientLifecycleMode::Auto {
+        preferred_versions: vec![
+            ProtocolVersion::V_2026_07_28,
+            ProtocolVersion::V_2025_11_25,
+            ProtocolVersion::V_2025_06_18,
+            ProtocolVersion::V_2025_03_26,
+            ProtocolVersion::V_2024_11_05,
+        ],
+        legacy_version: Some(ProtocolVersion::V_2025_11_25),
+    }
+}

--- a/crates/mcp-utils/src/testing.rs
+++ b/crates/mcp-utils/src/testing.rs
@@ -1,11 +1,12 @@
+use crate::protocol::client_lifecycle_mode;
 use crate::transport::create_in_memory_transport;
 use rmcp::{
-    RoleClient, RoleServer, Service, serve_client, serve_server,
+    RoleClient, RoleServer, Service, serve_client_with_lifecycle, serve_server,
     service::{ClientInitializeError, RunningService, ServerInitializeError},
 };
 
 /// Helper function to connect an MCP server and client via in-memory transport
-/// This handles the initialization handshake by running both concurrently
+/// This handles the dual-era discovery/initialization handshake by running both concurrently
 pub async fn connect<S, C>(
     server: S,
     client: C,
@@ -16,8 +17,10 @@ where
 {
     let (client_transport, server_transport) = create_in_memory_transport();
 
-    let (server_result, client_result) =
-        tokio::join!(serve_server(server, server_transport), serve_client(client, client_transport));
+    let (server_result, client_result) = tokio::join!(
+        serve_server(server, server_transport),
+        serve_client_with_lifecycle(client, client_transport, client_lifecycle_mode())
+    );
 
     let server = server_result.map_err(ConnectError::ServerInit)?;
     let client = client_result.map_err(ConnectError::ClientInit)?;
@@ -31,4 +34,109 @@ pub enum ConnectError {
     ServerInit(ServerInitializeError),
     #[error("Client initialization failed: {0}")]
     ClientInit(ClientInitializeError),
+}
+
+#[cfg(test)]
+mod tests {
+    use super::connect;
+    use rmcp::{
+        ClientHandler, ServerHandler,
+        model::{ErrorData, Implementation, InitializeRequestParams, ProtocolVersion, ServerCapabilities, ServerInfo},
+        service::RequestContext,
+    };
+    use std::borrow::Cow;
+
+    #[tokio::test]
+    async fn connect_prefers_stateless_discovery_for_modern_servers() {
+        let (_server, client) = connect(McpServer728, TestClient).await.expect("connect");
+        assert_eq!(client.peer_info().expect("peer info").protocol_version, ProtocolVersion::V_2026_07_28);
+        client.list_tools(None).await.expect("list tools");
+        client.cancel().await.expect("cancel client");
+    }
+
+    #[tokio::test]
+    async fn connect_selects_an_older_mutually_supported_revision() {
+        let (_server, client) = connect(McpServer618, TestClient).await.expect("connect");
+
+        assert_eq!(client.peer_info().expect("peer info").protocol_version, ProtocolVersion::V_2025_06_18);
+        client.list_tools(None).await.expect("list tools");
+        client.cancel().await.expect("cancel client");
+    }
+
+    #[tokio::test]
+    async fn connect_falls_back_to_legacy_initialization() {
+        let (_server, client) = connect(McpServer1125, TestClient).await.expect("connect");
+
+        assert_eq!(client.peer_info().expect("peer info").protocol_version, ProtocolVersion::V_2025_11_25);
+        client.cancel().await.expect("cancel client");
+    }
+
+    #[derive(Clone, Default)]
+    struct TestClient;
+
+    impl ClientHandler for TestClient {}
+
+    #[derive(Clone, Default)]
+    struct McpServer728;
+
+    impl ServerHandler for McpServer728 {
+        fn get_info(&self) -> ServerInfo {
+            ServerInfo::new(ServerCapabilities::builder().enable_tools().build())
+                .with_server_info(Implementation::new("modern-only", "1.0.0"))
+                .with_protocol_version(ProtocolVersion::V_2026_07_28)
+        }
+
+        fn supported_protocol_versions(&self) -> Cow<'static, [ProtocolVersion]> {
+            Cow::Owned(vec![ProtocolVersion::V_2026_07_28])
+        }
+
+        fn initialize(
+            &self,
+            _request: InitializeRequestParams,
+            _context: RequestContext<rmcp::RoleServer>,
+        ) -> impl std::future::Future<Output = Result<rmcp::model::InitializeResult, ErrorData>> + Send + '_ {
+            std::future::ready(Err(ErrorData::new(
+                rmcp::model::ErrorCode::METHOD_NOT_FOUND,
+                "initialize is not supported",
+                None,
+            )))
+        }
+    }
+
+    #[derive(Clone, Default)]
+    struct McpServer618;
+
+    impl ServerHandler for McpServer618 {
+        fn get_info(&self) -> ServerInfo {
+            ServerInfo::new(ServerCapabilities::builder().enable_tools().build())
+                .with_server_info(Implementation::new("older-revision", "1.0.0"))
+                .with_protocol_version(ProtocolVersion::V_2025_06_18)
+        }
+
+        fn supported_protocol_versions(&self) -> Cow<'static, [ProtocolVersion]> {
+            Cow::Owned(vec![ProtocolVersion::V_2025_06_18])
+        }
+    }
+
+    #[derive(Clone, Default)]
+    struct McpServer1125;
+
+    impl ServerHandler for McpServer1125 {
+        fn get_info(&self) -> ServerInfo {
+            ServerInfo::new(ServerCapabilities::builder().enable_tools().build())
+                .with_server_info(Implementation::new("legacy", "1.0.0"))
+                .with_protocol_version(ProtocolVersion::V_2025_11_25)
+        }
+
+        fn discover(
+            &self,
+            _context: RequestContext<rmcp::RoleServer>,
+        ) -> impl Future<Output = Result<rmcp::model::DiscoverResult, ErrorData>> + Send + '_ {
+            std::future::ready(Err(ErrorData::new(
+                rmcp::model::ErrorCode::METHOD_NOT_FOUND,
+                "server/discover is not supported",
+                None,
+            )))
+        }
+    }
 }


### PR DESCRIPTION
This PR makes a change to upgrade rmcp to 3.1 and prefer connecting with the new 7-28-2026 mcp protocol 