### PR TITLE
refactor(aether-auth): Store credentials as opaque JSON values, so we can store MCP creds as serialized rmcp::StoredCredentials

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7491,7 +7491,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]

--- a/crates/aether-auth/src/credential.rs
+++ b/crates/aether-auth/src/credential.rs
@@ -3,13 +3,14 @@ use oauth2::basic::BasicClient;
 use oauth2::reqwest::redirect::Policy;
 use oauth2::{ClientId, RefreshToken, TokenResponse, TokenUrl};
 use serde::{Deserialize, Serialize};
+use serde_json::Value;
 use std::time::Duration;
 
 use crate::OAuthError;
 
 const TOKEN_EXPIRY_GRACE_PERIOD: Duration = Duration::from_mins(1);
 
-/// Credential for an OAuth provider.
+/// Credential for a non-MCP OAuth provider.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct OAuthCredential {
     pub client_id: String,
@@ -17,9 +18,6 @@ pub struct OAuthCredential {
     pub refresh_token: Option<String>,
     /// Unix timestamp in milliseconds when the token expires.
     pub expires_at: Option<u64>,
-    /// Scopes the authorization server granted with this token.
-    #[serde(default)]
-    pub granted_scopes: Vec<String>,
 }
 
 impl OAuthCredential {
@@ -30,10 +28,6 @@ impl OAuthCredential {
             access_token: token_response.access_token().secret().clone(),
             refresh_token: token_response.refresh_token().map(|token| token.secret().clone()),
             expires_at: expires_at_from_duration(token_response.expires_in()),
-            granted_scopes: token_response
-                .scopes()
-                .map(|scopes| scopes.iter().map(|scope| scope.to_string()).collect())
-                .unwrap_or_default(),
         }
     }
 
@@ -79,19 +73,33 @@ impl OAuthCredential {
     }
 }
 
-/// Trait for loading and saving OAuth credentials, keyed by provider ID or credential key.
+/// Storage for namespaced, opaque OAuth JSON values.
 ///
 /// Implementations include [`OsKeyringStore`](crate::OsKeyringStore) (OS keychain, feature `keyring`)
 /// and the in-memory [`FakeOAuthCredentialStore`](crate::FakeOAuthCredentialStore) for tests.
 #[async_trait]
 pub trait OAuthCredentialStorage: Send + Sync {
-    async fn load_credential(&self, key: &str) -> Result<Option<OAuthCredential>, OAuthError>;
+    async fn load(&self, key: &str) -> Result<Option<Value>, OAuthError>;
 
-    async fn save_credential(&self, key: &str, credential: OAuthCredential) -> Result<(), OAuthError>;
+    async fn save(&self, key: &str, value: Value) -> Result<(), OAuthError>;
 
-    async fn delete_credential(&self, key: &str) -> Result<(), OAuthError>;
+    async fn delete(&self, key: &str) -> Result<(), OAuthError>;
 
-    fn has_credential(&self, key: &str) -> bool;
+    fn contains(&self, key: &str) -> bool;
+
+    async fn load_credential(&self, key: &str) -> Result<Option<OAuthCredential>, OAuthError> {
+        self.load(key)
+            .await?
+            .map(serde_json::from_value)
+            .transpose()
+            .map_err(|error| OAuthError::CredentialStore(format!("invalid credential: {error}")))
+    }
+
+    async fn save_credential(&self, key: &str, credential: OAuthCredential) -> Result<(), OAuthError> {
+        let value = serde_json::to_value(credential)
+            .map_err(|error| OAuthError::CredentialStore(format!("failed to serialize credential: {error}")))?;
+        self.save(key, value).await
+    }
 }
 
 fn expires_at_from_duration(duration: Option<Duration>) -> Option<u64> {
@@ -163,7 +171,6 @@ mod tests {
             access_token: "access".to_string(),
             refresh_token: None,
             expires_at,
-            granted_scopes: Vec::new(),
         }
     }
 }

--- a/crates/aether-auth/src/encrypted_file.rs
+++ b/crates/aether-auth/src/encrypted_file.rs
@@ -1,4 +1,4 @@
-use crate::credential::{OAuthCredential, OAuthCredentialStorage};
+use crate::credential::OAuthCredentialStorage;
 use crate::error::OAuthError;
 use age::scrypt::{Identity, Recipient as ScryptRecipient};
 use age::secrecy::SecretString;
@@ -6,6 +6,7 @@ use age::{Decryptor, Encryptor};
 use async_trait::async_trait;
 use dirs::home_dir;
 use serde::{Deserialize, Serialize};
+use serde_json::Value;
 use std::collections::HashMap;
 use std::env::var;
 use std::io::{Read, Write};
@@ -15,9 +16,9 @@ use std::sync::Mutex;
 
 const DEFAULT_PASSWORD_ENV: &str = "AETHER_CREDENTIALS_PASSWORD";
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
 struct CredentialStore {
-    credentials: HashMap<String, OAuthCredential>,
+    credentials: HashMap<String, Value>,
 }
 
 pub struct EncryptedFileOAuthCredentialStorage {
@@ -86,14 +87,14 @@ impl EncryptedFileOAuthCredentialStorage {
         Ok(plaintext)
     }
 
-    fn load(&self) -> Result<CredentialStore, OAuthError> {
+    fn load_store(&self) -> Result<CredentialStore, OAuthError> {
         if !self.path.exists() {
-            return Ok(CredentialStore { credentials: HashMap::new() });
+            return Ok(CredentialStore::default());
         }
 
         let bytes = std::fs::read(&self.path)?;
         if bytes.is_empty() {
-            return Ok(CredentialStore { credentials: HashMap::new() });
+            return Ok(CredentialStore::default());
         }
 
         let plaintext = Self::decrypt(&bytes, &self.passphrase)?;
@@ -107,7 +108,7 @@ impl EncryptedFileOAuthCredentialStorage {
             .lock()
             .map_err(|_| OAuthError::CredentialStore("Failed to acquire write lock on credential store".to_string()))?;
 
-        let mut store = self.load()?;
+        let mut store = self.load_store()?;
         mutate(&mut store);
 
         let plaintext = serde_json::to_vec(&store)
@@ -146,31 +147,33 @@ fn write_atomic(path: &Path, data: &[u8]) -> Result<(), OAuthError> {
 
 #[async_trait]
 impl OAuthCredentialStorage for EncryptedFileOAuthCredentialStorage {
-    async fn load_credential(&self, key: &str) -> Result<Option<OAuthCredential>, OAuthError> {
-        let store = self.load()?;
-        Ok(store.credentials.get(key).cloned())
+    async fn load(&self, key: &str) -> Result<Option<serde_json::Value>, OAuthError> {
+        Ok(self.load_store()?.credentials.get(key).cloned())
     }
 
-    async fn save_credential(&self, key: &str, credential: OAuthCredential) -> Result<(), OAuthError> {
+    async fn save(&self, key: &str, value: serde_json::Value) -> Result<(), OAuthError> {
         self.update(|store| {
-            store.credentials.insert(key.to_string(), credential);
+            store.credentials.insert(key.to_string(), value);
         })
     }
 
-    async fn delete_credential(&self, key: &str) -> Result<(), OAuthError> {
+    async fn delete(&self, key: &str) -> Result<(), OAuthError> {
         self.update(|store| {
             store.credentials.remove(key);
         })
     }
 
-    fn has_credential(&self, key: &str) -> bool {
-        self.load().is_ok_and(|store| store.credentials.contains_key(key))
+    fn contains(&self, key: &str) -> bool {
+        self.load_store().is_ok_and(|store| store.credentials.contains_key(key))
     }
 }
 
 #[cfg(test)]
 mod tests {
+    use std::fs::write;
+
     use super::*;
+    use crate::OAuthCredential;
 
     /// `N = 2^10`, fast enough that the KDF stops dominating the suite.
     const TEST_WORK_FACTOR: u8 = 10;
@@ -186,7 +189,6 @@ mod tests {
         assert_eq!(loaded.client_id, "client_1");
         assert_eq!(loaded.access_token, "tok_abc");
         assert_eq!(loaded.refresh_token.as_deref(), Some("ref_xyz"));
-        assert_eq!(loaded.granted_scopes, vec!["scope1"]);
     }
 
     #[tokio::test]
@@ -199,10 +201,10 @@ mod tests {
     async fn delete_removes_credential() {
         let store = temp_store("pass");
         store.save_credential("server-1", test_credential()).await.unwrap();
-        assert!(store.has_credential("server-1"));
+        assert!(store.contains("server-1"));
 
-        store.delete_credential("server-1").await.unwrap();
-        assert!(!store.has_credential("server-1"));
+        store.delete("server-1").await.unwrap();
+        assert!(!store.contains("server-1"));
     }
 
     #[tokio::test]
@@ -226,14 +228,12 @@ mod tests {
             access_token: "token_a".to_string(),
             refresh_token: None,
             expires_at: None,
-            granted_scopes: vec![],
         };
         let cred_b = OAuthCredential {
             client_id: "b".to_string(),
             access_token: "token_b".to_string(),
             refresh_token: None,
             expires_at: None,
-            granted_scopes: vec![],
         };
 
         store.save_credential("server-a", cred_a).await.unwrap();
@@ -254,14 +254,12 @@ mod tests {
             access_token: "v1".to_string(),
             refresh_token: None,
             expires_at: None,
-            granted_scopes: vec![],
         };
         let cred_v2 = OAuthCredential {
             client_id: "c".to_string(),
             access_token: "v2".to_string(),
             refresh_token: None,
             expires_at: None,
-            granted_scopes: vec![],
         };
 
         store.save_credential("server", cred_v1).await.unwrap();
@@ -269,6 +267,44 @@ mod tests {
 
         let loaded = store.load_credential("server").await.unwrap().unwrap();
         assert_eq!(loaded.access_token, "v2");
+    }
+
+    #[tokio::test]
+    async fn loads_existing_encrypted_file_format() {
+        let store = temp_store("pass");
+        let plaintext = serde_json::to_vec(&serde_json::json!({
+            "credentials": {
+                "codex": {
+                    "client_id": "client_1",
+                    "access_token": "tok_abc",
+                    "refresh_token": "ref_xyz",
+                    "expires_at": 9_999_999_999_999_u64
+                }
+            }
+        }))
+        .unwrap();
+        let ciphertext =
+            EncryptedFileOAuthCredentialStorage::encrypt(&plaintext, "pass", Some(TEST_WORK_FACTOR)).unwrap();
+
+        write(&store.path, ciphertext).unwrap();
+        let credential = store.load_credential("codex").await.unwrap().expect("existing credential");
+        assert_eq!(credential.access_token, "tok_abc");
+    }
+
+    #[tokio::test]
+    async fn secrets_round_trip_through_encrypted_file() {
+        let store = temp_store("pass");
+        let secret = serde_json::json!({"client_id": "c", "granted_scopes": ["read"]});
+
+        store.save("mcp:slack", secret.clone()).await.unwrap();
+        store.save_credential("slack", test_credential()).await.unwrap();
+        let reopened = EncryptedFileOAuthCredentialStorage::new(store.path.clone(), "pass".to_string())
+            .with_scrypt_work_factor(TEST_WORK_FACTOR);
+        assert_eq!(reopened.load("mcp:slack").await.unwrap(), Some(secret));
+        assert!(reopened.load_credential("slack").await.unwrap().is_some());
+
+        reopened.delete("mcp:slack").await.unwrap();
+        assert!(store.load("mcp:slack").await.unwrap().is_none());
     }
 
     #[test]
@@ -286,7 +322,6 @@ mod tests {
             access_token: "tok_abc".to_string(),
             refresh_token: Some("ref_xyz".to_string()),
             expires_at: Some(9_999_999_999_999),
-            granted_scopes: vec!["scope1".to_string()],
         }
     }
 

--- a/crates/aether-auth/src/fake.rs
+++ b/crates/aether-auth/src/fake.rs
@@ -8,38 +8,43 @@ use crate::error::OAuthError;
 
 #[derive(Default)]
 pub struct FakeOAuthCredentialStore {
-    credentials: Mutex<HashMap<String, OAuthCredential>>,
+    values: Mutex<HashMap<String, serde_json::Value>>,
 }
 
 impl FakeOAuthCredentialStore {
     pub fn new() -> Self {
-        Self { credentials: Mutex::new(HashMap::new()) }
+        Self::default()
     }
 
     pub fn with_credential(self, key: &str, credential: OAuthCredential) -> Self {
-        self.credentials.lock().unwrap().insert(key.to_string(), credential);
+        self.values.lock().unwrap().insert(key.to_string(), serde_json::to_value(credential).unwrap());
+        self
+    }
+
+    pub fn with_value(self, key: &str, value: serde_json::Value) -> Self {
+        self.values.lock().unwrap().insert(key.to_string(), value);
         self
     }
 }
 
 #[async_trait]
 impl OAuthCredentialStorage for FakeOAuthCredentialStore {
-    async fn load_credential(&self, server_id: &str) -> Result<Option<OAuthCredential>, OAuthError> {
-        Ok(self.credentials.lock().unwrap().get(server_id).cloned())
+    async fn load(&self, key: &str) -> Result<Option<serde_json::Value>, OAuthError> {
+        Ok(self.values.lock().unwrap().get(key).cloned())
     }
 
-    async fn save_credential(&self, key: &str, credential: OAuthCredential) -> Result<(), OAuthError> {
-        self.credentials.lock().unwrap().insert(key.to_string(), credential);
+    async fn save(&self, key: &str, value: serde_json::Value) -> Result<(), OAuthError> {
+        self.values.lock().unwrap().insert(key.to_string(), value);
         Ok(())
     }
 
-    async fn delete_credential(&self, key: &str) -> Result<(), OAuthError> {
-        self.credentials.lock().unwrap().remove(key);
+    async fn delete(&self, key: &str) -> Result<(), OAuthError> {
+        self.values.lock().unwrap().remove(key);
         Ok(())
     }
 
-    fn has_credential(&self, key: &str) -> bool {
-        self.credentials.lock().unwrap().contains_key(key)
+    fn contains(&self, key: &str) -> bool {
+        self.values.lock().unwrap().contains_key(key)
     }
 }
 
@@ -62,7 +67,6 @@ mod tests {
             access_token: "tok_abc".to_string(),
             refresh_token: Some("ref_xyz".to_string()),
             expires_at: Some(9_999_999_999_999),
-            granted_scopes: Vec::new(),
         };
 
         store.save_credential("my-server", cred.clone()).await.unwrap();
@@ -81,17 +85,29 @@ mod tests {
             access_token: "t".to_string(),
             refresh_token: None,
             expires_at: None,
-            granted_scopes: Vec::new(),
         };
         store.save_credential("x", cred).await.unwrap();
-        assert!(store.has_credential("x"));
+        assert!(store.contains("x"));
 
-        store.delete_credential("x").await.unwrap();
-        assert!(!store.has_credential("x"));
+        store.delete("x").await.unwrap();
+        assert!(!store.contains("x"));
+    }
+
+    #[tokio::test]
+    async fn secrets_round_trip_and_delete() {
+        let store = FakeOAuthCredentialStore::new().with_value("mcp:slack", serde_json::json!({"a": 1}));
+
+        assert_eq!(store.load("mcp:slack").await.unwrap(), Some(serde_json::json!({"a": 1})));
+
+        store.save("mcp:slack", serde_json::json!({"a": 2})).await.unwrap();
+        assert_eq!(store.load("mcp:slack").await.unwrap(), Some(serde_json::json!({"a": 2})));
+
+        store.delete("mcp:slack").await.unwrap();
+        assert!(store.load("mcp:slack").await.unwrap().is_none());
     }
 
     #[test]
-    fn has_credential_reflects_state() {
+    fn has_value_reflects_state() {
         let store = FakeOAuthCredentialStore::new().with_credential(
             "present",
             OAuthCredential {
@@ -99,11 +115,10 @@ mod tests {
                 access_token: "t".to_string(),
                 refresh_token: None,
                 expires_at: None,
-                granted_scopes: Vec::new(),
             },
         );
 
-        assert!(store.has_credential("present"));
-        assert!(!store.has_credential("absent"));
+        assert!(store.contains("present"));
+        assert!(!store.contains("absent"));
     }
 }

--- a/crates/aether-auth/src/keyring/mod.rs
+++ b/crates/aether-auth/src/keyring/mod.rs
@@ -2,10 +2,11 @@
 
 use async_trait::async_trait;
 use keyring_core::{CredentialStore as KeyringCredentialStore, Entry, Error as KeyringError};
+use serde_json::Value;
 use std::sync::{Arc, LazyLock};
 use tokio::task;
 
-use crate::{OAuthCredential, OAuthCredentialStorage, OAuthError};
+use crate::{OAuthCredentialStorage, OAuthError};
 
 const KEYCHAIN_SERVICE: &str = "aether-oauth-v1";
 
@@ -46,32 +47,32 @@ impl OsKeyringStore {
 
 #[async_trait]
 impl OAuthCredentialStorage for OsKeyringStore {
-    async fn load_credential(&self, key: &str) -> Result<Option<OAuthCredential>, OAuthError> {
+    async fn load(&self, key: &str) -> Result<Option<Value>, OAuthError> {
         let store = self.clone();
         let key = key.to_string();
         spawn_blocking(move || load_from_keyring(&store, &key)).await
     }
 
-    async fn save_credential(&self, key: &str, credential: OAuthCredential) -> Result<(), OAuthError> {
+    async fn save(&self, key: &str, value: Value) -> Result<(), OAuthError> {
         let store = self.clone();
         let key = key.to_string();
-        spawn_blocking(move || save_to_keyring(&store, &key, &credential)).await
+        spawn_blocking(move || save_to_keyring(&store, &key, &value)).await
     }
 
-    async fn delete_credential(&self, key: &str) -> Result<(), OAuthError> {
+    async fn delete(&self, key: &str) -> Result<(), OAuthError> {
         let store = self.clone();
         let key = key.to_string();
         spawn_blocking(move || delete_from_keyring(&store, &key)).await
     }
 
-    fn has_credential(&self, key: &str) -> bool {
-        try_has_credential(self, key).unwrap_or(false)
+    fn contains(&self, key: &str) -> bool {
+        try_contains(self, key).unwrap_or(false)
     }
 }
 
 type BackendFactory = Box<dyn FnOnce() -> Result<Arc<KeyringCredentialStore>, OAuthError> + Send + Sync>;
 
-fn try_has_credential(store: &OsKeyringStore, key: &str) -> Result<bool, OAuthError> {
+fn try_contains(store: &OsKeyringStore, key: &str) -> Result<bool, OAuthError> {
     let entry = credential_entry(store, key)?;
     match entry.get_credential() {
         Ok(_) => Ok(true),
@@ -85,7 +86,7 @@ fn credential_entry(store: &OsKeyringStore, key: &str) -> Result<Entry, OAuthErr
     build_keyring_entry(backend.as_ref(), key)
 }
 
-fn load_from_keyring(store: &OsKeyringStore, key: &str) -> Result<Option<OAuthCredential>, OAuthError> {
+fn load_from_keyring(store: &OsKeyringStore, key: &str) -> Result<Option<Value>, OAuthError> {
     let entry = credential_entry(store, key)?;
     match entry.get_secret() {
         Ok(blob) => serde_json::from_slice(&blob)
@@ -96,9 +97,9 @@ fn load_from_keyring(store: &OsKeyringStore, key: &str) -> Result<Option<OAuthCr
     }
 }
 
-fn save_to_keyring(store: &OsKeyringStore, key: &str, credential: &OAuthCredential) -> Result<(), OAuthError> {
+fn save_to_keyring(store: &OsKeyringStore, key: &str, value: &Value) -> Result<(), OAuthError> {
     let entry = credential_entry(store, key)?;
-    let blob = serde_json::to_vec(credential)
+    let blob = serde_json::to_vec(value)
         .map_err(|e| OAuthError::CredentialStore(format!("failed to serialize credential: {e}")))?;
     entry.set_secret(&blob).map_err(map_keyring_err)?;
     Ok(())
@@ -167,6 +168,7 @@ async fn spawn_blocking<T: Send + 'static>(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::OAuthCredential;
     use std::sync::atomic::{AtomicUsize, Ordering};
 
     fn credential() -> OAuthCredential {
@@ -175,7 +177,6 @@ mod tests {
             access_token: "access".to_string(),
             refresh_token: Some("refresh".to_string()),
             expires_at: Some(1234),
-            granted_scopes: Vec::new(),
         }
     }
 
@@ -208,10 +209,10 @@ mod tests {
     async fn delete_removes_credential() {
         let store = OsKeyringStore::with_mock_store().unwrap();
         store.save_credential("server", credential()).await.unwrap();
-        assert!(store.has_credential("server"));
+        assert!(store.contains("server"));
 
-        store.delete_credential("server").await.unwrap();
-        assert!(!store.has_credential("server"));
+        store.delete("server").await.unwrap();
+        assert!(!store.contains("server"));
     }
 
     #[tokio::test]
@@ -237,10 +238,10 @@ mod tests {
         let save_err = store.save_credential("k", credential()).await.unwrap_err();
         assert!(matches!(save_err, OAuthError::CredentialStore(m) if m.contains("no dbus")));
 
-        let delete_err = store.delete_credential("k").await.unwrap_err();
+        let delete_err = store.delete("k").await.unwrap_err();
         assert!(matches!(delete_err, OAuthError::CredentialStore(m) if m.contains("no dbus")));
 
-        assert!(!store.has_credential("k"));
+        assert!(!store.contains("k"));
     }
 
     #[tokio::test]

--- a/crates/aether-auth/src/mcp/credential_store.rs
+++ b/crates/aether-auth/src/mcp/credential_store.rs
@@ -1,26 +1,22 @@
 use async_trait::async_trait;
-use oauth2::{AccessToken, RefreshToken};
-use rmcp::transport::auth::{
-    AuthError, CredentialStore, OAuthTokenResponse, StoredCredentials, VendorExtraTokenFields,
-};
+use rmcp::transport::auth::{AuthError, CredentialStore, StoredCredentials};
 use std::sync::Arc;
-use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
-use crate::{OAuthCredential, OAuthCredentialStorage};
+use crate::{OAuthCredentialStorage, OAuthError};
 
 /// Per-server adapter that binds an [`OAuthCredentialStorage`] to a single MCP server id
-/// and implements `rmcp::transport::auth::CredentialStore`.
+/// and implements `rmcp::transport::auth::CredentialStore` by persisting rmcp's
+/// [`StoredCredentials`] verbatim as a namespaced, opaque JSON secret.
 #[derive(Clone)]
 pub struct McpCredentialStore {
     server_id: String,
     store: Arc<dyn OAuthCredentialStorage>,
     expected_client_id: Option<String>,
-    now_fn: fn() -> SystemTime,
 }
 
 impl McpCredentialStore {
     pub fn new(store: Arc<dyn OAuthCredentialStorage>, server_id: String) -> Self {
-        Self { server_id, store, expected_client_id: None, now_fn: SystemTime::now }
+        Self { server_id, store, expected_client_id: None }
     }
 
     /// Only serve stored credentials issued to this client id; credentials for any
@@ -30,272 +26,139 @@ impl McpCredentialStore {
         self
     }
 
-    pub fn with_now_fn(mut self, f: fn() -> SystemTime) -> Self {
-        self.now_fn = f;
-        self
-    }
-
-    fn now(&self) -> SystemTime {
-        (self.now_fn)()
+    fn secret_key(&self) -> String {
+        format!("mcp:{}", self.server_id)
     }
 }
 
 #[async_trait]
 impl CredentialStore for McpCredentialStore {
     async fn load(&self) -> Result<Option<StoredCredentials>, AuthError> {
-        let cred = self
-            .store
-            .load_credential(&self.server_id)
+        self.store
+            .load(&self.secret_key())
             .await
-            .map_err(|e| AuthError::InternalError(e.to_string()))?
-            .filter(|c| self.expected_client_id.as_deref().is_none_or(|expected| c.client_id == expected));
-
-        let now = self.now();
-        Ok(cred.map(|c| {
-            let token_received_at = c.expires_at.map(|_| now.duration_since(UNIX_EPOCH).unwrap_or_default().as_secs());
-            let token_response = build_token_response(&c, now);
-            StoredCredentials::new(c.client_id, Some(token_response), c.granted_scopes, token_received_at)
-        }))
+            .map_err(|error| internal_err(&error))?
+            .map(serde_json::from_value::<StoredCredentials>)
+            .transpose()
+            .map_err(|error| AuthError::InternalError(format!("invalid MCP credential: {error}")))
+            .map(|credentials| {
+                credentials.filter(|credential| {
+                    self.expected_client_id.as_deref().is_none_or(|expected| credential.client_id == expected)
+                })
+            })
     }
 
     async fn save(&self, credentials: StoredCredentials) -> Result<(), AuthError> {
-        let token = credentials
-            .token_response
-            .ok_or_else(|| AuthError::InternalError("No token response to save".to_string()))?;
-
-        let preserved_refresh_token = self
-            .store
-            .load_credential(&self.server_id)
-            .await
-            .map_err(|e| AuthError::InternalError(e.to_string()))?
-            .and_then(|cred| (cred.client_id == credentials.client_id).then_some(cred.refresh_token).flatten());
-        let credential = OAuthCredential::from_token_response(credentials.client_id, &token);
-        let credential = OAuthCredential {
-            refresh_token: credential.refresh_token.or(preserved_refresh_token),
-            granted_scopes: credentials.granted_scopes,
-            ..credential
-        };
-        self.store
-            .save_credential(&self.server_id, credential)
-            .await
-            .map_err(|e| AuthError::InternalError(e.to_string()))
+        let value = serde_json::to_value(&credentials)
+            .map_err(|e| AuthError::InternalError(format!("failed to serialize credentials: {e}")))?;
+        self.store.save(&self.secret_key(), value).await.map_err(|e| internal_err(&e))
     }
 
     async fn clear(&self) -> Result<(), AuthError> {
-        self.store.delete_credential(&self.server_id).await.map_err(|e| AuthError::InternalError(e.to_string()))
+        self.store.delete(&self.secret_key()).await.map_err(|e| internal_err(&e))
     }
 }
 
-fn build_token_response(cred: &OAuthCredential, now: SystemTime) -> OAuthTokenResponse {
-    let mut response = OAuthTokenResponse::new(
-        AccessToken::new(cred.access_token.clone()),
-        oauth2::basic::BasicTokenType::Bearer,
-        VendorExtraTokenFields::default(),
-    );
-
-    if let Some(ref refresh) = cred.refresh_token {
-        response.set_refresh_token(Some(RefreshToken::new(refresh.clone())));
-    }
-
-    if let Some(expires_at_millis) = cred.expires_at {
-        let expires_at = UNIX_EPOCH + Duration::from_millis(expires_at_millis);
-        let remaining = expires_at.duration_since(now).unwrap_or_default();
-        response.set_expires_in(Some(&remaining));
-    }
-
-    response
+fn internal_err(error: &OAuthError) -> AuthError {
+    AuthError::InternalError(error.to_string())
 }
 
 #[cfg(test)]
 mod tests {
-    use oauth2::TokenResponse;
     use oauth2::basic::BasicTokenType;
+    use oauth2::{AccessToken, RefreshToken, TokenResponse};
+    use rmcp::transport::auth::{OAuthTokenResponse, VendorExtraTokenFields};
+    use std::time::Duration;
 
     use super::*;
     use crate::FakeOAuthCredentialStore;
 
-    const FAKE_NOW_SECS: u64 = 2_000_000;
-
-    fn fake_now() -> SystemTime {
-        UNIX_EPOCH + Duration::from_secs(FAKE_NOW_SECS)
+    fn stored_credentials(client_id: &str) -> StoredCredentials {
+        let mut token_response = OAuthTokenResponse::new(
+            AccessToken::new("access".to_string()),
+            BasicTokenType::Bearer,
+            VendorExtraTokenFields::default(),
+        );
+        token_response.set_refresh_token(Some(RefreshToken::new("refresh".to_string())));
+        token_response.set_expires_in(Some(&Duration::from_hours(1)));
+        StoredCredentials::new(client_id.to_string(), Some(token_response), vec!["read".to_string()], Some(2_000_000))
+            .with_issuer(Some("https://issuer.example".to_string()))
     }
 
     fn mcp_store(store: Arc<FakeOAuthCredentialStore>) -> McpCredentialStore {
-        McpCredentialStore::new(store, "server".to_string()).with_now_fn(fake_now)
-    }
-
-    fn credential_expiring_at(expires_at: SystemTime) -> OAuthCredential {
-        OAuthCredential {
-            client_id: "client".to_string(),
-            access_token: "access".to_string(),
-            refresh_token: Some("refresh".to_string()),
-            expires_at: Some(systime_to_millis(expires_at)),
-            granted_scopes: Vec::new(),
-        }
-    }
-
-    fn systime_to_millis(t: SystemTime) -> u64 {
-        u64::try_from(t.duration_since(UNIX_EPOCH).unwrap_or_default().as_millis()).unwrap_or(u64::MAX)
+        McpCredentialStore::new(store, "server".to_string())
     }
 
     #[tokio::test]
-    async fn mcp_store_round_trips_stored_credentials() {
+    async fn save_then_load_round_trips_stored_credentials_verbatim() {
         let store = Arc::new(FakeOAuthCredentialStore::new());
         let mcp_store = mcp_store(store.clone());
-        let cred = credential_expiring_at(fake_now());
-        let token_response = build_token_response(&cred, fake_now());
-        let stored = StoredCredentials::new(cred.client_id, Some(token_response), Vec::new(), Some(FAKE_NOW_SECS));
 
-        CredentialStore::save(&mcp_store, stored).await.unwrap();
+        CredentialStore::save(&mcp_store, stored_credentials("client")).await.unwrap();
 
         let loaded = CredentialStore::load(&mcp_store).await.unwrap().unwrap();
-        let token = loaded.token_response.unwrap();
         assert_eq!(loaded.client_id, "client");
+        assert_eq!(loaded.granted_scopes, vec!["read"]);
+        assert_eq!(loaded.token_received_at, Some(2_000_000));
+        assert_eq!(loaded.issuer.as_deref(), Some("https://issuer.example"));
+        let token = loaded.token_response.unwrap();
         assert_eq!(token.access_token().secret(), "access");
         assert_eq!(token.refresh_token().map(|t| t.secret().as_str()), Some("refresh"));
+        assert_eq!(token.expires_in(), Some(Duration::from_hours(1)));
     }
 
     #[tokio::test]
-    async fn mcp_store_preserves_existing_refresh_token_when_save_omits_one() {
+    async fn tokenless_registration_round_trips() {
         let store = Arc::new(FakeOAuthCredentialStore::new());
-        store.save_credential("server", credential_expiring_at(fake_now())).await.unwrap();
         let mcp_store = mcp_store(store.clone());
-        let stored = StoredCredentials::new(
-            "client".to_string(),
-            Some(OAuthTokenResponse::new(
-                AccessToken::new("token".to_string()),
-                BasicTokenType::Bearer,
-                VendorExtraTokenFields::default(),
-            )),
-            Vec::new(),
-            Some(FAKE_NOW_SECS),
-        );
+        let registration =
+            StoredCredentials::new("https://client.example/metadata.json".to_string(), None, Vec::new(), None)
+                .with_issuer(Some("https://new-issuer.example".to_string()));
 
-        CredentialStore::save(&mcp_store, stored).await.unwrap();
-        let loaded = CredentialStore::load(&mcp_store).await.unwrap().unwrap();
-        let token = loaded.token_response.unwrap();
-        assert_eq!(token.access_token().secret(), "token");
-        assert_eq!(token.refresh_token().map(|t| t.secret().as_str()), Some("refresh"));
+        CredentialStore::save(&mcp_store, registration).await.unwrap();
+
+        let loaded = CredentialStore::load(&mcp_store).await.unwrap().expect("portable client registration");
+        assert_eq!(loaded.client_id, "https://client.example/metadata.json");
+        assert_eq!(loaded.issuer.as_deref(), Some("https://new-issuer.example"));
+        assert!(loaded.token_response.is_none());
     }
 
     #[tokio::test]
     async fn load_filters_credentials_for_unexpected_client() {
         let store = Arc::new(FakeOAuthCredentialStore::new());
-        store.save_credential("server", credential_expiring_at(fake_now())).await.unwrap();
+        CredentialStore::save(&mcp_store(store.clone()), stored_credentials("client")).await.unwrap();
 
-        let mcp_store = mcp_store(store.clone()).with_expected_client_id(Some("other-client"));
+        let filtered = mcp_store(store.clone()).with_expected_client_id(Some("other-client"));
 
-        assert!(CredentialStore::load(&mcp_store).await.unwrap().is_none());
-        assert!(store.load_credential("server").await.unwrap().is_some());
+        assert!(CredentialStore::load(&filtered).await.unwrap().is_none());
+        assert!(store.load("mcp:server").await.unwrap().is_some());
     }
 
     #[tokio::test]
     async fn load_serves_credentials_for_expected_client() {
         let store = Arc::new(FakeOAuthCredentialStore::new());
-        store.save_credential("server", credential_expiring_at(fake_now())).await.unwrap();
+        CredentialStore::save(&mcp_store(store.clone()), stored_credentials("client")).await.unwrap();
 
-        let mcp_store = mcp_store(store).with_expected_client_id(Some("client"));
+        let matching = mcp_store(store).with_expected_client_id(Some("client"));
 
-        let loaded = CredentialStore::load(&mcp_store).await.unwrap().unwrap();
-        assert_eq!(loaded.client_id, "client");
+        assert_eq!(CredentialStore::load(&matching).await.unwrap().unwrap().client_id, "client");
     }
 
     #[tokio::test]
-    async fn mcp_store_clear_removes_credential() {
-        let store = Arc::new(FakeOAuthCredentialStore::new());
-        store.save_credential("server", credential_expiring_at(fake_now())).await.unwrap();
+    async fn load_rejects_undecodable_value() {
+        let store = Arc::new(FakeOAuthCredentialStore::new().with_value("mcp:server", serde_json::json!("invalid")));
 
+        assert!(CredentialStore::load(&mcp_store(store)).await.is_err());
+    }
+
+    #[tokio::test]
+    async fn clear_removes_credential() {
+        let store = Arc::new(FakeOAuthCredentialStore::new());
         let mcp_store = mcp_store(store.clone());
+        CredentialStore::save(&mcp_store, stored_credentials("client")).await.unwrap();
+
         CredentialStore::clear(&mcp_store).await.unwrap();
 
-        assert!(store.load_credential("server").await.unwrap().is_none());
-    }
-
-    #[tokio::test]
-    async fn load_populates_token_received_at_when_expiry_info_present() {
-        let store = Arc::new(FakeOAuthCredentialStore::new());
-        store.save_credential("server", credential_expiring_at(fake_now() + Duration::from_hours(1))).await.unwrap();
-
-        let loaded = CredentialStore::load(&mcp_store(store)).await.unwrap().unwrap();
-
-        assert_eq!(loaded.token_received_at, Some(FAKE_NOW_SECS));
-    }
-
-    #[tokio::test]
-    async fn load_omits_token_received_at_when_no_expiry_info() {
-        let cred = OAuthCredential {
-            client_id: "client".to_string(),
-            access_token: "access".to_string(),
-            refresh_token: Some("refresh".to_string()),
-            expires_at: None,
-            granted_scopes: Vec::new(),
-        };
-        let store = Arc::new(FakeOAuthCredentialStore::new());
-        store.save_credential("server", cred).await.unwrap();
-
-        let loaded = CredentialStore::load(&mcp_store(store)).await.unwrap().unwrap();
-
-        assert!(loaded.token_received_at.is_none());
-        assert!(loaded.token_response.unwrap().expires_in().is_none());
-    }
-
-    #[tokio::test]
-    async fn expired_credential_with_refresh_token_sets_zero_expires_in() {
-        let store = Arc::new(FakeOAuthCredentialStore::new());
-        store.save_credential("server", credential_expiring_at(fake_now() - Duration::from_mins(10))).await.unwrap();
-
-        let loaded = CredentialStore::load(&mcp_store(store)).await.unwrap().unwrap();
-        let token = loaded.token_response.as_ref().unwrap();
-
-        assert_eq!(token.expires_in(), Some(Duration::ZERO));
-        assert_eq!(loaded.token_received_at, Some(FAKE_NOW_SECS));
-        assert_eq!(token.refresh_token().map(|t| t.secret().as_str()), Some("refresh"));
-    }
-
-    #[tokio::test]
-    async fn unexpired_credential_sets_exact_remaining_expires_in() {
-        let store = Arc::new(FakeOAuthCredentialStore::new());
-        store.save_credential("server", credential_expiring_at(fake_now() + Duration::from_hours(1))).await.unwrap();
-
-        let loaded = CredentialStore::load(&mcp_store(store)).await.unwrap().unwrap();
-        let token = loaded.token_response.as_ref().unwrap();
-
-        assert_eq!(token.expires_in(), Some(Duration::from_hours(1)));
-    }
-
-    #[tokio::test]
-    async fn load_round_trips_granted_scopes() {
-        let cred = OAuthCredential {
-            granted_scopes: vec!["read".to_string(), "write".to_string()],
-            ..credential_expiring_at(fake_now() + Duration::from_hours(1))
-        };
-        let store = Arc::new(FakeOAuthCredentialStore::new());
-        store.save_credential("server", cred).await.unwrap();
-
-        let loaded = CredentialStore::load(&mcp_store(store)).await.unwrap().unwrap();
-
-        assert_eq!(loaded.granted_scopes, vec!["read".to_string(), "write".to_string()]);
-    }
-
-    #[tokio::test]
-    async fn save_persists_granted_scopes_from_rmcp() {
-        let store = Arc::new(FakeOAuthCredentialStore::new());
-        let mcp_store = mcp_store(store.clone());
-        let token_response = OAuthTokenResponse::new(
-            AccessToken::new("access".to_string()),
-            BasicTokenType::Bearer,
-            VendorExtraTokenFields::default(),
-        );
-        let stored = StoredCredentials::new(
-            "client".to_string(),
-            Some(token_response),
-            vec!["read".to_string(), "admin".to_string()],
-            Some(FAKE_NOW_SECS),
-        );
-
-        CredentialStore::save(&mcp_store, stored).await.unwrap();
-
-        let persisted = store.load_credential("server").await.unwrap().unwrap();
-        assert_eq!(persisted.granted_scopes, vec!["read".to_string(), "admin".to_string()]);
+        assert!(store.load("mcp:server").await.unwrap().is_none());
     }
 }

--- a/crates/aether-auth/tests/mcp_oauth.rs
+++ b/crates/aether-auth/tests/mcp_oauth.rs
@@ -1,25 +1,19 @@
 #![cfg(feature = "mcp")]
 
 use aether_auth::{
-    FakeOAuthCredentialStore, OAuthCallback, OAuthCredential, OAuthCredentialStorage, OAuthError, OAuthHandler,
+    FakeOAuthCredentialStore, OAuthCallback, OAuthCredentialStorage, OAuthError, OAuthHandler,
     create_auth_manager_from_store, perform_oauth_flow,
 };
 use futures::future::BoxFuture;
+use rmcp::transport::auth::StoredCredentials;
 use std::sync::{Arc, Mutex};
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
 
 #[tokio::test]
 async fn configured_client_id_ignores_credentials_for_another_client() {
-    let store = Arc::new(FakeOAuthCredentialStore::new().with_credential(
-        "slack",
-        OAuthCredential {
-            client_id: "old-client".to_string(),
-            access_token: "old-token".to_string(),
-            refresh_token: None,
-            expires_at: None,
-            granted_scopes: Vec::new(),
-        },
-    ));
+    let stored = StoredCredentials::new("old-client".to_string(), None, Vec::new(), None);
+    let store =
+        Arc::new(FakeOAuthCredentialStore::new().with_value("mcp:slack", serde_json::to_value(stored).unwrap()));
 
     let manager =
         create_auth_manager_from_store("slack", "https://mcp.slack.com/mcp", Some("configured-client"), store.clone())
@@ -27,8 +21,8 @@ async fn configured_client_id_ignores_credentials_for_another_client() {
             .unwrap();
 
     assert!(manager.is_none());
-    let preserved = store.load_credential("slack").await.unwrap().expect("mismatched credential should be preserved");
-    assert_eq!(preserved.client_id, "old-client");
+    let preserved = store.load("mcp:slack").await.unwrap().expect("mismatched credential should be preserved");
+    assert_eq!(preserved["client_id"], "old-client");
 }
 
 struct FakeHandler {

--- a/crates/aether-cli/src/acp/model_config.rs
+++ b/crates/aether-cli/src/acp/model_config.rs
@@ -9,7 +9,7 @@ use std::collections::{BTreeMap, HashSet};
 use std::ops::Deref;
 
 fn needs_oauth_login(model: &LlmModel, store: &dyn OAuthCredentialStorage) -> bool {
-    model.oauth_provider_id().is_some_and(|id| !store.has_credential(id))
+    model.oauth_provider_id().is_some_and(|id| !store.contains(id))
 }
 
 pub(crate) fn supports_prompt_image(model: &LlmModel) -> bool {

--- a/crates/aether-cli/src/acp/state.rs
+++ b/crates/aether-cli/src/acp/state.rs
@@ -425,7 +425,7 @@ fn build_auth_methods(store: &dyn OAuthCredentialStorage) -> Vec<AuthMethod> {
                 .find(|m| m.oauth_provider_id() == Some(id))
                 .map_or(id, |m| m.provider_display_name());
             let mut method = acp::AuthMethodAgent::new(id, display);
-            if store.has_credential(id) {
+            if store.contains(id) {
                 method = method.description("authenticated");
             }
             AuthMethod::Agent(method)

--- a/crates/aether-cli/src/credentials.rs
+++ b/crates/aether-cli/src/credentials.rs
@@ -37,7 +37,7 @@ mod tests {
         );
 
         let store = oauth_credential_store_from_config(config).unwrap();
-        assert!(!store.has_credential("anything"));
+        assert!(!store.contains("anything"));
     }
 
     #[test]

--- a/crates/llm/src/providers/codex/oauth.rs
+++ b/crates/llm/src/providers/codex/oauth.rs
@@ -341,7 +341,6 @@ mod tests {
                 access_token: access_token.clone(),
                 refresh_token: Some("refresh-old".to_string()),
                 expires_at: Some(u64::MAX),
-                granted_scopes: Vec::new(),
             },
         ));
 
@@ -498,7 +497,6 @@ mod tests {
             access_token: access_token.to_string(),
             refresh_token: refresh_token.map(str::to_string),
             expires_at: Some(0),
-            granted_scopes: Vec::new(),
         }
     }
 

--- a/crates/llm/src/providers/codex/provider.rs
+++ b/crates/llm/src/providers/codex/provider.rs
@@ -209,7 +209,6 @@ mod tests {
             access_token: test_jwt("account-1"),
             refresh_token: None,
             expires_at: Some(u64::MAX),
-            granted_scopes: Vec::new(),
         };
         let store: Arc<dyn OAuthCredentialStorage> =
             Arc::new(FakeOAuthCredentialStore::new().with_credential("codex", credential));


### PR DESCRIPTION
### Summary

 This PR refactors `OAuthCredentialStorage` to persist opaque JSON values instead of `OAuthCredential`. This simplifies the code as it allows us to store MCP credentials directly as serialized `rmcp::StoredCredentials`. 

 Previously, we translated `rmcp::StoredCredentials` into Aether’s `OAuthCredential` type. This required custom logic for scopes, token timing, refresh tokens, and expiry reconstruction, and could not represent tokenless client registrations or newer rmcp fields.

