### PR TITLE
fix(mcp): classify OAuth challenges accurately

### DIFF
--- a/crates/aether-core/tests/mcp/oauth_tests.rs
+++ b/crates/aether-core/tests/mcp/oauth_tests.rs
@@ -8,6 +8,7 @@ use mcp_utils::client::{
 use mcp_utils::status::{McpServerAuthCapability, McpServerStatus};
 use rmcp::transport::streamable_http_client::StreamableHttpClientTransportConfig;
 use std::sync::Arc;
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
 use tokio::sync::mpsc;
 use tokio::task::JoinHandle;
 
@@ -38,6 +39,43 @@ impl FailingHttpEndpoint {
 }
 
 impl Drop for FailingHttpEndpoint {
+    fn drop(&mut self) {
+        self.task.abort();
+    }
+}
+
+struct UnauthorizedHttpEndpoint {
+    uri: String,
+    task: JoinHandle<()>,
+}
+
+impl UnauthorizedHttpEndpoint {
+    async fn bind(challenge: &'static str) -> Self {
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let uri = format!("http://{}/mcp", listener.local_addr().unwrap());
+        let task = tokio::spawn(async move {
+            while let Ok((mut stream, _)) = listener.accept().await {
+                let mut request = [0; 4096];
+                let _ = stream.read(&mut request).await;
+                let response = format!(
+                    "HTTP/1.1 401 Unauthorized\r\nWWW-Authenticate: {challenge}\r\nContent-Length: 0\r\nConnection: close\r\n\r\n"
+                );
+                let _ = stream.write_all(response.as_bytes()).await;
+            }
+        });
+        Self { uri, task }
+    }
+
+    fn server(&self, name: &str) -> McpServer {
+        McpServer::new(
+            name,
+            McpTransport::Http(StreamableHttpClientTransportConfig::with_uri(self.uri.as_str()).into()),
+            ToolExposure::Direct,
+        )
+    }
+}
+
+impl Drop for UnauthorizedHttpEndpoint {
     fn drop(&mut self) {
         self.task.abort();
     }
@@ -138,7 +176,21 @@ async fn http_server_without_handler_stashes_failed_status() {
 }
 
 #[tokio::test]
-async fn http_server_with_handler_stashes_needs_oauth_on_failure() {
+async fn real_401_challenge_is_classified_as_needs_oauth() {
+    let endpoint = UnauthorizedHttpEndpoint::bind(
+        r#"Bearer resource_metadata="https://example.com/.well-known/oauth-protected-resource", scope="tools:read""#,
+    )
+    .await;
+    let mut manager = test_manager(true);
+    manager.add_mcps(vec![endpoint.server("protected")]).await.unwrap();
+    let status = &manager.server_statuses()[0];
+    assert!(matches!(status.status, McpServerStatus::NeedsOAuth));
+    assert_eq!(status.auth_capability, McpServerAuthCapability::OAuth);
+    assert!(status.can_authenticate());
+}
+
+#[tokio::test]
+async fn http_server_with_handler_classifies_non_auth_failure_as_failed() {
     let endpoint = FailingHttpEndpoint::bind().await;
     let mut manager = test_manager(true);
 
@@ -148,11 +200,11 @@ async fn http_server_with_handler_stashes_needs_oauth_on_failure() {
     assert_eq!(statuses.len(), 1);
     assert_eq!(statuses[0].name, "test_oauth_server");
     assert!(
-        matches!(statuses[0].status, McpServerStatus::NeedsOAuth),
-        "Expected NeedsOAuth, got: {:?}",
+        matches!(statuses[0].status, McpServerStatus::Failed { .. }),
+        "Expected Failed, got: {:?}",
         statuses[0].status
     );
-    assert!(statuses[0].can_authenticate());
+    assert!(!statuses[0].can_authenticate());
 }
 
 #[tokio::test]
@@ -198,7 +250,7 @@ async fn oauth_handler_is_dyn_compatible() {
 }
 
 #[tokio::test]
-async fn tool_proxy_with_failing_http_surfaces_needs_oauth() {
+async fn tool_proxy_with_failing_http_surfaces_failure() {
     let endpoint = FailingHttpEndpoint::bind().await;
     let (_home, mut manager) = test_manager_with_home(true);
 
@@ -212,12 +264,12 @@ async fn tool_proxy_with_failing_http_surfaces_needs_oauth() {
 
     let remote_status = statuses.iter().find(|s| s.name == "remote").expect("Expected status entry for 'remote'");
     assert!(
-        matches!(remote_status.status, McpServerStatus::NeedsOAuth),
-        "Expected NeedsOAuth for failing HTTP server, got: {:?}",
+        matches!(remote_status.status, McpServerStatus::Failed { .. }),
+        "Expected Failed for failing HTTP server, got: {:?}",
         remote_status.status
     );
-    assert_eq!(remote_status.auth_capability, McpServerAuthCapability::OAuth);
-    assert!(remote_status.can_authenticate());
+    assert_eq!(remote_status.auth_capability, McpServerAuthCapability::Unavailable);
+    assert!(!remote_status.can_authenticate());
     assert!(remote_status.proxied, "Expected remote to be marked as proxied");
 
     let local_status = statuses.iter().find(|s| s.name == "local").expect("Expected status entry for 'local'");
@@ -231,15 +283,13 @@ async fn tool_proxy_with_failing_http_surfaces_needs_oauth() {
 }
 
 #[tokio::test]
-async fn selective_policy_survives_failed_and_successful_reauthentication() {
+async fn selective_policy_survives_reconnection_after_failure() {
     let endpoint = FailingHttpEndpoint::bind().await;
     let (home, mut manager) = test_manager_with_home(true);
     let selective = endpoint.server("remote", ToolExposure::Proxied(ToolProxyRules::new(&[], &["add_*"])));
     manager.add_mcps(vec![selective]).await.unwrap();
 
-    let task = manager.authenticate_server_task("remote").await.unwrap();
-    manager.apply_connection_attempt(task.await).await;
-    assert!(manager.authenticate_server_task("remote").await.is_ok());
+    assert!(manager.authenticate_server_task("remote").await.is_err());
 
     let connected = fake_mcp("remote", FakeMcpServer::new()).with_exposure(ToolExposure::proxied_all());
     let attempt = manager.connect_pending_task(connected).await;

--- a/crates/mcp-utils/src/client/connection.rs
+++ b/crates/mcp-utils/src/client/connection.rs
@@ -284,10 +284,10 @@ async fn connect_http(
         tracing::debug!("Using OAuth for server '{name}'");
         let auth_client = AuthClient::new(reqwest::Client::default(), auth_manager);
         let transport = StreamableHttpClientTransport::with_client(auth_client, config.transport.clone());
-        serve_client_with_lifecycle(mcp_client, transport, client_lifecycle_mode()).await.map_err(conn_err)
+        serve_client_with_lifecycle(mcp_client, transport, client_lifecycle_mode()).await
     } else {
         let transport = StreamableHttpClientTransport::from_config(config.transport.clone());
-        serve_client_with_lifecycle(mcp_client, transport, client_lifecycle_mode()).await.map_err(conn_err)
+        serve_client_with_lifecycle(mcp_client, transport, client_lifecycle_mode()).await
     };
 
     match result {
@@ -295,8 +295,10 @@ async fn connect_http(
             McpConnectOutcome::Connected { conn: McpServerConnection::from_parts(client, None), reauth_config: None }
         }
         Err(error) => {
+            let authorization_required = error.is_authorization_required() || error.auth_challenge().is_some();
+            let error = conn_err(error);
             tracing::warn!("Failed to connect to MCP server '{name}': {error}");
-            if oauth_handler_factory.is_some() && config.transport.auth_header.is_none() {
+            if oauth_handler_factory.is_some() && config.transport.auth_header.is_none() && authorization_required {
                 McpConnectOutcome::NeedsOAuth { config, error }
             } else {
                 McpConnectOutcome::Failed { error }


### PR DESCRIPTION
## Summary

Previously, any HTTP MCP connection failure was classified as `NeedsOAuth` whenever an OAuth handler was available. 

This made ordinary transport failures appear actionable through authentication. The connection now preserves the rmcp service error long enough to inspect its authorization metadata before mapping it into Aether's connection error.

