### PR TITLE
feat(website): publish OAuth client metadata

### DIFF
--- a/packages/website/public/oauth/client-metadata.json
+++ b/packages/website/public/oauth/client-metadata.json
@@ -1,0 +1,9 @@
+{
+  "client_id": "https://aether-agent.io/oauth/client-metadata.json",
+  "client_name": "Aether",
+  "redirect_uris": ["http://localhost:3118/"],
+  "grant_types": ["authorization_code", "refresh_token"],
+  "response_types": ["code"],
+  "token_endpoint_auth_method": "none",
+  "application_type": "native"
+}


### PR DESCRIPTION
## Summary

The MCP spec is moving towards using OAuth client metadata documents, away from dynamic client registration. This PR adds a metadata document for Aether. 
