### PR TITLE
refactor(wisp): DRY patch line construction into PatchLine constructors

### DIFF
--- a/crates/wisp/src/components/file_tree.rs
+++ b/crates/wisp/src/components/file_tree.rs
@@ -323,25 +323,15 @@ fn join_path(parent: &str, name: &str) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::git_diff::{FileDiff, FileStatus, Hunk, PatchLine, PatchLineKind, StageState};
+    use crate::git_diff::{FileDiff, FileStatus, Hunk, PatchLine, StageState};
 
     fn file(path: &str, status: FileStatus, additions: usize, deletions: usize) -> FileDiff {
         let mut lines = Vec::new();
         for i in 0..additions {
-            lines.push(PatchLine {
-                kind: PatchLineKind::Added,
-                text: format!("added {i}"),
-                old_line_no: None,
-                new_line_no: Some(i + 1),
-            });
+            lines.push(PatchLine::added(format!("added {i}"), i + 1));
         }
         for i in 0..deletions {
-            lines.push(PatchLine {
-                kind: PatchLineKind::Removed,
-                text: format!("removed {i}"),
-                old_line_no: Some(i + 1),
-                new_line_no: None,
-            });
+            lines.push(PatchLine::removed(format!("removed {i}"), i + 1));
         }
         FileDiff {
             old_path: None,

--- a/crates/wisp/src/components/git_diff/git_diff_compositor.rs
+++ b/crates/wisp/src/components/git_diff/git_diff_compositor.rs
@@ -192,7 +192,7 @@ mod tests {
     }
 
     fn added_line(text: &str) -> PatchLine {
-        PatchLine { kind: PatchLineKind::Added, text: text.to_string(), old_line_no: None, new_line_no: Some(1) }
+        PatchLine::added(text, 1)
     }
 
     fn rendered_patch_contains(compositor: &GitDiffCompositor, marker: &str) -> bool {
@@ -259,20 +259,7 @@ mod tests {
 
     #[test]
     fn comment_splices_preserve_input_order_for_same_anchor() {
-        let file = make_file(vec![
-            PatchLine {
-                kind: PatchLineKind::HunkHeader,
-                text: "@@ -1,1 +1,1 @@".to_string(),
-                old_line_no: None,
-                new_line_no: None,
-            },
-            PatchLine {
-                kind: PatchLineKind::Added,
-                text: "new_line();".to_string(),
-                old_line_no: None,
-                new_line_no: Some(1),
-            },
-        ]);
+        let file = make_file(vec![PatchLine::hunk_header("@@ -1,1 +1,1 @@"), PatchLine::added("new_line();", 1)]);
 
         let anchor = CommentAnchor(PatchAnchor { hunk: 0, line: 1 });
         let comments = vec![queued(anchor, "alpha"), queued(anchor, "beta")];
@@ -290,20 +277,7 @@ mod tests {
 
     #[test]
     fn comment_splice_uses_correct_after_row() {
-        let file = make_file(vec![
-            PatchLine {
-                kind: PatchLineKind::HunkHeader,
-                text: "@@ -1,1 +1,1 @@".to_string(),
-                old_line_no: None,
-                new_line_no: None,
-            },
-            PatchLine {
-                kind: PatchLineKind::Added,
-                text: "new_line();".to_string(),
-                old_line_no: None,
-                new_line_no: Some(1),
-            },
-        ]);
+        let file = make_file(vec![PatchLine::hunk_header("@@ -1,1 +1,1 @@"), PatchLine::added("new_line();", 1)]);
 
         let anchor = CommentAnchor(PatchAnchor { hunk: 0, line: 1 });
         let comments = vec![queued(anchor, "a comment")];

--- a/crates/wisp/src/components/git_diff/git_diff_panel.rs
+++ b/crates/wisp/src/components/git_diff/git_diff_panel.rs
@@ -110,12 +110,10 @@ impl FileView {
             .enumerate()
             .map(|(i, text)| {
                 let new_line_no = i + 1;
-                let added = self.added_line_numbers.contains(&new_line_no);
-                PatchLine {
-                    kind: if added { PatchLineKind::Added } else { PatchLineKind::Context },
-                    text: text.to_string(),
-                    old_line_no: (!added).then_some(new_line_no),
-                    new_line_no: Some(new_line_no),
+                if self.added_line_numbers.contains(&new_line_no) {
+                    PatchLine::added(*text, new_line_no)
+                } else {
+                    PatchLine::context(*text, new_line_no, new_line_no)
                 }
             })
             .collect();
@@ -484,20 +482,7 @@ mod tests {
                 old_count: 1,
                 new_start: 1,
                 new_count: 2,
-                lines: vec![
-                    PatchLine {
-                        kind: PatchLineKind::Context,
-                        text: "fn main() {".to_string(),
-                        old_line_no: Some(1),
-                        new_line_no: Some(1),
-                    },
-                    PatchLine {
-                        kind: PatchLineKind::Added,
-                        text: "    let value = 1;".to_string(),
-                        old_line_no: None,
-                        new_line_no: Some(2),
-                    },
-                ],
+                lines: vec![PatchLine::context("fn main() {", 1, 1), PatchLine::added("    let value = 1;", 2)],
             }],
             binary: false,
         }

--- a/crates/wisp/src/components/git_diff/patch_renderer.rs
+++ b/crates/wisp/src/components/git_diff/patch_renderer.rs
@@ -143,20 +143,7 @@ mod tests {
 
     #[test]
     fn rendered_patch_contains_insert_row_lookup() {
-        let file = make_file(vec![
-            PatchLine {
-                kind: PatchLineKind::HunkHeader,
-                text: "@@ -1,1 +1,1 @@".to_string(),
-                old_line_no: None,
-                new_line_no: None,
-            },
-            PatchLine {
-                kind: PatchLineKind::Context,
-                text: "fn test()".to_string(),
-                old_line_no: Some(1),
-                new_line_no: Some(1),
-            },
-        ]);
+        let file = make_file(vec![PatchLine::hunk_header("@@ -1,1 +1,1 @@"), PatchLine::context("fn test()", 1, 1)]);
         let context = ViewContext::new((120, 24));
         let result = RenderedPatch::from_file_diff(&file, 80, &context);
 
@@ -167,15 +154,7 @@ mod tests {
     #[test]
     fn long_lines_soft_wrapped_to_right_width() {
         let long_content = "x".repeat(200);
-        let file = make_file(vec![
-            PatchLine {
-                kind: PatchLineKind::HunkHeader,
-                text: "@@ -1,1 +1,1 @@".to_string(),
-                old_line_no: None,
-                new_line_no: None,
-            },
-            PatchLine { kind: PatchLineKind::Added, text: long_content, old_line_no: None, new_line_no: Some(1) },
-        ]);
+        let file = make_file(vec![PatchLine::hunk_header("@@ -1,1 +1,1 @@"), PatchLine::added(long_content, 1)]);
         let context = ViewContext::new((120, 24));
         let right_width = 60;
         let result = RenderedPatch::from_file_diff(&file, right_width, &context);
@@ -210,15 +189,7 @@ mod tests {
     #[test]
     fn added_row_continuation_preserves_added_background() {
         let long_content = "x".repeat(200);
-        let file = make_file(vec![
-            PatchLine {
-                kind: PatchLineKind::HunkHeader,
-                text: "@@ -1,1 +1,1 @@".to_string(),
-                old_line_no: None,
-                new_line_no: None,
-            },
-            PatchLine { kind: PatchLineKind::Added, text: long_content, old_line_no: None, new_line_no: Some(1) },
-        ]);
+        let file = make_file(vec![PatchLine::hunk_header("@@ -1,1 +1,1 @@"), PatchLine::added(long_content, 1)]);
         let context = ViewContext::new((120, 24));
         let added_bg = context.theme.diff_added_bg();
         let result = RenderedPatch::from_file_diff(&file, 60, &context);
@@ -238,15 +209,7 @@ mod tests {
 
     #[test]
     fn empty_added_line_fills_full_width_with_added_background() {
-        let file = make_file(vec![
-            PatchLine {
-                kind: PatchLineKind::HunkHeader,
-                text: "@@ -1,1 +1,1 @@".to_string(),
-                old_line_no: None,
-                new_line_no: None,
-            },
-            PatchLine { kind: PatchLineKind::Added, text: String::new(), old_line_no: None, new_line_no: Some(1) },
-        ]);
+        let file = make_file(vec![PatchLine::hunk_header("@@ -1,1 +1,1 @@"), PatchLine::added(String::new(), 1)]);
         let context = ViewContext::new((120, 24));
         let added_bg = context.theme.diff_added_bg();
         let total_width = 60;

--- a/crates/wisp/src/git_diff.rs
+++ b/crates/wisp/src/git_diff.rs
@@ -59,6 +59,33 @@ pub struct PatchLine {
     pub new_line_no: Option<usize>,
 }
 
+impl PatchLine {
+    pub fn hunk_header(header: &str) -> Self {
+        Self { kind: PatchLineKind::HunkHeader, text: header.to_string(), old_line_no: None, new_line_no: None }
+    }
+
+    pub fn context(text: impl Into<String>, old_line_no: usize, new_line_no: usize) -> Self {
+        Self {
+            kind: PatchLineKind::Context,
+            text: text.into(),
+            old_line_no: Some(old_line_no),
+            new_line_no: Some(new_line_no),
+        }
+    }
+
+    pub fn added(text: impl Into<String>, new_line_no: usize) -> Self {
+        Self { kind: PatchLineKind::Added, text: text.into(), old_line_no: None, new_line_no: Some(new_line_no) }
+    }
+
+    pub fn removed(text: impl Into<String>, old_line_no: usize) -> Self {
+        Self { kind: PatchLineKind::Removed, text: text.into(), old_line_no: Some(old_line_no), new_line_no: None }
+    }
+
+    pub fn meta(text: impl Into<String>) -> Self {
+        Self { kind: PatchLineKind::Meta, text: text.into(), old_line_no: None, new_line_no: None }
+    }
+}
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum PatchLineKind {
     HunkHeader,
@@ -308,20 +335,10 @@ async fn build_untracked_file_diff(repo_root: &Path, relative_path: String) -> F
 
     let hunk_header = format!("@@ -0,0 +1,{line_count} @@");
 
-    let mut patch_lines = vec![PatchLine {
-        kind: PatchLineKind::HunkHeader,
-        text: hunk_header.clone(),
-        old_line_no: None,
-        new_line_no: None,
-    }];
+    let mut patch_lines = vec![PatchLine::hunk_header(&hunk_header)];
 
     for (i, line) in text_lines.iter().enumerate() {
-        patch_lines.push(PatchLine {
-            kind: PatchLineKind::Added,
-            text: (*line).to_string(),
-            old_line_no: None,
-            new_line_no: Some(i + 1),
-        });
+        patch_lines.push(PatchLine::added(*line, i + 1));
     }
 
     let hunk = Hunk {
@@ -478,12 +495,7 @@ fn parse_hunk(lines: &[&str]) -> Result<(Hunk, usize), GitDiffError> {
     let (old_start, old_count, new_start, new_count) = parse_hunk_header(header)?;
 
     let mut patch_lines = Vec::new();
-    patch_lines.push(PatchLine {
-        kind: PatchLineKind::HunkHeader,
-        text: header.to_string(),
-        old_line_no: None,
-        new_line_no: None,
-    });
+    patch_lines.push(PatchLine::hunk_header(header));
 
     let mut old_line = old_start;
     let mut new_line = new_start;
@@ -496,45 +508,20 @@ fn parse_hunk(lines: &[&str]) -> Result<(Hunk, usize), GitDiffError> {
         }
 
         if let Some(text) = line.strip_prefix('+') {
-            patch_lines.push(PatchLine {
-                kind: PatchLineKind::Added,
-                text: text.to_string(),
-                old_line_no: None,
-                new_line_no: Some(new_line),
-            });
+            patch_lines.push(PatchLine::added(text, new_line));
             new_line += 1;
         } else if let Some(text) = line.strip_prefix('-') {
-            patch_lines.push(PatchLine {
-                kind: PatchLineKind::Removed,
-                text: text.to_string(),
-                old_line_no: Some(old_line),
-                new_line_no: None,
-            });
+            patch_lines.push(PatchLine::removed(text, old_line));
             old_line += 1;
         } else if let Some(text) = line.strip_prefix(' ') {
-            patch_lines.push(PatchLine {
-                kind: PatchLineKind::Context,
-                text: text.to_string(),
-                old_line_no: Some(old_line),
-                new_line_no: Some(new_line),
-            });
+            patch_lines.push(PatchLine::context(text, old_line, new_line));
             old_line += 1;
             new_line += 1;
         } else if line.starts_with('\\') {
-            patch_lines.push(PatchLine {
-                kind: PatchLineKind::Meta,
-                text: line.to_string(),
-                old_line_no: None,
-                new_line_no: None,
-            });
+            patch_lines.push(PatchLine::meta(line));
         } else {
             // Treat as context (git sometimes omits the leading space for empty lines)
-            patch_lines.push(PatchLine {
-                kind: PatchLineKind::Context,
-                text: line.to_string(),
-                old_line_no: Some(old_line),
-                new_line_no: Some(new_line),
-            });
+            patch_lines.push(PatchLine::context(line, old_line, new_line));
             old_line += 1;
             new_line += 1;
         }

--- a/crates/wisp/tests/component_tests/file_list_panel.rs
+++ b/crates/wisp/tests/component_tests/file_list_panel.rs
@@ -1,7 +1,7 @@
 use tui::testing::{TestTerminal, assert_buffer_eq, cols, key, render_component};
 use tui::{Component, Event, KeyCode, KeyModifiers, MouseEvent, MouseEventKind, ViewContext};
 use wisp::components::file_list_panel::FileListPanel;
-use wisp::git_diff::{FileDiff, FileStatus, Hunk, PatchLine, PatchLineKind, StageState};
+use wisp::git_diff::{FileDiff, FileStatus, Hunk, PatchLine, StageState};
 
 const W: u16 = 40;
 
@@ -26,20 +26,10 @@ fn assert_selected_tree_row(term: &TestTerminal, selected: usize, unselected: us
 fn file(path: &str, status: FileStatus, additions: usize, deletions: usize) -> FileDiff {
     let mut lines = Vec::new();
     for i in 0..additions {
-        lines.push(PatchLine {
-            kind: PatchLineKind::Added,
-            text: format!("added {i}"),
-            old_line_no: None,
-            new_line_no: Some(i + 1),
-        });
+        lines.push(PatchLine::added(format!("added {i}"), i + 1));
     }
     for i in 0..deletions {
-        lines.push(PatchLine {
-            kind: PatchLineKind::Removed,
-            text: format!("removed {i}"),
-            old_line_no: Some(i + 1),
-            new_line_no: None,
-        });
+        lines.push(PatchLine::removed(format!("removed {i}"), i + 1));
     }
     FileDiff {
         old_path: None,

--- a/crates/wisp/tests/component_tests/git_diff_view.rs
+++ b/crates/wisp/tests/component_tests/git_diff_view.rs
@@ -1,12 +1,12 @@
 use super::support::git_diff::{
-    added_line, comment_diff_document, context_line, git_diff_document, hunk, modified_file_with_hunks, removed_line,
-    sample_git_diff_document, wrapping_split_document,
+    comment_diff_document, git_diff_document, hunk, modified_file_with_hunks, sample_git_diff_document,
+    wrapping_split_document,
 };
 use std::path::PathBuf;
 use tui::testing::{assert_buffer_eq, cols, key, render_component, render_lines};
 use tui::{Component, Event, KeyCode, MIN_GUTTER_WIDTH, SEPARATOR_WIDTH, ViewContext};
 use wisp::components::app::{GitDiffLoadState, GitDiffMode};
-use wisp::git_diff::GitDiffDocument;
+use wisp::git_diff::{GitDiffDocument, PatchLine};
 
 const LEFT_HINT_LINE: &str = "j/k move  space stage  t scope  A stage all  C commit  d discard  Esc close";
 const RIGHT_HINT_LINE: &str = "space stage  t scope  c comment  C commit  d discard  s submit  o full file  Esc close";
@@ -89,7 +89,7 @@ fn wrapped_split_diff_continuation_row_keeps_neutral_padding() {
 fn diff_header_aligns_with_split_line_numbers() {
     let mut mode = make_mode(git_diff_document(vec![modified_file_with_hunks(
         "x.rs",
-        vec![hunk("@@ -1,2 +1,2 @@", 1, 2, 1, 2, vec![removed_line("old();", 1), added_line("new();", 1)])],
+        vec![hunk("@@ -1,2 +1,2 @@", 1, 2, 1, 2, vec![PatchLine::removed("old();", 1), PatchLine::added("new();", 1)])],
     )]));
     let lines = render_component(|ctx| mode.render(ctx), 140, 7).get_lines();
     let header = lines.iter().find(|line| line.contains("x.rs  modified")).expect("diff header should render");
@@ -107,7 +107,7 @@ fn git_diff_view_keeps_wrapped_code_out_of_the_line_number_gutter() {
             2,
             1,
             2,
-            vec![removed_line("LEFT_MARK", 1), added_line(format!("RIGHT_HEAD {filler} RIGHT_TAIL"), 1)],
+            vec![PatchLine::removed("LEFT_MARK", 1), PatchLine::added(format!("RIGHT_HEAD {filler} RIGHT_TAIL"), 1)],
         )],
     )]));
     let term = render_component(|ctx| mode.render(ctx), 140, 7);
@@ -137,8 +137,11 @@ fn screenshot_shaped_git_diff_wrap_row_stays_out_of_gutters() {
             57,
             2,
             vec![
-                removed_line("let left = left_lines.get(i).cloned().unwrap_or_else(|| blank_panel(left_panel));", 56),
-                added_line(
+                PatchLine::removed(
+                    "let left = left_lines.get(i).cloned().unwrap_or_else(|| blank_panel(left_panel));",
+                    56,
+                ),
+                PatchLine::added(
                     "let left = left_lines.get(i).cloned().unwrap_or_else(|| blank_panel(left_panel, theme.code_bg()));",
                     57,
                 ),
@@ -284,9 +287,9 @@ fn unified_added_only_diff_uses_one_line_number_column() {
             50,
             3,
             vec![
-                context_line("pub use existing::Item;", 50, 50),
-                added_line("pub use diffs::intraline::{IntralineEmphasis, intraline_emphasis};", 51),
-                context_line("pub use focus::{FocusOutcome, FocusRing};", 51, 52),
+                PatchLine::context("pub use existing::Item;", 50, 50),
+                PatchLine::added("pub use diffs::intraline::{IntralineEmphasis, intraline_emphasis};", 51),
+                PatchLine::context("pub use focus::{FocusOutcome, FocusRing};", 51, 52),
             ],
         )],
     )]));
@@ -360,11 +363,11 @@ async fn opening_full_file_retains_split_layout() {
             1,
             4,
             vec![
-                context_line("fn main() {", 1, 1),
-                removed_line("    old_call();", 2),
-                added_line("    new_call();", 2),
-                context_line("    keep();", 3, 3),
-                context_line("}", 4, 4),
+                PatchLine::context("fn main() {", 1, 1),
+                PatchLine::removed("    old_call();", 2),
+                PatchLine::added("    new_call();", 2),
+                PatchLine::context("    keep();", 3, 3),
+                PatchLine::context("}", 4, 4),
             ],
         )],
     )]);
@@ -412,11 +415,11 @@ async fn opening_full_file_stays_unified_when_narrow() {
             1,
             4,
             vec![
-                context_line("fn main() {", 1, 1),
-                removed_line("    old_call();", 2),
-                added_line("    new_call();", 2),
-                context_line("    keep();", 3, 3),
-                context_line("}", 4, 4),
+                PatchLine::context("fn main() {", 1, 1),
+                PatchLine::removed("    old_call();", 2),
+                PatchLine::added("    new_call();", 2),
+                PatchLine::context("    keep();", 3, 3),
+                PatchLine::context("}", 4, 4),
             ],
         )],
     )]);
@@ -443,7 +446,7 @@ async fn opening_full_file_stays_unified_when_narrow() {
 
 #[test]
 fn scroll_track_appears_when_patch_overflows_viewport() {
-    let body: Vec<_> = (1..=40).map(|line_no| added_line(format!("line_{line_no}();"), line_no)).collect();
+    let body: Vec<_> = (1..=40).map(|line_no| PatchLine::added(format!("line_{line_no}();"), line_no)).collect();
     let mut mode = make_mode(git_diff_document(vec![modified_file_with_hunks(
         "long.rs",
         vec![hunk("@@ -0,0 +1,40 @@", 0, 0, 1, 40, body)],
@@ -517,7 +520,7 @@ async fn send_keys(mode: &mut GitDiffMode, codes: &[KeyCode]) {
 #[tokio::test]
 async fn commit_composer_keeps_cursor_off_the_last_row() {
     use wisp::git_diff::StageState;
-    let body: Vec<_> = (0..40).map(|i| context_line(format!("line {i}"), i + 1, i + 1)).collect();
+    let body: Vec<_> = (0..40).map(|i| PatchLine::context(format!("line {i}"), i + 1, i + 1)).collect();
     let mut file = modified_file_with_hunks("a.rs", vec![hunk("@@ -1,40 +1,40 @@", 1, 40, 1, 40, body)]);
     file.staged = StageState::Staged;
     let mut mode = make_mode(git_diff_document(vec![file]));
@@ -545,7 +548,7 @@ async fn commit_composer_keeps_cursor_off_the_last_row() {
 #[tokio::test]
 async fn empty_commit_message_surfaces_error() {
     use wisp::git_diff::StageState;
-    let body: Vec<_> = (0..3).map(|i| context_line(format!("line {i}"), i + 1, i + 1)).collect();
+    let body: Vec<_> = (0..3).map(|i| PatchLine::context(format!("line {i}"), i + 1, i + 1)).collect();
     let mut file = modified_file_with_hunks("a.rs", vec![hunk("@@ -1,3 +1,3 @@", 1, 3, 1, 3, body)]);
     file.staged = StageState::Staged;
     let mut mode = make_mode(git_diff_document(vec![file]));

--- a/crates/wisp/tests/component_tests/support/git_diff.rs
+++ b/crates/wisp/tests/component_tests/support/git_diff.rs
@@ -1,6 +1,6 @@
 use std::path::PathBuf;
 
-use wisp::git_diff::{FileDiff, FileStatus, GitDiffDocument, Hunk, PatchLine, PatchLineKind, StageState};
+use wisp::git_diff::{FileDiff, FileStatus, GitDiffDocument, Hunk, PatchLine, StageState};
 
 pub fn git_diff_document(files: Vec<FileDiff>) -> GitDiffDocument {
     GitDiffDocument { repo_root: PathBuf::from("/tmp/test"), files }
@@ -22,7 +22,7 @@ pub fn modified_file_with_hunks(path: &str, hunks: Vec<Hunk>) -> FileDiff {
 }
 
 pub fn added_file(path: &str, lines: &[&str]) -> FileDiff {
-    let body_lines = lines.iter().enumerate().map(|(index, line)| added_line(*line, index + 1)).collect();
+    let body_lines = lines.iter().enumerate().map(|(index, line)| PatchLine::added(*line, index + 1)).collect();
     FileDiff {
         old_path: None,
         path: path.to_string(),
@@ -41,32 +41,10 @@ pub fn hunk(
     new_count: usize,
     body_lines: Vec<PatchLine>,
 ) -> Hunk {
-    let mut lines = vec![PatchLine {
-        kind: PatchLineKind::HunkHeader,
-        text: header.to_string(),
-        old_line_no: None,
-        new_line_no: None,
-    }];
+    let mut lines = vec![PatchLine::hunk_header(header)];
     lines.extend(body_lines);
 
     Hunk { header: header.to_string(), old_start, old_count, new_start, new_count, lines }
-}
-
-pub fn context_line(text: impl Into<String>, old_line_no: usize, new_line_no: usize) -> PatchLine {
-    PatchLine {
-        kind: PatchLineKind::Context,
-        text: text.into(),
-        old_line_no: Some(old_line_no),
-        new_line_no: Some(new_line_no),
-    }
-}
-
-pub fn removed_line(text: impl Into<String>, old_line_no: usize) -> PatchLine {
-    PatchLine { kind: PatchLineKind::Removed, text: text.into(), old_line_no: Some(old_line_no), new_line_no: None }
-}
-
-pub fn added_line(text: impl Into<String>, new_line_no: usize) -> PatchLine {
-    PatchLine { kind: PatchLineKind::Added, text: text.into(), old_line_no: None, new_line_no: Some(new_line_no) }
 }
 
 pub fn sample_git_diff_document() -> GitDiffDocument {
@@ -74,10 +52,10 @@ pub fn sample_git_diff_document() -> GitDiffDocument {
         modified_file(
             "a.rs",
             vec![
-                context_line("fn main() {", 1, 1),
-                removed_line("    old();", 2),
-                added_line("    new();", 2),
-                context_line("}", 3, 3),
+                PatchLine::context("fn main() {", 1, 1),
+                PatchLine::removed("    old();", 2),
+                PatchLine::added("    new();", 2),
+                PatchLine::context("}", 3, 3),
             ],
         ),
         added_file("b.rs", &["new_content"]),
@@ -97,9 +75,9 @@ pub fn wrapping_split_document() -> GitDiffDocument {
             1,
             2,
             vec![
-                removed_line("LEFT_MARK", 1),
-                added_line(format!("RIGHT_HEAD {} RIGHT_TAIL", "A".repeat(140)), 1),
-                context_line("}", 2, 2),
+                PatchLine::removed("LEFT_MARK", 1),
+                PatchLine::added(format!("RIGHT_HEAD {} RIGHT_TAIL", "A".repeat(140)), 1),
+                PatchLine::context("}", 2, 2),
             ],
         )],
         binary: false,
@@ -118,7 +96,7 @@ pub fn comment_diff_document() -> GitDiffDocument {
             0,
             1,
             3,
-            vec![added_line("line_one", 1), added_line("line_two", 2), added_line("line_three", 3)],
+            vec![PatchLine::added("line_one", 1), PatchLine::added("line_two", 2), PatchLine::added("line_three", 3)],
         )],
         binary: false,
     }])


### PR DESCRIPTION
## Summary

While surveying the codebase for the most impactful DRY/simplification opportunity, I found that `wisp`'s git-diff model type `PatchLine` was being constructed via inline five-field struct literals at **39 sites** across the crate — production parser code and test helpers alike. Each literal restated the line-number bookkeeping that each `PatchLineKind` requires (old-only, new-only, both, or neither).

Notably, this exact refactor was previously applied in 34a7b33d (*"chore(wisp-next): DRY PatchLine code with methods on PatchLine"*) but was lost when the `wisp-next` crate was replaced by the current `wisp` crate. This PR re-applies it.

## Changes

- Add `PatchLine::{hunk_header, context, added, removed, meta}` constructors in `wisp/src/git_diff.rs`, encoding each kind's line-number semantics in exactly one place
- Use them in the production paths: `parse_hunk`, `build_untracked_file_diff`, and `GitDiffPanel`'s synthetic untracked-file diff builder
- Collapse the duplicated test helpers:
  - `support/git_diff.rs`'s `added_line`/`removed_line`/`context_line` (identical to the constructors) are removed; `git_diff_view.rs` now calls the constructors directly
  - the byte-for-byte identical 38-line `file()` helpers in `file_tree.rs` and `file_list_panel.rs` no longer inline struct literals
  - `git_diff_compositor.rs`'s local `added_line` helper delegates to the constructor

**Net: −130 lines**, no behavior change.

## What this fixes

The duplication wasn't just verbose — it was a latent-bug factory. Adding a new `PatchLineKind` or changing line-number semantics previously required finding and correctly updating dozens of struct literals. Now the compiler directs you to the single constructor.

## Validation

- `cargo nextest run -p aether-wisp --lib --test component_tests` — 664 passed
- `cargo nextest run -p aether-wisp --test app_tests` — 159 passed
- `cargo clippy -p aether-wisp --all-targets --all-features -- -D warnings` — clean
- `cargo fmt --check` — clean

Existing parser tests (`parse_hunk_header_tracking`, `parse_meta_line`, `build_untracked_*`) pin the exact line-number behavior, which is unchanged.