### PR TITLE
feat: Allow proxying tools within a MCP server

### DIFF
--- a/crates/aether-cli/README.md
+++ b/crates/aether-cli/README.md
@@ -152,6 +152,8 @@ The `mcp.json` file configures MCP tool servers:
 - **coding** — Filesystem tools (read, write, bash, etc.) plus optional auto-read rules from configured `--rules-dir` paths
 - **skills** — Slash commands and reusable prompts loaded from the configured `--dir` paths
 
+Set `"proxy": true` on a server to place all of its tools behind Aether's shared `proxy__call_tool`. To partition tools, use `"proxy": { "include": [...], "exclude": [...] }`; patterns are exact MCP-local names or trailing-`*` prefixes, and `exclude` wins.
+
 ## Slash Commands
 
 Slash commands are markdown files served by the `skills` MCP server from any directory passed via `--dir`. Each entry is either a single `.md` file or a directory containing `SKILL.md` (plus optional supporting files). To make a prompt appear as a `/slash-command` in the TUI / ACP client, set `userInvocable: true` in its frontmatter.

--- a/crates/aether-cli/src/acp/protocol/mcp.rs
+++ b/crates/aether-cli/src/acp/protocol/mcp.rs
@@ -1,5 +1,5 @@
 use agent_client_protocol::schema::{HttpHeader, McpServer};
-use mcp_utils::client::{McpServer as RuntimeMcpServer, McpTransport};
+use mcp_utils::client::{McpServer as RuntimeMcpServer, McpTransport, ToolExposure};
 use rmcp::transport::streamable_http_client::StreamableHttpClientTransportConfig;
 
 /// Maps ACP MCP server definitions to internal MCP servers, skipping unsupported transports.
@@ -25,18 +25,20 @@ fn try_map_mcp_server(server: McpServer) -> Option<RuntimeMcpServer> {
                 args: stdio.args,
                 env: stdio.env.into_iter().map(|e| (e.name, e.value)).collect(),
             },
-            false,
+            ToolExposure::Direct,
         )),
 
         Http(http) => Some(RuntimeMcpServer::new(
             http.name,
             McpTransport::Http(http_config(http.url, &http.headers).into()),
-            false,
+            ToolExposure::Direct,
         )),
 
-        Sse(sse) => {
-            Some(RuntimeMcpServer::new(sse.name, McpTransport::Http(http_config(sse.url, &sse.headers).into()), false))
-        }
+        Sse(sse) => Some(RuntimeMcpServer::new(
+            sse.name,
+            McpTransport::Http(http_config(sse.url, &sse.headers).into()),
+            ToolExposure::Direct,
+        )),
 
         _ => None,
     }

--- a/crates/aether-cli/src/acp/testing.rs
+++ b/crates/aether-cli/src/acp/testing.rs
@@ -28,7 +28,7 @@ use agent_client_protocol::{Agent, Client, ConnectionTo};
 use llm::ProviderConnectionOverrides;
 use llm::testing::FakeLlmProvider;
 use llm::{ChatMessage, Context, LlmResponse, StreamingModelProvider};
-use mcp_utils::client::{McpServer, McpTransport};
+use mcp_utils::client::{McpServer, McpTransport, ToolExposure};
 use std::collections::HashMap;
 use std::path::PathBuf;
 use std::sync::{Arc, Mutex};
@@ -383,7 +383,7 @@ impl RuntimeFactory for FakeRuntimeFactory {
             vec![McpServer::new(
                 server_name.clone(),
                 McpTransport::InMemory { server: FakePromptMcp::new(prompt_name).into_dyn() },
-                false,
+                ToolExposure::Direct,
             )]
         });
         let mut spawn = mcp(&self.cwd)

--- a/crates/aether-cli/src/init/build_settings.rs
+++ b/crates/aether-cli/src/init/build_settings.rs
@@ -4,7 +4,7 @@ use super::recommendations::{ProviderRecommendations, recommended_for_provider};
 use aether_core::agent_spec::{ToolFilter, ToolMatcher};
 use aether_project::{AetherSettings, AgentConfig, McpSourceSpec, PromptSource};
 use llm::{ReasoningEffort, catalog::Provider};
-use mcp_utils::client::{InMemoryServerConfig, InMemoryType, McpServerConfig};
+use mcp_utils::client::{InMemoryServerConfig, InMemoryType, McpServerConfig, ToolExposure};
 
 const SYSTEM_PATH: &str = "SYSTEM.md";
 const SYSTEM_MD: &str = include_str!("templates/SYSTEM.md");
@@ -255,7 +255,7 @@ fn mcps(servers: Vec<(&str, Vec<String>)>) -> McpSourceSpec {
                     type_: InMemoryType::InMemory,
                     args,
                     input: None,
-                    proxy: false,
+                    proxy: ToolExposure::Direct,
                 }),
             )
         })

--- a/crates/aether-core/src/agent_spec.rs
+++ b/crates/aether-core/src/agent_spec.rs
@@ -7,6 +7,7 @@ use crate::core::Prompt;
 use llm::{LlmModel, ModelSettings, ProviderConnectionOverrides, ReasoningEffort, ToolDefinition};
 use mcp_utils::client::McpConfig;
 use std::path::PathBuf;
+use utils::matches_name_pattern;
 
 #[derive(Debug, Clone)]
 pub enum McpConfigSource {
@@ -108,7 +109,7 @@ impl ToolMatcher {
 
     pub fn matches(&self, tool: &ToolDefinition) -> bool {
         match self {
-            Self::Name(pattern) => matches_pattern(pattern, &tool.name),
+            Self::Name(pattern) => matches_name_pattern(pattern, &tool.name),
             Self::Annotations(matcher) => matcher.matches(tool),
         }
     }
@@ -178,11 +179,6 @@ impl ToolFilter {
         let denied = self.deny.iter().any(|matcher| matcher.matches(tool));
         allowed && !denied
     }
-}
-
-/// Match a pattern against a name, supporting a trailing `*` wildcard.
-fn matches_pattern(pattern: &str, name: &str) -> bool {
-    if let Some(prefix) = pattern.strip_suffix('*') { name.starts_with(prefix) } else { pattern == name }
 }
 
 /// Defines how an agent can be invoked.
@@ -424,11 +420,13 @@ mod tests {
     }
 
     #[test]
-    fn matches_pattern_exact_and_wildcard() {
-        assert!(matches_pattern("foo", "foo"));
-        assert!(!matches_pattern("foo", "foobar"));
-        assert!(matches_pattern("foo*", "foobar"));
-        assert!(matches_pattern("foo*", "foo"));
-        assert!(!matches_pattern("bar*", "foo"));
+    fn tool_matcher_uses_exact_and_trailing_wildcard_names() {
+        let exact = ToolMatcher::name("foo");
+        let wildcard = ToolMatcher::name("foo*");
+        assert!(exact.matches(&make_tool("foo")));
+        assert!(!exact.matches(&make_tool("foobar")));
+        assert!(wildcard.matches(&make_tool("foobar")));
+        assert!(wildcard.matches(&make_tool("foo")));
+        assert!(!wildcard.matches(&make_tool("bar")));
     }
 }

--- a/crates/aether-core/src/mcp/mcp_builder.rs
+++ b/crates/aether-core/src/mcp/mcp_builder.rs
@@ -185,7 +185,6 @@ impl McpBuilder {
 
         mcp_manager = mcp_manager.with_root_dir(self.root_dir);
 
-        mcp_manager.bootstrap_proxy_setup(&self.servers).await?;
         let pending = mcp_manager.register_pending(self.servers).await?;
 
         let mcp_handle = tokio::spawn(run_mcp_task(mcp_manager, mcp_command_rx, pending));
@@ -198,7 +197,7 @@ impl McpBuilder {
 mod tests {
     use super::*;
     use mcp_utils::{
-        client::{McpServerConfig, McpTransport, StdioServerConfig, StdioType},
+        client::{McpServerConfig, McpTransport, StdioServerConfig, StdioType, ToolExposure},
         status::McpServerStatus,
     };
     use std::collections::{BTreeMap, HashMap};
@@ -229,7 +228,7 @@ mod tests {
                 command: "from_inline".to_string(),
                 args: Vec::new(),
                 env: HashMap::new(),
-                proxy: false,
+                proxy: ToolExposure::Direct,
             }),
         )]));
         let sources = vec![
@@ -262,7 +261,7 @@ mod tests {
     async fn file_source_proxy_true_marks_all_file_servers_proxied() {
         let (_dir, file_path) = write_config_file(
             "proxied.json",
-            r#"{"servers":{"github":{"type":"stdio","command":"g","proxy":false},"browser":{"type":"stdio","command":"b"}}}"#,
+            r#"{"servers":{"github":{"type":"stdio","command":"g","proxy":{"exclude":["status"]}},"browser":{"type":"stdio","command":"b"}}}"#,
         );
 
         let builder = McpBuilder::new("/workspace")
@@ -272,6 +271,7 @@ mod tests {
 
         assert_eq!(proxy_for(&builder, "github"), Some(true));
         assert_eq!(proxy_for(&builder, "browser"), Some(true));
+        assert!(is_direct_tool(&builder, "github", "status"));
     }
 
     #[tokio::test]
@@ -359,7 +359,15 @@ mod tests {
         })
     }
 
+    fn is_direct_tool(builder: &McpBuilder, server_name: &str, tool_name: &str) -> bool {
+        builder
+            .servers
+            .iter()
+            .find(|server| server.name == server_name)
+            .is_some_and(|server| server.tool_exposure.is_direct_tool(tool_name))
+    }
+
     fn proxy_for(builder: &McpBuilder, name: &str) -> Option<bool> {
-        builder.servers.iter().find(|server| server.name == name).map(|server| server.proxy)
+        builder.servers.iter().find(|server| server.name == name).map(mcp_utils::client::McpServer::is_proxied)
     }
 }

--- a/crates/aether-core/src/mcp/run_mcp_task.rs
+++ b/crates/aether-core/src/mcp/run_mcp_task.rs
@@ -157,7 +157,6 @@ async fn on_command(
                         Err(_) => McpConnectAttempt::failed(
                             server_name,
                             McpError::ConnectionFailed("authentication timed out after 3 minutes".to_string()),
-                            false,
                         ),
                     }
                 });

--- a/crates/aether-core/src/testing/fake_mcp.rs
+++ b/crates/aether-core/src/testing/fake_mcp.rs
@@ -1,4 +1,3 @@
 pub use mcp_utils::testing::{
     CapturedTaskUpdate, CapturedToolCall, FakeMcpServer, FakeMcpState, FakeTool, FakeToolResponse, fake_mcp,
-    fake_mcp_with_proxy,
 };

--- a/crates/aether-core/src/testing/mcp_test.rs
+++ b/crates/aether-core/src/testing/mcp_test.rs
@@ -2,7 +2,9 @@ use crate::events::{TaskOutcomeState, TraceContext, task_created_result};
 use crate::mcp::run_mcp_task::McpCommand;
 use crate::mcp::tool_bridge::{convert_tool_result, map_task_result_to_outcome};
 use crate::mcp::{McpRuntime, mcp};
-use mcp_utils::client::{CancellationToken, McpConnectionDetails, McpServer, McpTransport, ToolCallEvent};
+use mcp_utils::client::{
+    CancellationToken, McpConnectionDetails, McpServer, McpTransport, ToolCallEvent, ToolExposure,
+};
 use mcp_utils::testing::ElicitationScript;
 use rmcp::ServerHandler;
 use rmcp::model::{CreateTaskResult, ElicitResult, ProgressNotificationParam};
@@ -75,14 +77,22 @@ impl McpTestBuilder {
     where
         S: ServerHandler,
     {
-        self.add_server(name, server, false)
+        self.server_with_exposure(name, server, ToolExposure::Direct)
     }
 
-    pub fn proxy_server<S>(self, name: impl Into<String>, server: S) -> Self
+    pub fn proxy_server<T>(self, name: impl Into<String>, server: T) -> Self
     where
-        S: ServerHandler,
+        T: ServerHandler,
     {
-        self.add_server(name, server, true)
+        self.server_with_exposure(name, server, ToolExposure::proxied_all())
+    }
+
+    pub fn server_with_exposure<T>(mut self, name: impl Into<String>, server: T, exposure: ToolExposure) -> Self
+    where
+        T: ServerHandler,
+    {
+        self.servers.push(McpServer::new(name, McpTransport::InMemory { server: Box::new(server) }, exposure));
+        self
     }
 
     pub fn elicitation_response(mut self, response: ElicitResult) -> Self {
@@ -123,14 +133,6 @@ impl McpTestBuilder {
             next_call_id: AtomicU64::new(1),
             _aether_home: aether_home,
         }
-    }
-
-    fn add_server<S>(mut self, name: impl Into<String>, server: S, proxy: bool) -> Self
-    where
-        S: ServerHandler,
-    {
-        self.servers.push(McpServer::new(name, McpTransport::InMemory { server: Box::new(server) }, proxy));
-        self
     }
 }
 

--- a/crates/aether-core/tests/mcp/config_parser_tests.rs
+++ b/crates/aether-core/tests/mcp/config_parser_tests.rs
@@ -50,7 +50,7 @@ async fn test_parse_stdio_config() {
     );
     with_env!([("GITHUB_TOKEN", "test_token")], {
         let server = parse_one(&json).await;
-        assert!(!server.proxy);
+        assert!(!server.is_proxied());
         match server.transport {
             McpTransport::Stdio { command, args, env } => {
                 assert_eq!(server.name, "githubMcp");
@@ -181,8 +181,8 @@ async fn test_parse_per_server_proxy_config() {
     }"#;
     let servers = parse_servers(json).await.unwrap();
     assert_eq!(servers.len(), 2);
-    assert!(servers.iter().find(|s| s.name == "github").unwrap().proxy);
-    assert!(!servers.iter().find(|s| s.name == "sentry").unwrap().proxy);
+    assert!(servers.iter().find(|s| s.name == "github").unwrap().is_proxied());
+    assert!(!servers.iter().find(|s| s.name == "sentry").unwrap().is_proxied());
 }
 
 #[test]

--- a/crates/aether-core/tests/mcp/oauth_tests.rs
+++ b/crates/aether-core/tests/mcp/oauth_tests.rs
@@ -1,8 +1,10 @@
 use aether_auth::{OAuthCallback, OAuthError, OAuthHandler, accept_oauth_callback};
 use aether_core::mcp::mcp;
-use aether_core::testing::{FakeMcpServer, fake_mcp_with_proxy};
+use aether_core::testing::{FakeMcpServer, fake_mcp};
 use futures::future::BoxFuture;
-use mcp_utils::client::{McpClientEvent, McpManager, McpServer, McpTransport, OAuthHandlerFactory};
+use mcp_utils::client::{
+    McpClientEvent, McpManager, McpServer, McpTransport, OAuthHandlerFactory, ToolExposure, ToolProxyRules,
+};
 use mcp_utils::status::{McpServerAuthCapability, McpServerStatus};
 use rmcp::transport::streamable_http_client::StreamableHttpClientTransportConfig;
 use std::sync::Arc;
@@ -26,11 +28,11 @@ impl FailingHttpEndpoint {
         Self { uri, task }
     }
 
-    fn server(&self, name: &str, proxied: bool) -> McpServer {
+    fn server(&self, name: &str, exposure: ToolExposure) -> McpServer {
         McpServer::new(
             name,
             McpTransport::Http(StreamableHttpClientTransportConfig::with_uri(self.uri.as_str()).into()),
-            proxied,
+            exposure,
         )
     }
 }
@@ -132,7 +134,7 @@ async fn builder_with_oauth_handler_factory_spawns_successfully() {
 async fn http_server_without_handler_stashes_failed_status() {
     let endpoint = FailingHttpEndpoint::bind().await;
     let mut manager = test_manager(false);
-    assert!(manager.add_mcps(vec![endpoint.server("test_server", false)]).await.is_ok());
+    assert!(manager.add_mcps(vec![endpoint.server("test_server", ToolExposure::Direct)]).await.is_ok());
 }
 
 #[tokio::test]
@@ -140,7 +142,7 @@ async fn http_server_with_handler_stashes_needs_oauth_on_failure() {
     let endpoint = FailingHttpEndpoint::bind().await;
     let mut manager = test_manager(true);
 
-    assert!(manager.add_mcps(vec![endpoint.server("test_oauth_server", false)]).await.is_ok());
+    assert!(manager.add_mcps(vec![endpoint.server("test_oauth_server", ToolExposure::Direct)]).await.is_ok());
 
     let statuses = manager.server_statuses();
     assert_eq!(statuses.len(), 1);
@@ -160,7 +162,10 @@ async fn add_mcps_continues_on_oauth_failure() {
 
     assert!(
         manager
-            .add_mcps(vec![endpoint.server("failing_server_1", false), endpoint.server("failing_server_2", false)])
+            .add_mcps(vec![
+                endpoint.server("failing_server_1", ToolExposure::Direct),
+                endpoint.server("failing_server_2", ToolExposure::Direct)
+            ])
             .await
             .is_ok()
     );
@@ -197,7 +202,10 @@ async fn tool_proxy_with_failing_http_surfaces_needs_oauth() {
     let endpoint = FailingHttpEndpoint::bind().await;
     let (_home, mut manager) = test_manager_with_home(true);
 
-    let servers = vec![fake_mcp_with_proxy("local", FakeMcpServer::new(), true), endpoint.server("remote", true)];
+    let servers = vec![
+        fake_mcp("local", FakeMcpServer::new()).with_exposure(ToolExposure::proxied_all()),
+        endpoint.server("remote", ToolExposure::proxied_all()),
+    ];
 
     let _ = manager.add_mcps(servers).await;
     let statuses = manager.server_statuses();
@@ -223,11 +231,41 @@ async fn tool_proxy_with_failing_http_surfaces_needs_oauth() {
 }
 
 #[tokio::test]
+async fn selective_policy_survives_failed_and_successful_reauthentication() {
+    let endpoint = FailingHttpEndpoint::bind().await;
+    let (home, mut manager) = test_manager_with_home(true);
+    let selective = endpoint.server("remote", ToolExposure::Proxied(ToolProxyRules::new(&[], &["add_*"])));
+    manager.add_mcps(vec![selective]).await.unwrap();
+
+    let task = manager.authenticate_server_task("remote").await.unwrap();
+    manager.apply_connection_attempt(task.await).await;
+    assert!(manager.authenticate_server_task("remote").await.is_ok());
+
+    let connected = fake_mcp("remote", FakeMcpServer::new()).with_exposure(ToolExposure::proxied_all());
+    let attempt = manager.connect_pending_task(connected).await;
+    manager.apply_connection_attempt(attempt).await;
+
+    let remote = manager.server_statuses().into_iter().find(|status| status.name == "remote").unwrap();
+    assert!(matches!(remote.status, McpServerStatus::Connected { .. }));
+    assert!(remote.proxied);
+    let names = manager.tool_definitions().into_iter().map(|tool| tool.name).collect::<Vec<_>>();
+    assert_eq!(names, ["proxy__call_tool", "remote__add_numbers"]);
+
+    let remote_dir = home.path().join("tool-proxy/proxy/remote");
+    assert!(!remote_dir.join("add_numbers.json").exists());
+    assert!(remote_dir.join("divide_numbers.json").exists());
+    assert!(remote_dir.join("slow_tool.json").exists());
+}
+
+#[tokio::test]
 async fn tool_proxy_partial_connection_works() {
     let endpoint = FailingHttpEndpoint::bind().await;
     let (_home, mut manager) = test_manager_with_home(false);
 
-    let servers = vec![fake_mcp_with_proxy("working", FakeMcpServer::new(), true), endpoint.server("broken", true)];
+    let servers = vec![
+        fake_mcp("working", FakeMcpServer::new()).with_exposure(ToolExposure::proxied_all()),
+        endpoint.server("broken", ToolExposure::proxied_all()),
+    ];
 
     let _ = manager.add_mcps(servers).await;
 

--- a/crates/aether-core/tests/mcp/tool_proxy_tests.rs
+++ b/crates/aether-core/tests/mcp/tool_proxy_tests.rs
@@ -1,5 +1,6 @@
-use aether_core::testing::{FakeMcpServer, McpTest, McpTestBuilder};
-use mcp_utils::client::McpConnectionDetails;
+use aether_core::testing::{FakeMcpServer, FakeTool, FakeToolResponse, McpTest, McpTestBuilder, fake_mcp};
+use mcp_utils::client::{McpClientEvent, McpConnectionDetails, McpManager, ToolExposure, ToolProxyRules};
+use tokio::sync::mpsc;
 
 async fn math_proxy() -> McpTest {
     McpTestBuilder::new().proxy_server("math", FakeMcpServer::new()).build().await
@@ -130,4 +131,157 @@ async fn test_tool_proxy_member_server_status_shows_connected_and_proxied() {
     let math = snapshot.server_statuses.iter().find(|status| status.name == "math").expect("math status exists");
     assert!(matches!(math.status, mcp_utils::status::McpServerStatus::Connected { .. }));
     assert!(math.proxied);
+}
+
+async fn selective_math_proxy() -> McpTest {
+    McpTestBuilder::new()
+        .server_with_exposure("math", FakeMcpServer::new(), ToolExposure::Proxied(ToolProxyRules::new(&[], &["add_*"])))
+        .build()
+        .await
+}
+
+#[tokio::test]
+async fn include_only_proxy_server_instructions_cover_its_direct_tools() {
+    let test = McpTestBuilder::new()
+        .server_with_exposure(
+            "math",
+            FakeMcpServer::new(),
+            ToolExposure::Proxied(ToolProxyRules::new(&["divide_*"], &[])),
+        )
+        .build()
+        .await;
+
+    assert!(test.snapshot().instructions.contains_key("math"));
+    assert!(test.snapshot().instructions.contains_key("proxy"));
+}
+
+#[tokio::test]
+async fn proxy_rules_with_no_direct_tools_do_not_emit_server_instructions() {
+    let test = McpTestBuilder::new()
+        .server_with_exposure("math", FakeMcpServer::new(), ToolExposure::Proxied(ToolProxyRules::new(&["*"], &[])))
+        .build()
+        .await;
+
+    assert!(!test.snapshot().instructions.contains_key("math"));
+    assert!(test.snapshot().instructions.contains_key("proxy"));
+}
+
+#[tokio::test]
+async fn selectively_proxied_server_instructions_cover_its_direct_tools() {
+    let test = selective_math_proxy().await;
+
+    assert!(test.snapshot().instructions.contains_key("math"));
+    assert!(test.snapshot().instructions.contains_key("proxy"));
+}
+
+#[tokio::test]
+async fn proxy_forwards_tools_added_after_initial_discovery() {
+    let server = FakeMcpServer::new();
+    let state = server.state();
+    let test = McpTestBuilder::new().proxy_server("dynamic", server).build().await;
+    state.add_tool(FakeTool::new("added_later").responds(FakeToolResponse::text("available")));
+
+    let result = call_proxy_tool(&test, "dynamic", "added_later", serde_json::json!({})).await;
+    assert!(result.unwrap().contains("available"));
+}
+
+#[tokio::test]
+async fn mixed_direct_full_proxy_and_selective_servers_have_stable_definitions_and_statuses() {
+    let test = McpTestBuilder::new()
+        .server("direct", FakeMcpServer::new())
+        .proxy_server("hidden", FakeMcpServer::new())
+        .server_with_exposure(
+            "selective",
+            FakeMcpServer::new(),
+            ToolExposure::Proxied(ToolProxyRules::new(&[], &["add_*"])),
+        )
+        .build()
+        .await;
+
+    let snapshot = test.snapshot();
+    let names = snapshot.tool_definitions.iter().map(|tool| tool.name.as_str()).collect::<Vec<_>>();
+    assert_eq!(
+        names,
+        [
+            "proxy__call_tool",
+            "direct__add_numbers",
+            "direct__divide_numbers",
+            "direct__slow_tool",
+            "selective__add_numbers"
+        ]
+    );
+    assert_eq!(
+        snapshot.server_statuses.iter().map(|status| (status.name.as_str(), status.proxied)).collect::<Vec<_>>(),
+        [("direct", false), ("hidden", true), ("selective", true)]
+    );
+}
+
+#[tokio::test]
+async fn selectively_proxied_tools_are_partitioned_between_direct_and_proxy_routes() {
+    let test = selective_math_proxy().await;
+    let names: Vec<&str> = test.snapshot().tool_definitions.iter().map(|tool| tool.name.as_str()).collect();
+    assert_eq!(names, ["proxy__call_tool", "math__add_numbers"]);
+
+    let direct_tool = test
+        .snapshot()
+        .tool_definitions
+        .iter()
+        .find(|tool| tool.name == "math__add_numbers")
+        .expect("selected tool is exposed directly");
+    assert!(direct_tool.description.contains("Adds two numbers"));
+    assert_eq!(direct_tool.server.as_deref(), Some("math"));
+    assert_eq!(direct_tool.parameters, serde_json::json!({"type": "object", "properties": {}}));
+
+    let direct = test.call("math", "add_numbers", serde_json::json!({"a": 3, "b": 4})).await;
+    assert!(direct.result.unwrap().result.contains('7'));
+
+    let direct_proxied = test.call("math", "divide_numbers", serde_json::json!({"a": 8, "b": 2})).await;
+    let direct_error = direct_proxied.result.expect_err("proxy-only tool has no direct route");
+    assert!(direct_error.error.contains("Tool not found: math__divide_numbers"));
+
+    assert!(
+        call_proxy_tool(&test, "math", "divide_numbers", serde_json::json!({"a": 8, "b": 2}))
+            .await
+            .unwrap()
+            .contains('4')
+    );
+    let direct_route_error = call_proxy_tool(&test, "math", "add_numbers", serde_json::json!({"a": 3, "b": 4}))
+        .await
+        .expect_err("direct tool is rejected by the proxy route");
+    assert!(direct_route_error.contains("call 'math__add_numbers' instead"));
+    assert!(call_proxy_tool(&test, "math", "unknown", serde_json::json!({})).await.is_err());
+}
+
+#[tokio::test]
+async fn proxy_discovery_write_failure_does_not_disconnect_server() {
+    let home = tempfile::tempdir().unwrap();
+    let proxy_dir = home.path().join("tool-proxy/proxy");
+    std::fs::create_dir_all(home.path().join("tool-proxy")).unwrap();
+    let (event_tx, _event_rx) = mpsc::channel::<McpClientEvent>(50);
+    let mut manager = McpManager::new(event_tx, None).with_aether_home(home.path());
+    let server = fake_mcp("math", FakeMcpServer::new()).with_exposure(ToolExposure::proxied_all());
+
+    let mut pending = manager.register_pending(vec![server]).await.unwrap();
+    if proxy_dir.exists() {
+        std::fs::remove_dir_all(&proxy_dir).unwrap();
+    }
+    std::fs::write(&proxy_dir, "not a directory").unwrap();
+
+    let attempt = manager.connect_pending_task(pending.pop().unwrap()).await;
+    manager.apply_connection_attempt(attempt).await;
+
+    let status = manager.server_statuses().into_iter().find(|status| status.name == "math").unwrap();
+    assert!(matches!(status.status, mcp_utils::status::McpServerStatus::Connected { .. }));
+    assert_eq!(manager.tool_definitions()[0].name, "proxy__call_tool");
+}
+
+#[tokio::test]
+async fn selectively_proxied_tools_are_omitted_from_proxy_discovery_files() {
+    let test = selective_math_proxy().await;
+    let tool_dir = extract_tool_dir(proxy_instructions(test.snapshot())).expect("tool directory is listed");
+    let math_dir = std::path::Path::new(&tool_dir).join("math");
+
+    assert!(!math_dir.join("add_numbers.json").exists());
+    assert!(math_dir.join("divide_numbers.json").exists());
+    assert!(math_dir.join("slow_tool.json").exists());
 }

--- a/crates/mcp-utils/src/client/config.rs
+++ b/crates/mcp-utils/src/client/config.rs
@@ -7,7 +7,7 @@ use std::collections::{BTreeMap, HashMap};
 use std::fmt::{Debug, Formatter};
 use std::num::NonZeroU16;
 use std::path::Path;
-use utils::is_false;
+use utils::matches_name_pattern;
 use utils::variables::{VarError, Vars};
 
 #[derive(Debug, Clone, Default, Deserialize, Serialize, JsonSchema)]
@@ -43,9 +43,9 @@ pub struct StdioServerConfig {
     #[serde(default)]
     pub env: HashMap<String, String>,
 
-    /// Expose this server's tools through Aether's tool proxy.
-    #[serde(default, skip_serializing_if = "is_false")]
-    pub proxy: bool,
+    /// Controls which tools are exposed through Aether's shared tool proxy.
+    #[serde(default, skip_serializing_if = "ToolExposure::is_direct")]
+    pub proxy: ToolExposure,
 }
 
 #[derive(Debug, Clone, Deserialize, Serialize, JsonSchema, PartialEq)]
@@ -73,9 +73,9 @@ pub struct RemoteServerConfig {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub oauth: Option<McpOAuthConfig>,
 
-    /// Expose this server's tools through Aether's tool proxy.
-    #[serde(default, skip_serializing_if = "is_false")]
-    pub proxy: bool,
+    /// Controls which tools are exposed through Aether's shared tool proxy.
+    #[serde(default, skip_serializing_if = "ToolExposure::is_direct")]
+    pub proxy: ToolExposure,
 }
 
 #[derive(Debug, Clone, Deserialize, Serialize, JsonSchema, PartialEq)]
@@ -93,9 +93,9 @@ pub struct InMemoryServerConfig {
     #[serde(default)]
     pub input: Option<Value>,
 
-    /// Expose this server's tools through Aether's tool proxy.
-    #[serde(default, skip_serializing_if = "is_false")]
-    pub proxy: bool,
+    /// Controls which tools are exposed through Aether's shared tool proxy.
+    #[serde(default, skip_serializing_if = "ToolExposure::is_direct")]
+    pub proxy: ToolExposure,
 }
 
 #[derive(Debug, Clone, Copy, Default, Deserialize, Serialize, JsonSchema, PartialEq)]
@@ -119,10 +119,32 @@ pub enum InMemoryType {
     InMemory,
 }
 
+/// Which of a server's tools are routed through Aether's shared tool proxy.
+#[derive(Debug, Clone, Default, PartialEq, Eq, Deserialize, Serialize, JsonSchema)]
+#[serde(from = "ToolExposureConfig", into = "ToolExposureConfig")]
+#[schemars(with = "ToolExposureConfig")]
+pub enum ToolExposure {
+    #[default]
+    Direct,
+    Proxied(ToolProxyRules),
+}
+
+#[derive(Debug, Clone, Default, Deserialize, Serialize, JsonSchema, PartialEq, Eq)]
+#[serde(deny_unknown_fields)]
+pub struct ToolProxyRules {
+    /// Tool names to proxy. An empty list includes every tool.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub include: Vec<String>,
+
+    /// Tool names to avoid proxying and directly expose. Exclude rules take precedence over include rules.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub exclude: Vec<String>,
+}
+
 pub struct McpServer {
     pub name: String,
     pub transport: McpTransport,
-    pub proxy: bool,
+    pub tool_exposure: ToolExposure,
 }
 
 pub enum McpTransport {
@@ -153,9 +175,90 @@ impl From<StreamableHttpClientTransportConfig> for McpHttpConfig {
     }
 }
 
+impl ToolExposure {
+    pub fn proxied_all() -> Self {
+        Self::Proxied(ToolProxyRules::default())
+    }
+
+    pub fn is_direct(&self) -> bool {
+        matches!(self, Self::Direct)
+    }
+
+    pub fn is_proxied(&self) -> bool {
+        matches!(self, Self::Proxied(_))
+    }
+
+    pub fn is_direct_tool(&self, tool_name: &str) -> bool {
+        match self {
+            Self::Direct => true,
+            Self::Proxied(rules) => !rules.matches(tool_name),
+        }
+    }
+
+    /// Route every tool through the proxy, preserving any existing rules.
+    pub fn mark_proxied(&mut self) {
+        if self.is_direct() {
+            *self = Self::proxied_all();
+        }
+    }
+}
+
+impl ToolProxyRules {
+    pub fn new(include: &[&str], exclude: &[&str]) -> Self {
+        Self {
+            include: include.iter().map(ToString::to_string).collect(),
+            exclude: exclude.iter().map(ToString::to_string).collect(),
+        }
+    }
+
+    fn matches(&self, tool_name: &str) -> bool {
+        let included =
+            self.include.is_empty() || self.include.iter().any(|pattern| matches_name_pattern(pattern, tool_name));
+        let excluded = self.exclude.iter().any(|pattern| matches_name_pattern(pattern, tool_name));
+        included && !excluded
+    }
+}
+
+/// The `proxy` config field's wire shape: a boolean or an include/exclude object.
+#[derive(Deserialize, Serialize, JsonSchema)]
+#[serde(untagged)]
+enum ToolExposureConfig {
+    Enabled(bool),
+    Rules(ToolProxyRules),
+}
+
+impl From<ToolExposureConfig> for ToolExposure {
+    fn from(repr: ToolExposureConfig) -> Self {
+        match repr {
+            ToolExposureConfig::Enabled(false) => Self::Direct,
+            ToolExposureConfig::Enabled(true) => Self::proxied_all(),
+            ToolExposureConfig::Rules(rules) => Self::Proxied(rules),
+        }
+    }
+}
+
+impl From<ToolExposure> for ToolExposureConfig {
+    fn from(exposure: ToolExposure) -> Self {
+        match exposure {
+            ToolExposure::Direct => Self::Enabled(false),
+            ToolExposure::Proxied(rules) if rules == ToolProxyRules::default() => Self::Enabled(true),
+            ToolExposure::Proxied(rules) => Self::Rules(rules),
+        }
+    }
+}
+
 impl McpServer {
-    pub fn new(name: impl Into<String>, transport: McpTransport, proxy: bool) -> Self {
-        Self { name: name.into(), transport, proxy }
+    pub fn new(name: impl Into<String>, transport: McpTransport, tool_exposure: ToolExposure) -> Self {
+        Self { name: name.into(), transport, tool_exposure }
+    }
+
+    pub fn with_exposure(mut self, exposure: ToolExposure) -> Self {
+        self.tool_exposure = exposure;
+        self
+    }
+
+    pub fn is_proxied(&self) -> bool {
+        self.tool_exposure.is_proxied()
     }
 
     /// Clone this server config. Fails for [`McpTransport::InMemory`], whose
@@ -169,7 +272,7 @@ impl McpServer {
             McpTransport::Http(config) => McpTransport::Http(config.clone()),
             McpTransport::InMemory { .. } => return Err(McpServerCloneError(self.name.clone())),
         };
-        Ok(Self { name: self.name.clone(), transport, proxy: self.proxy })
+        Ok(Self { name: self.name.clone(), transport, tool_exposure: self.tool_exposure.clone() })
     }
 }
 
@@ -182,7 +285,7 @@ impl Debug for McpServer {
         f.debug_struct("McpServer")
             .field("name", &self.name)
             .field("transport", &self.transport)
-            .field("proxy", &self.proxy)
+            .field("tool_exposure", &self.tool_exposure)
             .finish()
     }
 }
@@ -266,26 +369,27 @@ impl McpConfig {
 
     pub fn mark_all_proxy(&mut self) {
         for server in self.servers.values_mut() {
-            server.set_proxy(true);
+            server.mark_proxied();
         }
     }
 }
 
 impl McpServerConfig {
-    pub fn proxy(&self) -> bool {
+    pub fn proxy(&self) -> &ToolExposure {
         match self {
-            McpServerConfig::Stdio(config) => config.proxy,
-            McpServerConfig::Remote(config) => config.proxy,
-            McpServerConfig::InMemory(config) => config.proxy,
+            McpServerConfig::Stdio(config) => &config.proxy,
+            McpServerConfig::Remote(config) => &config.proxy,
+            McpServerConfig::InMemory(config) => &config.proxy,
         }
     }
 
-    pub fn set_proxy(&mut self, value: bool) {
-        match self {
-            McpServerConfig::Stdio(config) => config.proxy = value,
-            McpServerConfig::Remote(config) => config.proxy = value,
-            McpServerConfig::InMemory(config) => config.proxy = value,
-        }
+    pub fn mark_proxied(&mut self) {
+        let proxy = match self {
+            McpServerConfig::Stdio(config) => &mut config.proxy,
+            McpServerConfig::Remote(config) => &mut config.proxy,
+            McpServerConfig::InMemory(config) => &mut config.proxy,
+        };
+        proxy.mark_proxied();
     }
 
     pub async fn into_server(
@@ -295,9 +399,12 @@ impl McpServerConfig {
         vars: &Vars,
         force_proxy: bool,
     ) -> Result<McpServer, ParseError> {
-        let proxy = force_proxy || self.proxy();
+        let mut exposure = self.proxy().clone();
+        if force_proxy {
+            exposure.mark_proxied();
+        }
         let transport = self.into_transport(name.clone(), factories, vars).await?;
-        Ok(McpServer::new(name, transport, proxy))
+        Ok(McpServer { name, transport, tool_exposure: exposure })
     }
 
     async fn into_transport(
@@ -382,7 +489,7 @@ mod tests {
             McpServerConfig::Stdio(StdioServerConfig { command, args, proxy, .. }) => {
                 assert_eq!(command, "npx");
                 assert_eq!(args, &["-y", "chrome-devtools-mcp"]);
-                assert!(!proxy);
+                assert!(proxy.is_direct());
             }
             other => panic!("expected Stdio server, got {other:?}"),
         }
@@ -393,7 +500,7 @@ mod tests {
         let config =
             McpConfig::from_json(r#"{"servers": {"playwright": {"type": "stdio", "command": "npx", "proxy": true}}}"#)
                 .unwrap();
-        assert!(config.servers.get("playwright").unwrap().proxy());
+        assert!(config.servers.get("playwright").unwrap().proxy().is_proxied());
     }
 
     #[test]
@@ -457,12 +564,24 @@ mod tests {
     }
 
     #[test]
-    fn from_json_files_last_file_wins_on_collision_including_proxy() {
+    fn from_json_rejects_unknown_exposure_fields_for_all_transports() {
+        for server in [
+            r#"{"command":"x","direct_tool":["bash"]}"#,
+            r#"{"type":"http","url":"https://example.com","direct_tool":["bash"]}"#,
+            r#"{"type":"in-memory","direct_tool":["bash"]}"#,
+        ] {
+            let json = format!(r#"{{"servers":{{"bad":{server}}}}}"#);
+            assert!(McpConfig::from_json(&json).is_err(), "unknown field was accepted: {server}");
+        }
+    }
+
+    #[test]
+    fn from_json_files_last_file_wins_on_collision_including_exposure() {
         let dir = tempdir().unwrap();
         let a = write_config(
             dir.path(),
             "a.json",
-            r#"{"servers":{"coding":{"type":"stdio","command":"from_a","proxy":true}}}"#,
+            r#"{"servers":{"coding":{"type":"stdio","command":"from_a","proxy":{"exclude":["bash"]}}}}"#,
         );
         let b = write_config(dir.path(), "b.json", r#"{"servers":{"coding":{"type":"stdio","command":"from_b"}}}"#);
 
@@ -470,7 +589,7 @@ mod tests {
         match merged_ab.servers.get("coding").unwrap() {
             McpServerConfig::Stdio(StdioServerConfig { command, proxy, .. }) => {
                 assert_eq!(command, "from_b");
-                assert!(!proxy);
+                assert_eq!(proxy, &ToolExposure::Direct);
             }
             other => panic!("expected Stdio, got {other:?}"),
         }
@@ -479,7 +598,7 @@ mod tests {
         match merged_ba.servers.get("coding").unwrap() {
             McpServerConfig::Stdio(StdioServerConfig { command, proxy, .. }) => {
                 assert_eq!(command, "from_a");
-                assert!(*proxy);
+                assert_eq!(proxy, &ToolExposure::Proxied(ToolProxyRules::new(&[], &["bash"])));
             }
             other => panic!("expected Stdio, got {other:?}"),
         }
@@ -492,7 +611,7 @@ mod tests {
         )
         .unwrap();
         config.mark_all_proxy();
-        assert!(config.servers.values().all(McpServerConfig::proxy));
+        assert!(config.servers.values().all(|server| server.proxy().is_proxied()));
     }
 
     #[test]
@@ -523,8 +642,8 @@ mod tests {
         let servers = config.into_servers(&HashMap::new(), &Vars::new()).await.unwrap();
 
         assert_eq!(servers.len(), 2);
-        assert!(!servers.iter().find(|s| s.name == "github").unwrap().proxy);
-        assert!(servers.iter().find(|s| s.name == "playwright").unwrap().proxy);
+        assert!(!servers.iter().find(|s| s.name == "github").unwrap().is_proxied());
+        assert!(servers.iter().find(|s| s.name == "playwright").unwrap().is_proxied());
     }
 
     #[tokio::test]
@@ -532,7 +651,69 @@ mod tests {
         let config =
             McpConfig::from_json(r#"{"servers":{"github":{"type":"stdio","command":"g","proxy":false}}}"#).unwrap();
         let servers = config.into_servers_with_proxy(&HashMap::new(), &Vars::new(), true).await.unwrap();
-        assert!(servers[0].proxy);
+        assert!(servers[0].is_proxied());
+    }
+
+    #[test]
+    fn proxy_accepts_boolean_or_include_exclude_rules_for_all_transport_shapes() {
+        let config = McpConfig::from_json(
+            r#"{"servers":{"all":{"command":"a","proxy":true},"stdio":{"command":"x","proxy":{"include":["lsp_*"],"exclude":["lsp_rename"]}},"http":{"type":"http","url":"https://example.com","proxy":{"exclude":["bash"]}},"memory":{"type":"in-memory","proxy":{"include":["read"]}}}}"#,
+        )
+        .unwrap();
+
+        assert_eq!(config.servers["all"].proxy(), &ToolExposure::proxied_all());
+        assert_eq!(
+            config.servers["stdio"].proxy(),
+            &ToolExposure::Proxied(ToolProxyRules::new(&["lsp_*"], &["lsp_rename"]))
+        );
+        assert_eq!(config.servers["http"].proxy(), &ToolExposure::Proxied(ToolProxyRules::new(&[], &["bash"])));
+        assert_eq!(config.servers["memory"].proxy(), &ToolExposure::Proxied(ToolProxyRules::new(&["read"], &[])));
+    }
+
+    #[test]
+    fn proxy_rules_serialize_inside_proxy_and_defaults_are_omitted() {
+        let config = McpConfig::from_json(
+            r#"{"servers":{"coding":{"command":"x","proxy":{"exclude":["bash","lsp_*"]}},"direct":{"command":"y"},"full":{"command":"z","proxy":true}}}"#,
+        )
+        .unwrap();
+        let value = serde_json::to_value(config).unwrap();
+
+        assert_eq!(value["servers"]["coding"]["proxy"], serde_json::json!({"exclude":["bash", "lsp_*"]}));
+        assert!(value["servers"]["direct"].get("proxy").is_none());
+        assert_eq!(value["servers"]["full"]["proxy"], serde_json::json!(true));
+    }
+
+    #[test]
+    fn legacy_direct_tools_is_rejected() {
+        let result =
+            McpConfig::from_json(r#"{"servers":{"coding":{"command":"x","proxy":true,"direct_tools":["bash"]}}}"#);
+        assert!(result.is_err());
+    }
+
+    #[tokio::test]
+    async fn proxy_rules_partition_tools_with_exclude_winning() {
+        let config = McpConfig::from_json(
+            r#"{"servers":{"coding":{"command":"server","proxy":{"include":["lsp_*","bash"],"exclude":["lsp_rename"]}}}}"#,
+        )
+        .unwrap();
+        let servers = config.into_servers(&HashMap::new(), &Vars::new()).await.unwrap();
+        let exposure = &servers[0].tool_exposure;
+
+        assert!(!exposure.is_direct_tool("lsp_hover"));
+        assert!(exposure.is_direct_tool("lsp_rename"));
+        assert!(!exposure.is_direct_tool("bash"));
+        assert!(exposure.is_direct_tool("read_file"));
+    }
+
+    #[tokio::test]
+    async fn forced_proxy_preserves_per_server_proxy_rules() {
+        let config =
+            McpConfig::from_json(r#"{"servers":{"coding":{"command":"server","proxy":{"exclude":["bash"]}}}}"#)
+                .unwrap();
+        let servers = config.into_servers_with_proxy(&HashMap::new(), &Vars::new(), true).await.unwrap();
+        assert!(servers[0].is_proxied());
+        assert!(servers[0].tool_exposure.is_direct_tool("bash"));
+        assert!(!servers[0].tool_exposure.is_direct_tool("read_file"));
     }
 
     #[tokio::test]

--- a/crates/mcp-utils/src/client/connection.rs
+++ b/crates/mcp-utils/src/client/connection.rs
@@ -74,7 +74,6 @@ pub(super) struct ConnectConfig {
 /// The result of attempting to connect (or authenticate) to an MCP server.
 pub struct McpConnectAttempt {
     pub name: String,
-    pub proxied: bool,
     pub outcome: McpConnectOutcome,
 }
 
@@ -85,8 +84,8 @@ pub enum McpConnectOutcome {
 }
 
 impl McpConnectAttempt {
-    pub fn failed(name: impl Into<String>, error: McpError, proxied: bool) -> Self {
-        Self { name: name.into(), proxied, outcome: McpConnectOutcome::Failed { error } }
+    pub fn failed(name: impl Into<String>, error: McpError) -> Self {
+        Self { name: name.into(), outcome: McpConnectOutcome::Failed { error } }
     }
 }
 
@@ -126,7 +125,7 @@ impl McpServerConnection {
 }
 
 pub(super) async fn connect_server(server: McpServer, ctx: &ConnectConfig) -> McpConnectAttempt {
-    let McpServer { name, transport, proxy: proxied } = server;
+    let McpServer { name, transport, tool_exposure: _ } = server;
     let reauth_config = reauth_config_for(&transport, ctx.oauth_handler_factory.as_ref());
     let mcp_client = McpClient::new(ctx.client_info.clone(), name.clone(), ctx.event_sender.clone());
 
@@ -147,15 +146,10 @@ pub(super) async fn connect_server(server: McpServer, ctx: &ConnectConfig) -> Mc
         }
     };
 
-    McpConnectAttempt { name, proxied, outcome: outcome.with_reauth(reauth_config) }
+    McpConnectAttempt { name, outcome: outcome.with_reauth(reauth_config) }
 }
 
-pub async fn authenticate_http(
-    name: String,
-    config: McpHttpConfig,
-    ctx: Arc<ConnectConfig>,
-    proxied: bool,
-) -> McpConnectAttempt {
+pub async fn authenticate_http(name: String, config: McpHttpConfig, ctx: Arc<ConnectConfig>) -> McpConnectAttempt {
     let outcome = match async {
         let factory = ctx
             .oauth_handler_factory
@@ -186,7 +180,7 @@ pub async fn authenticate_http(
         Err(error) => McpConnectOutcome::Failed { error },
     };
 
-    McpConnectAttempt { name, proxied, outcome }
+    McpConnectAttempt { name, outcome }
 }
 
 impl McpConnectOutcome {

--- a/crates/mcp-utils/src/client/error.rs
+++ b/crates/mcp-utils/src/client/error.rs
@@ -5,6 +5,15 @@ pub enum McpError {
     /// Tool not found in the registry
     #[error("Tool not found: {0}")]
     ToolNotFound(String),
+    /// The tool is exposed directly and cannot be called through the proxy.
+    #[error("Tool '{tool_name}' is exposed directly; call '{direct_name}' instead")]
+    DirectToolRequiresDirectRoute { tool_name: String, direct_name: String },
+    /// The server's tools are not routed through the proxy
+    #[error("Server '{0}' is not part of the tool proxy")]
+    ServerNotProxied(String),
+    /// The proxied server has no active connection
+    #[error("Proxied server '{0}' is not connected")]
+    ProxiedServerNotConnected(String),
     /// Invalid tool name format (should be `server__tool`)
     #[error("Invalid tool name format: {0}")]
     InvalidToolNameFormat(String),

--- a/crates/mcp-utils/src/client/manager.rs
+++ b/crates/mcp-utils/src/client/manager.rs
@@ -2,27 +2,24 @@ use llm::ToolDefinition;
 
 use super::{
     McpError, Result,
-    config::{McpHttpConfig, McpServer},
+    config::{McpHttpConfig, McpServer, ToolExposure},
     connection::{
         ConnectConfig, McpConnectAttempt, McpConnectOutcome, McpServerConnection, Tool, authenticate_http,
         connect_server,
     },
     mcp_client::{McpClient, client_capabilities},
     naming::{create_namespaced_tool_name, split_on_server_name},
-    tool_proxy::ToolProxy,
+    tool_proxy::{self, PROXY_CALL_TOOL_NAME, PROXY_SERVER_NAME},
 };
 use aether_auth::{OAuthCredentialStorage, OAuthHandler};
 use futures::future::join_all;
 use rmcp::{
     RoleClient,
-    model::{
-        CallToolRequestParams, ClientInfo, ElicitRequestParams, ElicitResult, ElicitationAction, Implementation,
-        Tool as RmcpTool,
-    },
+    model::{CallToolRequestParams, ClientInfo, ElicitRequestParams, ElicitResult, ElicitationAction, Implementation},
     service::RunningService,
 };
 use serde_json::Value;
-use std::collections::{BTreeMap, HashMap, HashSet};
+use std::collections::{BTreeMap, HashMap};
 use std::future::Future;
 use std::num::NonZeroU16;
 use std::path::PathBuf;
@@ -31,8 +28,6 @@ use tokio::sync::{mpsc, oneshot};
 use tokio::task::JoinHandle;
 
 pub use crate::status::{McpServerAuthCapability, McpServerStatus, McpServerStatusEntry};
-
-pub const DEFAULT_PROXY_NAME: &str = "proxy";
 
 pub type OAuthHandlerFactory = Arc<dyn Fn(OAuthHandlerContext) -> Result<Arc<dyn OAuthHandler>> + Send + Sync>;
 
@@ -82,7 +77,6 @@ pub struct McpConnectionDetails {
 pub struct McpManager {
     servers: HashMap<String, ServerRecord>,
     server_order: Vec<String>,
-    proxy: Option<ToolProxy>,
     aether_home: Option<PathBuf>,
     client_info: ClientInfo,
     event_sender: mpsc::Sender<McpClientEvent>,
@@ -96,7 +90,6 @@ impl McpManager {
         Self {
             servers: HashMap::new(),
             server_order: Vec::new(),
-            proxy: None,
             aether_home: None,
             client_info: ClientInfo::new(client_capabilities(), Implementation::new("aether", "0.1.0")),
             event_sender,
@@ -122,31 +115,23 @@ impl McpManager {
     }
 
     pub async fn register_pending(&mut self, servers: Vec<McpServer>) -> Result<Vec<McpServer>> {
-        let has_proxy = servers.iter().any(|server| server.proxy);
-        if has_proxy && servers.iter().any(|server| server.name == DEFAULT_PROXY_NAME) {
+        let adds_proxied = servers.iter().any(|server| server.tool_exposure.is_proxied());
+        let proxy_name_taken = self.servers.contains_key(PROXY_SERVER_NAME)
+            || servers.iter().any(|server| server.name == PROXY_SERVER_NAME);
+        if (adds_proxied || self.proxy_enabled()) && proxy_name_taken {
             return Err(McpError::Other("server name 'proxy' collides with the tool proxy".into()));
         }
 
+        if adds_proxied && !self.proxy_enabled() {
+            tool_proxy::clean_dir(&self.proxy_tool_dir()?).await?;
+        }
+
         for server in &servers {
-            self.register_record(&server.name, ServerState::Connecting, None, server.proxy);
+            self.register_record(&server.name, ServerState::Connecting, None, server.tool_exposure.clone());
         }
 
         self.emit_server_statuses_changed().await;
         Ok(servers)
-    }
-
-    pub async fn bootstrap_proxy_setup(&mut self, servers: &[McpServer]) -> Result<()> {
-        let proxied_members: HashSet<String> =
-            servers.iter().filter(|server| server.proxy).map(|server| server.name.clone()).collect();
-
-        if proxied_members.is_empty() {
-            return Ok(());
-        }
-
-        let dir = self.proxy_tool_dir()?;
-        ToolProxy::clean_dir(&dir).await?;
-        self.register_proxy(dir, proxied_members);
-        Ok(())
     }
 
     pub fn connect_pending_task(&self, server: McpServer) -> impl Future<Output = McpConnectAttempt> + Send + 'static {
@@ -155,7 +140,6 @@ impl McpManager {
     }
 
     pub async fn add_mcps(&mut self, servers: Vec<McpServer>) -> Result<()> {
-        self.bootstrap_proxy_setup(&servers).await?;
         let pending = self.register_pending(servers).await?;
         let ctx = self.connect_config();
         let attempts = join_all(pending.into_iter().map(|server| connect_server(server, &ctx))).await;
@@ -177,13 +161,8 @@ impl McpManager {
         let (server_name, tool_name) = split_on_server_name(namespaced_tool_name)
             .ok_or_else(|| McpError::InvalidToolNameFormat(namespaced_tool_name.to_string()))?;
 
-        if let Some(proxy) = self.proxy.as_ref().filter(|proxy| proxy.name() == server_name) {
-            let call = proxy.resolve_call(arguments_json)?;
-            let conn = self.connection_for(&call.server).ok_or_else(|| {
-                McpError::ServerNotFound(format!("Proxied server '{}' is not connected", call.server))
-            })?;
-            let params = CallToolRequestParams::new(call.tool).with_arguments(call.arguments.unwrap_or_default());
-            return Ok((conn.client.clone(), params));
+        if server_name == PROXY_SERVER_NAME && self.proxy_enabled() {
+            return self.resolve_proxy_call(arguments_json);
         }
 
         let client =
@@ -200,15 +179,12 @@ impl McpManager {
 
     pub fn tool_definitions(&self) -> Vec<ToolDefinition> {
         let mut definitions = Vec::new();
-        if let Some(proxy) = self.proxy.as_ref() {
-            definitions.push(ToolProxy::call_tool_definition(proxy.name()));
+        if self.proxy_enabled() {
+            definitions.push(tool_proxy::call_tool_definition());
         }
         for name in &self.server_order {
             let Some(record) = self.servers.get(name) else { continue };
-            if record.proxied {
-                continue;
-            }
-            definitions.extend(record.tools().iter().map(|tool| {
+            definitions.extend(record.tools().iter().filter(|tool| record.is_direct_tool(&tool.name)).map(|tool| {
                 ToolDefinition::new(
                     create_namespaced_tool_name(name, &tool.name),
                     tool.description.clone(),
@@ -225,7 +201,7 @@ impl McpManager {
         let mut instructions: BTreeMap<String, String> = self
             .servers
             .iter()
-            .filter(|(name, _)| self.proxy.as_ref().is_none_or(|proxy| !proxy.contains_server(name)))
+            .filter(|(_, record)| record.has_direct_tools())
             .filter_map(|(name, record)| {
                 record
                     .connection()
@@ -265,32 +241,33 @@ impl McpManager {
 
         let name = name.to_string();
         let config = record.reauth_config.clone().expect("checked above");
-        let proxied = record.proxied;
         let ctx = self.connect_config();
 
         self.set_state(&name, ServerState::Authenticating);
         self.emit_server_statuses_changed().await;
 
-        Ok(async move { authenticate_http(name, config, ctx, proxied).await })
+        Ok(async move { authenticate_http(name, config, ctx).await })
     }
 
     pub async fn apply_connection_attempt(&mut self, attempt: McpConnectAttempt) {
-        let McpConnectAttempt { name, proxied, outcome } = attempt;
+        let McpConnectAttempt { name, outcome } = attempt;
         match outcome {
             McpConnectOutcome::Connected { conn, reauth_config } => {
-                match self.register_connection(&name, conn, reauth_config, proxied).await {
-                    Ok(tools) => {
-                        self.refresh_proxy_after_auth(&name, &tools, proxied).await;
+                match self.register_connection(&name, conn, reauth_config).await {
+                    Ok(()) => {
                         self.emit_server_statuses_changed().await;
                         self.emit_tool_definitions_changed().await;
-                        self.emit_instructions_after_connect(&name, proxied).await;
+                        self.emit_instructions_after_connect(&name).await;
                     }
                     Err(error) => self.apply_authentication_failure(name, error.to_string()).await,
                 }
             }
             McpConnectOutcome::NeedsOAuth { config, error } => {
                 tracing::warn!("Server '{name}' needs OAuth: {error}");
-                self.register_record(&name, ServerState::NeedsOAuth, Some(config), proxied);
+                if let Some(record) = self.servers.get_mut(&name) {
+                    record.state = ServerState::NeedsOAuth;
+                    record.reauth_config = Some(config);
+                }
                 self.emit_server_statuses_changed().await;
             }
             McpConnectOutcome::Failed { error } => {
@@ -373,7 +350,6 @@ impl McpManager {
         }
 
         self.server_order.clear();
-        self.proxy = None;
     }
 
     /// Shutdown a specific server by name
@@ -397,16 +373,10 @@ impl McpManager {
         self.emit_event(McpClientEvent::ToolDefinitionsChanged(self.tool_definitions())).await;
     }
 
-    async fn emit_instructions_after_connect(&self, server_name: &str, proxied: bool) {
-        if proxied {
-            if let Some((server, body)) = self.proxy_instructions() {
-                self.emit_event(McpClientEvent::ServerInstructionsUpdated { server, instructions: Some(body) }).await;
-            }
-            return;
-        }
-
-        if let Some(instructions) =
-            self.connection_for(server_name).and_then(|conn| conn.instructions.as_ref()).cloned()
+    async fn emit_instructions_after_connect(&self, server_name: &str) {
+        let Some(record) = self.servers.get(server_name) else { return };
+        if record.has_direct_tools()
+            && let Some(instructions) = record.connection().and_then(|conn| conn.instructions.as_ref()).cloned()
         {
             self.emit_event(McpClientEvent::ServerInstructionsUpdated {
                 server: server_name.to_string(),
@@ -414,19 +384,32 @@ impl McpManager {
             })
             .await;
         }
+
+        if record.exposure.is_proxied()
+            && let Some((server, body)) = self.proxy_instructions()
+        {
+            self.emit_event(McpClientEvent::ServerInstructionsUpdated { server, instructions: Some(body) }).await;
+        }
     }
 
     fn proxy_instructions(&self) -> Option<(String, String)> {
-        let proxy = self.proxy.as_ref()?;
-        let descriptions: Vec<(String, String)> = proxy
-            .members()
+        if !self.proxy_enabled() {
+            return None;
+        }
+        let tool_dir = self.proxy_tool_dir().ok()?;
+        let descriptions = self
+            .server_order
             .iter()
-            .filter_map(|member| {
-                let conn = self.connection_for(member)?;
-                Some((member.clone(), ToolProxy::extract_server_description(&conn.client, member)))
+            .filter_map(|name| {
+                let record = self.servers.get(name)?;
+                if !record.exposure.is_proxied() {
+                    return None;
+                }
+                let conn = record.connection()?;
+                Some((name.clone(), tool_proxy::extract_server_description(&conn.client, name)))
             })
-            .collect();
-        Some((proxy.name().to_string(), ToolProxy::build_instructions(proxy.tool_dir(), &descriptions)))
+            .collect::<Vec<_>>();
+        Some((PROXY_SERVER_NAME.to_string(), tool_proxy::build_instructions(&tool_dir, &descriptions)))
     }
 
     pub async fn emit_connection_ready(&self) {
@@ -458,11 +441,33 @@ impl McpManager {
         })
     }
 
+    fn proxy_enabled(&self) -> bool {
+        self.servers.values().any(|record| record.exposure.is_proxied())
+    }
+
     fn proxy_tool_dir(&self) -> Result<PathBuf> {
-        self.aether_home
-            .as_ref()
-            .map(|home| ToolProxy::dir_in_home(home, DEFAULT_PROXY_NAME))
-            .map_or_else(|| ToolProxy::dir(DEFAULT_PROXY_NAME), Ok)
+        self.aether_home.as_ref().map(|home| tool_proxy::dir_in_home(home)).map_or_else(tool_proxy::dir, Ok)
+    }
+
+    fn resolve_proxy_call(
+        &self,
+        arguments_json: &str,
+    ) -> Result<(Arc<RunningService<RoleClient, McpClient>>, CallToolRequestParams)> {
+        let call = tool_proxy::resolve_call(arguments_json)?;
+        let record = self.servers.get(&call.server).ok_or_else(|| McpError::ServerNotFound(call.server.clone()))?;
+        if !record.exposure.is_proxied() {
+            return Err(McpError::ServerNotProxied(call.server));
+        }
+        if record.is_direct_tool(&call.tool) {
+            let direct_name = create_namespaced_tool_name(&call.server, &call.tool);
+            if record.has_tool(&call.tool) {
+                return Err(McpError::DirectToolRequiresDirectRoute { tool_name: call.tool, direct_name });
+            }
+            return Err(McpError::ToolNotFound(direct_name));
+        }
+        let conn = record.connection().ok_or_else(|| McpError::ProxiedServerNotConnected(call.server.clone()))?;
+        let params = CallToolRequestParams::new(call.tool).with_arguments(call.arguments.unwrap_or_default());
+        Ok((conn.client.clone(), params))
     }
 
     async fn register_connection(
@@ -470,50 +475,28 @@ impl McpManager {
         name: &str,
         conn: McpServerConnection,
         reauth_config: Option<McpHttpConfig>,
-        proxied: bool,
-    ) -> Result<Vec<RmcpTool>> {
+    ) -> Result<()> {
         let tools = conn
             .list_tools()
             .await
             .map_err(|e| McpError::ToolDiscoveryFailed(format!("Failed to list tools for {name}: {e}")))?;
-        self.apply_connected(name, conn, &tools, reauth_config, proxied);
-        Ok(tools)
-    }
+        let record = self.servers.get(name).ok_or_else(|| McpError::ServerNotFound(name.to_string()))?;
+        let exposure = record.exposure.clone();
 
-    fn apply_connected(
-        &mut self,
-        name: &str,
-        conn: McpServerConnection,
-        tools: &[RmcpTool],
-        reauth_config: Option<McpHttpConfig>,
-        proxied: bool,
-    ) {
-        let existing_reauth = self.servers.get(name).and_then(|r| r.reauth_config.clone());
-        let final_reauth = reauth_config.or(existing_reauth);
-        let tools = tools.iter().map(Tool::from).collect();
-
-        self.remember_server_order(name);
-        self.servers.insert(name.to_string(), ServerRecord::connected(conn, tools, final_reauth, proxied));
-    }
-
-    fn register_proxy(&mut self, tool_dir: std::path::PathBuf, members: HashSet<String>) {
-        self.proxy = Some(ToolProxy::new(DEFAULT_PROXY_NAME.to_string(), members, tool_dir));
-    }
-
-    async fn refresh_proxy_after_auth(&mut self, name: &str, tools: &[RmcpTool], proxied: bool) {
-        if !proxied {
-            return;
+        if exposure.is_proxied() {
+            let write_result = match self.proxy_tool_dir() {
+                Ok(tool_dir) => tool_proxy::write_tool_entries_to_dir(name, &tools, &exposure, &tool_dir).await,
+                Err(error) => Err(error),
+            };
+            if let Err(error) = write_result {
+                tracing::warn!(server = %name, %error, "Failed to write proxy tool discovery files");
+            }
         }
 
-        if let Some(proxy) = self.proxy.as_mut() {
-            proxy.add_member(name.to_string());
-        }
-
-        if let Some(tool_dir) = self.proxy.as_ref().map(|proxy| proxy.tool_dir().to_path_buf())
-            && let Err(e) = ToolProxy::write_tool_entries_to_dir(name, tools, &tool_dir).await
-        {
-            tracing::warn!("Failed to write tool files for '{name}' after OAuth: {e}");
-        }
+        let record = self.servers.get_mut(name).expect("record checked above");
+        record.reauth_config = reauth_config.or_else(|| record.reauth_config.clone());
+        record.state = ServerState::Connected { connection: conn, tools: tools.iter().map(Tool::from).collect() };
+        Ok(())
     }
 
     fn remember_server_order(&mut self, name: &str) {
@@ -533,14 +516,20 @@ impl McpManager {
         match self.servers.get_mut(name) {
             Some(record) => record.state = state,
             None => {
-                self.servers.insert(name.to_string(), ServerRecord::new(state, None, false));
+                self.servers.insert(name.to_string(), ServerRecord::new(state, None, ToolExposure::Direct));
             }
         }
     }
 
-    fn register_record(&mut self, name: &str, state: ServerState, reauth_config: Option<McpHttpConfig>, proxied: bool) {
+    fn register_record(
+        &mut self,
+        name: &str,
+        state: ServerState,
+        reauth_config: Option<McpHttpConfig>,
+        exposure: ToolExposure,
+    ) {
         self.remember_server_order(name);
-        self.servers.insert(name.to_string(), ServerRecord::new(state, reauth_config, proxied));
+        self.servers.insert(name.to_string(), ServerRecord::new(state, reauth_config, exposure));
     }
 
     fn connection_for(&self, server_name: &str) -> Option<&McpServerConnection> {
@@ -552,13 +541,14 @@ impl McpManager {
     }
 
     fn is_routable_tool(&self, namespaced_tool_name: &str) -> bool {
-        if self.proxy.as_ref().is_some_and(|proxy| proxy.call_tool_name() == namespaced_tool_name) {
+        if namespaced_tool_name == PROXY_CALL_TOOL_NAME && self.proxy_enabled() {
             return true;
         }
         match split_on_server_name(namespaced_tool_name) {
-            Some((server_name, tool_name)) => {
-                self.servers.get(server_name).is_some_and(|record| !record.proxied && record.has_tool(tool_name))
-            }
+            Some((server_name, tool_name)) => self
+                .servers
+                .get(server_name)
+                .is_some_and(|record| record.is_direct_tool(tool_name) && record.has_tool(tool_name)),
             None => false,
         }
     }
@@ -582,7 +572,7 @@ impl Drop for McpManager {
 struct ServerRecord {
     state: ServerState,
     reauth_config: Option<McpHttpConfig>,
-    proxied: bool,
+    exposure: ToolExposure,
 }
 
 enum ServerState {
@@ -606,17 +596,8 @@ impl From<&ServerState> for McpServerStatus {
 }
 
 impl ServerRecord {
-    fn new(state: ServerState, reauth_config: Option<McpHttpConfig>, proxied: bool) -> Self {
-        Self { state, reauth_config, proxied }
-    }
-
-    fn connected(
-        connection: McpServerConnection,
-        tools: Vec<Tool>,
-        reauth_config: Option<McpHttpConfig>,
-        proxied: bool,
-    ) -> Self {
-        Self::new(ServerState::Connected { connection, tools }, reauth_config, proxied)
+    fn new(state: ServerState, reauth_config: Option<McpHttpConfig>, exposure: ToolExposure) -> Self {
+        Self { state, reauth_config, exposure }
     }
 
     fn tools(&self) -> &[Tool] {
@@ -627,6 +608,14 @@ impl ServerRecord {
             | ServerState::Failed { .. }
             | ServerState::NeedsOAuth => &[],
         }
+    }
+
+    fn has_direct_tools(&self) -> bool {
+        self.tools().iter().any(|tool| self.is_direct_tool(&tool.name))
+    }
+
+    fn is_direct_tool(&self, tool_name: &str) -> bool {
+        self.exposure.is_direct_tool(tool_name)
     }
 
     fn has_tool(&self, tool_name: &str) -> bool {
@@ -668,7 +657,7 @@ impl ServerRecord {
     fn status_entry(&self, name: &str) -> McpServerStatusEntry {
         McpServerStatusEntry::new(name, self.status())
             .with_auth_capability(self.auth_capability())
-            .with_proxied(self.proxied)
+            .with_proxied(self.exposure.is_proxied())
     }
 }
 
@@ -687,9 +676,9 @@ async fn await_server_shutdown(server_name: &str, handle: JoinHandle<()>) {
 
 #[cfg(test)]
 mod tests {
-    use super::{DEFAULT_PROXY_NAME, McpClientEvent, McpManager, McpServerStatus, ServerState};
+    use super::{McpClientEvent, McpManager, McpServerStatus, PROXY_SERVER_NAME, ServerState};
     use crate::client::OAuthHandlerFactory;
-    use crate::client::config::{McpHttpConfig, McpServer, McpTransport};
+    use crate::client::config::{McpHttpConfig, McpServer, McpTransport, ToolExposure};
     use crate::client::connection::{McpConnectAttempt, McpConnectOutcome};
     use crate::status::McpServerAuthCapability;
     use aether_auth::{OAuthCallback, OAuthError, OAuthHandler};
@@ -791,7 +780,7 @@ mod tests {
     async fn authenticate_server_task_rejects_record_without_reauth_config() {
         let (event_sender, _event_receiver) = mpsc::channel(1);
         let mut manager = McpManager::new(event_sender, Some(test_oauth_handler_factory()));
-        manager.register_record("public", ServerState::Connecting, None, false);
+        manager.register_record("public", ServerState::Connecting, None, ToolExposure::Direct);
 
         let error = match manager.authenticate_server_task("public").await {
             Ok(_) => panic!("non-OAuth server should be rejected"),
@@ -808,7 +797,7 @@ mod tests {
             "remote",
             ServerState::NeedsOAuth,
             Some(http_config("http://localhost:19999/mcp")),
-            false,
+            ToolExposure::Direct,
         );
 
         let _task = manager.authenticate_server_task("remote").await.expect("auth should start");
@@ -831,7 +820,7 @@ mod tests {
             "remote",
             ServerState::NeedsOAuth,
             Some(http_config("http://localhost:19999/mcp")),
-            false,
+            ToolExposure::Direct,
         );
         let _task = manager.authenticate_server_task("remote").await.expect("auth should start");
         let _authenticating_event = event_receiver.recv().await.expect("authenticating status change event");
@@ -839,7 +828,6 @@ mod tests {
         manager
             .apply_connection_attempt(McpConnectAttempt {
                 name: "remote".to_string(),
-                proxied: false,
                 outcome: McpConnectOutcome::Failed {
                     error: crate::client::McpError::ConnectionFailed("boom".to_string()),
                 },
@@ -872,14 +860,14 @@ mod tests {
             "with-oauth",
             ServerState::Connecting,
             Some(http_config("http://localhost/mcp")),
-            false,
+            ToolExposure::Direct,
         );
-        manager.register_record("without-oauth", ServerState::Connecting, None, false);
+        manager.register_record("without-oauth", ServerState::Connecting, None, ToolExposure::Direct);
         manager.register_record(
             "needs-oauth",
             ServerState::NeedsOAuth,
             Some(http_config("http://localhost/mcp2")),
-            false,
+            ToolExposure::Direct,
         );
 
         let statuses = manager.server_statuses();
@@ -898,8 +886,16 @@ mod tests {
         let mut manager = McpManager::new(event_sender, None);
 
         let servers = vec![
-            McpServer::new("alpha", McpTransport::InMemory { server: TestServer::default().into_dyn() }, false),
-            McpServer::new("beta", McpTransport::InMemory { server: TestServer::default().into_dyn() }, true),
+            McpServer::new(
+                "alpha",
+                McpTransport::InMemory { server: TestServer::default().into_dyn() },
+                ToolExposure::Direct,
+            ),
+            McpServer::new(
+                "beta",
+                McpTransport::InMemory { server: TestServer::default().into_dyn() },
+                ToolExposure::proxied_all(),
+            ),
         ];
 
         let returned = manager.register_pending(servers).await.unwrap();
@@ -923,8 +919,11 @@ mod tests {
         let (event_sender, mut event_receiver) = mpsc::channel(32);
         let mut manager = McpManager::new(event_sender, None);
 
-        let servers =
-            vec![McpServer::new("test", McpTransport::InMemory { server: TestServer::default().into_dyn() }, false)];
+        let servers = vec![McpServer::new(
+            "test",
+            McpTransport::InMemory { server: TestServer::default().into_dyn() },
+            ToolExposure::Direct,
+        )];
         manager.add_mcps(servers).await.unwrap();
 
         let mut update_for_test = None;
@@ -945,8 +944,16 @@ mod tests {
         let mut manager = McpManager::new(event_sender, None);
         manager
             .add_mcps(vec![
-                McpServer::new("direct", McpTransport::InMemory { server: TestServer::default().into_dyn() }, false),
-                McpServer::new("math", McpTransport::InMemory { server: TestServer::default().into_dyn() }, true),
+                McpServer::new(
+                    "direct",
+                    McpTransport::InMemory { server: TestServer::default().into_dyn() },
+                    ToolExposure::Direct,
+                ),
+                McpServer::new(
+                    "math",
+                    McpTransport::InMemory { server: TestServer::default().into_dyn() },
+                    ToolExposure::proxied_all(),
+                ),
             ])
             .await
             .unwrap();
@@ -955,7 +962,7 @@ mod tests {
         assert_eq!(statuses.iter().map(|status| status.name.as_str()).collect::<Vec<_>>(), vec!["direct", "math"]);
         assert!(!statuses.iter().find(|status| status.name == "direct").unwrap().proxied);
         assert!(statuses.iter().find(|status| status.name == "math").unwrap().proxied);
-        assert!(!statuses.iter().any(|status| status.name == DEFAULT_PROXY_NAME));
+        assert!(!statuses.iter().any(|status| status.name == PROXY_SERVER_NAME));
     }
 
     #[tokio::test]
@@ -964,8 +971,16 @@ mod tests {
         let mut manager = McpManager::new(event_sender, None);
         manager
             .add_mcps(vec![
-                McpServer::new("git", McpTransport::InMemory { server: TestServer::default().into_dyn() }, false),
-                McpServer::new("github", McpTransport::InMemory { server: TestServer::default().into_dyn() }, false),
+                McpServer::new(
+                    "git",
+                    McpTransport::InMemory { server: TestServer::default().into_dyn() },
+                    ToolExposure::Direct,
+                ),
+                McpServer::new(
+                    "github",
+                    McpTransport::InMemory { server: TestServer::default().into_dyn() },
+                    ToolExposure::Direct,
+                ),
             ])
             .await
             .unwrap();
@@ -989,7 +1004,7 @@ mod tests {
             .add_mcps(vec![McpServer::new(
                 "test",
                 McpTransport::InMemory { server: TestServer::default().into_dyn() },
-                false,
+                ToolExposure::Direct,
             )])
             .await
             .unwrap();
@@ -1009,7 +1024,7 @@ mod tests {
             .add_mcps(vec![McpServer::new(
                 "test",
                 McpTransport::InMemory { server: TestServer::default().into_dyn() },
-                false,
+                ToolExposure::Direct,
             )])
             .await
             .unwrap();

--- a/crates/mcp-utils/src/client/mod.rs
+++ b/crates/mcp-utils/src/client/mod.rs
@@ -17,7 +17,7 @@ pub use call_tool::{CallToolError, CallToolOptions, ToolCallEvent, call_tool};
 pub use config::{
     InMemoryServerConfig, InMemoryType, McpConfig, McpHttpConfig, McpOAuthConfig, McpServer, McpServerCloneError,
     McpServerConfig, McpTransport, ParseError, RemoteServerConfig, RemoteType, ServerFactory, StdioServerConfig,
-    StdioType,
+    StdioType, ToolExposure, ToolProxyRules,
 };
 pub use connection::{McpConnectAttempt, McpConnectOutcome, McpServerConnection};
 pub use connection_attempt_manager::McpConnectionAttemptManager;

--- a/crates/mcp-utils/src/client/tool_proxy.rs
+++ b/crates/mcp-utils/src/client/tool_proxy.rs
@@ -1,4 +1,7 @@
+use crate::client::aether_home;
+
 use super::McpError;
+use super::config::ToolExposure;
 use super::connection::convert_tool_annotations;
 use super::mcp_client::McpClient;
 use llm::{ToolAnnotations, ToolDefinition};
@@ -6,12 +9,17 @@ use rmcp::{RoleClient, service::RunningService};
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use serde_json::{Map, Value};
-use std::collections::HashSet;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use tokio::fs::{create_dir_all, remove_dir_all, write};
 
-/// Resolved proxy call returned by [`ToolProxy::resolve_call`].
+/// The reserved server name of Aether's shared MCP tool proxy.
+pub const PROXY_SERVER_NAME: &str = "proxy";
+
+/// The namespaced name of the proxy's `call_tool` virtual tool.
+pub const PROXY_CALL_TOOL_NAME: &str = "proxy__call_tool";
+
+/// Resolved proxy call returned by [`resolve_call`].
 #[derive(Debug)]
 pub struct ResolvedCall {
     pub server: String,
@@ -19,174 +27,116 @@ pub struct ResolvedCall {
     pub arguments: Option<Map<String, Value>>,
 }
 
-/// A tool-proxy that wraps multiple servers behind a single `call_tool`.
-pub struct ToolProxy {
-    name: String,
-    members: HashSet<String>,
-    tool_dir: PathBuf,
+/// Parse a proxy `call_tool` invocation.
+pub fn resolve_call(arguments_json: &str) -> super::Result<ResolvedCall> {
+    let args: ProxyCallArgs = serde_json::from_str(arguments_json)?;
+    Ok(ResolvedCall { server: args.server, tool: args.tool, arguments: args.arguments })
 }
 
-/// Parsed arguments from a proxy `call_tool` invocation.
-#[derive(Deserialize, JsonSchema)]
-struct ProxyCallArgs {
-    /// The server name (directory name in the tool-proxy folder)
-    server: String,
-    /// The tool name (file name without .json)
-    tool: String,
-    /// Arguments to pass to the tool
-    arguments: Option<Map<String, Value>>,
+/// Returns the directory for the tool-proxy's tool definitions.
+///
+/// Uses `$AETHER_HOME/tool-proxy/proxy` or `~/.aether/tool-proxy/proxy`.
+pub fn dir() -> Result<PathBuf, McpError> {
+    let base = aether_home().ok_or_else(|| McpError::Other("Home directory not set".into()))?;
+    Ok(dir_in_home(&base))
 }
 
-impl ToolProxy {
-    pub fn new(name: String, members: HashSet<String>, tool_dir: PathBuf) -> Self {
-        Self { name, members, tool_dir }
+pub fn dir_in_home(home: &Path) -> PathBuf {
+    home.join("tool-proxy").join(PROXY_SERVER_NAME)
+}
+
+/// Clean up the tool directory for the proxy, removing all tool files.
+pub async fn clean_dir(tool_dir: &Path) -> Result<(), McpError> {
+    if tool_dir.exists() {
+        remove_dir_all(tool_dir).await.map_err(|e| McpError::Other(format!("Failed to clean tool-proxy dir: {e}")))?;
+    }
+    Ok(())
+}
+
+/// Build the `call_tool` JSON schema used by the proxy's virtual tool.
+pub fn call_tool_schema() -> Arc<Map<String, Value>> {
+    let schema = schemars::schema_for!(ProxyCallArgs);
+    let value = serde_json::to_value(schema).expect("schema serialization cannot fail");
+    Arc::new(value.as_object().expect("schema is always an object").clone())
+}
+
+/// Build a `ToolDefinition` for the proxy's `call_tool` virtual tool.
+pub fn call_tool_definition() -> ToolDefinition {
+    let schema = call_tool_schema();
+    ToolDefinition::new(
+        PROXY_CALL_TOOL_NAME,
+        "Execute a tool on a nested MCP server when it is not exposed directly. Browse the tool-proxy directory to discover available tools first.",
+        Value::Object((*schema).clone()),
+    )
+    .with_server(PROXY_SERVER_NAME.to_string())
+}
+
+/// Write the exposure's proxied tool entries to `tool_dir/<server_name>/`,
+/// removing any stale files first. Directly exposed tools are omitted.
+pub(super) async fn write_tool_entries_to_dir(
+    server_name: &str,
+    tools: &[rmcp::model::Tool],
+    exposure: &ToolExposure,
+    tool_dir: &Path,
+) -> Result<(), McpError> {
+    let server_dir = tool_dir.join(server_name);
+    if server_dir.exists() {
+        remove_dir_all(&server_dir).await?;
+    }
+    create_dir_all(&server_dir).await?;
+
+    for tool in tools.iter().filter(|tool| !exposure.is_direct_tool(&tool.name)) {
+        let entry = ToolFileEntry {
+            name: tool.name.to_string(),
+            description: tool.description.clone().unwrap_or_default().to_string(),
+            server: server_name.to_string(),
+            parameters: Value::Object((*tool.input_schema).clone()),
+            annotations: tool.annotations.as_ref().map(convert_tool_annotations),
+        };
+
+        let file_path = server_dir.join(format!("{}.json", tool.name));
+        let json = serde_json::to_string_pretty(&entry)?;
+        write(&file_path, json).await?;
     }
 
-    pub fn name(&self) -> &str {
-        &self.name
-    }
+    Ok(())
+}
 
-    pub fn members(&self) -> &HashSet<String> {
-        &self.members
-    }
+/// Extract a one-line description for a nested server from its peer info.
+///
+/// Uses `server_info.description`, falling back to the server name.
+pub fn extract_server_description(client: &RunningService<RoleClient, McpClient>, server_name: &str) -> String {
+    client
+        .peer_info()
+        .and_then(|info| {
+            info.server_info
+                .as_ref()
+                .and_then(|server_info| server_info.description.as_deref())
+                .filter(|description| !description.is_empty())
+                .map(ToString::to_string)
+        })
+        .unwrap_or_else(|| server_name.to_string())
+}
 
-    /// Whether `server_name` is a nested member of this proxy.
-    pub fn contains_server(&self, server_name: &str) -> bool {
-        self.members.contains(server_name)
-    }
+/// Build proxy instructions describing the tool directory and connected servers.
+pub fn build_instructions(tool_dir: &Path, server_descriptions: &[(String, String)]) -> String {
+    use std::fmt::Write;
 
-    /// Parse and validate a proxy `call_tool` invocation.
-    pub fn resolve_call(&self, arguments_json: &str) -> super::Result<ResolvedCall> {
-        let args: ProxyCallArgs = serde_json::from_str(arguments_json)?;
-        if !self.contains_server(&args.server) {
-            return Err(McpError::ServerNotFound(format!(
-                "Server '{}' is not part of proxy '{}'",
-                args.server, self.name
-            )));
+    let mut instructions = format!(
+        "Tools that are not exposed directly are available through connected MCP servers at `{tool_dir}`.\n\
+         Each subdirectory in `{tool_dir}` represents a connected MCP server and contains JSON tool definitions.\n\
+         Browse or grep the directory to discover tools, then use `call_tool` to execute them.",
+        tool_dir = tool_dir.display()
+    );
+
+    if !server_descriptions.is_empty() {
+        instructions.push_str("\n\n## Connected Servers\n");
+        for (name, desc) in server_descriptions {
+            let _ = writeln!(instructions, "- **{name}**: {desc}");
         }
-        Ok(ResolvedCall { server: args.server, tool: args.tool, arguments: args.arguments })
     }
 
-    pub fn tool_dir(&self) -> &Path {
-        &self.tool_dir
-    }
-
-    /// Register a new member server (e.g. after late OAuth registration).
-    pub fn add_member(&mut self, server_name: String) {
-        self.members.insert(server_name);
-    }
-
-    /// Returns the directory for a tool-proxy's tool definitions.
-    ///
-    /// Uses `$AETHER_HOME/tool-proxy/<name>` or `~/.aether/tool-proxy/<name>`.
-    pub fn dir(name: &str) -> Result<PathBuf, McpError> {
-        let base = super::aether_home().ok_or_else(|| McpError::Other("Home directory not set".into()))?;
-        Ok(Self::dir_in_home(&base, name))
-    }
-
-    pub fn dir_in_home(home: &Path, name: &str) -> PathBuf {
-        home.join("tool-proxy").join(name)
-    }
-
-    /// Clean up the tool directory for a proxy, removing all tool files.
-    pub async fn clean_dir(tool_dir: &Path) -> Result<(), McpError> {
-        if tool_dir.exists() {
-            remove_dir_all(tool_dir)
-                .await
-                .map_err(|e| McpError::Other(format!("Failed to clean tool-proxy dir: {e}")))?;
-        }
-        Ok(())
-    }
-
-    /// Build the `call_tool` JSON schema used by the proxy's virtual tool.
-    pub fn call_tool_schema() -> Arc<Map<String, Value>> {
-        let schema = schemars::schema_for!(ProxyCallArgs);
-        let value = serde_json::to_value(schema).expect("schema serialization cannot fail");
-        Arc::new(value.as_object().expect("schema is always an object").clone())
-    }
-
-    /// The namespaced name of this proxy's `call_tool` virtual tool.
-    pub fn call_tool_name(&self) -> String {
-        format!("{}__call_tool", self.name)
-    }
-
-    /// Build a `ToolDefinition` for the proxy's `call_tool` virtual tool.
-    pub fn call_tool_definition(proxy_name: &str) -> ToolDefinition {
-        let schema = Self::call_tool_schema();
-        let namespaced_name = format!("{proxy_name}__call_tool");
-        ToolDefinition::new(
-            namespaced_name,
-            "Execute a tool on a nested MCP server. Browse the tool-proxy directory to discover available tools first.",
-            Value::Object((*schema).clone()),
-        )
-        .with_server(proxy_name.to_string())
-    }
-
-    /// Write tool entries to `tool_dir/<server_name>/`, removing any stale files first.
-    pub(super) async fn write_tool_entries_to_dir(
-        server_name: &str,
-        tools: &[rmcp::model::Tool],
-        tool_dir: &Path,
-    ) -> Result<(), McpError> {
-        let server_dir = tool_dir.join(server_name);
-        if server_dir.exists() {
-            remove_dir_all(&server_dir).await?;
-        }
-        create_dir_all(&server_dir).await?;
-
-        for tool in tools {
-            let entry = ToolFileEntry {
-                name: tool.name.to_string(),
-                description: tool.description.clone().unwrap_or_default().to_string(),
-                server: server_name.to_string(),
-                parameters: Value::Object((*tool.input_schema).clone()),
-                annotations: tool.annotations.as_ref().map(convert_tool_annotations),
-            };
-
-            let file_path = server_dir.join(format!("{}.json", tool.name));
-            let json = serde_json::to_string_pretty(&entry)?;
-            write(&file_path, json).await?;
-        }
-
-        Ok(())
-    }
-
-    /// Extract a one-line description for a nested server from its peer info.
-    ///
-    /// Uses `server_info.description`, falling back to the server name.
-    pub fn extract_server_description(client: &RunningService<RoleClient, McpClient>, server_name: &str) -> String {
-        client
-            .peer_info()
-            .and_then(|info| {
-                info.server_info
-                    .as_ref()
-                    .and_then(|server_info| server_info.description.as_deref())
-                    .filter(|description| !description.is_empty())
-                    .map(ToString::to_string)
-            })
-            .unwrap_or_else(|| server_name.to_string())
-    }
-
-    /// Build proxy instructions describing the tool directory and connected servers.
-    pub fn build_instructions(tool_dir: &Path, server_descriptions: &[(String, String)]) -> String {
-        use std::fmt::Write;
-
-        let mut instructions = format!(
-            "You are connected to a set of MCP servers, whose tools are available at `{tool_dir}`.\n\
-             Each subdirectory in `{tool_dir}` represents a MCP server you're connected. And each subdir contains tool definitions in the form of JSON files.\n\
-             Browse or grep the directory to discover tools, then use `call_tool` to execute them.",
-            tool_dir = tool_dir.display()
-        );
-
-        if !server_descriptions.is_empty() {
-            instructions.push_str("\n\n## Connected Servers\n");
-            for (name, desc) in server_descriptions {
-                let _ = writeln!(instructions, "- **{name}**: {desc}");
-            }
-        }
-
-        instructions
-    }
+    instructions
 }
 
 /// A tool definition written to disk for agent browsing.
@@ -200,9 +150,23 @@ pub struct ToolFileEntry {
     pub annotations: Option<ToolAnnotations>,
 }
 
+/// Parsed arguments from a proxy `call_tool` invocation.
+#[derive(Deserialize, JsonSchema)]
+struct ProxyCallArgs {
+    /// The server name (directory name in the tool-proxy folder)
+    server: String,
+    /// The tool name (file name without .json)
+    tool: String,
+    /// Arguments to pass to the tool
+    arguments: Option<Map<String, Value>>,
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::client::config::ToolProxyRules;
+    use crate::client::naming::create_namespaced_tool_name;
+    use rmcp::model::{Tool, ToolAnnotations};
     use serde_json::json;
 
     #[test]
@@ -232,7 +196,7 @@ mod tests {
 
     #[test]
     fn call_tool_schema_is_valid() {
-        let schema = ToolProxy::call_tool_schema();
+        let schema = call_tool_schema();
         assert_eq!(schema.get("type").unwrap(), "object");
 
         let properties = schema.get("properties").unwrap().as_object().unwrap();
@@ -249,7 +213,7 @@ mod tests {
 
     #[test]
     fn tool_proxy_dir_appends_correct_suffix() {
-        let dir = ToolProxy::dir("proxy").unwrap();
+        let dir = dir().unwrap();
         assert!(
             dir.ends_with("tool-proxy/proxy"),
             "Expected path to end with tool-proxy/proxy, got: {}",
@@ -283,11 +247,12 @@ mod tests {
     }
 
     #[test]
-    fn call_tool_definition_has_correct_name_and_server() {
-        let def = ToolProxy::call_tool_definition("myproxy");
-        assert_eq!(def.name, "myproxy__call_tool");
-        assert_eq!(def.server, Some("myproxy".to_string()));
+    fn call_tool_definition_uses_proxy_name_constants() {
+        let def = call_tool_definition();
+        assert_eq!(def.name, PROXY_CALL_TOOL_NAME);
+        assert_eq!(def.server, Some(PROXY_SERVER_NAME.to_string()));
         assert!(def.description.contains("Execute a tool"));
+        assert_eq!(PROXY_CALL_TOOL_NAME, create_namespaced_tool_name(PROXY_SERVER_NAME, "call_tool"));
     }
 
     #[test]
@@ -295,7 +260,7 @@ mod tests {
         let tool_dir = std::path::Path::new("/tmp/tool-proxy/test");
         let descriptions =
             vec![("math".to_string(), "Math tools".to_string()), ("git".to_string(), "Git tools".to_string())];
-        let instr = ToolProxy::build_instructions(tool_dir, &descriptions);
+        let instr = build_instructions(tool_dir, &descriptions);
         assert!(instr.contains("/tmp/tool-proxy/test"));
         assert!(instr.contains("call_tool"));
         assert!(instr.contains("## Connected Servers"));
@@ -320,24 +285,38 @@ mod tests {
         std::fs::write(server_dir.join("old_tool.json"), serde_json::to_string_pretty(&old_entry).unwrap()).unwrap();
         assert!(server_dir.join("old_tool.json").exists());
 
-        let tools: Vec<rmcp::model::Tool> =
-            vec![rmcp::model::Tool::new("new_tool", "New tool", Arc::new(serde_json::Map::new()))];
-        ToolProxy::write_tool_entries_to_dir("my-server", &tools, &tool_dir).await.unwrap();
+        let tools: Vec<Tool> = vec![Tool::new("new_tool", "New tool", Arc::new(serde_json::Map::new()))];
+        write_tool_entries_to_dir("my-server", &tools, &ToolExposure::proxied_all(), &tool_dir).await.unwrap();
 
         assert!(!server_dir.join("old_tool.json").exists(), "stale file should be removed");
         assert!(server_dir.join("new_tool.json").exists(), "new file should be written");
     }
 
     #[tokio::test]
+    async fn write_tool_entries_to_dir_omits_direct_tools() {
+        let tmp = tempfile::tempdir().unwrap();
+        let tools = [
+            Tool::new("bash", "Shell", Arc::new(serde_json::Map::new())),
+            Tool::new("lsp_hover", "Hover", Arc::new(serde_json::Map::new())),
+            Tool::new("read_file", "Read", Arc::new(serde_json::Map::new())),
+        ];
+        let exposure = ToolExposure::Proxied(ToolProxyRules::new(&[], &["bash", "lsp_*"]));
+        write_tool_entries_to_dir("coding", &tools, &exposure, tmp.path()).await.unwrap();
+
+        let server_dir = tmp.path().join("coding");
+        assert!(!server_dir.join("bash.json").exists());
+        assert!(!server_dir.join("lsp_hover.json").exists());
+        assert!(server_dir.join("read_file.json").exists());
+    }
+
+    #[tokio::test]
     async fn write_tool_entries_to_dir_preserves_annotations() {
         let tmp = tempfile::tempdir().unwrap();
         let tool_dir = tmp.path().to_path_buf();
-        let tools = vec![
-            rmcp::model::Tool::new("read", "Read", Arc::new(serde_json::Map::new()))
-                .with_annotations(rmcp::model::ToolAnnotations::new().read_only(true).open_world(false)),
-        ];
+        let tools = [Tool::new("read", "Read", Arc::new(serde_json::Map::new()))
+            .with_annotations(ToolAnnotations::new().read_only(true).open_world(false))];
 
-        ToolProxy::write_tool_entries_to_dir("my-server", &tools, &tool_dir).await.unwrap();
+        write_tool_entries_to_dir("my-server", &tools, &ToolExposure::proxied_all(), &tool_dir).await.unwrap();
 
         let contents = std::fs::read_to_string(tool_dir.join("my-server/read.json")).unwrap();
         let parsed: ToolFileEntry = serde_json::from_str(&contents).unwrap();
@@ -346,50 +325,13 @@ mod tests {
         assert_eq!(annotations.open_world_hint, Some(false));
     }
 
-    fn make_proxy(members: &[&str]) -> ToolProxy {
-        let members: HashSet<String> = members.iter().map(std::string::ToString::to_string).collect();
-        ToolProxy::new("myproxy".to_string(), members, PathBuf::from("/tmp/tool-proxy/myproxy"))
-    }
-
-    #[test]
-    fn tool_proxy_contains_server() {
-        let proxy = make_proxy(&["math", "git"]);
-        assert!(proxy.contains_server("math"));
-        assert!(proxy.contains_server("git"));
-        assert!(!proxy.contains_server("unknown"));
-    }
-
     #[test]
     fn tool_proxy_resolve_call_success() {
-        let proxy = make_proxy(&["math"]);
         let json = r#"{"server":"math","tool":"add","arguments":{"a":1,"b":2}}"#;
-        let call = proxy.resolve_call(json).unwrap();
+        let call = resolve_call(json).unwrap();
         assert_eq!(call.server, "math");
         assert_eq!(call.tool, "add");
         assert!(call.arguments.is_some());
         assert_eq!(call.arguments.unwrap().get("a").unwrap(), 1);
-    }
-
-    #[test]
-    fn tool_proxy_resolve_call_unknown_server() {
-        let proxy = make_proxy(&["math"]);
-        let json = r#"{"server":"unknown","tool":"add","arguments":{}}"#;
-        let err = proxy.resolve_call(json).unwrap_err();
-        assert!(err.to_string().contains("not part of proxy"));
-    }
-
-    #[test]
-    fn tool_proxy_accessors() {
-        let proxy = make_proxy(&["math"]);
-        assert_eq!(proxy.name(), "myproxy");
-        assert_eq!(proxy.tool_dir(), Path::new("/tmp/tool-proxy/myproxy"));
-    }
-
-    #[test]
-    fn tool_proxy_add_member() {
-        let mut proxy = make_proxy(&["math"]);
-        assert!(!proxy.contains_server("git"));
-        proxy.add_member("git".to_string());
-        assert!(proxy.contains_server("git"));
     }
 }

--- a/crates/mcp-utils/src/docs/mcp_server_config.md
+++ b/crates/mcp-utils/src/docs/mcp_server_config.md
@@ -39,3 +39,26 @@ A remote server using a bearer token:
   "headers": { "Authorization": "Bearer ..." }
 }
 ```
+
+Set `"proxy": true` to expose every tool on this server through Aether's
+shared `proxy__call_tool`. For selective proxying, set `proxy` to an object with
+`include` and `exclude` lists. Entries match either an exact MCP-local tool name
+or a prefix ending in a trailing `*`:
+
+```json
+{
+  "type": "in-memory",
+  "proxy": {
+    "include": ["*"],
+    "exclude": ["bash", "lsp_*"]
+  }
+}
+```
+
+An omitted `include` list includes every tool. `exclude` is applied afterward
+and wins when both lists match. Included tools are omitted from direct tool
+definitions and written to proxy discovery files. Excluded or non-included tools
+remain available through their normal `server__tool` names and cannot be called
+through `proxy__call_tool`. Patterns use names local to the MCP server, without
+the `server__` prefix. A selectively proxied server's instructions remain
+available for its directly exposed tools.

--- a/crates/mcp-utils/src/testing.rs
+++ b/crates/mcp-utils/src/testing.rs
@@ -10,7 +10,6 @@ pub use elicitation_script::{CapturedElicitation, ElicitationScript};
 #[cfg(all(feature = "client", any(test, feature = "testing")))]
 pub use fake_mcp::{
     CapturedTaskUpdate, CapturedToolCall, FakeMcpServer, FakeMcpState, FakeTool, FakeToolResponse, fake_mcp,
-    fake_mcp_with_proxy,
 };
 
 #[cfg(all(feature = "client", any(test, feature = "testing")))]

--- a/crates/mcp-utils/src/testing/fake_mcp.rs
+++ b/crates/mcp-utils/src/testing/fake_mcp.rs
@@ -1,4 +1,4 @@
-use crate::client::{McpServer, McpTransport};
+use crate::client::{McpServer, McpTransport, ToolExposure};
 use rmcp::{
     ErrorData as McpError, RoleServer, ServerHandler,
     model::{
@@ -15,11 +15,7 @@ use std::sync::{Arc, Mutex};
 use std::time::Duration;
 
 pub fn fake_mcp(name: &str, server: FakeMcpServer) -> McpServer {
-    fake_mcp_with_proxy(name, server, false)
-}
-
-pub fn fake_mcp_with_proxy(name: &str, server: FakeMcpServer, proxy: bool) -> McpServer {
-    McpServer::new(name, McpTransport::InMemory { server: server.into_dyn() }, proxy)
+    McpServer::new(name, McpTransport::InMemory { server: server.into_dyn() }, ToolExposure::Direct)
 }
 
 /// A fake MCP server preloaded with the classic math tools (`add_numbers`,
@@ -146,7 +142,7 @@ impl FakeMcpState {
         self.lock().task_cancel_ids.push(request.task_id);
     }
 
-    fn add_tool(&self, tool: FakeTool) {
+    pub fn add_tool(&self, tool: FakeTool) {
         self.lock().tools.insert(tool.definition.name.to_string(), tool);
     }
 

--- a/crates/utils/src/lib.rs
+++ b/crates/utils/src/lib.rs
@@ -1,6 +1,7 @@
 #![doc = include_str!("../README.md")]
 
 pub mod markdown_file;
+pub mod name_pattern;
 pub mod plan_review;
 pub mod reasoning;
 pub mod resource_path;
@@ -11,6 +12,7 @@ pub mod substitution;
 pub mod variables;
 
 pub use markdown_file::MarkdownFile;
+pub use name_pattern::matches_name_pattern;
 pub use reasoning::ReasoningEffort;
 pub use resource_path::{PathOrObject, ResourcePath, string_or_object_schema};
 pub use serde_helpers::is_false;

--- a/crates/utils/src/name_pattern.rs
+++ b/crates/utils/src/name_pattern.rs
@@ -1,0 +1,18 @@
+/// Matches an exact name or a prefix pattern ending in `*`.
+pub fn matches_name_pattern(pattern: &str, name: &str) -> bool {
+    pattern.strip_suffix('*').map_or_else(|| pattern == name, |prefix| name.starts_with(prefix))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::matches_name_pattern;
+
+    #[test]
+    fn matches_exact_names_and_trailing_prefix_wildcards() {
+        assert!(matches_name_pattern("bash", "bash"));
+        assert!(!matches_name_pattern("bash", "bash_extra"));
+        assert!(matches_name_pattern("lsp_*", "lsp_hover"));
+        assert!(matches_name_pattern("*", "anything"));
+        assert!(!matches_name_pattern("lsp_*_tool", "lsp_hover_tool"));
+    }
+}

--- a/packages/website/src/content/docs/aether/settings/mcp-servers.mdx
+++ b/packages/website/src/content/docs/aether/settings/mcp-servers.mdx
@@ -70,7 +70,7 @@ If a server entry has a `command` and no `type`, it is treated as `"type": "stdi
     | `type` | `"in-memory"` | Required. |
     | `args` | `string[]` | Arguments passed to the registered in-memory server factory. |
     | `input` | any JSON or `null` | Optional factory input for in-memory servers that accept one. |
-    | `proxy` | `boolean` | Whether to hide this server behind the MCP tool proxy. |
+    | `proxy` | `boolean \| object` | `true` proxies every tool; an object partitions tools with `include` and `exclude` patterns. |
 
   </TabItem>
   <TabItem label="Stdio">
@@ -100,7 +100,7 @@ If a server entry has a `command` and no `type`, it is treated as `"type": "stdi
     | `command` | `string` | Executable to run. |
     | `args` | `string[]` | Command arguments. |
     | `env` | `object` | Environment variables for the subprocess. |
-    | `proxy` | `boolean` | Whether to expose this server through `proxy__call_tool`. |
+    | `proxy` | `boolean \| object` | `true` proxies every tool; an object partitions tools with `include` and `exclude` patterns. |
 
   </TabItem>
   <TabItem label="HTTP">
@@ -126,7 +126,7 @@ If a server entry has a `command` and no `type`, it is treated as `"type": "stdi
     | `url` | `string` | Streamable HTTP endpoint URL. |
     | `headers` | `object` | Optional headers. Aether currently forwards the `Authorization` header to the transport. |
     | `oauth` | `object` | Optional pre-registered public OAuth client. See [Pre-registered OAuth clients](#pre-registered-oauth-clients). |
-    | `proxy` | `boolean` | Whether to expose this server through `proxy__call_tool`. |
+    | `proxy` | `boolean \| object` | `true` proxies every tool; an object partitions tools with `include` and `exclude` patterns. |
 
   </TabItem>
   <TabItem label="SSE">
@@ -152,7 +152,7 @@ If a server entry has a `command` and no `type`, it is treated as `"type": "stdi
     | `url` | `string` | SSE endpoint URL. |
     | `headers` | `object` | Optional headers. Aether currently forwards the `Authorization` header to the transport. |
     | `oauth` | `object` | Optional pre-registered public OAuth client. See [Pre-registered OAuth clients](#pre-registered-oauth-clients). |
-    | `proxy` | `boolean` | Whether to expose this server through `proxy__call_tool`. |
+    | `proxy` | `boolean \| object` | `true` proxies every tool; an object partitions tools with `include` and `exclude` patterns. |
 
   </TabItem>
 </Tabs>
@@ -301,11 +301,11 @@ In this user-level example, `mcp.json` resolves to `$HOME/.aether/mcp.json` by d
 
 ## Merging and proxy behavior
 
-Multiple MCP sources are loaded in order after settings resolution. Server names are unique keys; when two sources define the same server, the later source wins, including its `proxy` flag.
+Multiple MCP sources are loaded in order after settings resolution. Server names are unique keys; when two sources define the same server, the later source wins, including its `proxy` configuration.
 
 A server can be proxied in two ways:
 
-1. Set `"proxy": true` on the server entry in an MCP config file.
+1. Set `"proxy": true` on a server entry to proxy every tool, or use a `proxy` object with `include` and `exclude` rules.
 2. Reference a file source with `{ "type": "file", "path": "...", "proxy": true }`, which marks every server loaded from that file as proxied.
 
 `proxy` and `optional` can be combined: `{ "type": "file", "path": "${WORKSPACE}/.aether/external-mcp.json", "proxy": true, "optional": true }`.
@@ -317,7 +317,10 @@ A server can be proxied in two ways:
       "type": "stdio",
       "command": "npx",
       "args": ["-y", "chrome-devtools-mcp@latest"],
-      "proxy": true
+      "proxy": {
+        "include": ["performance_*", "take_screenshot"],
+        "exclude": ["performance_stop_trace"]
+      }
     },
     "linear": {
       "type": "http",
@@ -329,6 +332,12 @@ A server can be proxied in two ways:
 ```
 
 When any server is proxied, Aether exposes one virtual tool named `proxy__call_tool`, writes nested tool definitions under `$HOME/.aether/tool-proxy/proxy` by default, or `$AETHER_HOME/tool-proxy/proxy` when `AETHER_HOME` is set, and adds instructions telling the agent how to browse those files. The server name `proxy` is reserved when proxied servers are present.
+
+A server's `proxy` value can be `false`, `true`, or a rule object. `false` (and omission) exposes every tool directly. `true` proxies every tool. An object enables the proxy and partitions MCP-local tool names using `include` and `exclude` arrays. An omitted or empty `include` starts with every tool; `exclude` then removes matching tools and wins on overlap. Patterns match exact names such as `bash` or prefixes with one trailing `*`, such as `lsp_*`.
+
+Tools selected for proxying are written to proxy discovery files and called through `proxy__call_tool`. All other tools remain available by their direct `server__tool` names and cannot be called through the proxy. A file source with `proxy: true` forces servers loaded from that file into the proxy while preserving any per-server include/exclude rules. Instructions from selectively proxied servers remain available alongside the shared proxy instructions so directly exposed tools retain their server guidance.
+
+Agent-level `tools.allow` and `tools.deny` filters apply after this partition and can remove direct definitions. They do not move nested proxy tools into the direct tool list.
 
 ## Variable expansion
 


### PR DESCRIPTION
Prior to these changes users could enable dynamic tool discovery by configuring Aether to proxy _all_ tools an MCP exposed. 

This PR extends that to support proxying a subset of tools within an MCP server. A strong use case for this is you might want to give your agent access to all the tools our 1st party `coding` server offers (e.g. grep, ast-grep etc). But, to save tokens you might want the agent to start with only the `Bash` tool loaded. 

Now users can do that easily in their `settings.json` by setting `proxy: { "exclude": ["Bash"] }` as an example. 