### PR TITLE
feat(mcp-servers): Bash and Sub-agents can now be run in foreground or background by main agent

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -301,7 +301,6 @@ dependencies = [
  "tokio",
  "tracing",
  "url",
- "uuid",
 ]
 
 [[package]]

--- a/crates/aether-cli/src/acp/agent_runtime.rs
+++ b/crates/aether-cli/src/acp/agent_runtime.rs
@@ -7,7 +7,7 @@ use aether_core::agent_spec::AgentSpec;
 use aether_core::agent_spec::ToolFilter;
 use aether_core::core::{AgentDeps, AgentHandle};
 use aether_core::events::{AgentCommand, AgentEvent, Command};
-use aether_core::mcp::run_mcp_task::McpCommand;
+use aether_core::mcp::{McpRuntime, run_mcp_task::McpCommand};
 use llm::ChatMessage;
 use mcp_utils::client::{
     ElicitingOAuthHandler, McpClientEvent, McpConnectionDetails, McpError, McpServer, McpServerStatusEntry,
@@ -27,10 +27,9 @@ pub(crate) const RUNTIME_EVENT_CHANNEL_CAPACITY: usize = 50;
 
 pub(crate) struct AgentRuntime {
     agent_tx: mpsc::Sender<Command>,
-    mcp_tx: mpsc::Sender<McpCommand>,
     latest_mcp_snapshot: watch::Receiver<McpConnectionDetails>,
     agent_handle: Option<AgentHandle>,
-    mcp_handle: JoinHandle<()>,
+    mcp_runtime: McpRuntime,
     agent_pump_handle: JoinHandle<()>,
     mcp_pump_handle: JoinHandle<()>,
 }
@@ -43,9 +42,8 @@ impl AgentRuntime {
         agent_tx: mpsc::Sender<Command>,
         mut agent_rx: mpsc::Receiver<AgentEvent>,
         agent_handle: Option<AgentHandle>,
-        mcp_tx: mpsc::Sender<McpCommand>,
         mut event_rx: mpsc::Receiver<McpClientEvent>,
-        mcp_handle: JoinHandle<()>,
+        mcp_runtime: McpRuntime,
         snapshot: McpConnectionDetails,
         runtime_event_tx: mpsc::Sender<RuntimeEvent>,
     ) -> Self {
@@ -75,7 +73,7 @@ impl AgentRuntime {
             }
         });
 
-        Self { agent_tx, mcp_tx, latest_mcp_snapshot, agent_handle, mcp_handle, agent_pump_handle, mcp_pump_handle }
+        Self { agent_tx, latest_mcp_snapshot, agent_handle, mcp_runtime, agent_pump_handle, mcp_pump_handle }
     }
 
     pub(crate) async fn send_agent_command(&self, command: Command) -> Result<(), SessionError> {
@@ -93,18 +91,18 @@ impl AgentRuntime {
     }
 
     pub(crate) fn mcp_tx(&self) -> &mpsc::Sender<McpCommand> {
-        &self.mcp_tx
+        self.mcp_runtime.command_tx()
     }
 
     pub(crate) async fn list_prompts(&self) -> Result<Vec<McpPrompt>, SessionError> {
-        list_prompts(&self.mcp_tx).await.map_err(|error| match error {
+        list_prompts(self.mcp_tx()).await.map_err(|error| match error {
             SlashCommandError::CommandChannel(message) => SessionError::CommandChannel(message),
             other => SessionError::McpOperation(other.to_string()),
         })
     }
 
     pub(crate) async fn authenticate_mcp_server(&self, name: &str) -> Result<(), SessionError> {
-        self.mcp_tx
+        self.mcp_tx()
             .send(McpCommand::AuthenticateServer { name: name.to_string() })
             .await
             .map_err(|e| SessionError::CommandChannel(format!("failed to send AuthenticateServer command: {e}")))
@@ -120,7 +118,6 @@ impl Drop for AgentRuntime {
         if let Some(handle) = &self.agent_handle {
             handle.abort();
         }
-        self.mcp_handle.abort();
         self.agent_pump_handle.abort();
         self.mcp_pump_handle.abort();
     }
@@ -186,16 +183,15 @@ impl RuntimeFactory for ProductionRuntimeFactory {
             server_statuses: Vec::new(),
         };
 
-        let Runtime { agent_tx, agent_rx, agent_handle, mcp_tx, event_rx, mcp_handle } = runtime;
+        let Runtime { agent_tx, agent_rx, agent_handle, event_rx, mcp_runtime } = runtime;
         Ok(AgentRuntime::new(
             agent,
             spec,
             agent_tx,
             agent_rx,
             Some(agent_handle),
-            mcp_tx,
             event_rx,
-            mcp_handle,
+            mcp_runtime,
             snapshot,
             runtime_event_tx,
         ))

--- a/crates/aether-cli/src/acp/testing.rs
+++ b/crates/aether-cli/src/acp/testing.rs
@@ -20,7 +20,6 @@ use aether_auth::OAuthCredentialStorage;
 use aether_core::agent_spec::{AgentSpec, AgentSpecExposure};
 use aether_core::core::{AgentBuilder, AgentHandle, Prompt};
 use aether_core::events::{AgentEvent, Command, MessageEvent};
-use aether_core::mcp::McpSpawnResult;
 use aether_core::mcp::mcp;
 use aether_core::session::{SessionControlEvent, SessionEvent, SessionMeta, UserEvent, last_agent_from_events};
 use aether_project::AgentCatalog;
@@ -396,7 +395,7 @@ impl RuntimeFactory for FakeRuntimeFactory {
             .block_until_ready()
             .await
             .ok_or_else(|| SessionError::McpOperation("fake MCP bootstrap aborted".to_string()))?;
-        let McpSpawnResult { command_tx: mcp_tx, event_rx, handle: mcp_handle } = spawn;
+        let (mcp_runtime, event_rx) = spawn.split();
 
         let filtered_tools = spec.tools.apply(snapshot.tool_definitions.clone());
         let mut builder = AgentBuilder::new(provider).max_auto_continues(0);
@@ -404,7 +403,7 @@ impl RuntimeFactory for FakeRuntimeFactory {
             builder = builder.system_prompt(prompt.clone());
         }
         let (agent_tx, agent_rx, agent_handle) = builder
-            .tools(mcp_tx.clone(), filtered_tools)
+            .tools(mcp_runtime.command_tx().clone(), filtered_tools)
             .messages(initial_messages)
             .spawn()
             .await
@@ -416,9 +415,8 @@ impl RuntimeFactory for FakeRuntimeFactory {
             agent_tx,
             agent_rx,
             Some(agent_handle),
-            mcp_tx,
             event_rx,
-            mcp_handle,
+            mcp_runtime,
             snapshot,
             runtime_event_tx,
         ))
@@ -458,7 +456,7 @@ impl RuntimeFactory for StubRuntimeFactory {
             .block_until_ready()
             .await
             .ok_or_else(|| SessionError::McpOperation("stub MCP bootstrap aborted".to_string()))?;
-        let McpSpawnResult { command_tx: mcp_tx, event_rx, handle: mcp_handle } = spawn;
+        let (mcp_runtime, event_rx) = spawn.split();
 
         Ok(AgentRuntime::new(
             agent,
@@ -466,9 +464,8 @@ impl RuntimeFactory for StubRuntimeFactory {
             parts.tx,
             parts.rx,
             Some(parts.handle),
-            mcp_tx,
             event_rx,
-            mcp_handle,
+            mcp_runtime,
             snapshot,
             runtime_event_tx,
         ))

--- a/crates/aether-cli/src/headless/run.rs
+++ b/crates/aether-cli/src/headless/run.rs
@@ -47,7 +47,7 @@ async fn run_agent(config: RunConfig, telemetry: Option<Arc<TelemetryRuntime>>) 
         .build_ready(vec![])
         .await?;
 
-    let prompt = expand_prompt(&agent.mcp_tx, config.prompt).await;
+    let prompt = expand_prompt(agent.mcp_runtime.command_tx(), config.prompt).await;
 
     agent
         .agent_tx

--- a/crates/aether-cli/src/runtime.rs
+++ b/crates/aether-cli/src/runtime.rs
@@ -3,15 +3,14 @@ use aether_core::agent_spec::{AgentSpec, McpConfigSource};
 use aether_core::core::{AgentBuilder, AgentDeps, AgentHandle, Prompt};
 use aether_core::events::{AgentEvent, Command};
 use aether_core::mcp::McpBuilder;
-use aether_core::mcp::McpSpawnResult;
 use aether_core::mcp::mcp;
 use aether_core::mcp::run_mcp_task::McpCommand;
+use aether_core::mcp::{McpRuntime, McpSpawnResult};
 use llm::{ChatMessage, ToolDefinition};
 use mcp_servers::McpBuilderExt;
 use mcp_utils::client::{McpClientEvent, McpConnectionDetails, McpServer, OAuthHandlerFactory};
 use std::path::PathBuf;
 use tokio::sync::mpsc::{Receiver, Sender};
-use tokio::task::JoinHandle;
 use tracing::debug;
 
 pub struct RuntimeBuilder {
@@ -27,9 +26,8 @@ pub struct Runtime {
     pub agent_tx: Sender<Command>,
     pub agent_rx: Receiver<AgentEvent>,
     pub agent_handle: AgentHandle,
-    pub mcp_tx: Sender<McpCommand>,
     pub event_rx: Receiver<McpClientEvent>,
-    pub mcp_handle: JoinHandle<()>,
+    pub mcp_runtime: McpRuntime,
 }
 
 pub struct PromptInfo {
@@ -78,10 +76,10 @@ impl RuntimeBuilder {
     ) -> Result<Runtime, CliError> {
         let deps = self.agent_deps.clone();
         let (spec, spawn) = self.spawn_mcp().await?;
-        let McpSpawnResult { command_tx: mcp_tx, event_rx, handle: mcp_handle } = spawn;
+        let (mcp_runtime, event_rx) = spawn.split();
 
         let (agent_tx, agent_rx, agent_handle) =
-            spawn_agent(&spec, &deps, mcp_tx.clone(), Vec::new(), |mut agent_builder| {
+            spawn_agent(&spec, &deps, mcp_runtime.command_tx().clone(), Vec::new(), |mut agent_builder| {
                 if let Some(prompt) = custom_prompt {
                     agent_builder = agent_builder.system_prompt(prompt);
                 }
@@ -92,7 +90,7 @@ impl RuntimeBuilder {
             })
             .await?;
 
-        Ok(Runtime { agent_tx, agent_rx, agent_handle, mcp_tx, event_rx, mcp_handle })
+        Ok(Runtime { agent_tx, agent_rx, agent_handle, event_rx, mcp_runtime })
     }
 
     /// Spawn MCP, block until every server finishes its initial connection,
@@ -108,19 +106,19 @@ impl RuntimeBuilder {
             .block_until_ready()
             .await
             .ok_or_else(|| CliError::McpError("MCP bootstrap aborted before completion".to_string()))?;
-        let McpSpawnResult { command_tx: mcp_tx, event_rx, handle: mcp_handle } = spawn;
+        let (mcp_runtime, event_rx) = spawn.split();
 
         let filtered_tools = spec.tools.apply(snapshot.tool_definitions.clone());
         let mut runtime_spec = spec;
         runtime_spec.prompts.push(Prompt::McpInstructions(snapshot.instructions.clone()));
 
         let (agent_tx, agent_rx, agent_handle) =
-            spawn_agent(&runtime_spec, &deps, mcp_tx.clone(), filtered_tools, |agent_builder| {
+            spawn_agent(&runtime_spec, &deps, mcp_runtime.command_tx().clone(), filtered_tools, |agent_builder| {
                 agent_builder.messages(messages)
             })
             .await?;
 
-        Ok((Runtime { agent_tx, agent_rx, agent_handle, mcp_tx, event_rx, mcp_handle }, snapshot))
+        Ok((Runtime { agent_tx, agent_rx, agent_handle, event_rx, mcp_runtime }, snapshot))
     }
 
     pub async fn build_prompt_info(self) -> Result<PromptInfo, CliError> {

--- a/crates/aether-core/examples/mcp_agent.rs
+++ b/crates/aether-core/examples/mcp_agent.rs
@@ -16,11 +16,10 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let llm = OpenRouterProvider::default("z-ai/glm-4.5-air")?;
     let mut spawn = mcp(std::env::current_dir()?).from_json_files(&["examples/mcp.json"]).await?.spawn().await?;
     let connection_details = spawn.block_until_ready().await.ok_or("MCP bootstrap aborted before completion")?;
-    let _mcp_handle = spawn.handle;
 
     let (tx, mut rx, _handle) = agent(llm)
         .system_prompt(Prompt::text("You are a helpful assistant with access to web browsing tools via Playwright."))
-        .tools(spawn.command_tx, connection_details.tool_definitions)
+        .tools(spawn.command_tx().clone(), connection_details.tool_definitions)
         .spawn()
         .await?;
 

--- a/crates/aether-core/src/core/tool_execution.rs
+++ b/crates/aether-core/src/core/tool_execution.rs
@@ -63,7 +63,9 @@ impl ToolExecutions {
     pub(super) fn on_event(&mut self, tool_id: &str, event: ToolCallEvent) -> ToolExecutionUpdate {
         match event {
             ToolCallEvent::Progress(progress) => {
-                let Some(execution) = self.foreground(tool_id) else {
+                let Some(execution) = self.executions.get(tool_id).filter(|execution| {
+                    matches!(execution.phase, ToolExecutionPhase::Foreground | ToolExecutionPhase::Background)
+                }) else {
                     return ToolExecutionUpdate::Ignored;
                 };
                 ToolExecutionUpdate::Event(ToolEvent::Progress {
@@ -170,10 +172,6 @@ impl ToolExecutions {
             preserve
         });
         removed
-    }
-
-    fn foreground(&self, tool_id: &str) -> Option<&ToolExecution> {
-        self.executions.get(tool_id).filter(|execution| execution.phase == ToolExecutionPhase::Foreground)
     }
 
     fn take_retiring(&mut self, tool_id: &str) -> Option<ToolExecution> {

--- a/crates/aether-core/src/mcp/mcp_builder.rs
+++ b/crates/aether-core/src/mcp/mcp_builder.rs
@@ -19,18 +19,39 @@ pub fn mcp(root_dir: impl AsRef<Path>) -> McpBuilder {
     McpBuilder::new(root_dir)
 }
 
-/// Handle to the spawned MCP manager task. Consumers receive incremental
-/// updates over `event_rx` (starting with an initial `ServerStatusesChanged`
-/// reflecting every configured server in `Connecting`) and can call
-/// `block_until_ready()` to block until every server has finished its initial
-/// connection attempt.
+/// Owns a spawned MCP manager. Dropping this value aborts the manager task.
+pub struct McpRuntime {
+    command_tx: Sender<McpCommand>,
+    handle: JoinHandle<()>,
+}
+
+impl McpRuntime {
+    pub fn command_tx(&self) -> &Sender<McpCommand> {
+        &self.command_tx
+    }
+}
+
+impl Drop for McpRuntime {
+    fn drop(&mut self) {
+        self.handle.abort();
+    }
+}
+
+/// A freshly spawned MCP manager paired with its event stream. Consumers
+/// receive incremental updates over the event stream (starting with an initial
+/// `ServerStatusesChanged` reflecting every configured server in `Connecting`)
+/// and can call [`split`](Self::split) to separate the stream from the
+/// [`McpRuntime`] that keeps the manager task alive.
 pub struct McpSpawnResult {
-    pub command_tx: Sender<McpCommand>,
-    pub event_rx: Receiver<McpClientEvent>,
-    pub handle: JoinHandle<()>,
+    runtime: McpRuntime,
+    event_rx: Receiver<McpClientEvent>,
 }
 
 impl McpSpawnResult {
+    pub fn command_tx(&self) -> &Sender<McpCommand> {
+        self.runtime.command_tx()
+    }
+
     /// Block until the manager finishes bootstrapping every initially-configured
     /// server, then return the consolidated snapshot. Returns `None` if the
     /// event channel closes before `ConnectionReady` is received.
@@ -41,6 +62,10 @@ impl McpSpawnResult {
             }
         }
         None
+    }
+
+    pub fn split(self) -> (McpRuntime, Receiver<McpClientEvent>) {
+        (self.runtime, self.event_rx)
     }
 }
 
@@ -165,7 +190,7 @@ impl McpBuilder {
 
         let mcp_handle = tokio::spawn(run_mcp_task(mcp_manager, mcp_command_rx, pending));
 
-        Ok(McpSpawnResult { command_tx: mcp_command_tx, event_rx, handle: mcp_handle })
+        Ok(McpSpawnResult { runtime: McpRuntime { command_tx: mcp_command_tx, handle: mcp_handle }, event_rx })
     }
 }
 
@@ -266,7 +291,7 @@ mod tests {
 
     #[tokio::test]
     async fn spawn_returns_immediately_and_emits_initial_connecting_status() {
-        let mut spawn = McpBuilder::new("/workspace")
+        let spawn = McpBuilder::new("/workspace")
             .from_mcp_config_sources(&[json_source(
                 r#"{"servers":{"slow":{"type":"stdio","command":"sleep","args":["30"]}}}"#,
             )])
@@ -276,12 +301,12 @@ mod tests {
             .await
             .expect("spawn should succeed");
 
-        let event = spawn.event_rx.try_recv().expect("spawn() should buffer an initial ServerStatusesChanged");
+        let (_runtime, mut event_rx) = spawn.split();
+        let event = event_rx.try_recv().expect("spawn() should buffer an initial ServerStatusesChanged");
         let McpClientEvent::ServerStatusesChanged(statuses) = event else {
             panic!("expected ServerStatusesChanged, got {event:?}");
         };
         assert!(matches!(statuses[0].status, McpServerStatus::Connecting));
-        spawn.handle.abort();
     }
 
     #[tokio::test]

--- a/crates/aether-core/src/testing/mcp_test.rs
+++ b/crates/aether-core/src/testing/mcp_test.rs
@@ -1,7 +1,7 @@
 use crate::events::{TaskOutcomeState, TraceContext, task_created_result};
-use crate::mcp::mcp;
 use crate::mcp::run_mcp_task::McpCommand;
 use crate::mcp::tool_bridge::{convert_tool_result, map_task_result_to_outcome};
+use crate::mcp::{McpRuntime, mcp};
 use mcp_utils::client::{CancellationToken, McpConnectionDetails, McpServer, McpTransport, ToolCallEvent};
 use mcp_utils::testing::ElicitationScript;
 use rmcp::ServerHandler;
@@ -38,6 +38,7 @@ fn task_outcome(outcome: crate::events::TaskOutcome) -> TaskOutcome {
 
 pub struct McpTest {
     command_tx: mpsc::Sender<McpCommand>,
+    _runtime: McpRuntime,
     snapshot: McpConnectionDetails,
     elicitations: ElicitationScript,
     deferred_tools: tokio::sync::Mutex<VecDeque<DeferredTool>>,
@@ -108,11 +109,13 @@ impl McpTestBuilder {
             .await
             .expect("MCP test manager spawns");
         let snapshot = spawn.block_until_ready().await.expect("MCP test manager becomes ready");
+        let (runtime, event_rx) = spawn.split();
 
         McpTest {
-            command_tx: spawn.command_tx,
+            command_tx: runtime.command_tx().clone(),
+            _runtime: runtime,
             snapshot,
-            elicitations: ElicitationScript::spawn(spawn.event_rx, self.elicitation_responses),
+            elicitations: ElicitationScript::spawn(event_rx, self.elicitation_responses),
             deferred_tools: tokio::sync::Mutex::new(VecDeque::new()),
             cancel_tokens: Mutex::new(HashMap::new()),
             trace_context: self.trace_context,

--- a/crates/aether-core/src/testing/utils.rs
+++ b/crates/aether-core/src/testing/utils.rs
@@ -388,7 +388,7 @@ impl TestAgentBuilder {
         let mut builder = agent(llm);
         if let Some(spawn) = &mut mcp_spawn {
             let snapshot = spawn.block_until_ready().await.expect("bootstrap completes");
-            builder = builder.tools(spawn.command_tx.clone(), snapshot.tool_definitions);
+            builder = builder.tools(spawn.command_tx().clone(), snapshot.tool_definitions);
         }
         if let Some(timeout) = config.timeout {
             builder = builder.tool_timeout(timeout);

--- a/crates/aether-core/tests/agent/cancel_tests.rs
+++ b/crates/aether-core/tests/agent/cancel_tests.rs
@@ -2,7 +2,7 @@ use aether_core::events::{AgentEvent, MessageEvent, ToolEvent, TurnEvent};
 use aether_core::testing::{FakeMcpServer, FakeTool, FakeToolResponse, TestScenario, test_agent};
 use llm::LlmResponse;
 use llm::testing::llm_response;
-use rmcp::model::{CallToolResult, CreateTaskResult, DetailedTask, Task, TaskPayload, TaskStatus};
+use rmcp::model::{CallToolResult, ContentBlock, CreateTaskResult, DetailedTask, Task, TaskPayload, TaskStatus};
 use std::sync::Arc;
 use tokio::sync::Notify;
 
@@ -84,6 +84,61 @@ async fn immediate_background_outcome_follows_deferred_event() {
         .position(|event| matches!(event, AgentEvent::Tool(ToolEvent::TaskCompleted { request, .. } | ToolEvent::TaskFailed { request, .. }) if request.id == "terminal-call"))
         .unwrap();
     assert!(deferred < outcome);
+}
+
+#[tokio::test]
+async fn background_task_progress_reaches_agent_events() {
+    let now = chrono::Utc::now().to_rfc3339();
+    let seed = Task::new("progress-task", TaskStatus::Working, now.clone(), now.clone()).with_poll_interval_ms(10);
+    let working = Task::new("progress-task", TaskStatus::Working, now.clone(), now.clone()).with_poll_interval_ms(10);
+    let completed = Task::new("progress-task", TaskStatus::Completed, now.clone(), now);
+    let result = CallToolResult::success(vec![ContentBlock::text("finished")]);
+    let server = FakeMcpServer::new()
+        .with_tool(
+            FakeTool::new("deferred")
+                .responds(FakeToolResponse::task(CreateTaskResult::new(seed)).task_progress(1.0, Some(2.0))),
+        )
+        .with_task(
+            "progress-task",
+            [
+                DetailedTask::new(working, TaskPayload::Working),
+                DetailedTask::new(
+                    completed,
+                    TaskPayload::Completed {
+                        result: serde_json::from_value(serde_json::to_value(result).unwrap()).unwrap(),
+                    },
+                ),
+            ],
+        );
+    let arguments = serde_json::json!({}).to_string();
+
+    let events = test_agent()
+        .fake_mcp_server("tasks", server)
+        .llm_responses(&[
+            llm_response("msg_1").tool_call("progress-call", "tasks__deferred", &[&arguments]).build(),
+            llm_response("msg_2").text(&["background task started"]).build(),
+            llm_response("msg_3").text(&["handled result"]).build(),
+        ])
+        .scenario(
+            TestScenario::new()
+                .user_text("start background task")
+                .wait_for(|event| matches!(event, AgentEvent::Tool(ToolEvent::TaskCreated { request, .. }) if request.id == "progress-call"))
+                .wait_for(|event| matches!(event, AgentEvent::Tool(ToolEvent::Progress { request, .. }) if request.id == "progress-call"))
+                .wait_for_turn_end(),
+        )
+        .run()
+        .await
+        .unwrap();
+
+    let created = events
+        .iter()
+        .position(|event| matches!(event, AgentEvent::Tool(ToolEvent::TaskCreated { request, .. }) if request.id == "progress-call"))
+        .unwrap();
+    let progress = events
+        .iter()
+        .position(|event| matches!(event, AgentEvent::Tool(ToolEvent::Progress { request, .. }) if request.id == "progress-call"))
+        .unwrap();
+    assert!(created < progress);
 }
 
 #[tokio::test]

--- a/crates/aether-core/tests/mcp/instructions_tests.rs
+++ b/crates/aether-core/tests/mcp/instructions_tests.rs
@@ -80,7 +80,7 @@ async fn test_agent_builder_includes_mcp_instructions_in_system_prompt() {
     let (tx, mut rx, _handle) = agent(llm)
         .system_prompt(Prompt::text("You are a test agent"))
         .system_prompt(Prompt::McpInstructions(instructions(&[("test-server", "Test instructions")])))
-        .tools(spawn.command_tx, snapshot.tool_definitions)
+        .tools(spawn.command_tx().clone(), snapshot.tool_definitions)
         .spawn()
         .await
         .unwrap();
@@ -126,7 +126,7 @@ async fn test_agent_builder_works_without_mcp_instructions() {
     // No mcp_instructions provided - should still work
     let (tx, mut rx, _handle) = agent(llm)
         .system_prompt(Prompt::text("You are a test agent"))
-        .tools(spawn.command_tx, snapshot.tool_definitions)
+        .tools(spawn.command_tx().clone(), snapshot.tool_definitions)
         .spawn()
         .await
         .unwrap();

--- a/crates/mcp-servers/Cargo.toml
+++ b/crates/mcp-servers/Cargo.toml
@@ -43,7 +43,6 @@ coding = [
     "dep:thiserror",
     "dep:lsp-types",
     "dep:reqwest",
-    "dep:uuid",
     "dep:chrono",
     "dep:htmd",
     "dep:dom_smoothie",
@@ -99,7 +98,6 @@ tracing = { workspace = true, optional = true }
 thiserror = { workspace = true, optional = true }
 lsp-types = { workspace = true, optional = true }
 reqwest = { workspace = true, optional = true }
-uuid = { workspace = true, optional = true }
 chrono = { workspace = true, optional = true }
 htmd = { workspace = true, optional = true }
 dom_smoothie = { workspace = true, optional = true }

--- a/crates/mcp-servers/README.md
+++ b/crates/mcp-servers/README.md
@@ -7,7 +7,7 @@ Pre-built [MCP](https://modelcontextprotocol.io/) tool servers for Aether agents
 | `coding` | [`CodingMcp`](src/coding/README.md) | File read/write/edit, bash, grep, `ast_grep` structural search, find, LSP integration, web fetch/search |
 | `skills` | [`SkillsMcp`](src/skills/README.md) | Slash commands and reusable skill prompts |
 | `tasks` | [`TasksMcp`](src/tasks/README.md) | Hierarchical task management with dependencies |
-| `subagents` | [`SubAgentsMcp`](src/subagents/README.md) | Spawn and orchestrate sub-agents |
+| `subagents` | [`SubAgentsMcp`](src/subagents/README.md) | Spawn concurrent sub-agents in the foreground or as an MCP Task |
 | `survey` | [`SurveyMcp`](src/survey/README.md) | Human-in-the-loop elicitation (ask the user questions) |
 | `plan` | [`PlanMcp`](src/plan/README.md) | Submit markdown plans for approval via native elicitation |
 

--- a/crates/mcp-servers/src/coding/README.md
+++ b/crates/mcp-servers/src/coding/README.md
@@ -42,8 +42,7 @@ File operations, code search, bash execution, LSP integration, and web tools. Th
 
 | Tool | Description |
 |------|-------------|
-| `bash` | Execute a shell command with optional timeout (max 10 minutes, default 2 minutes). Supports background execution. |
-| `read_background_bash` | Read output from a background bash process by its shell ID. Supports regex filtering. |
+| `bash` | Execute a shell command with optional timeout. Set `runInBackground: true` to return an MCP Task; the client must support the Tasks extension and receives complete output when the task finishes. |
 
 ### Web
 

--- a/crates/mcp-servers/src/coding/default_tools.rs
+++ b/crates/mcp-servers/src/coding/default_tools.rs
@@ -1,9 +1,9 @@
 use super::error::CodingError;
+use super::tools::bash::execute_command_in_dir;
 use super::{
-    AstGrepInput, AstGrepOutput, BackgroundProcessHandle, BashInput, BashResult, EditFileArgs, EditFileResponse,
-    FindInput, FindOutput, GrepInput, GrepOutput, ListFilesArgs, ListFilesResult, ReadBackgroundBashOutput,
-    ReadFileArgs, ReadFileResult, WriteFileArgs, WriteFileResponse, edit_file_contents, execute_command_in_dir,
-    find_files, list_files, perform_ast_grep, perform_grep, read_background_bash, read_file_contents,
+    AstGrepInput, AstGrepOutput, BashInput, BashOutput, EditFileArgs, EditFileResponse, FindInput, FindOutput,
+    GrepInput, GrepOutput, ListFilesArgs, ListFilesResult, ReadFileArgs, ReadFileResult, WriteFileArgs,
+    WriteFileResponse, edit_file_contents, find_files, list_files, perform_ast_grep, perform_grep, read_file_contents,
     tools_trait::CodingTools, write_file_contents,
 };
 use std::path::PathBuf;
@@ -39,16 +39,8 @@ impl CodingTools for DefaultCodingTools {
         list_files(args).await.map_err(CodingError::from)
     }
 
-    async fn bash(&self, args: BashInput, cwd: Option<PathBuf>) -> Result<BashResult, CodingError> {
+    async fn bash(&self, args: BashInput, cwd: Option<PathBuf>) -> Result<BashOutput, CodingError> {
         execute_command_in_dir(args, cwd.as_deref()).await.map_err(CodingError::from)
-    }
-
-    async fn read_background_bash(
-        &self,
-        handle: BackgroundProcessHandle,
-        filter: Option<String>,
-    ) -> Result<(ReadBackgroundBashOutput, Option<BackgroundProcessHandle>), CodingError> {
-        read_background_bash(handle, filter).await.map_err(CodingError::from)
     }
 
     async fn grep(&self, args: GrepInput) -> Result<GrepOutput, CodingError> {

--- a/crates/mcp-servers/src/coding/error.rs
+++ b/crates/mcp-servers/src/coding/error.rs
@@ -62,22 +62,6 @@ pub enum BashError {
     /// Failed to spawn process
     #[error("Failed to execute command '{command}': {reason}")]
     SpawnFailed { command: String, reason: String },
-
-    /// Invalid regex pattern for filtering
-    #[error("Invalid regex pattern: {0}")]
-    InvalidRegex(#[source] regex::Error),
-
-    /// Failed to join background task
-    #[error("Failed to join background task: {0}")]
-    JoinFailed(#[source] tokio::task::JoinError),
-
-    /// Shell ID not found
-    #[error("Shell ID not found: {0}")]
-    ShellNotFound(String),
-
-    /// Wait on child process failed
-    #[error("Wait failed: {0}")]
-    WaitFailed(String),
 }
 
 /// Errors related to building glob filters, shared across search tools

--- a/crates/mcp-servers/src/coding/mod.rs
+++ b/crates/mcp-servers/src/coding/mod.rs
@@ -8,23 +8,19 @@ use rmcp::{
         wrapper::{Json, Parameters},
     },
     model::{
-        CallToolRequestParams, CallToolResponse, CallToolResult, ContentBlock, ElicitRequest, ElicitRequestParams,
-        ElicitResult, ElicitationAction, ElicitationSchema, EnumSchema, Implementation, InputRequest, InputRequests,
-        ProgressNotificationParam, ServerCapabilities, ServerInfo,
+        CallToolRequestParams, CallToolResponse, CallToolResult, CancelTaskParams, ClientCapabilities, ContentBlock,
+        CreateTaskResult, ElicitRequest, ElicitRequestParams, ElicitResult, ElicitationAction, ElicitationSchema,
+        EnumSchema, GetTaskParams, GetTaskResult, Implementation, InputRequest, InputRequests,
+        ProgressNotificationParam, ServerCapabilities, ServerInfo, UpdateTaskParams,
     },
     service::RequestContext,
+    task_manager::{TaskContext, TaskExit, TaskManager, TaskOptions},
     tool, tool_handler, tool_router,
 };
-use std::fmt::Write as _;
+use std::fmt::{Debug, Formatter, Write as _};
 use std::path::PathBuf;
-use std::{
-    collections::{HashMap, HashSet},
-    sync::Arc,
-};
-use tokio::{
-    fs::try_exists,
-    sync::{Mutex, RwLock},
-};
+use std::{collections::HashSet, sync::Arc};
+use tokio::{fs::try_exists, sync::RwLock};
 
 pub mod default_tools;
 pub mod error;
@@ -54,10 +50,7 @@ use mcp_utils::server::tool::parse_arguments;
 
 use mcp_utils::display_meta::{ToolDisplayMeta, ToolResultMeta, basename, truncate};
 use tools::ast_grep::{AstGrepInput, AstGrepOutput, perform_ast_grep};
-use tools::bash::{
-    BackgroundProcessHandle, BashInput, BashOutput, BashResult, ReadBackgroundBashInput, ReadBackgroundBashOutput,
-    execute_command_in_dir, read_background_bash,
-};
+use tools::bash::{BashInput, BashOutput, validate_args};
 use tools::edit_file::{EditFileArgs, EditFileResponse, edit_file_contents};
 use tools::find::{FindInput, FindOutput, find_files};
 use tools::grep::{GrepInput, GrepOutput, perform_grep};
@@ -123,13 +116,12 @@ impl CodingMcpArgs {
 }
 
 #[doc = include_str!("../docs/coding_mcp.md")]
-#[derive(Debug)]
 pub struct CodingMcp<T: CodingTools = DefaultCodingTools> {
     tool_router: ToolRouter<Self>,
-    background_processes: Mutex<HashMap<String, BackgroundProcessHandle>>,
+    task_manager: TaskManager,
     /// Track files that have been read to enforce read-before-edit safety
     files_read: RwLock<HashSet<String>>,
-    tools: T,
+    tools: Arc<T>,
     /// Optional LSP operations (enabled with `.with_lsp()`)
     lsp: Option<Arc<LspRegistry>>,
     web_fetcher: WebFetcher,
@@ -156,7 +148,7 @@ fn build_rule_catalog(configured_rules_dirs: &[PathBuf]) -> aether_project::Prom
 impl<T: CodingTools + 'static> ServerHandler for CodingMcp<T> {
     fn get_info(&self) -> ServerInfo {
         let instructions = self.build_instructions();
-        ServerInfo::new(ServerCapabilities::builder().enable_tools().build())
+        ServerInfo::new(ServerCapabilities::builder().enable_tools().enable_tasks().build())
             .with_server_info(Implementation::new("coding-mcp", "0.1.0"))
             .with_instructions(instructions)
     }
@@ -166,6 +158,16 @@ impl<T: CodingTools + 'static> ServerHandler for CodingMcp<T> {
         request: CallToolRequestParams,
         context: RequestContext<RoleServer>,
     ) -> Result<CallToolResponse, ErrorData> {
+        let background_args = background_bash_args(&request);
+        if let Some(args) = &background_args {
+            if !context.client_capabilities().is_some_and(|capabilities| capabilities.supports_tasks()) {
+                return Err(ErrorData::missing_required_client_capability(
+                    ClientCapabilities::builder().enable_tasks().build(),
+                ));
+            }
+            validate_args(args).map_err(|error| ErrorData::invalid_params(error.to_string(), None))?;
+        }
+
         if let Some(prompt) = self.permission_prompt(&request) {
             let action = get_next_mrtr_action(request.input_responses.as_ref(), || {
                 Ok(InputRequests::from([(
@@ -196,7 +198,37 @@ impl<T: CodingTools + 'static> ServerHandler for CodingMcp<T> {
                 }
             }
         }
+        if let Some(args) = background_args {
+            return Ok(CallToolResponse::Task(CreateTaskResult::new(self.create_background_bash_task(args))));
+        }
+
         self.tool_router.call(ToolCallContext::new(self, request, context)).await
+    }
+
+    async fn get_task(
+        &self,
+        request: GetTaskParams,
+        _context: RequestContext<RoleServer>,
+    ) -> Result<GetTaskResult, ErrorData> {
+        Ok(GetTaskResult::new(self.task_manager.get_task(&request.task_id)?))
+    }
+
+    async fn update_task(
+        &self,
+        request: UpdateTaskParams,
+        _context: RequestContext<RoleServer>,
+    ) -> Result<(), ErrorData> {
+        self.task_manager.update_task(&request.task_id, request.input_responses)?;
+        Ok(())
+    }
+
+    async fn cancel_task(
+        &self,
+        request: CancelTaskParams,
+        _context: RequestContext<RoleServer>,
+    ) -> Result<(), ErrorData> {
+        self.task_manager.cancel_task(&request.task_id)?;
+        Ok(())
     }
 }
 
@@ -253,15 +285,21 @@ fn is_dangerous_cmd(command: &str) -> bool {
     false
 }
 
+/// Bounds both how long a background command may run and how long its finished
+/// result stays pollable — rmcp couples the hard-stop and terminal-entry
+/// eviction to this single TTL. `None` would retain every finished task's
+/// output for the server's lifetime.
+const BACKGROUND_TASK_TTL_MS: u64 = 3_600_000;
+
 #[tool_router]
 impl<T: CodingTools + 'static> CodingMcp<T> {
     /// Create a `CodingMcp` with custom tool implementation
     pub fn with_tools(tools: T) -> Self {
         Self {
             tool_router: Self::tool_router(),
-            background_processes: Mutex::new(HashMap::new()),
+            task_manager: TaskManager::new(),
             files_read: RwLock::new(HashSet::new()),
-            tools,
+            tools: Arc::new(tools),
             lsp: None,
             web_fetcher: WebFetcher::new(),
             web_searcher: WebSearcher::try_new().ok(),
@@ -299,6 +337,28 @@ impl<T: CodingTools + 'static> CodingMcp<T> {
     pub fn with_permission_mode(mut self, mode: PermissionMode) -> Self {
         self.permission_mode = mode;
         self
+    }
+
+    fn create_background_bash_task(&self, args: BashInput) -> rmcp::model::Task {
+        let tools = Arc::clone(&self.tools);
+        let cwd = self.root_dir.clone();
+        let description = args.description.clone().unwrap_or_else(|| truncate(&args.command, 80));
+        let options = TaskOptions::new().with_ttl_ms(BACKGROUND_TASK_TTL_MS).with_status_message(description);
+
+        self.task_manager.spawn(options, move |task_context: TaskContext| {
+            Box::pin(async move {
+                tokio::select! {
+                    () = task_context.cancelled() => Err(TaskExit::Cancelled),
+                    result = tools.bash(args, Some(cwd)) => Ok(match result {
+                        Ok(output) => serde_json::to_value(output).map_or_else(
+                            |error| CallToolResult::error(vec![ContentBlock::text(error.to_string())]),
+                            CallToolResult::structured,
+                        ),
+                        Err(error) => CallToolResult::error(vec![ContentBlock::text(error.to_string())]),
+                    }),
+                }
+            })
+        })
     }
 
     fn workspace_paths(&self) -> WorkspacePaths {
@@ -583,56 +643,8 @@ When using tools that take file paths, always use absolute paths from:
         let Parameters(args) = request;
         notify_preview(&context, ToolDisplayMeta::new("Run command", truncate(&args.command, 40))).await;
 
-        let command = args.command.clone();
         let cwd = self.root_dir.clone();
         let result = self.tools.bash(args, Some(cwd)).await.map_err(|e| e.to_string())?;
-
-        match result {
-            BashResult::Completed(output) => Ok(Json(output)),
-            BashResult::Background(handle) => {
-                let shell_id = handle.shell_id.clone();
-
-                // Store the background process
-                self.background_processes.lock().await.insert(shell_id.clone(), handle);
-
-                let display_meta =
-                    ToolDisplayMeta::new("Run command", format!("{} (background)", truncate(&command, 40)));
-
-                // Return immediate response with shell_id
-                Ok(Json(BashOutput {
-                    output: String::new(),
-                    exit_code: 0,
-                    killed: None,
-                    shell_id: Some(shell_id),
-                    meta: Some(display_meta.into()),
-                }))
-            }
-        }
-    }
-
-    #[doc = include_str!("tools/bash/read_background_description.md")]
-    #[tool(annotations(read_only_hint = true, open_world_hint = false))]
-    pub async fn read_background_bash(
-        &self,
-        request: Parameters<ReadBackgroundBashInput>,
-    ) -> Result<Json<ReadBackgroundBashOutput>, String> {
-        let Parameters(args) = request;
-
-        let handle = self
-            .background_processes
-            .lock()
-            .await
-            .remove(&args.bash_id)
-            .ok_or_else(|| format!("Shell ID not found: {}", args.bash_id))?;
-
-        let (result, handle_opt) =
-            self.tools.read_background_bash(handle, args.filter).await.map_err(|e| e.to_string())?;
-
-        // Put handle back if still running
-        if let Some(handle) = handle_opt {
-            self.background_processes.lock().await.insert(args.bash_id, handle);
-        }
-
         Ok(Json(result))
     }
 
@@ -799,6 +811,33 @@ fn decision_form(tool_name: &str, description: &str) -> ElicitRequestParams {
             )
             .build()
             .unwrap(),
+    }
+}
+
+fn background_bash_args(request: &CallToolRequestParams) -> Option<BashInput> {
+    if request.name.as_ref() != "bash" {
+        return None;
+    }
+
+    let args = parse_arguments::<BashInput>(request).ok()?;
+    args.run_in_background.is_some_and(|background| background).then_some(args)
+}
+
+// TaskManager has no Drop of its own: aborting the tasks here drops their
+// in-flight command futures, whose kill_on_drop reaps the child processes.
+impl<T: CodingTools> Drop for CodingMcp<T> {
+    fn drop(&mut self) {
+        self.task_manager.shutdown();
+    }
+}
+
+impl<T: CodingTools> Debug for CodingMcp<T> {
+    fn fmt(&self, formatter: &mut Formatter<'_>) -> std::fmt::Result {
+        formatter
+            .debug_struct("CodingMcp")
+            .field("root_dir", &self.root_dir)
+            .field("permission_mode", &self.permission_mode)
+            .finish_non_exhaustive()
     }
 }
 

--- a/crates/mcp-servers/src/coding/mod.rs
+++ b/crates/mcp-servers/src/coding/mod.rs
@@ -8,10 +8,10 @@ use rmcp::{
         wrapper::{Json, Parameters},
     },
     model::{
-        CallToolRequestParams, CallToolResponse, CallToolResult, CancelTaskParams, ClientCapabilities, ContentBlock,
-        CreateTaskResult, ElicitRequest, ElicitRequestParams, ElicitResult, ElicitationAction, ElicitationSchema,
-        EnumSchema, GetTaskParams, GetTaskResult, Implementation, InputRequest, InputRequests,
-        ProgressNotificationParam, ServerCapabilities, ServerInfo, UpdateTaskParams,
+        CallToolRequestParams, CallToolResponse, CallToolResult, CancelTaskParams, ContentBlock, CreateTaskResult,
+        ElicitRequest, ElicitRequestParams, ElicitResult, ElicitationAction, ElicitationSchema, EnumSchema,
+        GetTaskParams, GetTaskResult, Implementation, InputRequest, InputRequests, ProgressNotificationParam,
+        ServerCapabilities, ServerInfo, UpdateTaskParams,
     },
     service::RequestContext,
     task_manager::{TaskContext, TaskExit, TaskManager, TaskOptions},
@@ -46,6 +46,7 @@ use crate::{
     workspace_paths::WorkspacePaths,
 };
 use mcp_utils::server::mrtr::{MrtrAction, get_next_mrtr_action, parse_response};
+use mcp_utils::server::tasks::{BACKGROUND_TASK_TTL_MS, require_tasks_capability};
 use mcp_utils::server::tool::parse_arguments;
 
 use mcp_utils::display_meta::{ToolDisplayMeta, ToolResultMeta, basename, truncate};
@@ -160,11 +161,7 @@ impl<T: CodingTools + 'static> ServerHandler for CodingMcp<T> {
     ) -> Result<CallToolResponse, ErrorData> {
         let background_args = background_bash_args(&request);
         if let Some(args) = &background_args {
-            if !context.client_capabilities().is_some_and(|capabilities| capabilities.supports_tasks()) {
-                return Err(ErrorData::missing_required_client_capability(
-                    ClientCapabilities::builder().enable_tasks().build(),
-                ));
-            }
+            require_tasks_capability(&context)?;
             validate_args(args).map_err(|error| ErrorData::invalid_params(error.to_string(), None))?;
         }
 
@@ -284,12 +281,6 @@ fn is_dangerous_cmd(command: &str) -> bool {
 
     false
 }
-
-/// Bounds both how long a background command may run and how long its finished
-/// result stays pollable — rmcp couples the hard-stop and terminal-entry
-/// eviction to this single TTL. `None` would retain every finished task's
-/// output for the server's lifetime.
-const BACKGROUND_TASK_TTL_MS: u64 = 3_600_000;
 
 #[tool_router]
 impl<T: CodingTools + 'static> CodingMcp<T> {

--- a/crates/mcp-servers/src/coding/tools/bash/description.md
+++ b/crates/mcp-servers/src/coding/tools/bash/description.md
@@ -1,4 +1,4 @@
-Executes bash commands in a persistent shell session.
+Executes a bash command. Each call runs in a fresh shell — no state persists between calls.
 
 **For terminal operations only** (git, npm, docker, cargo, etc.). Use dedicated tools for file operations.
 
@@ -12,8 +12,8 @@ Executes bash commands in a persistent shell session.
 
 - `command` — **required**, the bash command
 - `description` — concise description (5-10 words)
-- `timeout` — max runtime in ms (default: 120000, max: 600000)
-- `run_in_background` — run async, check output with `read_background_bash`
+- `timeout` — max runtime in ms (max: 600000)
+- `run_in_background` — Run a task in the background. You don't need to poll, results are delivered automatically into context when it completes.
 
 ## Tips
 

--- a/crates/mcp-servers/src/coding/tools/bash/mod.rs
+++ b/crates/mcp-servers/src/coding/tools/bash/mod.rs
@@ -2,11 +2,7 @@ use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use std::path::Path;
 use std::time::Duration;
-use tokio::io::{AsyncBufReadExt, BufReader};
 use tokio::process::Command;
-use tokio::sync::mpsc;
-use tokio::task::JoinHandle;
-use uuid::Uuid;
 
 use crate::coding::error::BashError;
 use mcp_utils::display_meta::{ToolDisplayMeta, ToolResultMeta, truncate};
@@ -33,258 +29,67 @@ pub struct BashOutput {
     /// Exit code of the command
     pub exit_code: i32,
     /// Whether the command was killed due to timeout
-    pub killed: Option<bool>,
-    /// Shell ID for background processes
-    pub shell_id: Option<String>,
+    pub killed: bool,
     /// Display metadata for human-friendly rendering
     #[serde(rename = "_meta", skip_serializing_if = "Option::is_none")]
     #[schemars(skip)]
     pub meta: Option<ToolResultMeta>,
 }
 
-#[derive(Debug)]
-pub struct BackgroundProcessHandle {
-    pub shell_id: String,
-    pub output_rx: mpsc::UnboundedReceiver<String>,
-    pub task_handle: JoinHandle<(i32, bool)>,
-}
-
-#[derive(Debug)]
-pub enum BashResult {
-    Completed(BashOutput),
-    Background(BackgroundProcessHandle),
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
-#[serde(rename_all = "camelCase")]
-pub struct ReadBackgroundBashInput {
-    /// The ID of the background shell to retrieve output from
-    #[serde(alias = "bash_id")]
-    pub bash_id: String,
-    /// Optional regex to filter output lines
-    pub filter: Option<String>,
-}
-
-/// Status of a background shell process.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
-#[serde(rename_all = "lowercase")]
-pub enum BackgroundShellStatus {
-    Running,
-    Completed,
-    Failed,
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
-#[serde(rename_all = "camelCase")]
-pub struct ReadBackgroundBashOutput {
-    /// New output since last check
-    pub output: String,
-    /// Current shell status
-    pub status: BackgroundShellStatus,
-    /// Exit code (when completed)
-    pub exit_code: Option<i32>,
-    /// Display metadata for human-friendly rendering
-    #[serde(rename = "_meta", skip_serializing_if = "Option::is_none")]
-    #[schemars(skip)]
-    pub meta: Option<ToolResultMeta>,
-}
-
-pub async fn read_background_bash(
-    handle: BackgroundProcessHandle,
-    filter: Option<String>,
-) -> Result<(ReadBackgroundBashOutput, Option<BackgroundProcessHandle>), BashError> {
-    let BackgroundProcessHandle { shell_id, mut output_rx, task_handle } = handle;
-
-    // Collect all available output
-    let mut output = String::new();
-    let filter_regex = if let Some(pattern) = filter {
-        Some(regex::Regex::new(&pattern).map_err(BashError::InvalidRegex)?)
-    } else {
-        None
-    };
-
-    while let Ok(line) = output_rx.try_recv() {
-        if let Some(ref regex) = filter_regex {
-            if regex.is_match(&line) {
-                output.push_str(&line);
-            }
-        } else {
-            output.push_str(&line);
-        }
-    }
-
-    if task_handle.is_finished() {
-        let (exit_code, killed) = task_handle.await.map_err(BashError::JoinFailed)?;
-
-        let status = if killed { BackgroundShellStatus::Failed } else { BackgroundShellStatus::Completed };
-
-        let display_meta = ToolDisplayMeta::new("Run command", format!("<background> (exit {exit_code})"));
-
-        Ok((
-            ReadBackgroundBashOutput { output, status, exit_code: Some(exit_code), meta: Some(display_meta.into()) },
-            None,
-        ))
-    } else {
-        let display_meta = ToolDisplayMeta::new("Run command", "<background> (running)");
-
-        Ok((
-            ReadBackgroundBashOutput {
-                output,
-                status: BackgroundShellStatus::Running,
-                exit_code: None,
-                meta: Some(display_meta.into()),
-            },
-            Some(BackgroundProcessHandle { shell_id, output_rx, task_handle }),
-        ))
-    }
-}
-
-async fn run_command_with_timeout(
-    command: String,
-    timeout: Option<Duration>,
-    output_tx: mpsc::UnboundedSender<String>,
-    cwd: Option<&std::path::Path>,
-) -> (i32, bool) {
-    let mut cmd = Command::new("bash");
-    cmd.arg("-c").arg(&command);
-    if let Some(dir) = cwd {
-        cmd.current_dir(dir);
-    }
-    cmd.stdout(std::process::Stdio::piped());
-    cmd.stderr(std::process::Stdio::piped());
-
-    let tx_clone = output_tx.clone();
-    let run_command = async move {
-        let mut child = cmd.spawn().map_err(|e| format!("Failed to spawn: {e}"))?;
-
-        if let Some(stdout) = child.stdout.take() {
-            let tx = tx_clone.clone();
-            tokio::spawn(async move {
-                let reader = BufReader::new(stdout);
-                let mut lines = reader.lines();
-                while let Ok(Some(line)) = lines.next_line().await {
-                    let _ = tx.send(line + "\n");
-                }
-            });
-        }
-
-        // Stream stderr
-        if let Some(stderr) = child.stderr.take() {
-            let tx = tx_clone.clone();
-            tokio::spawn(async move {
-                let reader = BufReader::new(stderr);
-                let mut lines = reader.lines();
-                while let Ok(Some(line)) = lines.next_line().await {
-                    let _ = tx.send(line + "\n");
-                }
-            });
-        }
-
-        let status = child.wait().await.map_err(|e| format!("Wait failed: {e}"))?;
-        Ok::<_, String>((status.code().unwrap_or(-1), false))
-    };
-
-    if let Some(timeout_duration) = timeout {
-        tokio::time::timeout(timeout_duration, run_command).await.map_or_else(
-            |_| {
-                let _ = output_tx.send("Command timed out\n".to_string());
-                (-1, true)
-            },
-            |inner| inner.unwrap_or((-1, false)),
-        )
-    } else {
-        run_command.await.unwrap_or((-1, false))
-    }
-}
-
-pub async fn execute_command(args: BashInput) -> Result<BashResult, BashError> {
-    execute_command_in_dir(args, None).await
-}
-
-pub async fn execute_command_in_dir(args: BashInput, cwd: Option<&std::path::Path>) -> Result<BashResult, BashError> {
+pub fn validate_args(args: &BashInput) -> Result<(), BashError> {
     if args.command.trim() == "rm" {
-        return Err(BashError::Forbidden("No you can't fucking delete files".to_string()));
+        return Err(BashError::Forbidden("Deleting files with a bare 'rm' is not allowed".to_string()));
     }
 
-    // Validate timeout is within bounds
-    if let Some(timeout_ms) = args.timeout
-        && timeout_ms > 600_000
-    {
+    if args.timeout.is_some_and(|timeout_ms| timeout_ms > 600_000) {
         return Err(BashError::TimeoutTooLarge);
     }
 
-    let run_in_background = args.run_in_background.unwrap_or(false);
-    let timeout_duration = args.timeout.map(Duration::from_millis);
+    Ok(())
+}
 
-    if run_in_background {
-        let shell_id = Uuid::new_v4().to_string();
-        let command = args.command.clone();
-        let cwd = cwd.map(Path::to_path_buf);
+pub async fn execute_command(args: BashInput) -> Result<BashOutput, BashError> {
+    execute_command_in_dir(args, None).await
+}
 
-        let (output_tx, output_rx) = mpsc::unbounded_channel();
+/// Runs `args.command` to completion; `args.timeout: None` means no timeout.
+pub async fn execute_command_in_dir(args: BashInput, cwd: Option<&Path>) -> Result<BashOutput, BashError> {
+    validate_args(&args)?;
 
-        let task_handle = tokio::spawn(async move {
-            run_command_with_timeout(command, timeout_duration, output_tx, cwd.as_deref()).await
-        });
+    let timeout = args.timeout.map(Duration::from_millis);
 
-        Ok(BashResult::Background(BackgroundProcessHandle { shell_id, output_rx, task_handle }))
-    } else {
-        // Run synchronously with default timeout of 120000ms (2 minutes)
-        let timeout = timeout_duration.or(Some(Duration::from_mins(2)));
-        let command = args.command.clone();
-
-        // Collect output in-memory for synchronous case
-        let mut cmd = Command::new("bash");
-        cmd.arg("-c").arg(&command);
-        if let Some(dir) = cwd {
-            cmd.current_dir(dir);
-        }
-
-        let result = if let Some(timeout_duration) = timeout {
-            tokio::time::timeout(timeout_duration, cmd.output()).await
-        } else {
-            Ok(cmd.output().await)
-        };
-
-        let Ok(output) = result else {
-            let timeout_ms = timeout.map_or(120_000, |d| d.as_millis());
-            let display_meta =
-                ToolDisplayMeta::new("Run command", format!("{} (exit -1, timed out)", truncate(&args.command, 40)));
-            return Ok(BashResult::Completed(BashOutput {
-                output: format!("Command timed out after {timeout_ms}ms"),
-                exit_code: -1,
-                killed: Some(true),
-                shell_id: None,
-                meta: Some(display_meta.into()),
-            }));
-        };
-
-        let output = match output {
-            Ok(output) => output,
-            Err(e) => return Err(BashError::SpawnFailed { command: args.command, reason: e.to_string() }),
-        };
-
-        let stdout = String::from_utf8_lossy(&output.stdout).to_string();
-        let stderr = String::from_utf8_lossy(&output.stderr).to_string();
-        let exit_code = output.status.code().unwrap_or(-1);
-
-        let combined_output = if stderr.is_empty() {
-            stdout
-        } else if stdout.is_empty() {
-            stderr
-        } else {
-            format!("{stdout}{stderr}")
-        };
-
-        let display_meta =
-            ToolDisplayMeta::new("Run command", format!("{} (exit {exit_code})", truncate(&args.command, 40)));
-
-        Ok(BashResult::Completed(BashOutput {
-            output: combined_output,
-            exit_code,
-            killed: Some(false),
-            shell_id: None,
-            meta: Some(display_meta.into()),
-        }))
+    let mut command = Command::new("bash");
+    command.arg("-c").arg(&args.command);
+    if let Some(dir) = cwd {
+        command.current_dir(dir);
     }
+    command.kill_on_drop(true);
+
+    let output = match timeout {
+        Some(timeout) => {
+            let Ok(result) = tokio::time::timeout(timeout, command.output()).await else {
+                let display_meta = ToolDisplayMeta::new(
+                    "Run command",
+                    format!("{} (exit -1, timed out)", truncate(&args.command, 40)),
+                );
+                return Ok(BashOutput {
+                    output: format!("Command timed out after {}ms", timeout.as_millis()),
+                    exit_code: -1,
+                    killed: true,
+                    meta: Some(display_meta.into()),
+                });
+            };
+            result
+        }
+        None => command.output().await,
+    }
+    .map_err(|error| BashError::SpawnFailed { command: args.command.clone(), reason: error.to_string() })?;
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    let exit_code = output.status.code().unwrap_or(-1);
+    let display_meta =
+        ToolDisplayMeta::new("Run command", format!("{} (exit {exit_code})", truncate(&args.command, 40)));
+
+    Ok(BashOutput { output: format!("{stdout}{stderr}"), exit_code, killed: false, meta: Some(display_meta.into()) })
 }

--- a/crates/mcp-servers/src/coding/tools/bash/read_background_description.md
+++ b/crates/mcp-servers/src/coding/tools/bash/read_background_description.md
@@ -1,5 +1,0 @@
-Retrieves output from a background bash shell (started with `run_in_background: true`).
-
-- `bash_id` — **required**, shell ID returned from the original bash call
-- Returns only new output since the last check, along with shell status (running/completed/failed)
-- Supports optional regex filtering to show only matching lines

--- a/crates/mcp-servers/src/coding/tools_trait.rs
+++ b/crates/mcp-servers/src/coding/tools_trait.rs
@@ -1,10 +1,9 @@
-use std::fmt::Debug;
 use std::future::Future;
 use std::path::PathBuf;
 
 use super::error::CodingError;
 use super::tools::ast_grep::{AstGrepInput, AstGrepOutput, perform_ast_grep};
-use super::tools::bash::{BackgroundProcessHandle, BashInput, BashResult, ReadBackgroundBashOutput};
+use super::tools::bash::{BashInput, BashOutput};
 use super::tools::edit_file::{EditFileArgs, EditFileResponse};
 use super::tools::find::{FindInput, FindOutput, find_files};
 use super::tools::grep::{GrepInput, GrepOutput, perform_grep};
@@ -13,7 +12,7 @@ use super::tools::read_file::{ReadFileArgs, ReadFileResult};
 use super::tools::write_file::{WriteFileArgs, WriteFileResponse};
 
 #[doc = include_str!("../docs/coding_tools.md")]
-pub trait CodingTools: Send + Sync + Debug {
+pub trait CodingTools: Send + Sync {
     /// Read a file's contents
     fn read_file(&self, args: ReadFileArgs) -> impl Future<Output = Result<ReadFileResult, CodingError>> + Send;
 
@@ -26,19 +25,12 @@ pub trait CodingTools: Send + Sync + Debug {
     /// List files in a directory
     fn list_files(&self, args: ListFilesArgs) -> impl Future<Output = Result<ListFilesResult, CodingError>> + Send;
 
-    /// Execute a bash command with an optional working directory
+    // Execute a bash command with an optional working directory
     fn bash(
         &self,
         args: BashInput,
         cwd: Option<PathBuf>,
-    ) -> impl Future<Output = Result<BashResult, CodingError>> + Send;
-
-    /// Read output from a background bash process
-    fn read_background_bash(
-        &self,
-        handle: BackgroundProcessHandle,
-        filter: Option<String>,
-    ) -> impl Future<Output = Result<(ReadBackgroundBashOutput, Option<BackgroundProcessHandle>), CodingError>> + Send;
+    ) -> impl Future<Output = Result<BashOutput, CodingError>> + Send;
 
     /// Search file contents using regex patterns.
     fn grep(&self, args: GrepInput) -> impl Future<Output = Result<GrepOutput, CodingError>> + Send {

--- a/crates/mcp-servers/src/docs/coding_error.md
+++ b/crates/mcp-servers/src/docs/coding_error.md
@@ -17,7 +17,7 @@ Error types for all coding tool operations.
 # Sub-error types
 
 - [`FileError`] -- `NotFound`, `ReadFailed`, `WriteFailed`, `CreateDirFailed`, `InvalidOffset`, `PatternNotFound`, `Io`.
-- [`BashError`] -- `Forbidden`, `TimeoutTooLarge`, `SpawnFailed`, `InvalidRegex`, `JoinFailed`, `ShellNotFound`, `WaitFailed`.
+- [`BashError`] -- `Forbidden`, `TimeoutTooLarge`, `SpawnFailed`.
 - [`GlobError`] -- `InvalidPattern`, `BuildFailed` (shared by the search tools).
 - [`GrepError`] -- `Glob`, `InvalidRegex`, `SearchFailed`, `PathNotFound`.
 - [`AstGrepError`] -- `PathNotFound`, `Glob`, `UnsupportedLanguage`, `InvalidPattern`, `ReadFailed`, `SearchFailed`.

--- a/crates/mcp-servers/src/docs/coding_mcp.md
+++ b/crates/mcp-servers/src/docs/coding_mcp.md
@@ -33,8 +33,7 @@ let server = CodingMcp::with_tools(my_custom_tools);
 - `list_files` -- List directory contents with metadata
 
 **Shell & search:**
-- `bash` -- Execute shell commands (with background process support)
-- `read_background_bash` -- Read output from a running background process
+- `bash` -- Execute shell commands (with background process support) 
 - `grep` -- Regex search across files with glob filters
 - `find` -- Find files by glob pattern. Bare patterns like `README*`, `justfile`, and `*.rs` match basenames recursively; slash-containing patterns like `crates/**/*.rs` match paths relative to the search path. Limited searches stop early and set `truncated` when more matches exist.
 

--- a/crates/mcp-servers/src/docs/coding_tools.md
+++ b/crates/mcp-servers/src/docs/coding_tools.md
@@ -11,7 +11,6 @@ Implement this trait to provide a custom backend -- for example, a sandboxed fil
 - **`edit_file`** -- Replace a string pattern in an existing file.
 - **`list_files`** -- List directory entries with metadata (size, type, modified time).
 - **`bash`** -- Execute a shell command, returning stdout/stderr and exit code. Supports background execution.
-- **`read_background_bash`** -- Read accumulated output from a running background process.
 
 **Provided** (default implementations using standalone functions):
 

--- a/crates/mcp-servers/src/subagents/README.md
+++ b/crates/mcp-servers/src/subagents/README.md
@@ -1,7 +1,7 @@
 # SubAgentsMcp
 
 Spawn and orchestrate sub-agents authored in project `.aether/settings.json`.
-Sub-agents run in parallel and have access to built-in MCP servers.
+Sub-agents in a batch run concurrently and have access to built-in MCP servers. Foreground execution is the default. Background execution returns one protocol-level MCP Task, requires MCP Tasks support, and cancelling the batch task stops all remaining agents.
 
 **Flag:** `--project-root <path>` (defaults to current directory; `--dir` alias supported)
 
@@ -46,26 +46,29 @@ Only agents with `agentInvocable: true` are exposed by SubAgentsMcp. Top-level `
 
 | Tool | Description |
 |------|-------------|
-| `spawn_subagent` | Spawn one or more sub-agents with specific prompts. All agents run in parallel. |
+| `spawn_subagent` | Spawn one or more sub-agents concurrently. Waits for the whole batch by default; `runInBackground: true` returns an MCP Task. |
 
 ## Spawning Agents
 
-`spawn_subagent` accepts a list of tasks, each with an `agent_name` and `prompt`. All tasks execute in parallel:
+`spawn_subagent` accepts a list of tasks, each with an `agentName` and `prompt`. All children execute concurrently and results preserve input order. By default the call waits for the entire batch, allowing the parent to use the results in its next step. Set `runInBackground: true` for independent work that may complete later:
 
 ```json
 {
   "tasks": [
-    { "agent_name": "explore", "prompt": "Find all API endpoints in this codebase" },
-    { "agent_name": "explore", "prompt": "Document the database schema" }
-  ]
+    {"agentName": "codebase-explorer", "prompt": "Find all API endpoints"},
+    {"agentName": "rust-code-monkey", "prompt": "Write tests for auth module"}
+  ],
+  "runInBackground": true
 }
 ```
 
 ## Structured Output
 
-Sub-agents are encouraged to return structured output with:
+Foreground calls return `results`, `successCount`, `errorCount`, and display metadata directly. Background calls return an MCP Task whose completed payload contains the same data. Background mode requires the client to support MCP Tasks.
+
+Each item in `results` includes the child agent's structured output. Child agents are instructed to return:
 
 - **summary** -- what was accomplished
 - **artifacts** -- files read or modified
 - **decisions** -- key decisions made
-- **next_steps** -- suggested follow-up actions
+- **nextSteps** -- suggested follow-up actions

--- a/crates/mcp-servers/src/subagents/server.rs
+++ b/crates/mcp-servers/src/subagents/server.rs
@@ -1,19 +1,21 @@
 use aether_core::core::AgentDeps;
-use aether_core::events::{AgentEvent, SubAgentProgressPayload, TraceContext};
+use aether_core::events::{AgentEvent, McpRequestInstrumentation, SubAgentProgressPayload, TraceContext};
 use aether_project::{AetherSettings, AgentCatalog};
 use clap::Parser;
+use mcp_utils::server::tasks::{BACKGROUND_TASK_TTL_MS, require_tasks_capability};
+use rmcp::model::{CallToolResult, Task};
 use rmcp::{
-    RoleServer, ServerHandler,
-    handler::server::{
-        router::tool::ToolRouter,
-        wrapper::{Json, Parameters},
+    ErrorData, RoleServer, ServerHandler,
+    handler::server::{router::tool::ToolRouter, wrapper::Parameters},
+    model::{
+        CallToolResponse, CancelTaskParams, CreateTaskResult, GetTaskParams, GetTaskResult, Implementation,
+        ProgressNotificationParam, ServerCapabilities, ServerInfo, UpdateTaskParams,
     },
-    model::{Implementation, ProgressNotificationParam, ServerCapabilities, ServerInfo},
     service::RequestContext,
+    task_manager::{TaskContext, TaskExit, TaskManager, TaskOptions},
     tool, tool_handler, tool_router,
 };
 use std::path::{Path, PathBuf};
-use std::sync::Arc;
 use std::sync::atomic::{AtomicU64, Ordering};
 
 use super::tools::{AgentExecutor, SpawnSubAgentsInput, SpawnSubAgentsOutput};
@@ -22,7 +24,6 @@ use crate::workspace_paths::resolve_path;
 
 type ProgressCallback = Box<dyn Fn(&str, &str, &AgentEvent) + Send + Sync>;
 
-/// The name `spawn_subagent` is exposed under, as callers see it on the wire.
 const SPAWN_SUBAGENT_TOOL: &str = "spawn_subagent";
 
 #[derive(Debug, Clone, Parser)]
@@ -36,28 +37,25 @@ impl SubAgentsMcpArgs {
     pub fn from_args(args: Vec<String>) -> Result<Self, ServerInitError> {
         let mut full_args = vec!["subagents-mcp".to_string()];
         full_args.extend(args);
-
         Self::try_parse_from(full_args).map_err(ServerInitError::InvalidArgs)
     }
 
-    /// The project root to serve, falling back to `default_root` when the
-    /// caller did not name one.
     fn resolve_root(self, default_root: &Path) -> PathBuf {
         self.project_root.map_or_else(|| default_root.to_path_buf(), |path| resolve_path(default_root, path))
     }
 }
 
 #[doc = include_str!("../docs/subagents_mcp.md")]
-#[derive(Clone)]
 pub struct SubAgentsMcp {
     tool_router: ToolRouter<Self>,
+    task_manager: TaskManager,
     project_root: PathBuf,
     agent_deps: AgentDeps,
 }
 
 impl SubAgentsMcp {
     pub fn embedded(project_root: PathBuf, agent_deps: AgentDeps) -> Self {
-        Self { tool_router: Self::tool_router(), project_root, agent_deps }
+        Self { tool_router: Self::tool_router(), task_manager: TaskManager::new(), project_root, agent_deps }
     }
 
     pub fn embedded_from_args(
@@ -87,29 +85,117 @@ impl SubAgentsMcp {
 
         if invocable.peek().is_none() {
             instructions.push_str(
-                "\n\n**No sub-agents are currently available.** \
-                 The spawn_subagent tool has no registered agents and should not be called.",
+                "\n\n**No sub-agents are currently available.** The spawn_subagent tool has no registered agents and should not be called.",
             );
         } else {
             instructions.push_str("\n\n## Available Sub-Agents\n");
             instructions.push_str("The following sub-agents are available:\n\n");
-
             for agent in invocable {
                 use std::fmt::Write as _;
                 let _ = writeln!(instructions, "- **{}**: {}", agent.name, agent.description);
             }
         }
-
         instructions
+    }
+
+    fn instrumentation(&self, context: &RequestContext<RoleServer>) -> Option<Box<dyn McpRequestInstrumentation>> {
+        let trace_context = TraceContext::from_meta(&context.meta);
+        self.agent_deps
+            .observer_factory
+            .as_ref()
+            .map(|factory| factory.tool_call_request(SPAWN_SUBAGENT_TOOL, trace_context.as_ref()))
+    }
+
+    fn executor(&self, context: &RequestContext<RoleServer>, child_parent: Option<TraceContext>) -> AgentExecutor {
+        let deps = self.agent_deps.clone().with_parent_trace_context(child_parent);
+        let callback = progress_callback(context.meta.get_progress_token(), context.peer.clone());
+        AgentExecutor::new(self.project_root.clone(), deps).with_progress_callback(callback)
+    }
+
+    fn validate(&self, args: &SpawnSubAgentsInput, context: &RequestContext<RoleServer>) -> Result<(), ErrorData> {
+        if !args.tasks.is_empty() && self.agent_deps.agent_registry.agent_invocable().next().is_none() {
+            return Err(ErrorData::invalid_params(
+                "No agent-invocable sub-agents are registered in this project. The spawn_subagent tool is not usable — do not call it again.",
+                None,
+            ));
+        }
+        if args.run_in_background {
+            require_tasks_capability(context)?;
+        }
+        Ok(())
+    }
+
+    async fn spawn_subagents_in_foreground(
+        &self,
+        args: SpawnSubAgentsInput,
+        context: &RequestContext<RoleServer>,
+        child_parent: Option<TraceContext>,
+    ) -> Result<CallToolResponse, ErrorData> {
+        let output = self.executor(context, child_parent).execute_tasks(args.tasks).await;
+        output_result(output).map(CallToolResponse::Complete)
+    }
+
+    fn spawn_subagents_in_background(
+        &self,
+        args: SpawnSubAgentsInput,
+        context: &RequestContext<RoleServer>,
+        instrumentation: InstrumentationGuard,
+    ) -> Task {
+        let status = match args.tasks.as_slice() {
+            [] => "No sub-agents requested".to_string(),
+            [task] => format!("Running {}", task.agent_name),
+            tasks => format!("Running {} sub-agents", tasks.len()),
+        };
+        let executor = self.executor(context, instrumentation.trace_context());
+        let options = TaskOptions::new().with_ttl_ms(BACKGROUND_TASK_TTL_MS).with_status_message(status);
+
+        self.task_manager.spawn(options, move |task_context: TaskContext| {
+            Box::pin(async move {
+                tokio::select! {
+                    () = task_context.cancelled() => Err(TaskExit::Cancelled),
+                    output = executor.execute_tasks(args.tasks) => {
+                        let result = output_result(output);
+                        instrumentation.finish(result.as_ref().err().map(ToString::to_string).as_deref());
+                        result.map_err(TaskExit::Error)
+                    }
+                }
+            })
+        })
     }
 }
 
 #[tool_handler(router = self.tool_router)]
 impl ServerHandler for SubAgentsMcp {
     fn get_info(&self) -> ServerInfo {
-        ServerInfo::new(ServerCapabilities::builder().enable_tools().build())
+        ServerInfo::new(ServerCapabilities::builder().enable_tools().enable_tasks().build())
             .with_server_info(Implementation::new("subagents-mcp", "0.1.0"))
             .with_instructions(self.build_instructions())
+    }
+
+    async fn get_task(
+        &self,
+        request: GetTaskParams,
+        _context: RequestContext<RoleServer>,
+    ) -> Result<GetTaskResult, ErrorData> {
+        Ok(GetTaskResult::new(self.task_manager.get_task(&request.task_id)?))
+    }
+
+    async fn update_task(
+        &self,
+        request: UpdateTaskParams,
+        _context: RequestContext<RoleServer>,
+    ) -> Result<(), ErrorData> {
+        self.task_manager.update_task(&request.task_id, request.input_responses)?;
+        Ok(())
+    }
+
+    async fn cancel_task(
+        &self,
+        request: CancelTaskParams,
+        _context: RequestContext<RoleServer>,
+    ) -> Result<(), ErrorData> {
+        self.task_manager.cancel_task(&request.task_id)?;
+        Ok(())
     }
 }
 
@@ -124,81 +210,84 @@ impl SubAgentsMcp {
     ))]
     pub async fn spawn_subagent(
         &self,
-        request: Parameters<SpawnSubAgentsInput>,
+        Parameters(args): Parameters<SpawnSubAgentsInput>,
         context: RequestContext<RoleServer>,
-    ) -> Result<Json<SpawnSubAgentsOutput>, String> {
-        let Parameters(args) = request;
-        let remote_parent = TraceContext::from_meta(&context.meta);
-        let request_instrumentation = self
-            .agent_deps
-            .observer_factory
-            .as_ref()
-            .map(|factory| factory.tool_call_request(SPAWN_SUBAGENT_TOOL, remote_parent.as_ref()));
+    ) -> Result<CallToolResponse, ErrorData> {
+        let instrumentation = InstrumentationGuard(self.instrumentation(&context));
 
-        let child_parent = request_instrumentation.as_ref().and_then(|instrumentation| instrumentation.trace_context());
-        let result = self.spawn(args, &context, child_parent).await;
-        if let Some(instrumentation) = request_instrumentation {
-            instrumentation.finish(result.as_ref().err().map(String::as_str));
+        if let Err(error) = self.validate(&args, &context) {
+            instrumentation.finish(Some(&error.to_string()));
+            return Err(error);
         }
-        result.map(Json)
+
+        if args.run_in_background {
+            let task = self.spawn_subagents_in_background(args, &context, instrumentation);
+            Ok(CallToolResponse::Task(CreateTaskResult::new(task)))
+        } else {
+            let child_parent = instrumentation.trace_context();
+            let result = self.spawn_subagents_in_foreground(args, &context, child_parent).await;
+            instrumentation.finish(result.as_ref().err().map(ToString::to_string).as_deref());
+            result
+        }
+    }
+}
+
+impl Drop for SubAgentsMcp {
+    fn drop(&mut self) {
+        self.task_manager.shutdown();
+    }
+}
+
+struct InstrumentationGuard(Option<Box<dyn McpRequestInstrumentation>>);
+
+impl InstrumentationGuard {
+    fn trace_context(&self) -> Option<TraceContext> {
+        self.0.as_deref().and_then(McpRequestInstrumentation::trace_context)
     }
 
-    /// Runs the requested tasks, leaving the caller to report the outcome to
-    /// whatever is instrumenting the request. Sub-agents trace beneath
-    /// `parent_trace_context`, which is this request's own span.
-    async fn spawn(
-        &self,
-        args: SpawnSubAgentsInput,
-        context: &RequestContext<RoleServer>,
-        parent_trace_context: Option<TraceContext>,
-    ) -> Result<SpawnSubAgentsOutput, String> {
-        if !args.tasks.is_empty() && self.agent_deps.agent_registry.agent_invocable().next().is_none() {
-            return Err("No agent-invocable sub-agents are registered in this project. \
-                 The spawn_subagent tool is not usable — do not call it again."
-                .to_string());
+    fn finish(mut self, error: Option<&str>) {
+        if let Some(instrumentation) = self.0.take() {
+            instrumentation.finish(error);
         }
+    }
+}
 
-        let progress_token = context.meta.get_progress_token();
-        let peer = Arc::new(context.peer.clone());
-        let message_counter = Arc::new(AtomicU64::new(0));
+impl Drop for InstrumentationGuard {
+    fn drop(&mut self) {
+        if let Some(instrumentation) = self.0.take() {
+            instrumentation.finish(Some("Sub-agent execution cancelled"));
+        }
+    }
+}
 
-        let progress_callback: ProgressCallback = {
-            let progress_token = progress_token.clone();
-            let peer = Arc::clone(&peer);
-            let message_counter = Arc::clone(&message_counter);
+fn output_result(output: SpawnSubAgentsOutput) -> Result<CallToolResult, ErrorData> {
+    serde_json::to_value(output)
+        .map(CallToolResult::structured)
+        .map_err(|error| ErrorData::internal_error(error.to_string(), None))
+}
 
-            Box::new(move |task_id: &str, agent_name: &str, message: &AgentEvent| {
-                if let Some(ref token) = progress_token {
-                    let counter = message_counter.fetch_add(1, Ordering::Relaxed);
-                    let progress_payload = SubAgentProgressPayload {
-                        task_id: task_id.to_string(),
-                        agent_name: agent_name.to_string(),
-                        event: message.clone(),
-                    };
-
-                    let peer = Arc::clone(&peer);
-                    let token = token.clone();
-                    let progress_data_str = serde_json::to_string(&progress_payload).unwrap_or_default();
-
-                    tokio::spawn(async move {
-                        let _ = peer
-                            .notify_progress(
-                                ProgressNotificationParam::new(token, {
-                                    #[allow(clippy::cast_precision_loss)]
-                                    let progress = counter as f64;
-                                    progress
-                                })
-                                .with_message(progress_data_str),
-                            )
-                            .await;
-                    });
-                }
-            })
+fn progress_callback(
+    progress_token: Option<rmcp::model::ProgressToken>,
+    peer: rmcp::Peer<RoleServer>,
+) -> ProgressCallback {
+    let Some(token) = progress_token else {
+        return Box::new(|_, _, _| {});
+    };
+    let message_counter = AtomicU64::new(0);
+    Box::new(move |task_id: &str, agent_name: &str, message: &AgentEvent| {
+        let counter = message_counter.fetch_add(1, Ordering::Relaxed);
+        let payload = SubAgentProgressPayload {
+            task_id: task_id.to_string(),
+            agent_name: agent_name.to_string(),
+            event: message.clone(),
         };
-
-        let deps = self.agent_deps.clone().with_parent_trace_context(parent_trace_context);
-        let executor = AgentExecutor::new(self.project_root.clone(), deps).with_progress_callback(progress_callback);
-
-        Ok(executor.execute_tasks(args.tasks).await)
-    }
+        let peer = peer.clone();
+        let token = token.clone();
+        let message = serde_json::to_string(&payload).unwrap_or_default();
+        tokio::spawn(async move {
+            #[allow(clippy::cast_precision_loss)]
+            let progress = counter as f64;
+            let _ = peer.notify_progress(ProgressNotificationParam::new(token, progress).with_message(message)).await;
+        });
+    })
 }

--- a/crates/mcp-servers/src/subagents/tools/spawn_subagent/description.md
+++ b/crates/mcp-servers/src/subagents/tools/spawn_subagent/description.md
@@ -7,12 +7,12 @@ Spawns sub-agents in parallel to perform concurrent tasks.
   "tasks": [
     {"agentName": "codebase-explorer", "prompt": "Find all API endpoints"},
     {"agentName": "rust-code-monkey", "prompt": "Write tests for auth module"}
-  ]
+  ],
+  "runInBackground": false
 }
 ```
 
 - `tasks` — **required**, array of task objects
   - `agentName` — agent name from project `.aether/settings.json` (`agents[].name`) with `agentInvocable: true`
   - `prompt` — task for the agent to perform
-
-All agents execute in parallel. Results returned when ALL complete.
+- `runInBackground` — optional, defaults to `false`. When `true`, subagents run in the background, so you can continue working -- use when you don't want to wait for the sub-agents to finish; results are automatically injected into context when the sub-agents complete.

--- a/crates/mcp-servers/src/subagents/tools/spawn_subagent/mod.rs
+++ b/crates/mcp-servers/src/subagents/tools/spawn_subagent/mod.rs
@@ -3,15 +3,18 @@ use aether_core::{
     agent_spec::McpConfigSource,
     core::{AgentBuilder, AgentDeps, AgentHandle, Prompt},
     events::{AgentEvent, Command, MessageEvent, TurnEvent, TurnOutcome, UserCommand},
-    mcp::{McpSpawnResult, mcp, run_mcp_task::McpCommand},
+    mcp::{McpRuntime, McpSpawnResult, mcp, run_mcp_task::McpCommand},
 };
+use futures::FutureExt;
 use llm::ToolDefinition;
 use mcp_utils::display_meta::{ToolDisplayMeta, ToolResultMeta};
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
+use std::panic::AssertUnwindSafe;
 use std::path::PathBuf;
 use std::sync::Arc;
-use tokio::{spawn, sync::mpsc};
+use tokio::sync::mpsc;
+use tokio::task::JoinSet;
 
 /// Reference to a file artifact discovered or modified by a sub-agent
 #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
@@ -83,6 +86,9 @@ pub struct SubAgentTask {
 pub struct SpawnSubAgentsInput {
     /// Array of agent tasks to execute in parallel
     pub tasks: Vec<SubAgentTask>,
+    /// Run sub-agents in the background, so you can continue work without waiting for them to complete.
+    #[serde(default, alias = "run_in_background", skip_serializing_if = "std::ops::Not::not")]
+    pub run_in_background: bool,
 }
 
 /// Status of a sub-agent execution
@@ -91,7 +97,6 @@ pub struct SpawnSubAgentsInput {
 pub enum SubAgentStatus {
     Success,
     Error,
-    Cancelled,
 }
 
 /// Result from a single sub-agent
@@ -180,28 +185,32 @@ impl AgentExecutor {
         let task_count = tasks.len();
         let first_agent_name = tasks.first().unwrap().agent_name.clone();
 
-        let handles: Vec<_> = tasks
-            .into_iter()
-            .enumerate()
-            .map(|(i, task)| {
-                let executor = self.clone();
-                spawn(async move { executor.execute_single(format!("task_{i}"), task).await })
-            })
-            .collect();
+        let mut children = JoinSet::new();
+        for (index, task) in tasks.into_iter().enumerate() {
+            let executor = self.clone();
+            let task_id = format!("task_{index}");
+            let agent_name = task.agent_name.clone();
+            children.spawn(async move {
+                let result = AssertUnwindSafe(executor.execute_single(task_id.clone(), task))
+                    .catch_unwind()
+                    .await
+                    .unwrap_or_else(|panic| SubAgentResult {
+                        task_id,
+                        agent_name,
+                        status: SubAgentStatus::Error,
+                        output: None,
+                        error: Some(format!("Sub-agent task panicked: {}", panic_message(&panic))),
+                    });
+                (index, result)
+            });
+        }
 
-        let results: Vec<SubAgentResult> = futures::future::join_all(handles)
-            .await
-            .into_iter()
-            .map(|join_result| {
-                join_result.unwrap_or_else(|e| SubAgentResult {
-                    task_id: "unknown".to_string(),
-                    agent_name: "unknown".to_string(),
-                    status: SubAgentStatus::Error,
-                    output: None,
-                    error: Some(format!("Task panicked: {e}")),
-                })
-            })
-            .collect();
+        let mut indexed_results = Vec::with_capacity(task_count);
+        while let Some(joined) = children.join_next().await {
+            indexed_results.push(joined.expect("sub-agent tasks are only aborted when the batch future is dropped"));
+        }
+        indexed_results.sort_unstable_by_key(|(index, _)| *index);
+        let results: Vec<SubAgentResult> = indexed_results.into_iter().map(|(_, result)| result).collect();
 
         let success_count = results.iter().filter(|r| matches!(r.status, SubAgentStatus::Success)).count();
 
@@ -224,20 +233,21 @@ impl AgentExecutor {
                 .resolve_agent_invocable(&task.agent_name)
                 .map_err(|error| error.to_string())?;
 
-            let mut spawn_result = self.spawn_mcps(&spec.mcp_config_sources).await?;
-            let snapshot = spawn_result
-                .block_until_ready()
-                .await
-                .ok_or_else(|| "MCP bootstrap aborted before completion".to_string())?;
+            let mut spawn = self.spawn_mcps(&spec.mcp_config_sources).await?;
+            let snapshot =
+                spawn.block_until_ready().await.ok_or_else(|| "MCP bootstrap aborted before completion".to_string())?;
+            let (mcp_runtime, _) = spawn.split();
 
             let filtered_tools = spec.tools.apply(snapshot.tool_definitions);
             spec.prompts.push(Prompt::McpInstructions(snapshot.instructions));
-            let command_tx = spawn_result.command_tx;
+            let command_tx = mcp_runtime.command_tx().clone();
 
-            let (user_tx, mut agent_rx, _agent_handle) = self.spawn_agent(spec, command_tx, filtered_tools).await?;
+            let (user_tx, mut agent_rx, agent_handle) = self.spawn_agent(spec, command_tx, filtered_tools).await?;
+            let running_agent = RunningAgent { user_tx, agent_handle, _mcp_runtime: mcp_runtime };
 
             let prompt_with_instructions = format!("{}\n\n{}", task.prompt, STRUCTURED_OUTPUT_INSTRUCTIONS);
-            user_tx
+            running_agent
+                .user_tx
                 .send(Command::UserCommand(UserCommand::Text {
                     content: vec![llm::ContentBlock::text(&prompt_with_instructions)],
                 }))
@@ -315,6 +325,26 @@ impl AgentExecutor {
             .await
             .map_err(|e| format!("Failed to spawn agent: {e}"))
     }
+}
+
+struct RunningAgent {
+    user_tx: mpsc::Sender<Command>,
+    agent_handle: AgentHandle,
+    _mcp_runtime: McpRuntime,
+}
+
+impl Drop for RunningAgent {
+    fn drop(&mut self) {
+        self.agent_handle.abort();
+    }
+}
+
+fn panic_message(panic: &(dyn std::any::Any + Send)) -> &str {
+    panic
+        .downcast_ref::<&str>()
+        .copied()
+        .or_else(|| panic.downcast_ref::<String>().map(String::as_str))
+        .unwrap_or("unknown panic")
 }
 
 #[cfg(test)]

--- a/crates/mcp-servers/tests/integration/common/mod.rs
+++ b/crates/mcp-servers/tests/integration/common/mod.rs
@@ -29,9 +29,9 @@ pub fn test_client_info() -> ClientInfo {
     ClientInfo::new(ClientCapabilities::default(), Implementation::new("test-client", "0.1.0"))
 }
 
-/// Client info declaring the same form + url elicitation support that
-/// `McpManager` advertises in production.
-pub fn test_client_info_with_elicitation() -> ClientInfo {
+/// Client info declaring the same capabilities `McpManager` advertises in
+/// production: form + url elicitation and MCP tasks.
+pub fn production_client_info() -> ClientInfo {
     ClientInfo::new(client_capabilities(), Implementation::new("test-client", "0.1.0"))
 }
 
@@ -39,14 +39,14 @@ pub fn test_client_info_with_elicitation() -> ClientInfo {
 /// calls resolve as Cancel.
 pub fn silent_mcp_client(server_name: &str) -> McpClient {
     let (event_tx, _event_rx) = mpsc::channel(8);
-    McpClient::new(test_client_info_with_elicitation(), server_name.to_string(), event_tx)
+    McpClient::new(production_client_info(), server_name.to_string(), event_tx)
 }
 
 /// An `McpClient` plus a script answering the next elicitation request with
 /// `response` and capturing what arrived for assertions.
 pub fn scripted_mcp_client(server_name: &str, response: ElicitResult) -> (McpClient, ElicitationScript) {
     let (event_tx, event_rx) = mpsc::channel(8);
-    let client = McpClient::new(test_client_info_with_elicitation(), server_name.to_string(), event_tx);
+    let client = McpClient::new(production_client_info(), server_name.to_string(), event_tx);
     (client, ElicitationScript::spawn(event_rx, [response]))
 }
 

--- a/crates/mcp-servers/tests/integration/plugins_mcp_agents.rs
+++ b/crates/mcp-servers/tests/integration/plugins_mcp_agents.rs
@@ -1,7 +1,8 @@
-use crate::common::{TestClient, TestResult, test_error};
+use crate::common::{TestClient, TestResult, production_client_info, test_client_info, test_error};
 use aether_auth::FakeOAuthCredentialStore;
 use aether_core::agent_spec::McpConfigSource;
 use aether_core::core::AgentDeps;
+use aether_core::events::{AgentEvent, AgentObserver, McpRequestInstrumentation, ObserverFactory, TraceContext};
 use aether_core::mcp::mcp;
 use aether_core::mcp::run_mcp_task::McpCommand;
 use aether_core::mcp::tool_bridge::convert_tool_result;
@@ -10,9 +11,13 @@ use mcp_servers::McpBuilderExt;
 use mcp_servers::subagents::SubAgentsMcp;
 use mcp_servers::subagents::tools::{SpawnSubAgentsInput, SubAgentTask};
 use mcp_utils::client::ToolCallEvent;
+use rmcp::model::{
+    CallToolRequestParams, CallToolResponse, CallToolResult, CancelTaskParams, DetailedTask, GetTaskParams,
+    TaskPayload, TaskStatus,
+};
 use std::fs;
 use std::path::Path;
-use std::sync::Arc;
+use std::sync::{Arc, Mutex};
 use std::time::Duration;
 use tempfile::TempDir;
 use tokio::sync::mpsc;
@@ -26,7 +31,12 @@ fn spawn_input(tasks: &[(&str, &str)]) -> SpawnSubAgentsInput {
                 prompt: (*prompt).to_string(),
             })
             .collect(),
+        run_in_background: false,
     }
+}
+
+fn background_spawn_input(tasks: &[(&str, &str)]) -> SpawnSubAgentsInput {
+    SpawnSubAgentsInput { run_in_background: true, ..spawn_input(tasks) }
 }
 
 const RUNTIME_PROVIDER_URL: &str = "http://127.0.0.1:1";
@@ -134,14 +144,17 @@ async fn test_spawn_agent_with_coding_mcp_from_settings_catalog() {
 #[tokio::test]
 async fn test_spawn_subagent_codex_uses_oauth_store() -> TestResult {
     let temp_dir = create_project_with_codex_agent();
-    let mcp = TestClient::start(|| {
-        let deps = AgentDeps::new(Arc::new(FakeOAuthCredentialStore::new()), None)
-            .with_agent_registry(test_registry(temp_dir.path()));
-        SubAgentsMcp::embedded(temp_dir.path().to_path_buf(), deps)
-    })
+    let mcp = TestClient::start_with(
+        || {
+            let deps = AgentDeps::new(Arc::new(FakeOAuthCredentialStore::new()), None)
+                .with_agent_registry(test_registry(temp_dir.path()));
+            SubAgentsMcp::embedded(temp_dir.path().to_path_buf(), deps)
+        },
+        production_client_info(),
+    )
     .await?;
 
-    let parsed = mcp.call("spawn_subagent", spawn_input(&[("explorer", "Read README.md")])).await?;
+    let parsed = call_complete(&mcp, spawn_input(&[("explorer", "Read README.md")])).await?;
 
     let error = parsed["results"][0]["error"].as_str().expect("Expected sub-agent error");
     assert!(error.contains("No Codex OAuth credentials found"));
@@ -149,11 +162,11 @@ async fn test_spawn_subagent_codex_uses_oauth_store() -> TestResult {
 }
 
 #[tokio::test]
-async fn test_spawn_subagents_empty_tasks() -> TestResult {
+async fn spawn_subagent_empty_batch_completes_with_empty_output() -> TestResult {
     let temp_dir = TempDir::new().expect("Failed to create temp directory");
-    let mcp = TestClient::start(|| create_test_server(temp_dir.path())).await?;
+    let mcp = TestClient::start_with(|| create_test_server(temp_dir.path()), test_client_info()).await?;
 
-    let parsed = mcp.call("spawn_subagent", spawn_input(&[])).await?;
+    let parsed = call_complete(&mcp, spawn_input(&[])).await?;
 
     let results = parsed["results"].as_array().expect("Expected results array");
     assert_eq!(results.len(), 0);
@@ -165,25 +178,24 @@ async fn test_spawn_subagents_empty_tasks() -> TestResult {
 #[tokio::test]
 async fn test_spawn_subagent_errors_when_no_invocable_agents() -> TestResult {
     let temp_dir = TempDir::new().expect("Failed to create temp directory");
-    let mcp = TestClient::start(|| create_test_server(temp_dir.path())).await?;
+    let mcp = TestClient::start_with(|| create_test_server(temp_dir.path()), production_client_info()).await?;
 
-    let result = mcp.call_raw("spawn_subagent", spawn_input(&[("any-agent", "Do something")])).await?;
+    let error =
+        mcp.raw().call_tool_once(tool_request(spawn_input(&[("any-agent", "Do something")]))).await.unwrap_err();
 
-    let text = result.content.first().and_then(|c| c.as_text()).expect("Expected text content in error response");
     assert!(
-        text.text.contains("No agent-invocable sub-agents are registered"),
-        "Error message should explain no agents are registered, got: {}",
-        text.text,
+        error.to_string().contains("No agent-invocable sub-agents are registered"),
+        "Error message should explain no agents are registered, got: {error}",
     );
     Ok(())
 }
 
 #[tokio::test]
-async fn test_spawn_subagent_agent_not_found() -> TestResult {
+async fn spawn_subagent_defaults_to_foreground_without_tasks_capability() -> TestResult {
     let temp_dir = create_project_with_invocable_agent();
-    let mcp = TestClient::start(|| create_test_server(temp_dir.path())).await?;
+    let mcp = TestClient::start_with(|| create_test_server(temp_dir.path()), test_client_info()).await?;
 
-    let parsed = mcp.call("spawn_subagent", spawn_input(&[("nonexistent-agent", "Do something")])).await?;
+    let parsed = call_complete(&mcp, spawn_input(&[("nonexistent-agent", "Do something")])).await?;
 
     let results = parsed["results"].as_array().expect("Expected results array");
     assert_eq!(results.len(), 1);
@@ -199,13 +211,13 @@ async fn test_spawn_subagent_agent_not_found() -> TestResult {
 }
 
 #[tokio::test]
-async fn test_spawn_subagents_task_id_assignment() -> TestResult {
+async fn spawn_subagent_preserves_child_result_order_and_ids() -> TestResult {
     let temp_dir = create_project_with_invocable_agent();
-    let mcp = TestClient::start(|| create_test_server(temp_dir.path())).await?;
+    let mcp = task_client(temp_dir.path()).await?;
 
-    let parsed = mcp
-        .call("spawn_subagent", spawn_input(&[("missing-agent-a", "First task"), ("missing-agent-b", "Second task")]))
-        .await?;
+    let parsed =
+        call_complete(&mcp, spawn_input(&[("missing-agent-a", "First task"), ("missing-agent-b", "Second task")]))
+            .await?;
 
     let results = parsed["results"].as_array().expect("Expected results array");
     assert_eq!(results.len(), 2);
@@ -213,6 +225,127 @@ async fn test_spawn_subagents_task_id_assignment() -> TestResult {
     assert_eq!(results[0]["taskId"], "task_0");
     assert_eq!(results[1]["taskId"], "task_1");
     Ok(())
+}
+
+#[tokio::test]
+async fn spawn_subagent_background_returns_mcp_task() -> TestResult {
+    let temp_dir = create_project_with_invocable_agent();
+    let mcp = task_client(temp_dir.path()).await?;
+
+    let parsed = call_task(&mcp, background_spawn_input(&[("missing-agent", "Do something")])).await?;
+
+    assert_eq!(parsed["results"][0]["status"], "error");
+    Ok(())
+}
+
+#[tokio::test]
+async fn cancelling_background_subagents_cancels_the_batch_without_publishing_a_result() -> TestResult {
+    let temp_dir = create_project_with_blocked_agent();
+    let mcp = task_client(temp_dir.path()).await?;
+    let response =
+        mcp.raw().call_tool_once(tool_request(background_spawn_input(&[("blocked", "Wait for MCP startup")]))).await?;
+    let CallToolResponse::Task(created) = response else {
+        return Err(test_error(format!("expected task response: {response:?}")).into());
+    };
+
+    mcp.raw().cancel_task(CancelTaskParams::new(created.task.task_id.clone())).await?;
+
+    let cancelled = await_terminal_task(&mcp, &created.task.task_id).await?;
+    assert!(matches!(cancelled.payload, TaskPayload::Cancelled));
+
+    for _ in 0..3 {
+        tokio::task::yield_now().await;
+    }
+    let task = mcp.raw().get_task(GetTaskParams::new(created.task.task_id)).await?.task;
+    assert!(matches!(task.payload, TaskPayload::Cancelled));
+    Ok(())
+}
+
+#[tokio::test]
+async fn background_instrumentation_finishes_when_the_batch_settles() -> TestResult {
+    let temp_dir = create_project_with_blocked_agent();
+    let project_root = temp_dir.path().to_path_buf();
+    let finishes = Arc::new(Mutex::new(Vec::new()));
+    let recorded = Arc::clone(&finishes);
+    let mcp = TestClient::start_with(
+        move || {
+            let mut deps = AgentDeps::default().with_agent_registry(test_registry(&project_root));
+            deps.observer_factory = Some(Arc::new(RecordingObserverFactory { finishes: recorded }));
+            SubAgentsMcp::embedded(project_root.clone(), deps)
+        },
+        production_client_info(),
+    )
+    .await?;
+
+    let response =
+        mcp.raw().call_tool_once(tool_request(background_spawn_input(&[("blocked", "Wait for MCP startup")]))).await?;
+    let CallToolResponse::Task(created) = response else {
+        return Err(test_error(format!("expected task response: {response:?}")).into());
+    };
+    assert!(finishes.lock().unwrap().is_empty(), "span must stay open while the batch is still running");
+
+    mcp.raw().cancel_task(CancelTaskParams::new(created.task.task_id.clone())).await?;
+    await_terminal_task(&mcp, &created.task.task_id).await?;
+
+    assert_eq!(finishes.lock().unwrap().as_slice(), [Some("Sub-agent execution cancelled".to_string())]);
+    Ok(())
+}
+
+#[tokio::test]
+async fn spawn_subagent_background_requires_tasks_capability() -> TestResult {
+    let temp_dir = create_project_with_invocable_agent();
+    let mcp = TestClient::start_with(|| create_test_server(temp_dir.path()), test_client_info()).await?;
+
+    let error = mcp
+        .raw()
+        .call_tool_once(tool_request(background_spawn_input(&[("missing-agent", "Do something")])))
+        .await
+        .unwrap_err();
+
+    assert!(error.to_string().to_lowercase().contains("missing required client capability"));
+    Ok(())
+}
+
+async fn task_client(project_root: &Path) -> TestResult<TestClient<SubAgentsMcp>> {
+    TestClient::start_with(|| create_test_server(project_root), production_client_info()).await
+}
+
+async fn await_terminal_task(client: &TestClient<SubAgentsMcp>, task_id: &str) -> TestResult<DetailedTask> {
+    loop {
+        let task = client.raw().get_task(GetTaskParams::new(task_id.to_string())).await?.task;
+        if task.status().is_terminal() {
+            return Ok(task);
+        }
+        tokio::task::yield_now().await;
+    }
+}
+
+fn tool_request(input: SpawnSubAgentsInput) -> CallToolRequestParams {
+    let arguments = serde_json::to_value(input).unwrap().as_object().unwrap().clone();
+    CallToolRequestParams::new("spawn_subagent").with_arguments(arguments)
+}
+
+async fn call_complete(client: &TestClient<SubAgentsMcp>, input: SpawnSubAgentsInput) -> TestResult<serde_json::Value> {
+    let response = client.raw().call_tool_once(tool_request(input)).await?;
+    let CallToolResponse::Complete(result) = response else {
+        return Err(test_error(format!("expected completed response: {response:?}")).into());
+    };
+    result.structured_content.ok_or_else(|| test_error("completed response had no structured content").into())
+}
+
+async fn call_task(client: &TestClient<SubAgentsMcp>, input: SpawnSubAgentsInput) -> TestResult<serde_json::Value> {
+    let response = client.raw().call_tool_once(tool_request(input)).await?;
+    let CallToolResponse::Task(created) = response else {
+        return Err(test_error(format!("expected task response: {response:?}")).into());
+    };
+    assert_eq!(created.task.status, TaskStatus::Working);
+
+    let detailed = await_terminal_task(client, &created.task.task_id).await?;
+    let TaskPayload::Completed { result } = detailed.payload else {
+        return Err(test_error(format!("expected completed task: {detailed:?}")).into());
+    };
+    let result: CallToolResult = serde_json::from_value(serde_json::Value::Object(result))?;
+    result.structured_content.ok_or_else(|| test_error("completed task had no structured content").into())
 }
 
 async fn call_subagent_through_manager(
@@ -243,7 +376,7 @@ async fn call_subagent_through_manager(
 
     let (event_tx, mut event_rx) = mpsc::channel(4);
     spawn
-        .command_tx
+        .command_tx()
         .send(McpCommand::ExecuteTool {
             request: request.clone(),
             trace_context: None,
@@ -254,9 +387,15 @@ async fn call_subagent_through_manager(
         .await?;
 
     while let Some(event) = event_rx.recv().await {
-        if let ToolCallEvent::Complete(outcome) = event {
-            let (result, _) = convert_tool_result(&request, outcome).map_err(|error| test_error(error.error))?;
-            return Ok(result.result);
+        match event {
+            ToolCallEvent::Complete(outcome) => {
+                let (result, _) = convert_tool_result(&request, outcome).map_err(|error| test_error(error.error))?;
+                return Ok(result.result);
+            }
+            ToolCallEvent::TaskComplete { .. } => {
+                return Err(test_error("foreground subagent call unexpectedly returned an MCP Task").into());
+            }
+            _ => {}
         }
     }
     Err(test_error("MCP manager stopped before returning the tool result").into())
@@ -293,6 +432,22 @@ fn create_project_with_invocable_agent() -> TempDir {
         ),
         (".aether/prompts/coder.md", "You are a coding assistant."),
     ])
+}
+
+fn create_project_with_blocked_agent() -> TempDir {
+    create_test_files(&[(
+        ".aether/settings.json",
+        r#"{
+  "agents": [{
+    "name": "blocked",
+    "description": "An agent whose MCP runtime never becomes ready",
+    "model": "anthropic:claude-sonnet-4-5",
+    "agentInvocable": true,
+    "prompts": [{"type":"text","text":"Wait."}],
+    "mcps": [{"type":"inline","servers":{"blocked":{"type":"stdio","command":"sleep","args":["60"]}}}]
+  }]
+}"#,
+    )])
 }
 
 fn create_project_with_codex_agent() -> TempDir {
@@ -344,4 +499,42 @@ fn test_registry(test_dir: &Path) -> aether_core::core::AgentRegistry {
 fn create_test_server(test_dir: &Path) -> SubAgentsMcp {
     let deps = AgentDeps::default().with_agent_registry(test_registry(test_dir));
     SubAgentsMcp::embedded(test_dir.to_path_buf(), deps)
+}
+
+struct RecordingObserverFactory {
+    finishes: Arc<Mutex<Vec<Option<String>>>>,
+}
+
+impl ObserverFactory for RecordingObserverFactory {
+    fn agent(&self, _agent_name: Option<&str>, _parent: Option<&TraceContext>) -> Box<dyn AgentObserver> {
+        Box::new(NoopAgentObserver)
+    }
+
+    fn tool_call_request(
+        &self,
+        _tool_name: &str,
+        _parent: Option<&TraceContext>,
+    ) -> Box<dyn McpRequestInstrumentation> {
+        Box::new(RecordingInstrumentation { finishes: Arc::clone(&self.finishes) })
+    }
+}
+
+struct NoopAgentObserver;
+
+impl AgentObserver for NoopAgentObserver {
+    fn on_event(&mut self, _message: &AgentEvent) {}
+}
+
+struct RecordingInstrumentation {
+    finishes: Arc<Mutex<Vec<Option<String>>>>,
+}
+
+impl McpRequestInstrumentation for RecordingInstrumentation {
+    fn trace_context(&self) -> Option<TraceContext> {
+        None
+    }
+
+    fn finish(self: Box<Self>, error: Option<&str>) {
+        self.finishes.lock().unwrap().push(error.map(str::to_string));
+    }
 }

--- a/crates/mcp-servers/tests/integration/test_bash.rs
+++ b/crates/mcp-servers/tests/integration/test_bash.rs
@@ -1,295 +1,116 @@
+use mcp_servers::CodingMcp;
 use mcp_servers::coding::error::BashError;
-use mcp_servers::coding::tools::bash::{
-    BackgroundProcessHandle, BackgroundShellStatus, BashInput, BashResult, ReadBackgroundBashOutput, execute_command,
-    read_background_bash,
-};
+use mcp_servers::coding::tools::bash::{BashInput, execute_command, execute_command_in_dir};
+use rmcp::model::{CallToolRequestParams, CallToolResponse, TaskPayload, TaskStatus};
 use std::fs::canonicalize;
 
-async fn read_until_terminal(mut handle: BackgroundProcessHandle, filter: Option<String>) -> ReadBackgroundBashOutput {
-    let mut output = String::new();
-    loop {
-        let (mut result, next) = read_background_bash(handle, filter.clone()).await.unwrap();
-        output.push_str(&result.output);
-        if let Some(next) = next {
-            handle = next;
-            tokio::task::yield_now().await;
-        } else {
-            result.output = output;
-            return result;
-        }
-    }
-}
+use super::common::{TestClient, TestResult, production_client_info, test_client_info};
 
 #[tokio::test]
 async fn test_basic_command() {
-    let args = BashInput {
-        command: "echo 'hello world'".to_string(),
-        timeout: None,
-        description: None,
-        run_in_background: None,
-    };
-
-    let result = execute_command(args).await.unwrap();
-
-    match result {
-        BashResult::Completed(output) => {
-            assert_eq!(output.output.trim(), "hello world");
-            assert_eq!(output.exit_code, 0);
-            assert_eq!(output.killed, Some(false));
-            assert_eq!(output.shell_id, None);
-        }
-        BashResult::Background(_) => panic!("Expected completed result, got background"),
-    }
+    let output =
+        execute_command(BashInput { command: "echo 'hello world'".into(), ..Default::default() }).await.unwrap();
+    assert_eq!(output.output.trim(), "hello world");
+    assert_eq!(output.exit_code, 0);
+    assert!(!output.killed);
 }
 
 #[tokio::test]
-async fn test_command_with_exit_code() {
-    let args = BashInput { command: "exit 42".to_string(), timeout: None, description: None, run_in_background: None };
-
-    let result = execute_command(args).await.unwrap();
-
-    match result {
-        BashResult::Completed(output) => {
-            assert_eq!(output.exit_code, 42);
-            assert_eq!(output.killed, Some(false));
-        }
-        BashResult::Background(_) => panic!("Expected completed result, got background"),
-    }
-}
-
-#[tokio::test]
-async fn test_command_with_stderr() {
-    let args = BashInput {
-        command: "echo 'error' >&2".to_string(),
-        timeout: None,
-        description: None,
-        run_in_background: None,
-    };
-
-    let result = execute_command(args).await.unwrap();
-
-    match result {
-        BashResult::Completed(output) => {
-            assert_eq!(output.output.trim(), "error");
-            assert_eq!(output.exit_code, 0);
-        }
-        BashResult::Background(_) => panic!("Expected completed result, got background"),
-    }
+async fn test_command_with_exit_code_and_stderr() {
+    let output =
+        execute_command(BashInput { command: "echo error >&2; exit 42".into(), ..Default::default() }).await.unwrap();
+    assert!(output.output.contains("error"));
+    assert_eq!(output.exit_code, 42);
+    assert!(!output.killed);
 }
 
 #[tokio::test]
 async fn test_command_timeout() {
-    let args = BashInput {
-        command: "sleep 10".to_string(),
-        timeout: Some(100), // 100ms timeout
-        description: None,
-        run_in_background: None,
-    };
-
-    let result = execute_command(args).await.unwrap();
-
-    match result {
-        BashResult::Completed(output) => {
-            assert!(output.output.contains("timed out"));
-            assert_eq!(output.exit_code, -1);
-            assert_eq!(output.killed, Some(true));
-        }
-        BashResult::Background(_) => panic!("Expected completed result, got background"),
-    }
+    let output = execute_command(BashInput { command: "sleep 10".into(), timeout: Some(100), ..Default::default() })
+        .await
+        .unwrap();
+    assert!(output.output.contains("timed out"));
+    assert_eq!(output.exit_code, -1);
+    assert!(output.killed);
 }
 
 #[tokio::test]
 async fn test_timeout_validation() {
-    let args = BashInput {
-        command: "echo test".to_string(),
-        timeout: Some(700_000), // Exceeds max of 600000
-        description: None,
-        run_in_background: None,
-    };
-
-    let result = execute_command(args).await;
-    assert!(result.is_err());
+    let result =
+        execute_command(BashInput { command: "echo test".into(), timeout: Some(700_000), ..Default::default() }).await;
     assert!(matches!(result.unwrap_err(), BashError::TimeoutTooLarge));
 }
 
 #[tokio::test]
-async fn test_background_process() {
-    let args = BashInput {
-        command: "echo 'line1'; sleep 0.1; echo 'line2'".to_string(),
-        timeout: None,
-        description: Some("Test background command".to_string()),
-        run_in_background: Some(true),
-    };
-
-    let result = execute_command(args).await.unwrap();
-
-    match result {
-        BashResult::Background(handle) => {
-            assert!(!handle.shell_id.is_empty());
-
-            let (result1, mut handle_opt) = read_background_bash(handle, None).await.unwrap();
-            assert!(
-                result1.status == BackgroundShellStatus::Running || result1.status == BackgroundShellStatus::Completed
-            );
-
-            let mut combined_output = result1.output.clone();
-            let (final_status, final_exit) = loop {
-                let Some(handle) = handle_opt.take() else {
-                    panic!("expected at least one read iteration");
-                };
-                let (result, next) = read_background_bash(handle, None).await.unwrap();
-                combined_output.push_str(&result.output);
-                match next {
-                    Some(h) => {
-                        handle_opt = Some(h);
-                        tokio::task::yield_now().await;
-                    }
-                    None => break (result.status, result.exit_code),
-                }
-            };
-
-            assert_eq!(final_status, BackgroundShellStatus::Completed);
-            assert_eq!(final_exit, Some(0));
-            assert!(combined_output.contains("line1"));
-            assert!(combined_output.contains("line2"));
-        }
-        BashResult::Completed(_) => panic!("Expected background result, got completed"),
-    }
-}
-
-#[tokio::test]
-async fn test_background_process_with_timeout() {
-    let args = BashInput {
-        command: "sleep 10".to_string(),
-        timeout: Some(100), // 100ms timeout
-        description: None,
-        run_in_background: Some(true),
-    };
-
-    let result = execute_command(args).await.unwrap();
-
-    match result {
-        BashResult::Background(handle) => {
-            let result = read_until_terminal(handle, None).await;
-
-            assert_eq!(result.status, BackgroundShellStatus::Failed);
-            assert!(result.output.contains("timed out"));
-        }
-        BashResult::Completed(_) => panic!("Expected background result, got completed"),
-    }
-}
-
-#[tokio::test]
 async fn test_rm_command_blocked() {
-    let args = BashInput { command: "rm".to_string(), timeout: None, description: None, run_in_background: None };
-
-    let result = execute_command(args).await;
-    assert!(result.is_err());
+    let result = execute_command(BashInput { command: "rm".into(), ..Default::default() }).await;
     assert!(matches!(result.unwrap_err(), BashError::Forbidden(_)));
 }
 
 #[tokio::test]
-async fn test_read_background_bash() {
-    let args = BashInput {
-        command: "echo 'line1'; sleep 0.1; echo 'line2'; echo 'error' >&2".to_string(),
-        timeout: None,
-        description: None,
-        run_in_background: Some(true),
-    };
-
-    let result = execute_command(args).await.unwrap();
-
-    match result {
-        BashResult::Background(handle) => {
-            let result = read_until_terminal(handle, None).await;
-
-            assert!(result.output.contains("line1"));
-            assert!(result.output.contains("line2"));
-            assert!(result.output.contains("error"));
-            assert_eq!(result.status, BackgroundShellStatus::Completed);
-            assert_eq!(result.exit_code, Some(0));
-        }
-        BashResult::Completed(_) => panic!("Expected background result"),
-    }
-}
-
-#[tokio::test]
-async fn test_read_background_bash_with_filter() {
-    let args = BashInput {
-        command: "echo 'ERROR: something went wrong'; echo 'INFO: all good'; echo 'ERROR: another issue'".to_string(),
-        timeout: None,
-        description: None,
-        run_in_background: Some(true),
-    };
-
-    let result = execute_command(args).await.unwrap();
-
-    match result {
-        BashResult::Background(handle) => {
-            let result = read_until_terminal(handle, Some("ERROR".to_string())).await;
-
-            assert!(result.output.contains("ERROR: something went wrong"));
-            assert!(result.output.contains("ERROR: another issue"));
-            assert!(!result.output.contains("INFO: all good"));
-            assert_eq!(result.status, BackgroundShellStatus::Completed);
-        }
-        BashResult::Completed(_) => panic!("Expected background result"),
-    }
-}
-
-#[tokio::test]
-async fn test_read_background_bash_running_status() {
-    let args =
-        BashInput { command: "sleep 10".to_string(), timeout: None, description: None, run_in_background: Some(true) };
-
-    let result = execute_command(args).await.unwrap();
-
-    match result {
-        BashResult::Background(handle) => {
-            let (result, _) = read_background_bash(handle, None).await.unwrap();
-
-            assert_eq!(result.status, BackgroundShellStatus::Running);
-            assert_eq!(result.exit_code, None);
-        }
-        BashResult::Completed(_) => panic!("Expected background result"),
-    }
-}
-
-#[tokio::test]
-async fn test_read_background_bash_failed_status() {
-    let args = BashInput {
-        command: "sleep 10".to_string(),
-        timeout: Some(100), // Will timeout
-        description: None,
-        run_in_background: Some(true),
-    };
-
-    let result = execute_command(args).await.unwrap();
-
-    match result {
-        BashResult::Background(handle) => {
-            let result = read_until_terminal(handle, None).await;
-
-            assert_eq!(result.status, BackgroundShellStatus::Failed);
-            assert!(result.exit_code.is_some());
-        }
-        BashResult::Completed(_) => panic!("Expected background result"),
-    }
-}
-
-#[tokio::test]
 async fn test_execute_command_in_dir_foreground() -> Result<(), Box<dyn std::error::Error>> {
-    use mcp_servers::coding::tools::bash::execute_command_in_dir;
-
     let temp = tempfile::tempdir()?;
-    let args = BashInput { command: "pwd".to_string(), timeout: None, description: None, run_in_background: None };
-    let result = execute_command_in_dir(args, Some(temp.path())).await?;
-    let BashResult::Completed(output) = result else {
-        return Err("Expected completed result".into());
+    let output =
+        execute_command_in_dir(BashInput { command: "pwd".into(), ..Default::default() }, Some(temp.path())).await?;
+    assert_eq!(canonicalize(output.output.trim())?, canonicalize(temp.path())?);
+    Ok(())
+}
+
+#[tokio::test]
+async fn background_bash_uses_tasks_and_returns_structured_output() -> TestResult {
+    let client = TestClient::start_with(CodingMcp::new, production_client_info()).await?;
+    let response = client
+        .raw()
+        .call_tool_once(
+            CallToolRequestParams::new("bash").with_arguments(
+                serde_json::json!({
+                    "command": "echo stdout; echo stderr >&2; exit 7",
+                    "runInBackground": true
+                })
+                .as_object()
+                .unwrap()
+                .clone(),
+            ),
+        )
+        .await?;
+    let CallToolResponse::Task(created) = response else {
+        panic!("expected task response: {response:?}");
     };
+    assert_eq!(created.task.status, TaskStatus::Working);
 
-    let pwd = output.output.trim();
+    let detailed = loop {
+        let result = client.raw().get_task(rmcp::model::GetTaskParams::new(created.task.task_id.clone())).await?;
+        if result.task.status().is_terminal() {
+            break result.task;
+        }
+        tokio::task::yield_now().await;
+    };
+    let TaskPayload::Completed { result } = detailed.payload else {
+        panic!("expected completed task");
+    };
+    let result: rmcp::model::CallToolResult = serde_json::from_value(serde_json::Value::Object(result))?;
+    assert_eq!(result.is_error, Some(false));
+    let structured = result.structured_content.as_ref().unwrap();
+    let output = structured["output"].as_str().unwrap();
+    assert!(output.contains("stdout"));
+    assert!(output.contains("stderr"));
+    assert_eq!(structured["exitCode"], 7);
+    Ok(())
+}
 
-    assert_eq!(canonicalize(pwd)?, canonicalize(temp.path())?);
+#[tokio::test]
+async fn background_bash_requires_tasks_capability() -> TestResult {
+    let client = TestClient::start_with(CodingMcp::new, test_client_info()).await?;
+    let error = client
+        .raw()
+        .call_tool_once(CallToolRequestParams::new("bash").with_arguments(
+            serde_json::json!({ "command": "echo never", "runInBackground": true }).as_object().unwrap().clone(),
+        ))
+        .await
+        .unwrap_err();
+    assert!(
+        error.to_string().to_lowercase().contains("missing required client capability"),
+        "unexpected error: {error}"
+    );
     Ok(())
 }

--- a/crates/mcp-utils/src/client/call_tool.rs
+++ b/crates/mcp-utils/src/client/call_tool.rs
@@ -148,7 +148,7 @@ pub fn call_tool(
                 }
                 Ok(CallToolResponse::Task(task)) => {
                     let driver = TaskDriver::new(&server_name, client.as_ref(), options.timeout, options.cancel.clone());
-                    let mut events = Box::pin(driver.stream(task));
+                    let mut events = Box::pin(driver.stream(task, progress));
                     while let Some(event) = events.next().await {
                         yield event;
                     }

--- a/crates/mcp-utils/src/client/task.rs
+++ b/crates/mcp-utils/src/client/task.rs
@@ -2,11 +2,12 @@ use crate::client::McpClient;
 use crate::client::call_tool::{CallToolError, ToolCallEvent};
 use crate::client::elicitation::{ElicitInputsError, elicit_inputs};
 use async_stream::stream;
-use futures::Stream;
 use futures::future::{Either, select};
+use futures::{Stream, StreamExt, pin_mut};
 use rmcp::RoleClient;
 use rmcp::model::{
-    CancelTaskParams, CreateTaskResult, GetTaskParams, InputRequests, Task, TaskPayload, TaskStatus, UpdateTaskParams,
+    CancelTaskParams, CreateTaskResult, GetTaskParams, InputRequests, ProgressNotificationParam, Task, TaskPayload,
+    TaskStatus, UpdateTaskParams,
 };
 use rmcp::service::{RunningService, ServiceError};
 use std::collections::HashSet;
@@ -62,11 +63,42 @@ impl<'a> TaskDriver<'a> {
         Self { client, server_name, timeout, cancellation_token, default_poll_interval: Duration::from_secs(1) }
     }
 
-    pub(crate) fn stream(self, created: CreateTaskResult) -> impl Stream<Item = ToolCallEvent> + 'a {
+    pub(crate) fn stream<T: Stream<Item = ProgressNotificationParam> + Send + 'a>(
+        self,
+        created: CreateTaskResult,
+        progress_events: T,
+    ) -> impl Stream<Item = ToolCallEvent> + 'a {
         stream! {
             yield ToolCallEvent::TaskCreated(created.clone());
+            let task_events = self.stream_task_events(created.task);
+            pin_mut!(task_events);
+            pin_mut!(progress_events);
+
+            loop {
+                tokio::select! {
+                    progress_event = progress_events.next() => {
+                        let Some(progress_event) = progress_event else {
+                            while let Some(event) = task_events.next().await {
+                                yield event;
+                            }
+                            return;
+                        };
+                        yield ToolCallEvent::Progress(progress_event);
+                    }
+                    event = task_events.next() => {
+                        let Some(event) = event else {
+                            return;
+                        };
+                        yield event;
+                    }
+                }
+            }
+        }
+    }
+
+    fn stream_task_events(self, mut task: Task) -> impl Stream<Item = ToolCallEvent> + 'a {
+        stream! {
             let bounds = TaskBounds::new(self.timeout, self.cancellation_token.clone());
-            let mut task = created.task;
             let mut answered_input_keys = HashSet::new();
 
             loop {
@@ -297,6 +329,44 @@ mod tests {
                     && result.content.first().and_then(|content| content.as_text()).is_some_and(|text| text.text == "finished")
         ));
         assert_eq!(result.state.task_get_ids(), ["task-1"]);
+    }
+
+    #[tokio::test]
+    async fn call_tool_forwards_progress_after_task_creation() {
+        let seed = task(TaskStatus::Working);
+        let server = FakeMcpServer::new()
+            .with_tool(
+                FakeTool::new("deferred")
+                    .responds(FakeToolResponse::task(CreateTaskResult::new(seed)).task_progress(1.0, Some(2.0))),
+            )
+            .with_task(
+                "task-1",
+                [DetailedTask::new(task(TaskStatus::Working), TaskPayload::Working), completed_task()],
+            );
+        let (event_tx, _event_rx) = mpsc::channel::<McpClientEvent>(4);
+        let client = McpClient::new(
+            ClientInfo::new(client_capabilities(), Implementation::new("test-client", "0.1.0")),
+            "task-server".into(),
+            event_tx,
+        );
+        let (_server, client) = connect(server, client).await.expect("connect task server");
+
+        let events = call_tool(
+            Arc::new(client),
+            CallToolRequestParams::new("deferred"),
+            CallToolOptions { timeout: Duration::from_secs(1), ..CallToolOptions::default() },
+        )
+        .collect::<Vec<_>>()
+        .await;
+
+        assert!(matches!(events.first(), Some(ToolCallEvent::TaskCreated(_))));
+        assert!(events.iter().any(|event| matches!(
+            event,
+            ToolCallEvent::Progress(progress)
+                if (progress.progress - 1.0).abs() < f64::EPSILON
+                    && progress.total.is_some_and(|total| (total - 2.0).abs() < f64::EPSILON)
+        )));
+        assert!(matches!(events.last(), Some(ToolCallEvent::TaskComplete { result: Ok(_), .. })));
     }
 
     #[tokio::test]

--- a/crates/mcp-utils/src/server/mod.rs
+++ b/crates/mcp-utils/src/server/mod.rs
@@ -1,2 +1,3 @@
 pub mod mrtr;
+pub mod tasks;
 pub mod tool;

--- a/crates/mcp-utils/src/server/tasks.rs
+++ b/crates/mcp-utils/src/server/tasks.rs
@@ -1,0 +1,15 @@
+use rmcp::model::ClientCapabilities;
+use rmcp::service::RequestContext;
+use rmcp::{ErrorData, RoleServer};
+
+/// Bounds both task execution and terminal-result retention because rmcp uses
+/// one TTL for both concerns.
+pub const BACKGROUND_TASK_TTL_MS: u64 = 3_600_000;
+
+pub fn require_tasks_capability(context: &RequestContext<RoleServer>) -> Result<(), ErrorData> {
+    if context.client_capabilities().is_some_and(|capabilities| capabilities.supports_tasks()) {
+        Ok(())
+    } else {
+        Err(ErrorData::missing_required_client_capability(ClientCapabilities::builder().enable_tasks().build()))
+    }
+}

--- a/crates/mcp-utils/src/testing/fake_mcp.rs
+++ b/crates/mcp-utils/src/testing/fake_mcp.rs
@@ -58,6 +58,7 @@ pub struct FakeToolResponse {
     response: CallToolResponse,
     delay: Duration,
     progress: Vec<(f64, Option<f64>)>,
+    task_progress: Vec<(f64, Option<f64>)>,
 }
 
 impl FakeMcpServer {
@@ -215,7 +216,7 @@ impl FakeTool {
 
 impl FakeToolResponse {
     pub fn new(response: impl Into<CallToolResponse>) -> Self {
-        Self { response: response.into(), delay: Duration::ZERO, progress: Vec::new() }
+        Self { response: response.into(), delay: Duration::ZERO, progress: Vec::new(), task_progress: Vec::new() }
     }
 
     pub fn text(text: impl Into<String>) -> Self {
@@ -233,6 +234,11 @@ impl FakeToolResponse {
 
     pub fn progress(mut self, progress: f64, total: Option<f64>) -> Self {
         self.progress.push((progress, total));
+        self
+    }
+
+    pub fn task_progress(mut self, progress: f64, total: Option<f64>) -> Self {
+        self.task_progress.push((progress, total));
         self
     }
 }
@@ -337,6 +343,20 @@ impl ServerHandler for FakeMcpServer {
                     notification = notification.with_total(total);
                 }
                 let _ = context.peer.notify_progress(notification).await;
+            }
+            if !response.task_progress.is_empty() {
+                let peer = context.peer.clone();
+                let token = token.clone();
+                tokio::spawn(async move {
+                    tokio::task::yield_now().await;
+                    for (progress, total) in response.task_progress {
+                        let mut notification = ProgressNotificationParam::new(token.clone(), progress);
+                        if let Some(total) = total {
+                            notification = notification.with_total(total);
+                        }
+                        let _ = peer.notify_progress(notification).await;
+                    }
+                });
             }
         }
         Ok(response.response)

--- a/packages/website/src/content/docs/aether/built-in-servers/coding.mdx
+++ b/packages/website/src/content/docs/aether/built-in-servers/coding.mdx
@@ -56,8 +56,7 @@ Permission modes:
 
 | Tool                   | Description                                                                                     |
 | ---------------------- | ----------------------------------------------------------------------------------------------- |
-| `bash`                 | Execute a shell command in a persistent shell session. Supports foreground and background mode. |
-| `read_background_bash` | Read new output from a background bash command.                                                 |
+| `bash`                 | Execute a shell command. Background mode uses MCP Tasks and returns complete output at completion. |
 
 ## Web
 

--- a/packages/website/src/content/docs/aether/built-in-servers/subagents.mdx
+++ b/packages/website/src/content/docs/aether/built-in-servers/subagents.mdx
@@ -62,7 +62,7 @@ Tool filters use exact tool names or a trailing `*` prefix match. For example, `
 
 | Tool             | Description                                                           |
 | ---------------- | --------------------------------------------------------------------- |
-| `spawn_subagent` | Spawn one or more sub-agent tasks in parallel and return all results. |
+| `spawn_subagent` | Spawn all requested agents concurrently. Wait for results by default, or run as an MCP Task. |
 
 ## Example
 
@@ -81,7 +81,11 @@ Tool filters use exact tool names or a trailing `*` prefix match. For example, `
 }
 ```
 
-The output contains one result per input task, in input order:
+`spawn_subagent` waits for the whole batch by default, so the parent receives all results before its next reasoning step. All children run concurrently, and the output contains one result per input task in input order. Rich child progress may be displayed while the call runs.
+
+For independent work that can complete later, set `runInBackground: true` at the top level. The call then immediately returns one MCP Task for the whole batch. Background mode requires MCP Tasks support; cancelling the task stops all remaining agents, and its completed payload has the same shape as the foreground response.
+
+The result payload is:
 
 ```json
 {
@@ -113,10 +117,12 @@ Aether appends structured-output instructions to each sub-agent prompt. Agents a
 | `nextSteps` | Recommended follow-up tasks.                                |
 | `details`   | Optional expanded detail.                                   |
 
-The tool currently returns the sub-agent's raw final output string. Parent agents should parse or summarize that output before continuing.
+Each result's `output` contains the sub-agent's raw final output string. Parent agents should parse or summarize it before continuing.
 
 ## Failure modes
 
-- If no `agentInvocable` agents are registered and tasks are requested, the tool returns an error and should not be retried until configuration changes.
+- Clients that do not advertise MCP Tasks support can use foreground mode but cannot set `runInBackground: true`.
+- If a background batch task is cancelled, all remaining child execution is stopped.
+- If no `agentInvocable` agents are registered and tasks are requested, the tool returns an error before creating a task and should not be retried until configuration changes.
 - If a named agent is missing or not `agentInvocable`, that task result is returned with `status: "error"`.
 - Empty `tasks` returns an empty result set.

--- a/packages/website/src/content/docs/aether/settings/mcp-servers.mdx
+++ b/packages/website/src/content/docs/aether/settings/mcp-servers.mdx
@@ -444,7 +444,7 @@ MCP servers can attach tool annotations and you can filter tools based on those:
       "mcps": [".aether/mcp.json"],
       "tools": {
         "allow": ["coding__*"],
-        "deny": ["coding__bash", "coding__read_background_bash"]
+        "deny": ["coding__bash"]
       }
     }
   ]

--- a/packages/website/src/content/docs/aether/settings/overview.mdx
+++ b/packages/website/src/content/docs/aether/settings/overview.mdx
@@ -251,7 +251,7 @@ Add `tools` when the agent should use only a subset of the tools exposed by its 
       ],
       "tools": {
         "allow": ["coding__*", "tasks__*"],
-        "deny": ["coding__bash", "coding__read_background_bash"]
+        "deny": ["coding__bash"]
       },
       "userInvocable": true
     }


### PR DESCRIPTION
This PR updates the `Bash` tool in the coding MCP server and the sub-agent's MCP server to use MCP tasks, which allows the main agent to make tool calls in either the foreground or background (using MCP tasks). 