### PR TITLE
fix(aether-core): allow headless agents to shut down

### DIFF
--- a/crates/aether-core/src/core/agent.rs
+++ b/crates/aether-core/src/core/agent.rs
@@ -204,9 +204,11 @@ impl Agent {
                 self.on_iteration_complete(id, iteration).await;
             }
 
-            if input_closed && !self.turn_active && !self.is_busy() && self.tool_executions.is_empty() {
+            if input_closed && !self.turn_active && !self.is_busy() {
+                if self.tool_executions.is_empty() {
+                    break;
+                }
                 self.abort_in_flight_work(ToolAbortPolicy::CancelAll).await;
-                break;
             }
         }
 

--- a/crates/aether-core/src/core/tool_execution.rs
+++ b/crates/aether-core/src/core/tool_execution.rs
@@ -160,16 +160,18 @@ impl ToolExecutions {
 
     pub(super) fn abort(&mut self, policy: &ToolAbortPolicy) -> Vec<String> {
         let mut removed = Vec::new();
-        self.executions.retain(|tool_id, execution| {
-            execution.cancellation_token.cancel();
-            let background = matches!(execution.phase, ToolExecutionPhase::Background | ToolExecutionPhase::Cancelling);
-            if background {
+        self.executions.retain(|tool_id, execution| match execution.phase {
+            ToolExecutionPhase::Background | ToolExecutionPhase::Cancelling => {
+                execution.cancellation_token.cancel();
                 execution.phase = match policy {
                     ToolAbortPolicy::PreserveBackgroundAcknowledgements => ToolExecutionPhase::Cancelling,
                     ToolAbortPolicy::CancelAll => ToolExecutionPhase::Retiring,
                 };
                 true
-            } else {
+            }
+            ToolExecutionPhase::Retiring if matches!(policy, ToolAbortPolicy::CancelAll) => true,
+            ToolExecutionPhase::Foreground | ToolExecutionPhase::Retiring => {
+                execution.cancellation_token.cancel();
                 removed.push(tool_id.clone());
                 false
             }

--- a/crates/aether-core/src/mcp/mcp_builder.rs
+++ b/crates/aether-core/src/mcp/mcp_builder.rs
@@ -114,8 +114,12 @@ impl McpSession {
             }
         }
 
+        let agent_tx = agent_tx.downgrade();
         self.runtime.agent_sync_handle = Some(tokio::spawn(async move {
             while snapshots.changed().await.is_ok() {
+                let Some(agent_tx) = agent_tx.upgrade() else {
+                    break;
+                };
                 let snapshot = snapshots.borrow_and_update().clone();
                 let tools = snapshot.tool_definitions();
                 if tools != previous_tools {

--- a/crates/aether-core/tests/agent/cancel_tests.rs
+++ b/crates/aether-core/tests/agent/cancel_tests.rs
@@ -142,6 +142,35 @@ async fn background_task_progress_reaches_agent_events() {
 }
 
 #[tokio::test]
+async fn closing_agent_input_cancels_background_tasks() {
+    let now = chrono::Utc::now().to_rfc3339();
+    let task = Task::new("shutdown-task", TaskStatus::Working, now.clone(), now).with_poll_interval_ms(10);
+    let server = FakeMcpServer::new()
+        .with_tool(FakeTool::new("deferred").responds(FakeToolResponse::task(CreateTaskResult::new(task.clone()))))
+        .with_task("shutdown-task", [DetailedTask::new(task, TaskPayload::Working)]);
+    let server_state = server.state();
+    let arguments = serde_json::json!({}).to_string();
+
+    test_agent()
+        .fake_mcp_server("tasks", server)
+        .llm_responses(&[
+            llm_response("msg_1").tool_call("shutdown-call", "tasks__deferred", &[&arguments]).build(),
+            llm_response("msg_2").text(&["background task started"]).build(),
+        ])
+        .scenario(
+            TestScenario::new()
+                .user_text("start background task")
+                .wait_for(|event| matches!(event, AgentEvent::Tool(ToolEvent::TaskCreated { request, .. }) if request.id == "shutdown-call"))
+                .wait_for_turn_end(),
+        )
+        .run()
+        .await
+        .unwrap();
+
+    assert_eq!(server_state.task_cancel_ids(), ["shutdown-task"]);
+}
+
+#[tokio::test]
 async fn user_cancel_surfaces_background_task_cancellation() {
     let now = chrono::Utc::now().to_rfc3339();
     let task = Task::new("cancel-task", TaskStatus::Working, now.clone(), now).with_poll_interval_ms(10);

--- a/crates/aether-core/tests/mcp/agent_sync_tests.rs
+++ b/crates/aether-core/tests/mcp/agent_sync_tests.rs
@@ -9,6 +9,20 @@ use rmcp::{RoleServer, service::DynService};
 use tokio::sync::mpsc;
 
 #[tokio::test]
+async fn session_synchronization_does_not_keep_agent_input_open() {
+    let session = mcp("/workspace").spawn().await.unwrap();
+    let (agent_tx, agent_rx) = mpsc::channel(32);
+    let (runtime, _) = session.connect_agent(agent_tx.clone()).await.split();
+
+    assert_eq!(agent_rx.sender_strong_count(), 1);
+    assert_eq!(agent_rx.sender_weak_count(), 1);
+
+    drop(agent_tx);
+    assert_eq!(agent_rx.sender_strong_count(), 0);
+    drop(runtime);
+}
+
+#[tokio::test]
 async fn session_synchronizes_agent_while_forwarding_host_events() {
     let server = FakeMcpServer::new();
     let state = server.state();
@@ -32,7 +46,7 @@ async fn session_synchronizes_agent_while_forwarding_host_events() {
         .unwrap();
     let handle = session.handle().clone();
     let (agent_tx, mut agent_rx) = mpsc::channel(32);
-    let (runtime, mut host_events) = session.connect_agent(agent_tx).await.split();
+    let (runtime, mut host_events) = session.connect_agent(agent_tx.clone()).await.split();
 
     let mut received_initial_tools = false;
     let mut received_initial_instructions = false;


### PR DESCRIPTION
## Summary

This PR fixes a regression where the CLI's headless mode would hang after the agent shutdown due to the MCP synchronization task holding onto a tokio channel component that kept the channel open. 