### PR TITLE
refactor: Use new acp type for context usage, use rmcp's list_all methods and use acp native elicitation

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,7 +44,7 @@ tracing-subscriber = { version = "0.3.23", features = ["env-filter", "json"] }
 tracing-appender = "0.2"
 
 # ACP
-agent-client-protocol = "2.0.0"
+agent-client-protocol = { version = "2.0.0", features = ["unstable_elicitation"] }
 
 # MCP and API clients
 rmcp = { version = "^3.1.1", default-features = false }

--- a/crates/acp-utils/README.md
+++ b/crates/acp-utils/README.md
@@ -16,7 +16,8 @@ Utilities for the [Agent Client Protocol](https://agentclientprotocol.com/) (ACP
 
 ## Key Types
 
-- **`ElicitationParams` / `ElicitationResponse`** -- Schema-driven user prompts and responses
+- **`elicitation`** -- Typed conversion between MCP elicitation and native ACP `elicitation/create` messages
+- **`ContextUsageParams`** -- Token usage tracking notifications
 - **`McpNotification` / `McpRequest`** -- MCP message tunneling over ACP
 - **`TokioAcpAgent`** -- Tokio-native ACP transport
 

--- a/crates/acp-utils/README.md
+++ b/crates/acp-utils/README.md
@@ -17,7 +17,6 @@ Utilities for the [Agent Client Protocol](https://agentclientprotocol.com/) (ACP
 ## Key Types
 
 - **`ElicitationParams` / `ElicitationResponse`** -- Schema-driven user prompts and responses
-- **`ContextUsageParams`** -- Token usage tracking notifications
 - **`McpNotification` / `McpRequest`** -- MCP message tunneling over ACP
 - **`TokioAcpAgent`** -- Tokio-native ACP transport
 

--- a/crates/acp-utils/src/client/event.rs
+++ b/crates/acp-utils/src/client/event.rs
@@ -2,12 +2,13 @@ use acp::Error;
 use acp::Responder;
 use acp::schema::v1::{SessionUpdate, StopReason};
 use agent_client_protocol as acp;
-use agent_client_protocol::schema::v1::{SessionConfigOption, SessionId, SessionInfo};
+use agent_client_protocol::schema::v1::{
+    CreateElicitationRequest, CreateElicitationResponse, SessionConfigOption, SessionId, SessionInfo,
+};
 
 use crate::notifications::{
-    AuthMethodsUpdatedParams, ContextClearedParams, ContextCompactionParams, ElicitationParams, ElicitationResponse,
-    McpNotification, PromptSearchResponse, SessionPreviewResponse, SubAgentProgressParams, WorkspaceListResponse,
-    WorkspaceMoveResponse,
+    AuthMethodsUpdatedParams, ContextClearedParams, ContextCompactionParams, McpNotification, PromptSearchResponse,
+    SessionPreviewResponse, SubAgentProgressParams, WorkspaceListResponse, WorkspaceMoveResponse,
 };
 
 /// Events forwarded from the ACP connection to the main event loop.
@@ -18,7 +19,7 @@ pub enum AcpEvent {
     SubAgentProgress(SubAgentProgressParams),
     AuthMethodsUpdated(AuthMethodsUpdatedParams),
     McpNotification(McpNotification),
-    ElicitationRequest { params: ElicitationParams, responder: Responder<ElicitationResponse> },
+    ElicitationRequest { params: Box<CreateElicitationRequest>, responder: Responder<CreateElicitationResponse> },
     PromptDone(StopReason),
     PromptError(Error),
     AuthenticateComplete { method_id: String },

--- a/crates/acp-utils/src/client/event.rs
+++ b/crates/acp-utils/src/client/event.rs
@@ -5,9 +5,9 @@ use agent_client_protocol as acp;
 use agent_client_protocol::schema::v1::{SessionConfigOption, SessionId, SessionInfo};
 
 use crate::notifications::{
-    AuthMethodsUpdatedParams, ContextClearedParams, ContextCompactionParams, ContextUsageParams, ElicitationParams,
-    ElicitationResponse, McpNotification, PromptSearchResponse, SessionPreviewResponse, SubAgentProgressParams,
-    WorkspaceListResponse, WorkspaceMoveResponse,
+    AuthMethodsUpdatedParams, ContextClearedParams, ContextCompactionParams, ElicitationParams, ElicitationResponse,
+    McpNotification, PromptSearchResponse, SessionPreviewResponse, SubAgentProgressParams, WorkspaceListResponse,
+    WorkspaceMoveResponse,
 };
 
 /// Events forwarded from the ACP connection to the main event loop.
@@ -15,7 +15,6 @@ pub enum AcpEvent {
     SessionUpdate { session_id: SessionId, update: Box<SessionUpdate> },
     ContextCleared(ContextClearedParams),
     ContextCompaction(ContextCompactionParams),
-    ContextUsage(ContextUsageParams),
     SubAgentProgress(SubAgentProgressParams),
     AuthMethodsUpdated(AuthMethodsUpdatedParams),
     McpNotification(McpNotification),

--- a/crates/acp-utils/src/client/session.rs
+++ b/crates/acp-utils/src/client/session.rs
@@ -2,8 +2,8 @@ use super::error::AcpClientError;
 use super::event::AcpEvent;
 use super::prompt_handle::{AcpPromptHandle, PromptCommand};
 use crate::notifications::{
-    AuthMethodsUpdatedParams, ContextClearedParams, ContextCompactionParams, ContextUsageParams, ElicitationParams,
-    McpNotification, McpRequest, SubAgentProgressParams,
+    AuthMethodsUpdatedParams, ContextClearedParams, ContextCompactionParams, ElicitationParams, McpNotification,
+    McpRequest, SubAgentProgressParams,
 };
 use agent_client_protocol::schema::v1::{
     AuthMethod, AuthenticateRequest, CancelNotification, ConfigOptionUpdate, ContentBlock, InitializeRequest,
@@ -106,16 +106,6 @@ async fn run_client_connection(
                 let event_tx = event_tx.clone();
                 async move |SessionNotification { session_id, update, .. }: SessionNotification, _cx| {
                     let _ = event_tx.send(AcpEvent::SessionUpdate { session_id, update: Box::new(update) });
-                    Ok(())
-                }
-            },
-            acp::on_receive_notification!(),
-        )
-        .on_receive_notification(
-            {
-                let event_tx = event_tx.clone();
-                async move |params: ContextUsageParams, _cx| {
-                    let _ = event_tx.send(AcpEvent::ContextUsage(params));
                     Ok(())
                 }
             },

--- a/crates/acp-utils/src/client/session.rs
+++ b/crates/acp-utils/src/client/session.rs
@@ -2,15 +2,16 @@ use super::error::AcpClientError;
 use super::event::AcpEvent;
 use super::prompt_handle::{AcpPromptHandle, PromptCommand};
 use crate::notifications::{
-    AuthMethodsUpdatedParams, ContextClearedParams, ContextCompactionParams, ElicitationParams, McpNotification,
-    McpRequest, SubAgentProgressParams,
+    AuthMethodsUpdatedParams, ContextClearedParams, ContextCompactionParams, McpNotification, McpRequest,
+    SubAgentProgressParams,
 };
 use agent_client_protocol::schema::v1::{
-    AuthMethod, AuthenticateRequest, CancelNotification, ConfigOptionUpdate, ContentBlock, InitializeRequest,
-    InitializeResponse, ListSessionsRequest, LoadSessionRequest, NewSessionRequest, NewSessionResponse,
-    PermissionOptionId, PermissionOptionKind, PromptCapabilities, PromptRequest, RequestPermissionOutcome,
-    RequestPermissionRequest, RequestPermissionResponse, SelectedPermissionOutcome, SessionCapabilities,
-    SessionConfigOption, SessionId, SessionNotification, SessionUpdate, SetSessionConfigOptionRequest, TextContent,
+    AuthMethod, AuthenticateRequest, CancelNotification, ConfigOptionUpdate, ContentBlock, CreateElicitationRequest,
+    InitializeRequest, InitializeResponse, ListSessionsRequest, LoadSessionRequest, NewSessionRequest,
+    NewSessionResponse, PermissionOptionId, PermissionOptionKind, PromptCapabilities, PromptRequest,
+    RequestPermissionOutcome, RequestPermissionRequest, RequestPermissionResponse, SelectedPermissionOutcome,
+    SessionCapabilities, SessionConfigOption, SessionId, SessionNotification, SessionUpdate,
+    SetSessionConfigOptionRequest, TextContent,
 };
 use agent_client_protocol::{self as acp, Client, ConnectTo, ConnectionTo, JsonRpcRequest};
 use tokio::sync::mpsc;
@@ -31,10 +32,6 @@ pub struct AcpSession {
 }
 
 /// Spawn an ACP agent and establish an ACP session.
-///
-/// The connection auto-approves permissions, forwards session notifications as
-/// [`AcpEvent`]s, and tunnels elicitation requests through the `_aether/elicitation`
-/// extension method.
 pub async fn spawn_acp_session(
     agent: impl ConnectTo<Client> + 'static,
     init_request: InitializeRequest,
@@ -89,8 +86,10 @@ async fn run_client_connection(
         .on_receive_request(
             {
                 let event_tx = event_tx.clone();
-                async move |params: ElicitationParams, responder, _cx| {
-                    if let Err(send_err) = event_tx.send(AcpEvent::ElicitationRequest { params, responder }) {
+                async move |params: CreateElicitationRequest, responder, _cx| {
+                    if let Err(send_err) =
+                        event_tx.send(AcpEvent::ElicitationRequest { params: Box::new(params), responder })
+                    {
                         // Recover the responder and reply with an error so the remote caller doesn't hang.
                         if let AcpEvent::ElicitationRequest { responder, .. } = send_err.0 {
                             return responder.respond_with_error(acp::Error::internal_error());

--- a/crates/acp-utils/src/elicitation.rs
+++ b/crates/acp-utils/src/elicitation.rs
@@ -33,7 +33,7 @@ pub fn map_mcp_elicitation_request_to_acp(
             CreateElicitationRequest::new(
                 acp::ElicitationUrlMode::new(
                     scope(),
-                    build_scoped_elicitation_id(server_name, elicitation_id),
+                    build_scoped_elicitation_id(session_id, server_name, elicitation_id),
                     url.clone(),
                 ),
                 message.clone(),
@@ -63,10 +63,11 @@ pub fn map_acp_elicitation_response_to_mcp(
 }
 
 pub fn build_acp_elicitation_completion_notification(
+    session_id: &SessionId,
     server_name: &str,
     elicitation_id: &str,
 ) -> CompleteElicitationNotification {
-    CompleteElicitationNotification::new(build_scoped_elicitation_id(server_name, elicitation_id))
+    CompleteElicitationNotification::new(build_scoped_elicitation_id(session_id, server_name, elicitation_id))
 }
 
 /// The MCP server a converted elicitation originated from, if any.
@@ -268,8 +269,8 @@ fn owned_string(value: Option<&str>) -> Option<String> {
     value.map(str::to_owned)
 }
 
-fn build_scoped_elicitation_id(server_name: &str, elicitation_id: &str) -> String {
-    format!("{server_name}:{elicitation_id}")
+fn build_scoped_elicitation_id(session_id: &SessionId, server_name: &str, elicitation_id: &str) -> String {
+    json!([session_id.0.as_ref(), server_name, elicitation_id]).to_string()
 }
 
 #[cfg(test)]
@@ -334,7 +335,7 @@ mod tests {
     }
 
     #[test]
-    fn url_ids_are_namespaced_per_mcp_server_and_match_completions() {
+    fn url_ids_are_namespaced_per_session_and_mcp_server() {
         let request = ElicitRequestParams::UrlElicitationParams {
             meta: None,
             message: "Authorize".to_string(),
@@ -344,19 +345,28 @@ mod tests {
 
         let alpha = map_mcp_elicitation_request_to_acp("alpha", &SessionId::new("session-1"), &request).unwrap();
         let bravo = map_mcp_elicitation_request_to_acp("bravo", &SessionId::new("session-1"), &request).unwrap();
+        let other_session =
+            map_mcp_elicitation_request_to_acp("alpha", &SessionId::new("session-2"), &request).unwrap();
         let ElicitationMode::Url(alpha_url) = alpha.mode else { panic!("expected URL mode") };
         let ElicitationMode::Url(bravo_url) = bravo.mode else { panic!("expected URL mode") };
+        let ElicitationMode::Url(other_session_url) = other_session.mode else { panic!("expected URL mode") };
 
         assert_ne!(alpha_url.elicitation_id, bravo_url.elicitation_id);
+        assert_ne!(alpha_url.elicitation_id, other_session_url.elicitation_id);
         assert_eq!(
-            build_acp_elicitation_completion_notification("alpha", "oauth").elicitation_id,
+            build_acp_elicitation_completion_notification(&SessionId::new("session-1"), "alpha", "oauth")
+                .elicitation_id,
             alpha_url.elicitation_id
         );
-        assert_eq!(
-            build_acp_elicitation_completion_notification("bravo", "oauth").elicitation_id,
-            bravo_url.elicitation_id
-        );
         assert_eq!(alpha_url.url, "https://example.com/oauth");
+    }
+
+    #[test]
+    fn url_id_namespacing_is_unambiguous() {
+        let first = build_scoped_elicitation_id(&SessionId::new("session"), "alpha:bravo", "oauth");
+        let second = build_scoped_elicitation_id(&SessionId::new("session"), "alpha", "bravo:oauth");
+
+        assert_ne!(first, second);
     }
 
     #[test]

--- a/crates/acp-utils/src/elicitation.rs
+++ b/crates/acp-utils/src/elicitation.rs
@@ -1,0 +1,394 @@
+use crate::notifications::AETHER_META_NAMESPACE;
+use agent_client_protocol::schema::v1::{
+    self as acp, CompleteElicitationNotification, CreateElicitationRequest, CreateElicitationResponse, Meta, SessionId,
+};
+use rmcp::model::{self as mcp, ElicitRequestParams, ElicitResult};
+use serde_json::{Map, Number, Value, json};
+
+#[derive(Debug, thiserror::Error)]
+pub enum ElicitationConversionError {
+    #[error("unsupported {0}")]
+    Unsupported(&'static str),
+    #[error("legacy MCP enum has a different number of values and titles")]
+    MismatchedEnumTitles,
+    #[error("ACP elicitation response contains a non-finite number")]
+    NonFiniteNumber,
+}
+
+pub fn map_mcp_elicitation_request_to_acp(
+    server_name: &str,
+    session_id: &SessionId,
+    request: &ElicitRequestParams,
+) -> Result<CreateElicitationRequest, ElicitationConversionError> {
+    let scope = || acp::ElicitationSessionScope::new(session_id.clone());
+    let (request, meta) = match request {
+        ElicitRequestParams::FormElicitationParams { meta, message, requested_schema } => (
+            CreateElicitationRequest::new(
+                acp::ElicitationFormMode::new(scope(), map_mcp_elicitation_schema_to_acp(requested_schema)?),
+                message.clone(),
+            ),
+            meta,
+        ),
+        ElicitRequestParams::UrlElicitationParams { meta, message, url, elicitation_id } => (
+            CreateElicitationRequest::new(
+                acp::ElicitationUrlMode::new(
+                    scope(),
+                    build_scoped_elicitation_id(server_name, elicitation_id),
+                    url.clone(),
+                ),
+                message.clone(),
+            ),
+            meta,
+        ),
+        _ => return Err(ElicitationConversionError::Unsupported("MCP elicitation request variant")),
+    };
+    Ok(request.meta(map_mcp_meta_to_acp(meta.as_ref(), server_name)))
+}
+
+pub fn map_acp_elicitation_response_to_mcp(
+    response: CreateElicitationResponse,
+) -> Result<ElicitResult, ElicitationConversionError> {
+    let mut result = match response.action {
+        acp::ElicitationAction::Accept(accept) => {
+            let mut result = ElicitResult::new(mcp::ElicitationAction::Accept);
+            result.content = accept.content.map(map_acp_elicitation_content_to_mcp).transpose()?;
+            result
+        }
+        acp::ElicitationAction::Decline => ElicitResult::new(mcp::ElicitationAction::Decline),
+        acp::ElicitationAction::Cancel => ElicitResult::new(mcp::ElicitationAction::Cancel),
+        _ => return Err(ElicitationConversionError::Unsupported("ACP elicitation response action")),
+    };
+    result.meta = response.meta.map(mcp::MetaObject::from);
+    Ok(result)
+}
+
+pub fn build_acp_elicitation_completion_notification(
+    server_name: &str,
+    elicitation_id: &str,
+) -> CompleteElicitationNotification {
+    CompleteElicitationNotification::new(build_scoped_elicitation_id(server_name, elicitation_id))
+}
+
+/// The MCP server a converted elicitation originated from, if any.
+pub fn source_mcp_server_name(meta: Option<&Meta>) -> Option<&str> {
+    meta.and_then(|meta| meta.get(AETHER_META_NAMESPACE))
+        .and_then(Value::as_object)
+        .and_then(|source| source.get("mcpServer"))
+        .and_then(Value::as_str)
+}
+
+fn map_mcp_elicitation_schema_to_acp(
+    schema: &mcp::ElicitationSchema,
+) -> Result<acp::ElicitationSchema, ElicitationConversionError> {
+    let required = schema.required.as_deref().unwrap_or_default();
+    schema.properties.iter().try_fold(
+        acp::ElicitationSchema::new()
+            .title(owned_string(schema.title.as_deref()))
+            .description(owned_string(schema.description.as_deref())),
+        |converted, (name, property)| {
+            Ok(converted.property(name, map_mcp_primitive_schema_to_acp(property)?, required.contains(name)))
+        },
+    )
+}
+
+fn map_mcp_primitive_schema_to_acp(
+    property: &mcp::PrimitiveSchemaDefinition,
+) -> Result<acp::ElicitationPropertySchema, ElicitationConversionError> {
+    match property {
+        mcp::PrimitiveSchemaDefinition::String(schema) => Ok(map_mcp_string_schema_to_acp(schema)?.into()),
+        mcp::PrimitiveSchemaDefinition::Number(schema) => Ok(acp::NumberPropertySchema::new()
+            .title(owned_string(schema.title.as_deref()))
+            .description(owned_string(schema.description.as_deref()))
+            .minimum(schema.minimum)
+            .maximum(schema.maximum)
+            .default_value(schema.default)
+            .into()),
+        mcp::PrimitiveSchemaDefinition::Integer(schema) => Ok(acp::IntegerPropertySchema::new()
+            .title(owned_string(schema.title.as_deref()))
+            .description(owned_string(schema.description.as_deref()))
+            .minimum(schema.minimum)
+            .maximum(schema.maximum)
+            .default_value(schema.default)
+            .into()),
+        mcp::PrimitiveSchemaDefinition::Boolean(schema) => Ok(acp::BooleanPropertySchema::new()
+            .title(owned_string(schema.title.as_deref()))
+            .description(owned_string(schema.description.as_deref()))
+            .default_value(schema.default)
+            .into()),
+        mcp::PrimitiveSchemaDefinition::Enum(schema) => map_mcp_enum_schema_to_acp(schema),
+        _ => Err(ElicitationConversionError::Unsupported("MCP elicitation schema variant")),
+    }
+}
+
+fn map_mcp_string_schema_to_acp(
+    schema: &mcp::StringSchema,
+) -> Result<acp::StringPropertySchema, ElicitationConversionError> {
+    let mut converted = acp::StringPropertySchema::new()
+        .title(owned_string(schema.title.as_deref()))
+        .description(owned_string(schema.description.as_deref()))
+        .min_length(schema.min_length)
+        .max_length(schema.max_length)
+        .default_value(schema.default.clone());
+    if let Some(format) = schema.format {
+        converted = converted.format(map_mcp_string_format_to_acp(format)?);
+    }
+    Ok(converted)
+}
+
+fn map_mcp_string_format_to_acp(format: mcp::StringFormat) -> Result<acp::StringFormat, ElicitationConversionError> {
+    match format {
+        mcp::StringFormat::Email => Ok(acp::StringFormat::Email),
+        mcp::StringFormat::Uri => Ok(acp::StringFormat::Uri),
+        mcp::StringFormat::Date => Ok(acp::StringFormat::Date),
+        mcp::StringFormat::DateTime => Ok(acp::StringFormat::DateTime),
+        _ => Err(ElicitationConversionError::Unsupported("MCP elicitation string format")),
+    }
+}
+
+fn map_mcp_enum_schema_to_acp(
+    schema: &mcp::EnumSchema,
+) -> Result<acp::ElicitationPropertySchema, ElicitationConversionError> {
+    match schema {
+        mcp::EnumSchema::Single(mcp::SingleSelectEnumSchema::Untitled(schema)) => Ok(build_acp_single_select_schema(
+            schema.title.as_deref(),
+            schema.description.as_deref(),
+            schema.default.clone(),
+        )
+        .enum_values(schema.enum_.clone())
+        .into()),
+        mcp::EnumSchema::Single(mcp::SingleSelectEnumSchema::Titled(schema)) => Ok(build_acp_single_select_schema(
+            schema.title.as_deref(),
+            schema.description.as_deref(),
+            schema.default.clone(),
+        )
+        .one_of(map_mcp_enum_options_to_acp(&schema.one_of))
+        .into()),
+        mcp::EnumSchema::Multi(mcp::MultiSelectEnumSchema::Untitled(schema)) => {
+            Ok(acp::MultiSelectPropertySchema::new(schema.items.enum_.clone())
+                .title(owned_string(schema.title.as_deref()))
+                .description(owned_string(schema.description.as_deref()))
+                .min_items(schema.min_items)
+                .max_items(schema.max_items)
+                .default_value(schema.default.clone())
+                .into())
+        }
+        mcp::EnumSchema::Multi(mcp::MultiSelectEnumSchema::Titled(schema)) => {
+            Ok(acp::MultiSelectPropertySchema::titled(map_mcp_enum_options_to_acp(&schema.items.any_of))
+                .title(owned_string(schema.title.as_deref()))
+                .description(owned_string(schema.description.as_deref()))
+                .min_items(schema.min_items)
+                .max_items(schema.max_items)
+                .default_value(schema.default.clone())
+                .into())
+        }
+        mcp::EnumSchema::Legacy(schema) => {
+            let (enum_values, one_of) = match &schema.enum_names {
+                Some(titles) if titles.len() == schema.enum_.len() => (
+                    None,
+                    Some(
+                        schema
+                            .enum_
+                            .iter()
+                            .zip(titles)
+                            .map(|(value, title)| acp::EnumOption::new(value, title))
+                            .collect::<Vec<_>>(),
+                    ),
+                ),
+                Some(_) => return Err(ElicitationConversionError::MismatchedEnumTitles),
+                None => (Some(schema.enum_.clone()), None),
+            };
+            Ok(build_acp_single_select_schema(
+                schema.title.as_deref(),
+                schema.description.as_deref(),
+                schema.default.clone(),
+            )
+            .enum_values(enum_values)
+            .one_of(one_of)
+            .into())
+        }
+        _ => Err(ElicitationConversionError::Unsupported("MCP elicitation schema variant")),
+    }
+}
+
+fn build_acp_single_select_schema(
+    title: Option<&str>,
+    description: Option<&str>,
+    default: Option<String>,
+) -> acp::StringPropertySchema {
+    acp::StringPropertySchema::new()
+        .title(title.map(str::to_owned))
+        .description(description.map(str::to_owned))
+        .default_value(default)
+}
+
+fn map_mcp_enum_options_to_acp(options: &[mcp::ConstTitle]) -> Vec<acp::EnumOption> {
+    options.iter().map(|option| acp::EnumOption::new(&option.const_, &option.title)).collect()
+}
+
+fn map_mcp_meta_to_acp(meta: Option<&mcp::RequestMetaObject>, server_name: &str) -> Meta {
+    let mut meta: Meta =
+        meta.map(|meta| meta.iter().map(|(key, value)| (key.clone(), value.clone())).collect()).unwrap_or_default();
+    let source = meta.entry(AETHER_META_NAMESPACE.to_string()).or_insert_with(|| json!({}));
+    if !source.is_object() {
+        *source = json!({});
+    }
+    source["mcpServer"] = json!(server_name);
+    meta
+}
+
+fn map_acp_elicitation_content_to_mcp(
+    content: std::collections::BTreeMap<String, acp::ElicitationContentValue>,
+) -> Result<Value, ElicitationConversionError> {
+    Ok(Value::Object(
+        content
+            .into_iter()
+            .map(|(name, value)| map_acp_elicitation_content_value_to_mcp(value).map(|value| (name, value)))
+            .collect::<Result<Map<_, _>, _>>()?,
+    ))
+}
+
+fn map_acp_elicitation_content_value_to_mcp(
+    value: acp::ElicitationContentValue,
+) -> Result<Value, ElicitationConversionError> {
+    match value {
+        acp::ElicitationContentValue::String(value) => Ok(Value::String(value)),
+        acp::ElicitationContentValue::Integer(value) => Ok(Value::Number(value.into())),
+        acp::ElicitationContentValue::Number(value) => {
+            Number::from_f64(value).map(Value::Number).ok_or(ElicitationConversionError::NonFiniteNumber)
+        }
+        acp::ElicitationContentValue::Boolean(value) => Ok(Value::Bool(value)),
+        acp::ElicitationContentValue::StringArray(values) => {
+            Ok(Value::Array(values.into_iter().map(Value::String).collect()))
+        }
+        _ => Err(ElicitationConversionError::Unsupported("ACP elicitation response content")),
+    }
+}
+
+fn owned_string(value: Option<&str>) -> Option<String> {
+    value.map(str::to_owned)
+}
+
+fn build_scoped_elicitation_id(server_name: &str, elicitation_id: &str) -> String {
+    format!("{server_name}:{elicitation_id}")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use agent_client_protocol::schema::v1::{
+        ElicitationAction, ElicitationMode, ElicitationPropertySchema, ElicitationScope,
+    };
+
+    #[test]
+    fn form_request_converts_with_session_scope_and_source_server() {
+        let request = ElicitRequestParams::FormElicitationParams {
+            meta: Some(mcp::RequestMetaObject::from(Map::from_iter([("ui".to_string(), json!("planReview"))]))),
+            message: "Review the plan".to_string(),
+            requested_schema: rmcp::model::ElicitationSchema::builder().required_bool("approved").build().unwrap(),
+        };
+
+        let converted = map_mcp_elicitation_request_to_acp("plan", &SessionId::new("session-1"), &request).unwrap();
+
+        let ElicitationMode::Form(form) = converted.mode else { panic!("expected form mode") };
+        let ElicitationScope::Session(scope) = form.scope else { panic!("expected session scope") };
+        assert_eq!(&*scope.session_id.0, "session-1");
+        assert!(form.requested_schema.properties.contains_key("approved"));
+        assert_eq!(converted.message, "Review the plan");
+        assert_eq!(converted.meta.as_ref().and_then(|meta| meta.get("ui")), Some(&json!("planReview")));
+        assert_eq!(source_mcp_server_name(converted.meta.as_ref()), Some("plan"));
+    }
+
+    #[test]
+    fn legacy_enum_names_convert_to_titled_acp_options() {
+        let mut legacy = rmcp::model::LegacyEnumSchema::new(vec!["small".into(), "large".into()]);
+        legacy.enum_names = Some(vec!["Small".into(), "Large".into()]);
+        legacy.default = Some("large".into());
+        let request = ElicitRequestParams::FormElicitationParams {
+            meta: None,
+            message: "Pick a size".to_string(),
+            requested_schema: rmcp::model::ElicitationSchema::builder()
+                .required_property(
+                    "size",
+                    rmcp::model::PrimitiveSchemaDefinition::Enum(rmcp::model::EnumSchema::Legacy(legacy)),
+                )
+                .build()
+                .unwrap(),
+        };
+
+        let converted = map_mcp_elicitation_request_to_acp("catalog", &SessionId::new("session-1"), &request).unwrap();
+        let ElicitationMode::Form(form) = converted.mode else { panic!("expected form mode") };
+        let Some(ElicitationPropertySchema::String(size)) = form.requested_schema.properties.get("size") else {
+            panic!("expected string property")
+        };
+
+        assert_eq!(size.default.as_deref(), Some("large"));
+        assert_eq!(
+            size.one_of
+                .as_ref()
+                .unwrap()
+                .iter()
+                .map(|option| (option.value.as_str(), option.title.as_str()))
+                .collect::<Vec<_>>(),
+            vec![("small", "Small"), ("large", "Large")]
+        );
+    }
+
+    #[test]
+    fn url_ids_are_namespaced_per_mcp_server_and_match_completions() {
+        let request = ElicitRequestParams::UrlElicitationParams {
+            meta: None,
+            message: "Authorize".to_string(),
+            url: "https://example.com/oauth".to_string(),
+            elicitation_id: "oauth".to_string(),
+        };
+
+        let alpha = map_mcp_elicitation_request_to_acp("alpha", &SessionId::new("session-1"), &request).unwrap();
+        let bravo = map_mcp_elicitation_request_to_acp("bravo", &SessionId::new("session-1"), &request).unwrap();
+        let ElicitationMode::Url(alpha_url) = alpha.mode else { panic!("expected URL mode") };
+        let ElicitationMode::Url(bravo_url) = bravo.mode else { panic!("expected URL mode") };
+
+        assert_ne!(alpha_url.elicitation_id, bravo_url.elicitation_id);
+        assert_eq!(
+            build_acp_elicitation_completion_notification("alpha", "oauth").elicitation_id,
+            alpha_url.elicitation_id
+        );
+        assert_eq!(
+            build_acp_elicitation_completion_notification("bravo", "oauth").elicitation_id,
+            bravo_url.elicitation_id
+        );
+        assert_eq!(alpha_url.url, "https://example.com/oauth");
+    }
+
+    #[test]
+    fn responses_convert_explicitly_and_unknown_actions_fail() {
+        let accept = CreateElicitationResponse::new(acp::ElicitationAcceptAction::new().content(
+            std::collections::BTreeMap::from([
+                ("approved".to_string(), acp::ElicitationContentValue::Boolean(true)),
+                ("count".to_string(), acp::ElicitationContentValue::Integer(3)),
+                ("name".to_string(), acp::ElicitationContentValue::String("Ada".to_string())),
+                (
+                    "tags".to_string(),
+                    acp::ElicitationContentValue::StringArray(vec!["rust".to_string(), "acp".to_string()]),
+                ),
+            ]),
+        ))
+        .meta(Map::from_iter([("traceId".to_string(), json!("trace-1"))]));
+        let result = map_acp_elicitation_response_to_mcp(accept).unwrap();
+        assert_eq!(result.action, rmcp::model::ElicitationAction::Accept);
+        assert_eq!(
+            result.content,
+            Some(json!({ "approved": true, "count": 3, "name": "Ada", "tags": ["rust", "acp"] }))
+        );
+        assert_eq!(result.meta.as_ref().and_then(|meta| meta.get("traceId")), Some(&json!("trace-1")));
+
+        let decline =
+            map_acp_elicitation_response_to_mcp(CreateElicitationResponse::new(ElicitationAction::Decline)).unwrap();
+        assert_eq!(decline.action, rmcp::model::ElicitationAction::Decline);
+
+        let unknown = CreateElicitationResponse::new(acp::OtherElicitationAction::new(
+            "_defer",
+            std::collections::BTreeMap::new(),
+        ));
+        assert!(map_acp_elicitation_response_to_mcp(unknown).is_err());
+    }
+}

--- a/crates/acp-utils/src/lib.rs
+++ b/crates/acp-utils/src/lib.rs
@@ -7,6 +7,7 @@ pub const AETHER_TOOL_NAME_META_KEY: &str = "aetherToolName";
 pub mod config_meta;
 pub mod config_option_id;
 pub mod content;
+pub mod elicitation;
 pub mod notifications;
 pub mod settings;
 
@@ -18,10 +19,3 @@ pub mod server;
 
 #[cfg(feature = "testing")]
 pub mod testing;
-
-// Re-export rmcp elicitation schema types so downstream crates (e.g. wisp)
-// don't need a direct rmcp dependency.
-pub use rmcp::model::{
-    ConstTitle, ElicitRequestParams, ElicitationSchema, EnumSchema, MultiSelectEnumSchema, PrimitiveSchemaDefinition,
-    SingleSelectEnumSchema,
-};

--- a/crates/acp-utils/src/notifications.rs
+++ b/crates/acp-utils/src/notifications.rs
@@ -63,14 +63,6 @@ impl ContextUsage {
     }
 }
 
-/// Parameters for `_aether/context_usage` notifications.
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, JsonRpcNotification)]
-#[notification(method = "_aether/context_usage")]
-pub struct ContextUsageParams {
-    #[serde(flatten)]
-    pub usage: ContextUsage,
-}
-
 /// Parameters for `_aether/context_compaction` notifications.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, JsonRpcNotification)]
 #[notification(method = "_aether/context_compaction")]
@@ -376,48 +368,6 @@ mod tests {
         let move_params =
             WorkspaceMoveParams { session_id: String::new(), target: WorkspaceMoveTarget::New { name: String::new() } };
         assert_eq!(move_params.method(), "_aether/workspace_move");
-    }
-
-    #[test]
-    fn context_usage_params_roundtrip() {
-        let params = ContextUsageParams {
-            usage: ContextUsage {
-                usage_ratio: Some(0.75),
-                context_limit: Some(100_000),
-                input_tokens: 75_000,
-                output_tokens: 1_200,
-                cache_read_tokens: Some(40_000),
-                cache_creation_tokens: Some(2_000),
-                reasoning_tokens: Some(500),
-                total_input_tokens: 200_000,
-                total_output_tokens: 8_000,
-                total_cache_read_tokens: 90_000,
-                total_cache_creation_tokens: 5_000,
-                total_reasoning_tokens: 1_500,
-            },
-        };
-
-        let untyped = params.to_untyped_message().expect("serializable");
-        assert_eq!(untyped.method(), "_aether/context_usage");
-        let parsed = ContextUsageParams::parse_message(untyped.method(), untyped.params()).expect("roundtrip");
-        assert_eq!(parsed, params);
-    }
-
-    #[test]
-    fn context_usage_params_omits_unset_optional_token_fields() {
-        let params = ContextUsageParams {
-            usage: ContextUsage {
-                usage_ratio: Some(0.1),
-                context_limit: Some(1_000),
-                input_tokens: 100,
-                ..ContextUsage::default()
-            },
-        };
-
-        let raw = serde_json::to_string(&params).unwrap();
-        assert!(!raw.contains("\"cache_read_tokens\""));
-        assert!(!raw.contains("\"cache_creation_tokens\""));
-        assert!(!raw.contains("\"reasoning_tokens\""));
     }
 
     #[test]

--- a/crates/acp-utils/src/notifications.rs
+++ b/crates/acp-utils/src/notifications.rs
@@ -5,7 +5,6 @@ use std::path::PathBuf;
 use agent_client_protocol::schema::v1::{AuthMethod, Meta};
 use agent_client_protocol::{JsonRpcNotification, JsonRpcRequest, JsonRpcResponse};
 pub use mcp_utils::display_meta::{ToolDisplayMeta, ToolResultMeta};
-pub use rmcp::model::ElicitRequestParams;
 use serde::{Deserialize, Serialize, de::DeserializeOwned};
 
 pub use mcp_utils::status::{McpServerAuthCapability, McpServerStatus, McpServerStatusEntry};
@@ -81,20 +80,6 @@ pub struct ContextClearedParams {}
 pub struct AuthMethodsUpdatedParams {
     pub auth_methods: Vec<AuthMethod>,
 }
-
-/// Request parameters for the `_aether/elicitation` ext method.
-///
-/// Carries the full RMCP elicitation request plus the originating server name
-/// so the client can distinguish form vs URL mode and display which server is
-/// requesting.
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, JsonRpcRequest)]
-#[request(method = "_aether/elicitation", response = ElicitationResponse)]
-pub struct ElicitationParams {
-    pub server_name: String,
-    pub request: ElicitRequestParams,
-}
-
-pub use rmcp::model::ElicitationAction;
 
 /// Parameters for the `_aether/prompt_search` request.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, JsonRpcRequest)]
@@ -272,14 +257,6 @@ fn from_aether_meta<T: DeserializeOwned + Default>(meta: Option<&Meta>) -> T {
         .unwrap_or_default()
 }
 
-/// Response returned from the client for an elicitation request.
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, JsonRpcResponse)]
-pub struct ElicitationResponse {
-    pub action: ElicitationAction,
-    /// Structured form data when action is "accept".
-    pub content: Option<serde_json::Value>,
-}
-
 /// Server→client MCP extension notifications (relay → wisp).
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, JsonRpcNotification)]
 #[notification(method = "_aether/mcp_event")]
@@ -446,48 +423,6 @@ mod tests {
 
         let untyped = params.to_untyped_message().expect("serializable");
         assert_eq!(untyped.method(), "_aether/sub_agent_progress");
-    }
-
-    #[test]
-    fn elicitation_params_roundtrip() {
-        use rmcp::model::{ElicitationSchema, EnumSchema};
-
-        let params = ElicitationParams {
-            server_name: "github".to_string(),
-            request: ElicitRequestParams::FormElicitationParams {
-                meta: None,
-                message: "Pick a color".to_string(),
-                requested_schema: ElicitationSchema::builder()
-                    .required_enum_schema(
-                        "color",
-                        EnumSchema::builder(vec!["red".into(), "green".into(), "blue".into()]).untitled().build(),
-                    )
-                    .build()
-                    .unwrap(),
-            },
-        };
-
-        let untyped = params.to_untyped_message().expect("serializable");
-        assert_eq!(untyped.method(), "_aether/elicitation");
-        let parsed = ElicitationParams::parse_message(untyped.method(), untyped.params()).expect("roundtrip");
-        assert_eq!(parsed, params);
-    }
-
-    #[test]
-    fn elicitation_params_url_variant_has_mode_field() {
-        let params = ElicitationParams {
-            server_name: "github".to_string(),
-            request: ElicitRequestParams::UrlElicitationParams {
-                meta: None,
-                message: "Authorize GitHub".to_string(),
-                url: "https://github.com/login/oauth".to_string(),
-                elicitation_id: "el-123".to_string(),
-            },
-        };
-
-        let json = serde_json::to_string(&params).unwrap();
-        assert!(json.contains("\"mode\":\"url\""));
-        assert!(json.contains("\"server_name\":\"github\""));
     }
 
     #[test]

--- a/crates/acp-utils/src/testing.rs
+++ b/crates/acp-utils/src/testing.rs
@@ -5,18 +5,15 @@
 //! need to exercise the full serialize/dispatch path (so wire-format
 //! regressions like extension method-name typos surface in tests).
 //!
-//! When a test needs to pass a real [`Responder<ElicitationResponse>`] into a
-//! component under test (e.g. an elicitation UI) and observe what that
-//! component eventually sends, call [`TestPeer::fake_elicitation`]: it kicks
-//! off a placeholder elicitation request, hands back the captured responder,
-//! and returns a receiver that resolves when the responder is consumed.
 
-use crate::notifications::{ElicitationParams, ElicitationResponse, McpNotification};
-use agent_client_protocol::schema::v1::SessionNotification;
+use crate::notifications::McpNotification;
+use agent_client_protocol::schema::v1::{
+    CompleteElicitationNotification, CreateElicitationRequest, CreateElicitationResponse, ElicitationFormMode,
+    ElicitationSchema, ElicitationSessionScope, SessionNotification,
+};
 use agent_client_protocol::{
     self as acp, Agent, Builder, ByteStreams, Client, ConnectionTo, HandleDispatchFrom, NullRun, Responder,
 };
-use rmcp::model::{ElicitRequestParams, ElicitationSchema};
 use std::collections::VecDeque;
 use std::sync::{Arc, Mutex};
 use tokio::io::DuplexStream;
@@ -29,22 +26,21 @@ pub type DuplexByteStreams = ByteStreams<Compat<DuplexStream>, Compat<DuplexStre
 pub struct TestPeer {
     session_notifications: mpsc::UnboundedReceiver<SessionNotification>,
     mcp_notifications: mpsc::UnboundedReceiver<McpNotification>,
-    elicitation_requests: mpsc::UnboundedReceiver<ElicitationParams>,
-    elicitation_responses: Arc<Mutex<VecDeque<ElicitationResponse>>>,
-    responder_capture: Arc<Mutex<Option<oneshot::Sender<Responder<ElicitationResponse>>>>>,
+    elicitation_requests: mpsc::UnboundedReceiver<CreateElicitationRequest>,
+    elicitation_completions: mpsc::UnboundedReceiver<CompleteElicitationNotification>,
+    elicitation_responses: Arc<Mutex<VecDeque<CreateElicitationResponse>>>,
+    responder_capture: Arc<Mutex<Option<oneshot::Sender<Responder<CreateElicitationResponse>>>>>,
 }
 
 impl TestPeer {
-    /// Build a `TestPeer` plus a pre-wired `Client.builder()` whose
-    /// notification handlers route session/mcp/elicitation traffic into the
-    /// peer. The caller decides whether to run the builder via `connect_to`
-    /// (drop the agent-side cx) or `connect_with` (capture the agent-side cx).
     pub fn new() -> (Self, Builder<Client, impl HandleDispatchFrom<Agent>, NullRun>) {
         let (sn_tx, sn_rx) = mpsc::unbounded_channel::<SessionNotification>();
         let (mcp_tx, mcp_rx) = mpsc::unbounded_channel::<McpNotification>();
-        let (el_tx, el_rx) = mpsc::unbounded_channel::<ElicitationParams>();
-        let elicitation_responses: Arc<Mutex<VecDeque<ElicitationResponse>>> = Arc::new(Mutex::new(VecDeque::new()));
-        let responder_capture: Arc<Mutex<Option<oneshot::Sender<Responder<ElicitationResponse>>>>> =
+        let (el_tx, el_rx) = mpsc::unbounded_channel::<CreateElicitationRequest>();
+        let (complete_tx, complete_rx) = mpsc::unbounded_channel::<CompleteElicitationNotification>();
+        let elicitation_responses: Arc<Mutex<VecDeque<CreateElicitationResponse>>> =
+            Arc::new(Mutex::new(VecDeque::new()));
+        let responder_capture: Arc<Mutex<Option<oneshot::Sender<Responder<CreateElicitationResponse>>>>> =
             Arc::new(Mutex::new(None));
 
         let builder = Client
@@ -69,12 +65,22 @@ impl TestPeer {
                 },
                 acp::on_receive_notification!(),
             )
+            .on_receive_notification(
+                {
+                    let tx = complete_tx;
+                    async move |notification: CompleteElicitationNotification, _cx| {
+                        let _ = tx.send(notification);
+                        Ok(())
+                    }
+                },
+                acp::on_receive_notification!(),
+            )
             .on_receive_request(
                 {
                     let tx = el_tx;
                     let responses = elicitation_responses.clone();
                     let capture = responder_capture.clone();
-                    async move |req: ElicitationParams, responder: Responder<ElicitationResponse>, _cx| {
+                    async move |req: CreateElicitationRequest, responder: Responder<CreateElicitationResponse>, _cx| {
                         if let Some(capture_tx) = capture.lock().unwrap().take() {
                             return match capture_tx.send(responder) {
                                 Ok(()) => Ok(()),
@@ -96,6 +102,7 @@ impl TestPeer {
             session_notifications: sn_rx,
             mcp_notifications: mcp_rx,
             elicitation_requests: el_rx,
+            elicitation_completions: complete_rx,
             elicitation_responses,
             responder_capture,
         };
@@ -110,40 +117,26 @@ impl TestPeer {
         self.mcp_notifications.recv().await.expect("peer channel closed")
     }
 
-    pub async fn next_elicitation_request(&mut self) -> ElicitationParams {
+    pub async fn next_elicitation_request(&mut self) -> CreateElicitationRequest {
         self.elicitation_requests.recv().await.expect("peer channel closed")
     }
 
-    /// Queue a response the peer will hand back for the next incoming
-    /// elicitation request. If the queue is empty when a request arrives, the
-    /// peer responds with a protocol error, which exercises the
-    /// `cancel_result()` fallback path in the caller.
-    pub fn queue_elicitation_response(&self, response: ElicitationResponse) {
+    pub async fn next_elicitation_completion(&mut self) -> CompleteElicitationNotification {
+        self.elicitation_completions.recv().await.expect("peer channel closed")
+    }
+
+    pub fn queue_elicitation_response(&self, response: CreateElicitationResponse) {
         self.elicitation_responses.lock().unwrap().push_back(response);
     }
 
-    pub fn capture_next_elicitation(&self) -> oneshot::Receiver<Responder<ElicitationResponse>> {
-        let (responder_tx, responder_rx) = oneshot::channel::<Responder<ElicitationResponse>>();
-        *self.responder_capture.lock().unwrap() = Some(responder_tx);
-        responder_rx
-    }
-
-    /// Kick off a placeholder elicitation request from the agent side of `cx`,
-    /// hand back the [`Responder<ElicitationResponse>`] captured on the client
-    /// side, and return a receiver that resolves when the responder is
-    /// consumed.
-    ///
-    /// Use in tests that pass a `Responder<ElicitationResponse>` into code
-    /// under test and want to observe the response without driving a full ACP
-    /// round-trip themselves.
     pub async fn fake_elicitation(
         &mut self,
         cx: &ConnectionTo<Client>,
-    ) -> (Responder<ElicitationResponse>, oneshot::Receiver<ElicitationResponse>) {
-        let (responder_tx, responder_rx) = oneshot::channel::<Responder<ElicitationResponse>>();
+    ) -> (Responder<CreateElicitationResponse>, oneshot::Receiver<CreateElicitationResponse>) {
+        let (responder_tx, responder_rx) = oneshot::channel::<Responder<CreateElicitationResponse>>();
         *self.responder_capture.lock().unwrap() = Some(responder_tx);
 
-        let (response_tx, response_rx) = oneshot::channel::<ElicitationResponse>();
+        let (response_tx, response_rx) = oneshot::channel::<CreateElicitationResponse>();
         let cx = cx.clone();
         spawn_local(async move {
             if let Ok(resp) = cx.send_request(placeholder_params()).block_task().await {
@@ -193,13 +186,9 @@ pub async fn test_connection() -> (ConnectionTo<Client>, TestPeer) {
     (cx, peer)
 }
 
-fn placeholder_params() -> ElicitationParams {
-    ElicitationParams {
-        server_name: String::new(),
-        request: ElicitRequestParams::FormElicitationParams {
-            meta: None,
-            message: String::new(),
-            requested_schema: ElicitationSchema::builder().build().expect("empty schema is valid"),
-        },
-    }
+fn placeholder_params() -> CreateElicitationRequest {
+    CreateElicitationRequest::new(
+        ElicitationFormMode::new(ElicitationSessionScope::new("test-session"), ElicitationSchema::new()),
+        String::new(),
+    )
 }

--- a/crates/aether-cli/src/acp/agent_runtime.rs
+++ b/crates/aether-cli/src/acp/agent_runtime.rs
@@ -149,10 +149,12 @@ impl RuntimeFactory for ProductionRuntimeFactory {
     ) -> Result<AgentRuntime, SessionError> {
         let extra_servers = self.mcp_servers.clone();
 
-        let builder = RuntimeBuilder::from_spec(self.cwd.clone(), spec.clone())
+        let mut builder = RuntimeBuilder::from_spec(self.cwd.clone(), spec.clone())
             .extra_servers(extra_servers)
-            .oauth_handler_factory(mcp_oauth_handler_factory())
             .agent_deps(self.agent_deps.clone());
+        if self.agent_deps.supports_mcp_url_elicitation() {
+            builder = builder.oauth_handler_factory(mcp_oauth_handler_factory());
+        }
 
         let runtime = builder.build(None, Some(initial_messages)).await?;
 

--- a/crates/aether-cli/src/acp/protocol/events.rs
+++ b/crates/aether-cli/src/acp/protocol/events.rs
@@ -1,6 +1,6 @@
 use acp_utils::notifications::{
-    ContextClearedParams, ContextCompactionParams, ContextUsageParams, SubAgentEvent, SubAgentProgressParams,
-    SubAgentToolCallUpdate, SubAgentToolError, SubAgentToolRequest, SubAgentToolResult,
+    ContextClearedParams, ContextCompactionParams, SubAgentEvent, SubAgentProgressParams, SubAgentToolCallUpdate,
+    SubAgentToolError, SubAgentToolRequest, SubAgentToolResult,
 };
 use aether_core::events::{
     AgentEvent, ContextEvent, MessageEvent, ModelEvent, SubAgentProgressPayload, ToolEvent, TurnEvent, TurnOutcome,
@@ -9,7 +9,7 @@ use aether_core::events::{
 use agent_client_protocol::schema::v1::{
     self as acp, Content, ContentBlock, ContentChunk, Diff, MessageId, PlanEntry, PlanEntryPriority, PlanEntryStatus,
     SessionId, SessionNotification, SessionUpdate, TextContent, ToolCall, ToolCallContent, ToolCallId, ToolCallStatus,
-    ToolCallUpdate, ToolCallUpdateFields,
+    ToolCallUpdate, ToolCallUpdateFields, UsageUpdate,
 };
 use agent_client_protocol::{JsonRpcMessage, UntypedMessage};
 use llm::{ToolCallError, ToolCallRequest, ToolCallResult};
@@ -24,16 +24,14 @@ pub fn map_agent_event_to_session_notification(session_id: SessionId, msg: &Agen
 /// to the client. Each variant serializes to its own `_aether/*` wire method
 /// and is sent via [`ConnectionTo<Client>::send_notification`].
 pub enum AgentExtNotification {
-    ContextUsage(ContextUsageParams),
     ContextCompaction(ContextCompactionParams),
     ContextCleared(ContextClearedParams),
-    SubAgentProgress(SubAgentProgressParams),
+    SubAgentProgress(Box<SubAgentProgressParams>),
 }
 
 impl AgentExtNotification {
     pub fn method(&self) -> &str {
         match self {
-            Self::ContextUsage(params) => params.method(),
             Self::ContextCompaction(params) => params.method(),
             Self::ContextCleared(params) => params.method(),
             Self::SubAgentProgress(params) => params.method(),
@@ -42,7 +40,6 @@ impl AgentExtNotification {
 
     pub fn to_untyped(&self) -> Result<UntypedMessage, agent_client_protocol::Error> {
         match self {
-            Self::ContextUsage(params) => params.to_untyped_message(),
             Self::ContextCompaction(params) => params.to_untyped_message(),
             Self::ContextCleared(params) => params.to_untyped_message(),
             Self::SubAgentProgress(params) => params.to_untyped_message(),
@@ -52,9 +49,6 @@ impl AgentExtNotification {
 
 pub fn try_into_agent_notification(msg: &AgentEvent) -> Option<AgentExtNotification> {
     match msg {
-        AgentEvent::Context(ContextEvent::UsageUpdated { usage }) => {
-            Some(AgentExtNotification::ContextUsage(ContextUsageParams { usage: usage.clone() }))
-        }
         AgentEvent::Context(ContextEvent::CompactionStarted { .. }) => {
             Some(AgentExtNotification::ContextCompaction(ContextCompactionParams { active: true }))
         }
@@ -65,7 +59,7 @@ pub fn try_into_agent_notification(msg: &AgentEvent) -> Option<AgentExtNotificat
         AgentEvent::Tool(ToolEvent::Progress { request, message, .. }) => {
             let msg_str = message.as_ref()?;
             let params = try_parse_sub_agent_progress(msg_str, request)?;
-            Some(AgentExtNotification::SubAgentProgress(params))
+            Some(AgentExtNotification::SubAgentProgress(Box::new(params)))
         }
         AgentEvent::Context(ContextEvent::Cleared) => {
             Some(AgentExtNotification::ContextCleared(ContextClearedParams::default()))
@@ -100,6 +94,13 @@ pub(crate) fn map_agent_event_to_notification(
     mode: NotificationMode,
 ) -> Option<SessionNotification> {
     match msg {
+        AgentEvent::Context(ContextEvent::UsageUpdated { usage }) => usage.context_limit.map(|context_limit| {
+            SessionNotification::new(
+                session_id,
+                SessionUpdate::UsageUpdate(UsageUpdate::new(usage.input_tokens.into(), context_limit.into())),
+            )
+        }),
+
         AgentEvent::Message(MessageEvent::Text { message_id, chunk, is_complete, .. }) => map_chunk_to_notification(
             session_id,
             chunk,
@@ -182,8 +183,7 @@ pub(crate) fn map_agent_event_to_notification(
         }
 
         AgentEvent::Context(
-            ContextEvent::UsageUpdated { .. }
-            | ContextEvent::Cleared
+            ContextEvent::Cleared
             | ContextEvent::CompactionStarted { .. }
             | ContextEvent::CompactionEnded { .. }
             | ContextEvent::CompactionResult { .. },
@@ -403,8 +403,9 @@ fn to_sub_agent_event(event: &AgentEvent) -> SubAgentEvent {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use acp_utils::notifications::{ContextUsage, SubAgentEvent};
+    use acp_utils::notifications::SubAgentEvent;
     use aether_core::events::CompactionOutcome;
+    use aether_core::events::ContextUsage;
     use llm::ToolCallRequest;
 
     #[test]
@@ -451,24 +452,36 @@ mod tests {
     }
 
     #[test]
+    fn context_usage_maps_to_native_acp_usage_update() {
+        let event = AgentEvent::Context(ContextEvent::UsageUpdated {
+            usage: ContextUsage { input_tokens: 75_000, context_limit: Some(100_000), ..ContextUsage::default() },
+        });
+
+        let notification = map_agent_event_to_session_notification(SessionId::new("session"), &event)
+            .expect("context usage notification");
+        let SessionUpdate::UsageUpdate(update) = notification.update else {
+            panic!("expected usage update");
+        };
+
+        assert_eq!(update.used, 75_000);
+        assert_eq!(update.size, 100_000);
+    }
+
+    #[test]
     fn extension_notifications_report_and_serialize_their_wire_methods() {
         let cases = [
-            (
-                AgentExtNotification::ContextUsage(ContextUsageParams { usage: ContextUsage::default() }),
-                "_aether/context_usage",
-            ),
             (
                 AgentExtNotification::ContextCompaction(ContextCompactionParams { active: true }),
                 "_aether/context_compaction",
             ),
             (AgentExtNotification::ContextCleared(ContextClearedParams::default()), "_aether/context_cleared"),
             (
-                AgentExtNotification::SubAgentProgress(SubAgentProgressParams {
+                AgentExtNotification::SubAgentProgress(Box::new(SubAgentProgressParams {
                     parent_tool_id: "parent".into(),
                     task_id: "task".into(),
                     agent_name: "agent".into(),
                     event: SubAgentEvent::Other,
-                }),
+                })),
                 "_aether/sub_agent_progress",
             ),
         ];

--- a/crates/aether-cli/src/acp/session_actor.rs
+++ b/crates/aether-cli/src/acp/session_actor.rs
@@ -1,4 +1,5 @@
-use acp_utils::notifications::{ElicitationParams, McpNotification};
+use acp_utils::elicitation;
+use acp_utils::notifications::McpNotification;
 use acp_utils::server::AcpServerError;
 use aether_auth::OAuthCredentialStorage;
 use aether_core::context::ext::conversation_messages_from_events;
@@ -10,7 +11,6 @@ use llm::catalog::LlmModel;
 use llm::parser::ModelProviderParser;
 use llm::{ChatMessage, ContentBlock, ProviderConnectionOverrides, ReasoningEffort};
 use mcp_utils::client::{ElicitationRequest, McpClientEvent, McpServerStatusEntry, cancel_result};
-use rmcp::model::{ElicitRequestParams, ElicitResult};
 use std::collections::HashMap;
 use std::sync::Arc;
 use tokio::sync::{mpsc, watch};
@@ -469,7 +469,7 @@ async fn on_runtime_event(actor: &mut SessionActor, io: &SessionIo, event: Runti
         }
         RuntimeEvent::Mcp { event, .. } => {
             let refresh_commands = matches!(event, McpClientEvent::ConnectionReady(_));
-            on_mcp_client_event(&io.connection, event);
+            on_mcp_client_event(&io.connection, &io.session_id, event);
             if refresh_commands {
                 match actor.list_available_commands().await {
                     Ok(commands) => send_available_commands(&io.connection, io.session_id.clone(), commands),
@@ -550,10 +550,19 @@ fn send_agent_notification(
     connection.send_notification(untyped).map_err(|error| AcpServerError::protocol(method, error))
 }
 
-fn on_mcp_client_event(connection: &ConnectionTo<Client>, event: McpClientEvent) {
+fn on_mcp_client_event(connection: &ConnectionTo<Client>, session_id: &SessionId, event: McpClientEvent) {
     match event {
-        McpClientEvent::Elicitation(elicitation) => {
-            spawn_elicitation_request(connection, *elicitation);
+        McpClientEvent::Elicitation(elicitation) => spawn_elicitation_request(connection, session_id, *elicitation),
+        McpClientEvent::ElicitationComplete { server_name, elicitation_id } => {
+            if let Err(error) = connection
+                .send_notification(elicitation::build_acp_elicitation_completion_notification(
+                    &server_name,
+                    &elicitation_id,
+                ))
+                .map_err(|error| AcpServerError::protocol("elicitation/complete", error))
+            {
+                error!("Failed to send elicitation completion: {error:?}");
+            }
         }
         McpClientEvent::ServerStatusesChanged(servers) => send_mcp_server_status(connection, servers),
         McpClientEvent::ConnectionReady(snapshot) => send_mcp_server_status(connection, snapshot.server_statuses()),
@@ -563,43 +572,42 @@ fn on_mcp_client_event(connection: &ConnectionTo<Client>, event: McpClientEvent)
     }
 }
 
-async fn on_elicitation_request(connection: &ConnectionTo<Client>, elicitation: ElicitationRequest) {
-    let params = build_elicitation_params(&elicitation.server_name, &elicitation.request);
+async fn on_elicitation_request(
+    connection: &ConnectionTo<Client>,
+    session_id: &SessionId,
+    elicitation: ElicitationRequest,
+) {
+    let result = async {
+        let request =
+            elicitation::map_mcp_elicitation_request_to_acp(&elicitation.server_name, session_id, &elicitation.request)
+                .map_err(|error| error.to_string())?;
+        let response = connection.send_request(request).block_task().await.map_err(|error| format!("{error:?}"))?;
+        elicitation::map_acp_elicitation_response_to_mcp(response).map_err(|error| error.to_string())
+    }
+    .await
+    .unwrap_or_else(|error| {
+        error!("ACP elicitation failed: {error}");
+        cancel_result()
+    });
 
-    let mcp_result = match connection
-        .send_request(params)
-        .block_task()
-        .await
-        .map_err(|e| AcpServerError::protocol("_aether/elicitation", e))
-    {
-        Ok(response) => {
-            let mut result = ElicitResult::new(response.action);
-            result.content = response.content;
-            result
-        }
-        Err(e) => {
-            error!("Failed to send elicitation request: {:?}", e);
-            cancel_result()
-        }
-    };
-
-    if elicitation.response_sender.send(mcp_result).is_err() {
+    if elicitation.response_sender.send(result).is_err() {
         error!("Failed to send elicitation response: receiver dropped");
     }
 }
 
-fn spawn_elicitation_request(connection: &ConnectionTo<Client>, elicitation: ElicitationRequest) {
+fn spawn_elicitation_request(
+    connection: &ConnectionTo<Client>,
+    session_id: &SessionId,
+    elicitation: ElicitationRequest,
+) {
     let connection = connection.clone();
+    let session_id = session_id.clone();
     if let Err(e) = connection.clone().spawn(async move {
-        on_elicitation_request(&connection, elicitation).await;
+        on_elicitation_request(&connection, &session_id, elicitation).await;
         Ok(())
     }) {
         error!("Failed to spawn elicitation request handler: {e:?}");
     }
-}
-
-fn build_elicitation_params(server_name: &str, request: &ElicitRequestParams) -> ElicitationParams {
-    ElicitationParams { server_name: server_name.to_string(), request: request.clone() }
 }
 
 #[cfg(test)]
@@ -766,54 +774,17 @@ mod tests {
         assert_eq!(s.effective_model(&validated_modes()), DEEPSEEK);
     }
 
-    #[test]
-    fn test_build_elicitation_params_from_form() {
-        let elicitation = ElicitRequestParams::FormElicitationParams {
-            meta: None,
-            message: "Pick a color".to_string(),
-            requested_schema: rmcp::model::ElicitationSchema::builder().required_bool("approved").build().unwrap(),
-        };
-
-        let params = build_elicitation_params("test-server", &elicitation);
-        assert_eq!(params.server_name, "test-server");
-        match &params.request {
-            ElicitRequestParams::FormElicitationParams { message, requested_schema, .. } => {
-                assert_eq!(message, "Pick a color");
-                assert_eq!(requested_schema.properties.len(), 1);
-                assert!(requested_schema.properties.contains_key("approved"));
-            }
-            ElicitRequestParams::UrlElicitationParams { .. } => panic!("Expected Form, got Url"),
-            _ => panic!("Expected Form elicitation"),
-        }
-    }
-
-    #[test]
-    fn test_build_elicitation_params_from_url() {
-        let elicitation = ElicitRequestParams::UrlElicitationParams {
-            meta: None,
-            message: "Authorize GitHub".to_string(),
-            url: "https://github.com/login/oauth".to_string(),
-            elicitation_id: "el-123".to_string(),
-        };
-
-        let params = build_elicitation_params("github", &elicitation);
-        assert_eq!(params.server_name, "github");
-        match &params.request {
-            ElicitRequestParams::UrlElicitationParams { message, url, elicitation_id, .. } => {
-                assert_eq!(message, "Authorize GitHub");
-                assert_eq!(url, "https://github.com/login/oauth");
-                assert_eq!(elicitation_id, "el-123");
-            }
-            ElicitRequestParams::FormElicitationParams { .. } => panic!("Expected Url, got Form"),
-            _ => panic!("Expected URL elicitation"),
-        }
-    }
-
     mod connection_tests {
         use super::*;
+        use acp_utils::elicitation::source_mcp_server_name;
         use acp_utils::testing::test_connection;
+        use rmcp::model::ElicitRequestParams;
         use tokio::sync::oneshot;
         use tokio::task::LocalSet;
+
+        fn dispatch_event(connection: &ConnectionTo<Client>, event: McpClientEvent) {
+            on_mcp_client_event(connection, &SessionId::new("session-1"), event);
+        }
 
         #[tokio::test(flavor = "current_thread")]
         async fn server_status_change_forwards_status_notification() {
@@ -825,7 +796,7 @@ mod tests {
                         mcp_utils::client::McpServerStatus::Connected { tool_count: 1 },
                     )];
 
-                    on_mcp_client_event(&cx, McpClientEvent::ServerStatusesChanged(servers));
+                    dispatch_event(&cx, McpClientEvent::ServerStatusesChanged(servers));
 
                     let received = peer.next_mcp_notification().await;
                     assert!(matches!(received, McpNotification::ServerStatus { .. }));
@@ -845,8 +816,8 @@ mod tests {
                         },
                     )];
 
-                    on_mcp_client_event(&cx, McpClientEvent::ServerStatusesChanged(servers));
-                    on_mcp_client_event(
+                    dispatch_event(&cx, McpClientEvent::ServerStatusesChanged(servers));
+                    dispatch_event(
                         &cx,
                         McpClientEvent::AuthenticationFailed {
                             server: "github".to_string(),
@@ -865,7 +836,7 @@ mod tests {
                 .run_until(async {
                     let (cx, mut peer) = test_connection().await;
 
-                    on_mcp_client_event(&cx, McpClientEvent::ServerStatusesChanged(vec![]));
+                    dispatch_event(&cx, McpClientEvent::ServerStatusesChanged(vec![]));
 
                     let McpNotification::ServerStatus { servers } = peer.next_mcp_notification().await;
                     assert!(servers.is_empty());
@@ -882,10 +853,30 @@ mod tests {
                         "github",
                         mcp_utils::client::McpServerStatus::Connected { tool_count: 1 },
                     )];
-                    on_mcp_client_event(&cx, McpClientEvent::ServerStatusesChanged(servers));
+                    dispatch_event(&cx, McpClientEvent::ServerStatusesChanged(servers));
 
                     let McpNotification::ServerStatus { servers } = peer.next_mcp_notification().await;
                     assert_eq!(servers[0].name, "github");
+                })
+                .await;
+        }
+
+        #[tokio::test(flavor = "current_thread")]
+        async fn elicitation_completion_forwards_native_acp_notification() {
+            LocalSet::new()
+                .run_until(async {
+                    let (cx, mut peer) = test_connection().await;
+
+                    dispatch_event(
+                        &cx,
+                        McpClientEvent::ElicitationComplete {
+                            server_name: "github".to_string(),
+                            elicitation_id: "el-1".to_string(),
+                        },
+                    );
+
+                    let completion = peer.next_elicitation_completion().await;
+                    assert_eq!(&*completion.elicitation_id.0, "github:el-1");
                 })
                 .await;
         }
@@ -895,10 +886,13 @@ mod tests {
             LocalSet::new()
                 .run_until(async {
                     let (cx, mut peer) = test_connection().await;
-                    peer.queue_elicitation_response(acp_utils::notifications::ElicitationResponse {
-                        action: rmcp::model::ElicitationAction::Accept,
-                        content: Some(serde_json::json!({ "color": "red" })),
-                    });
+                    peer.queue_elicitation_response(
+                        serde_json::from_value(serde_json::json!({
+                            "action": "accept",
+                            "content": { "color": "red" }
+                        }))
+                        .unwrap(),
+                    );
 
                     let (tx, rx) = oneshot::channel();
                     let elicitation = ElicitationRequest {
@@ -914,48 +908,17 @@ mod tests {
                         response_sender: tx,
                     };
 
-                    on_elicitation_request(&cx, elicitation).await;
+                    on_elicitation_request(&cx, &SessionId::new("session-1"), elicitation).await;
 
                     let result = rx.await.expect("response forwarded");
                     assert_eq!(result.action, rmcp::model::ElicitationAction::Accept);
                     assert_eq!(result.content, Some(serde_json::json!({ "color": "red" })));
 
                     let received = peer.next_elicitation_request().await;
-                    assert_eq!(received.server_name, "test-server");
-                })
-                .await;
-        }
-
-        #[tokio::test(flavor = "current_thread")]
-        async fn form_elicitation_request_does_not_block_the_caller() {
-            LocalSet::new()
-                .run_until(async {
-                    let (cx, peer) = test_connection().await;
-                    let responder_rx = peer.capture_next_elicitation();
-                    let (tx, rx) = oneshot::channel();
-                    let elicitation = ElicitationRequest {
-                        server_name: "test-server".to_string(),
-                        request: ElicitRequestParams::FormElicitationParams {
-                            meta: None,
-                            message: "Pick a color".to_string(),
-                            requested_schema: rmcp::model::ElicitationSchema::builder()
-                                .required_bool("approved")
-                                .build()
-                                .unwrap(),
-                        },
-                        response_sender: tx,
-                    };
-
-                    on_mcp_client_event(&cx, McpClientEvent::Elicitation(Box::new(elicitation)));
-
-                    let responder = responder_rx.await.expect("form elicitation request should reach peer");
-                    let _ = responder.respond(acp_utils::notifications::ElicitationResponse {
-                        action: rmcp::model::ElicitationAction::Accept,
-                        content: Some(serde_json::json!({ "approved": true })),
-                    });
-
-                    let result = rx.await.expect("spawned form request should forward response");
-                    assert_eq!(result.action, rmcp::model::ElicitationAction::Accept);
+                    assert_eq!(source_mcp_server_name(received.meta.as_ref()), Some("test-server"));
+                    let acp::ElicitationMode::Form(form) = received.mode else { panic!("expected form") };
+                    let acp::ElicitationScope::Session(scope) = form.scope else { panic!("expected session scope") };
+                    assert_eq!(&*scope.session_id.0, "session-1");
                 })
                 .await;
         }
@@ -977,7 +940,7 @@ mod tests {
                         response_sender: tx,
                     };
 
-                    on_elicitation_request(&cx, elicitation).await;
+                    on_elicitation_request(&cx, &SessionId::new("session-1"), elicitation).await;
 
                     let result = rx.await.expect("response forwarded");
                     assert_eq!(result.action, rmcp::model::ElicitationAction::Cancel);

--- a/crates/aether-cli/src/acp/session_actor.rs
+++ b/crates/aether-cli/src/acp/session_actor.rs
@@ -556,6 +556,7 @@ fn on_mcp_client_event(connection: &ConnectionTo<Client>, session_id: &SessionId
         McpClientEvent::ElicitationComplete { server_name, elicitation_id } => {
             if let Err(error) = connection
                 .send_notification(elicitation::build_acp_elicitation_completion_notification(
+                    session_id,
                     &server_name,
                     &elicitation_id,
                 ))
@@ -876,7 +877,7 @@ mod tests {
                     );
 
                     let completion = peer.next_elicitation_completion().await;
-                    assert_eq!(&*completion.elicitation_id.0, "github:el-1");
+                    assert_eq!(&*completion.elicitation_id.0, r#"["session-1","github","el-1"]"#);
                 })
                 .await;
         }

--- a/crates/aether-cli/src/acp/session_factory.rs
+++ b/crates/aether-cli/src/acp/session_factory.rs
@@ -9,6 +9,7 @@ use agent_client_protocol::{Client, ConnectionTo};
 use llm::catalog::{LlmModel, get_local_models};
 use llm::types::IsoString;
 use llm::{ProviderConnectionOverrides, ReasoningEffort};
+use rmcp::model::ClientCapabilities;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use tracing::{error, info, warn};
@@ -66,6 +67,7 @@ impl SessionFactory {
         &self,
         mut args: NewSessionRequest,
         cx: &ConnectionTo<Client>,
+        mcp_capabilities: ClientCapabilities,
     ) -> Result<CreatedSession, acp::Error> {
         // Inside a sandbox container the client sends the *host* cwd, but the
         // project is mounted at the container's working directory.
@@ -96,7 +98,8 @@ impl SessionFactory {
             error!("Failed to write session meta: {e}");
         }
 
-        let runtime_factory = self.production_runtime_factory(args.cwd, args.mcp_servers, mode_catalog.specs.catalog());
+        let runtime_factory =
+            self.production_runtime_factory(args.cwd, args.mcp_servers, mode_catalog.specs.catalog(), mcp_capabilities);
         self.build_session(SessionId::new(session_id), runtime_factory, mode_catalog, resolved, Vec::new(), cx).await
     }
 
@@ -104,6 +107,7 @@ impl SessionFactory {
         &self,
         args: LoadSessionRequest,
         cx: &ConnectionTo<Client>,
+        mcp_capabilities: ClientCapabilities,
     ) -> Result<CreatedSession, acp::Error> {
         let session_id = args.session_id.0.to_string();
         info!("Loading session: {session_id}");
@@ -116,7 +120,8 @@ impl SessionFactory {
         let mut mode_catalog = self.load_mode_catalog(&args.cwd).await?;
         let resolved = resolve_loaded_session(&mut mode_catalog, &meta, &events)?;
 
-        let runtime_factory = self.production_runtime_factory(args.cwd, args.mcp_servers, mode_catalog.specs.catalog());
+        let runtime_factory =
+            self.production_runtime_factory(args.cwd, args.mcp_servers, mode_catalog.specs.catalog(), mcp_capabilities);
         self.build_session(SessionId::new(session_id), runtime_factory, mode_catalog, resolved, events, cx).await
     }
 
@@ -125,10 +130,11 @@ impl SessionFactory {
         cwd: PathBuf,
         mcp_servers: Vec<acp::McpServer>,
         catalog: &AgentCatalog,
+        mcp_capabilities: ClientCapabilities,
     ) -> Arc<dyn RuntimeFactory> {
-        let registry = catalog.registry().clone();
         let deps = AgentDeps::new(Arc::clone(&self.oauth_credential_store), self.observer_factory.clone())
-            .with_agent_registry(registry);
+            .with_agent_registry(catalog.registry().clone())
+            .with_mcp_client_capabilities(mcp_capabilities);
         Arc::new(ProductionRuntimeFactory::new(cwd, map_acp_mcp_servers(mcp_servers), deps))
     }
 

--- a/crates/aether-cli/src/acp/state.rs
+++ b/crates/aether-cli/src/acp/state.rs
@@ -17,6 +17,7 @@ use agent_client_protocol::schema::v1::{
 use agent_client_protocol::{Client, ConnectionTo, Responder};
 use llm::catalog::{LlmModel, ModelSpec, get_local_models};
 use llm::{ContentBlock, ProviderConnectionOverrides};
+use mcp_utils::client::{client_capabilities, client_capabilities_for};
 use std::collections::{HashMap, HashSet};
 use std::io;
 use std::path::PathBuf;
@@ -47,6 +48,7 @@ pub(crate) struct AcpState {
     oauth_credential_store: Arc<dyn OAuthCredentialStorage>,
     factory: SessionFactory,
     telemetry: Option<Arc<TelemetryRuntime>>,
+    mcp_capabilities: Mutex<rmcp::model::ClientCapabilities>,
 }
 
 pub(crate) struct AcpStateConfig {
@@ -76,11 +78,13 @@ impl AcpState {
             oauth_credential_store: config.oauth_credential_store,
             factory,
             telemetry: config.telemetry,
+            mcp_capabilities: Mutex::new(client_capabilities()),
         }
     }
 
     pub(crate) async fn initialize(&self, args: InitializeRequest) -> Result<InitializeResponse, acp::Error> {
         info!("Received initialize request: {:?}", args);
+        *self.mcp_capabilities.lock().await = mcp_client_capabilities(&args.client_capabilities);
         let auth_methods = build_auth_methods(self.oauth_credential_store.as_ref());
         let available = get_local_models().await;
         let prompt_capabilities = prompt_capabilities_for_models(&available);
@@ -135,7 +139,8 @@ impl AcpState {
         req: NewSessionRequest,
         cx: &ConnectionTo<Client>,
     ) -> Result<NewSessionResponse, acp::Error> {
-        let created = self.factory.create(req, cx).await?;
+        let mcp_capabilities = self.mcp_capabilities.lock().await.clone();
+        let created = self.factory.create(req, cx, mcp_capabilities).await?;
         let response = NewSessionResponse::new(created.session_id.clone()).config_options(created.config_options);
         self.register_session(&created.session_id, created.handle).await;
         Ok(response)
@@ -146,7 +151,8 @@ impl AcpState {
         req: LoadSessionRequest,
         cx: &ConnectionTo<Client>,
     ) -> Result<LoadSessionResponse, acp::Error> {
-        let created = self.factory.load(req, cx).await?;
+        let mcp_capabilities = self.mcp_capabilities.lock().await.clone();
+        let created = self.factory.load(req, cx, mcp_capabilities).await?;
         let response = LoadSessionResponse::new().config_options(created.config_options);
         self.register_session(&created.session_id, created.handle).await;
         replay_to_client(&created.replay_events, cx, &created.session_id).await;
@@ -421,6 +427,14 @@ fn internal_error(message: impl Into<String>) -> acp::Error {
     acp::Error::new(i32::from(acp::ErrorCode::InternalError), message)
 }
 
+fn mcp_client_capabilities(client: &acp::ClientCapabilities) -> rmcp::model::ClientCapabilities {
+    let elicitation = client.elicitation.as_ref();
+    client_capabilities_for(
+        elicitation.is_some_and(|capabilities| capabilities.form.is_some()),
+        elicitation.is_some_and(|capabilities| capabilities.url.is_some()),
+    )
+}
+
 fn build_auth_methods(store: &dyn OAuthCredentialStorage) -> Vec<AuthMethod> {
     let mut seen = HashSet::new();
     LlmModel::all()
@@ -539,6 +553,24 @@ mod tests {
         assert!(capabilities.prompt_search);
         assert!(capabilities.session_preview);
         assert!(capabilities.workspace_move);
+    }
+
+    #[test]
+    fn mcp_elicitation_capabilities_mirror_the_acp_client() {
+        let none = mcp_client_capabilities(&acp::ClientCapabilities::new());
+        assert!(none.elicitation.is_none());
+
+        let form_only = acp::ClientCapabilities::new()
+            .elicitation(acp::ElicitationCapabilities::new().form(acp::ElicitationFormCapabilities::new()));
+        let form = mcp_client_capabilities(&form_only).elicitation.unwrap();
+        assert!(form.form.is_some());
+        assert!(form.url.is_none());
+
+        let url_only = acp::ClientCapabilities::new()
+            .elicitation(acp::ElicitationCapabilities::new().url(acp::ElicitationUrlCapabilities::new()));
+        let url = mcp_client_capabilities(&url_only).elicitation.unwrap();
+        assert!(url.form.is_none());
+        assert!(url.url.is_some());
     }
 
     #[test]

--- a/crates/aether-cli/src/mcp_command.rs
+++ b/crates/aether-cli/src/mcp_command.rs
@@ -226,7 +226,7 @@ async fn call_tool(
 async fn list_tools(
     client: &rmcp::service::RunningService<rmcp::RoleClient, ()>,
 ) -> Result<Vec<Tool>, McpCommandError> {
-    timed(DISCOVERY_TIMEOUT, client.list_tools(None)).await.map(|result| result.tools)
+    timed(DISCOVERY_TIMEOUT, client.list_all_tools()).await
 }
 
 async fn timed<T, U: Display>(

--- a/crates/aether-core/src/core/agent_deps.rs
+++ b/crates/aether-core/src/core/agent_deps.rs
@@ -42,10 +42,36 @@ impl AgentDeps {
         self
     }
 
+    pub fn supports_mcp_url_elicitation(&self) -> bool {
+        self.mcp_client_capabilities
+            .as_ref()
+            .and_then(|capabilities| capabilities.elicitation.as_ref())
+            .is_some_and(|elicitation| elicitation.url.is_some())
+    }
+
     /// A fresh observer isolated to one agent, if a factory is configured.
     pub fn observer(&self, agent_name: &str) -> Option<Box<dyn AgentObserver>> {
         self.observer_factory
             .as_ref()
             .map(|factory| factory.agent(Some(agent_name), self.parent_trace_context.as_ref()))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use rmcp::model::{ElicitationCapability, FormElicitationCapability, UrlElicitationCapability};
+
+    #[test]
+    fn mcp_url_elicitation_support_requires_advertised_url_capability() {
+        assert!(!AgentDeps::default().supports_mcp_url_elicitation());
+
+        let mut form_only = ClientCapabilities::default();
+        form_only.elicitation = Some(ElicitationCapability::new().with_form(FormElicitationCapability::new()));
+        assert!(!AgentDeps::default().with_mcp_client_capabilities(form_only).supports_mcp_url_elicitation());
+
+        let mut url = ClientCapabilities::default();
+        url.elicitation = Some(ElicitationCapability::new().with_url(UrlElicitationCapability::new()));
+        assert!(AgentDeps::default().with_mcp_client_capabilities(url).supports_mcp_url_elicitation());
     }
 }

--- a/crates/aether-core/src/core/agent_deps.rs
+++ b/crates/aether-core/src/core/agent_deps.rs
@@ -1,6 +1,7 @@
 use crate::core::AgentRegistry;
 use crate::events::{AgentObserver, DynObserverFactory, TraceContext};
 use aether_auth::OAuthCredentialStorage;
+use rmcp::model::ClientCapabilities;
 use std::sync::Arc;
 
 /// Cross-cutting dependencies threaded to every agent a run spawns — the root
@@ -14,6 +15,7 @@ pub struct AgentDeps {
     /// that spawned them.
     pub parent_trace_context: Option<TraceContext>,
     pub agent_registry: AgentRegistry,
+    pub mcp_client_capabilities: Option<ClientCapabilities>,
 }
 
 impl AgentDeps {
@@ -21,12 +23,7 @@ impl AgentDeps {
         oauth_credential_store: Arc<dyn OAuthCredentialStorage>,
         observer_factory: Option<DynObserverFactory>,
     ) -> Self {
-        Self {
-            oauth_credential_store: Some(oauth_credential_store),
-            observer_factory,
-            parent_trace_context: None,
-            agent_registry: AgentRegistry::default(),
-        }
+        Self { oauth_credential_store: Some(oauth_credential_store), observer_factory, ..Self::default() }
     }
 
     /// Continue `parent`'s trace in every agent built from these deps.
@@ -37,6 +34,11 @@ impl AgentDeps {
 
     pub fn with_agent_registry(mut self, registry: AgentRegistry) -> Self {
         self.agent_registry = registry;
+        self
+    }
+
+    pub fn with_mcp_client_capabilities(mut self, capabilities: ClientCapabilities) -> Self {
+        self.mcp_client_capabilities = Some(capabilities);
         self
     }
 

--- a/crates/aether-core/src/mcp/mcp_builder.rs
+++ b/crates/aether-core/src/mcp/mcp_builder.rs
@@ -322,6 +322,9 @@ impl McpBuilder {
         let mut mcp_manager = McpManager::new(event_tx, oauth_handler_factory)
             .with_tool_filter(tool_filter)
             .with_snapshot_sender(snapshot_tx);
+        if let Some(capabilities) = services.agent_deps.mcp_client_capabilities.clone() {
+            mcp_manager = mcp_manager.with_client_capabilities(capabilities);
+        }
         if let Some(instructions) = progressive_discovery_instructions {
             mcp_manager = mcp_manager.with_progressive_discovery_instructions(instructions);
         }

--- a/crates/aether-core/src/mcp/mcp_handle.rs
+++ b/crates/aether-core/src/mcp/mcp_handle.rs
@@ -77,13 +77,12 @@ impl McpHandle {
 
     pub async fn list_prompts(&self) -> Result<Vec<Prompt>, McpHandleError> {
         let futures = self.snapshot().clients_with_prompts().into_iter().map(|(server, client)| async move {
-            let response = client
-                .list_prompts(None)
+            let prompts = client
+                .list_all_prompts()
                 .await
                 .map_err(|error| McpHandleError::PromptList { server: server.clone(), message: error.to_string() })?;
             Ok::<_, McpHandleError>(
-                response
-                    .prompts
+                prompts
                     .into_iter()
                     .map(|prompt| {
                         Prompt::new(format!("{server}__{}", prompt.name), prompt.description, prompt.arguments)

--- a/crates/aether-core/src/testing/mcp_test.rs
+++ b/crates/aether-core/src/testing/mcp_test.rs
@@ -126,12 +126,11 @@ impl McpTestBuilder {
     }
 
     pub async fn build(self) -> McpTest {
+        let builder = mcp("/workspace").with_servers(self.servers);
         let builder = self
             .factories
             .into_iter()
-            .fold(mcp("/workspace").with_servers(self.servers), |builder, (name, factory)| {
-                builder.register_in_memory_server(name, factory)
-            });
+            .fold(builder, |builder, (name, factory)| builder.register_in_memory_server(name, factory));
         let mut spawn = builder.spawn().await.expect("MCP test manager spawns");
         let snapshot = spawn.block_until_ready().await.expect("MCP test manager becomes ready");
         let (runtime, event_rx) = spawn.split();

--- a/crates/aether-core/tests/mcp/agent_sync_tests.rs
+++ b/crates/aether-core/tests/mcp/agent_sync_tests.rs
@@ -1,11 +1,14 @@
 use aether_core::{
+    core::AgentDeps,
     events::{AgentCommand, Command},
     mcp::{ServerFactory, mcp},
     testing::{FakeMcpServer, FakeTool},
 };
 use futures::FutureExt;
 use mcp_utils::client::{InMemoryServerSpec, McpClientEvent, McpServer, McpTransport};
-use rmcp::{RoleServer, service::DynService};
+use rmcp::RoleServer;
+use rmcp::model::{ClientCapabilities, UrlElicitationCapability};
+use rmcp::service::DynService;
 use tokio::sync::mpsc;
 
 #[tokio::test]
@@ -20,6 +23,40 @@ async fn session_synchronization_does_not_keep_agent_input_open() {
     drop(agent_tx);
     assert_eq!(agent_rx.sender_strong_count(), 0);
     drop(runtime);
+}
+
+#[tokio::test]
+async fn spawned_mcp_client_advertises_the_configured_elicitation_support() {
+    let server = FakeMcpServer::new();
+    let state = server.state();
+    let factory_server = server.clone();
+    let factory: ServerFactory = Box::new(move |_, _| {
+        let server = factory_server.clone();
+        async move { Box::new(server) as Box<dyn DynService<RoleServer>> }.boxed()
+    });
+    let configured = McpServer::new(
+        "capability-capture",
+        McpTransport::InMemory {
+            spec: InMemoryServerSpec { factory: "capability-factory".to_string(), args: Vec::new(), input: None },
+        },
+        mcp_utils::client::ToolExposure::ModelVisible,
+    );
+    let mut url_only = ClientCapabilities::builder().enable_elicitation().build();
+    url_only.elicitation.as_mut().unwrap().url = Some(UrlElicitationCapability::default());
+    let mut session = mcp("/workspace")
+        .register_in_memory_server("capability-factory", factory)
+        .with_servers(vec![configured])
+        .with_agent_deps(AgentDeps::default().with_mcp_client_capabilities(url_only))
+        .spawn()
+        .await
+        .unwrap();
+
+    session.block_until_ready().await.expect("MCP bootstrap completes");
+
+    let capabilities = state.client_capabilities().expect("client capabilities were discovered");
+    let elicitation = capabilities.elicitation.expect("elicitation is advertised");
+    assert!(elicitation.form.is_none());
+    assert!(elicitation.url.is_some());
 }
 
 #[tokio::test]
@@ -67,7 +104,9 @@ async fn session_synchronizes_agent_while_forwarding_host_events() {
         match host_events.recv().await.expect("host event stream remains connected") {
             McpClientEvent::ServerStatusesChanged(_) => received_status = true,
             McpClientEvent::ConnectionReady(_) => break,
-            McpClientEvent::Elicitation(_) | McpClientEvent::AuthenticationFailed { .. } => {}
+            McpClientEvent::Elicitation(_)
+            | McpClientEvent::ElicitationComplete { .. }
+            | McpClientEvent::AuthenticationFailed { .. } => {}
         }
     }
     assert!(received_status);

--- a/crates/aether-core/tests/mcp/oauth_tests.rs
+++ b/crates/aether-core/tests/mcp/oauth_tests.rs
@@ -3,8 +3,8 @@ use aether_core::mcp::mcp;
 use aether_core::testing::{FakeMcpServer, fake_mcp};
 use futures::future::BoxFuture;
 use mcp_utils::client::{
-    DeferredToolRules, McpClientEvent, McpManager, OAuthHandlerFactory, RuntimeMcpServer, RuntimeMcpTransport,
-    ToolExposure,
+    DeferredToolRules, ElicitingOAuthHandler, McpClientEvent, McpManager, OAuthHandlerContext, OAuthHandlerFactory,
+    RuntimeMcpServer, RuntimeMcpTransport, ToolExposure,
 };
 use mcp_utils::status::{McpServerAuthCapability, McpServerStatus};
 use rmcp::transport::streamable_http_client::StreamableHttpClientTransportConfig;
@@ -109,6 +109,45 @@ async fn cancelling_handler_returns_user_cancelled() {
     let handler = CancellingOAuthHandler;
     let result = handler.authorize("https://example.com/auth").await;
     assert!(matches!(result, Err(OAuthError::UserCancelled)));
+}
+
+#[tokio::test]
+async fn eliciting_oauth_handler_emits_completion_after_callback() {
+    let (event_tx, mut event_rx) = mpsc::channel(4);
+    let handler = Arc::new(
+        ElicitingOAuthHandler::new(OAuthHandlerContext {
+            server_name: "linear".to_string(),
+            callback_port: None,
+            tx: event_tx,
+        })
+        .unwrap(),
+    );
+    let callback_url = handler.redirect_uri().to_string();
+    let authorize = {
+        let handler = handler.clone();
+        tokio::spawn(async move { handler.authorize("https://linear.app/oauth").await })
+    };
+
+    let McpClientEvent::Elicitation(request) = event_rx.recv().await.unwrap() else {
+        panic!("expected OAuth elicitation");
+    };
+    request.response_sender.send(rmcp::model::ElicitResult::new(rmcp::model::ElicitationAction::Accept)).unwrap();
+    let port = callback_url
+        .strip_prefix("http://localhost:")
+        .and_then(|value| value.strip_suffix('/'))
+        .unwrap()
+        .parse::<u16>()
+        .unwrap();
+    let mut stream = tokio::net::TcpStream::connect(("127.0.0.1", port)).await.unwrap();
+    stream.write_all(b"GET /?code=test-code&state=test-state HTTP/1.1\r\nHost: localhost\r\n\r\n").await.unwrap();
+    authorize.await.unwrap().unwrap();
+
+    let completion = event_rx.try_recv().expect("OAuth callback should complete the URL elicitation");
+    assert!(matches!(
+        completion,
+        McpClientEvent::ElicitationComplete { server_name, elicitation_id }
+            if server_name == "linear" && elicitation_id == "aether-oauth"
+    ));
 }
 
 #[tokio::test]

--- a/crates/mcp-servers/src/coding/mod.rs
+++ b/crates/mcp-servers/src/coding/mod.rs
@@ -45,7 +45,7 @@ use crate::{
     lsp::tools::document_info::{LspDocumentInput, LspDocumentOutput, execute_lsp_document},
     workspace_paths::WorkspacePaths,
 };
-use mcp_utils::server::mrtr::{AbortReason, InputKind, MrtrAction, parse_response, validate_input_requests};
+use mcp_utils::server::mrtr::{input_requests_supported, parse_response};
 use mcp_utils::server::tasks::{BACKGROUND_TASK_TTL_MS, require_tasks_capability};
 
 use mcp_utils::display_meta::{ToolDisplayMeta, ToolResultMeta, basename, truncate};
@@ -165,9 +165,7 @@ impl<T: CodingTools + 'static> ServerHandler for CodingMcp<T> {
         }
 
         if let Some(prompt) = self.permission_prompt(&request) {
-            let action = if let Some(responses) = request.input_responses.clone() {
-                MrtrAction::Resume(responses)
-            } else {
+            let Some(responses) = request.input_responses.clone() else {
                 let requests = InputRequests::from([(
                     "permission".to_string(),
                     InputRequest::Elicitation(ElicitRequest::new(decision_form(
@@ -175,32 +173,20 @@ impl<T: CodingTools + 'static> ServerHandler for CodingMcp<T> {
                         &prompt.description,
                     ))),
                 )]);
-
-                match validate_input_requests(context.client_capabilities().as_ref(), &requests) {
-                    Ok(()) => MrtrAction::Request(InputRequiredResult::from_input_requests(requests)),
-                    Err(_) => MrtrAction::Abort(AbortReason::UnsupportedInput {
-                        key: "permission".to_string(),
-                        kind: InputKind::FormElicitation,
-                    }),
-                }
-            };
-
-            match action {
-                MrtrAction::Request(request) => return Ok(request.into()),
-                MrtrAction::Abort(_) => {
+                if !input_requests_supported(context.client_capabilities().as_ref(), &requests) {
                     let message = permission_unsupported(&prompt.tool_name);
                     return Ok(CallToolResult::error(vec![ContentBlock::text(message)]).into());
                 }
-                MrtrAction::Resume(responses) => {
-                    let result: ElicitResult = parse_response(&responses, "permission")?;
-                    if !permission_granted(&result) {
-                        return Ok(CallToolResult::error(vec![ContentBlock::text(format!(
-                            "Operation declined by user: {}",
-                            prompt.tool_name
-                        ))])
-                        .into());
-                    }
-                }
+                return Ok(InputRequiredResult::from_input_requests(requests).into());
+            };
+
+            let result: ElicitResult = parse_response(&responses, "permission")?;
+            if !permission_granted(&result) {
+                return Ok(CallToolResult::error(vec![ContentBlock::text(format!(
+                    "Operation declined by user: {}",
+                    prompt.tool_name
+                ))])
+                .into());
             }
         }
         if let Some(args) = background_args {

--- a/crates/mcp-servers/src/coding/mod.rs
+++ b/crates/mcp-servers/src/coding/mod.rs
@@ -4,14 +4,14 @@ use rmcp::{
     ErrorData, RoleServer, ServerHandler,
     handler::server::{
         router::tool::ToolRouter,
-        tool::ToolCallContext,
+        tool::{ToolCallContext, parse_json_object},
         wrapper::{Json, Parameters},
     },
     model::{
         CallToolRequestParams, CallToolResponse, CallToolResult, CancelTaskParams, ContentBlock, CreateTaskResult,
         ElicitRequest, ElicitRequestParams, ElicitResult, ElicitationAction, ElicitationSchema, EnumSchema,
-        GetTaskParams, GetTaskResult, Implementation, InputRequest, InputRequests, ProgressNotificationParam,
-        ServerCapabilities, ServerInfo, UpdateTaskParams,
+        GetTaskParams, GetTaskResult, Implementation, InputRequest, InputRequests, InputRequiredResult,
+        ProgressNotificationParam, ServerCapabilities, ServerInfo, UpdateTaskParams,
     },
     service::RequestContext,
     task_manager::{TaskContext, TaskExit, TaskManager, TaskOptions},
@@ -45,9 +45,8 @@ use crate::{
     lsp::tools::document_info::{LspDocumentInput, LspDocumentOutput, execute_lsp_document},
     workspace_paths::WorkspacePaths,
 };
-use mcp_utils::server::mrtr::{MrtrAction, get_next_mrtr_action, parse_response};
+use mcp_utils::server::mrtr::{AbortReason, InputKind, MrtrAction, parse_response, validate_input_requests};
 use mcp_utils::server::tasks::{BACKGROUND_TASK_TTL_MS, require_tasks_capability};
-use mcp_utils::server::tool::parse_arguments;
 
 use mcp_utils::display_meta::{ToolDisplayMeta, ToolResultMeta, basename, truncate};
 use tools::ast_grep::{AstGrepInput, AstGrepOutput, perform_ast_grep};
@@ -166,16 +165,25 @@ impl<T: CodingTools + 'static> ServerHandler for CodingMcp<T> {
         }
 
         if let Some(prompt) = self.permission_prompt(&request) {
-            let action = get_next_mrtr_action(request.input_responses.as_ref(), || {
-                Ok(InputRequests::from([(
+            let action = if let Some(responses) = request.input_responses.clone() {
+                MrtrAction::Resume(responses)
+            } else {
+                let requests = InputRequests::from([(
                     "permission".to_string(),
                     InputRequest::Elicitation(ElicitRequest::new(decision_form(
                         &prompt.tool_name,
                         &prompt.description,
                     ))),
-                )]))
-            })?
-            .validate_for_client(&context);
+                )]);
+
+                match validate_input_requests(context.client_capabilities().as_ref(), &requests) {
+                    Ok(()) => MrtrAction::Request(InputRequiredResult::from_input_requests(requests)),
+                    Err(_) => MrtrAction::Abort(AbortReason::UnsupportedInput {
+                        key: "permission".to_string(),
+                        kind: InputKind::FormElicitation,
+                    }),
+                }
+            };
 
             match action {
                 MrtrAction::Request(request) => return Ok(request.into()),
@@ -416,15 +424,31 @@ When using tools that take file paths, always use absolute paths from:
                 if name != "bash" {
                     return None;
                 }
-                let command = parse_arguments::<BashInput>(request).ok()?.command;
+                let command = request
+                    .arguments
+                    .clone()
+                    .and_then(|arguments| parse_json_object::<BashInput>(arguments).ok())?
+                    .command;
+
                 is_dangerous_cmd(&command)
                     .then(|| PermissionPrompt { tool_name: name.to_string(), description: command })
             }
             PermissionMode::AlwaysAsk => {
                 let description = match name {
-                    "bash" => parse_arguments::<BashInput>(request).ok()?.command,
+                    "bash" => {
+                        request
+                            .arguments
+                            .clone()
+                            .and_then(|arguments| parse_json_object::<BashInput>(arguments).ok())?
+                            .command
+                    }
                     "write_file" | "edit_file" => {
-                        let file_path = parse_arguments::<FilePathArg>(request).ok()?.file_path;
+                        let file_path = request
+                            .arguments
+                            .clone()
+                            .and_then(|arguments| parse_json_object::<FilePathArg>(arguments).ok())?
+                            .file_path;
+
                         self.resolve_file_arg(&file_path).unwrap_or(file_path)
                     }
                     _ => {
@@ -810,7 +834,7 @@ fn background_bash_args(request: &CallToolRequestParams) -> Option<BashInput> {
         return None;
     }
 
-    let args = parse_arguments::<BashInput>(request).ok()?;
+    let args = request.arguments.clone().and_then(|arguments| parse_json_object::<BashInput>(arguments).ok())?;
     args.run_in_background.is_some_and(|background| background).then_some(args)
 }
 

--- a/crates/mcp-servers/src/plan/server.rs
+++ b/crates/mcp-servers/src/plan/server.rs
@@ -3,19 +3,19 @@ use crate::file_ops::{FileEdit, FileError, apply_edits, read_text_file, write_te
 use crate::workspace_paths::resolve_path;
 use clap::Parser;
 use mcp_utils::display_meta::{FileDiff, ToolDisplayMeta, ToolResultMeta, basename};
-use mcp_utils::server::mrtr::{ELICITATION_UNSUPPORTED, Elicited, MrtrAction, get_next_mrtr_action, parse_response};
+use mcp_utils::server::mrtr::{ELICITATION_UNSUPPORTED, parse_response, validate_input_requests};
 use rmcp::{
     ErrorData as McpError, RoleServer, ServerHandler,
     handler::server::{
         router::tool::ToolRouter,
-        tool::{InputResponses, schema_for_output},
+        tool::{InputResponses, IntoCallToolResult, RequestState, schema_for_output},
         wrapper::{Json, Parameters},
     },
     model::{
-        ElicitRequest, ElicitRequestParams, ElicitResult, ElicitationAction, ElicitationSchema, EnumSchema,
-        GetPromptRequestParams, GetPromptResponse, Implementation, InputRequest, InputRequests, ListPromptsResult,
-        PaginatedRequestParams, Prompt, PromptArgument, PromptMessage, RequestMetaObject, Role, ServerCapabilities,
-        ServerInfo,
+        CallToolResponse, CallToolResult, ContentBlock, ElicitRequest, ElicitRequestParams, ElicitResult,
+        ElicitationAction, ElicitationSchema, EnumSchema, GetPromptRequestParams, GetPromptResponse, Implementation,
+        InputRequest, InputRequests, InputRequiredResult, ListPromptsResult, PaginatedRequestParams, Prompt,
+        PromptArgument, PromptMessage, RequestMetaObject, Role, ServerCapabilities, ServerInfo,
     },
     service::RequestContext,
     tool, tool_handler, tool_router,
@@ -166,35 +166,36 @@ impl PlanMcp {
         &self,
         request: Parameters<SubmitPlanInput>,
         responses: InputResponses,
+        _request_state: RequestState,
         context: RequestContext<RoleServer>,
-    ) -> Result<Elicited<Json<SubmitPlanOutput>>, McpError> {
+    ) -> Result<CallToolResponse, McpError> {
         let Parameters(input) = request;
         let plan = match Plan::load_by_name(&self.plans_dir, &input.plan_name).await {
             Ok(plan) => plan,
-            Err(e) => return Ok(Elicited::error(e.to_string())),
+            Err(e) => return Ok(CallToolResult::error(vec![ContentBlock::text(e.to_string())]).into()),
         };
 
         if !self.submit_command.is_empty() {
             return match run_external_submit(&plan, &self.submit_command).await {
-                Ok(output) => Ok(Elicited::Done(Json(output))),
-                Err(e) => Ok(Elicited::error(e.to_string())),
+                Ok(output) => Ok(Json(output).into_call_tool_result()?),
+                Err(e) => Ok(CallToolResult::error(vec![ContentBlock::text(e.to_string())]).into()),
             };
         }
 
-        let action = get_next_mrtr_action(responses.0.as_ref(), || {
+        let responses = if let Some(responses) = responses.0 {
+            responses
+        } else {
             let params = Self::build_elicitation_form(&plan).map_err(|e| McpError::internal_error(e, None))?;
-            Ok(InputRequests::from([("review".to_string(), InputRequest::Elicitation(ElicitRequest::new(params)))]))
-        })?
-        .validate_for_client(&context);
-
-        let responses = match action {
-            MrtrAction::Request(request) => return Ok(Elicited::Respond(request.into())),
-            MrtrAction::Abort(_) => return Ok(Elicited::error(ELICITATION_UNSUPPORTED)),
-            MrtrAction::Resume(responses) => responses,
+            let requests =
+                InputRequests::from([("review".to_string(), InputRequest::Elicitation(ElicitRequest::new(params)))]);
+            if validate_input_requests(context.client_capabilities().as_ref(), &requests).is_err() {
+                return Ok(CallToolResult::error(vec![ContentBlock::text(ELICITATION_UNSUPPORTED)]).into());
+            }
+            return Ok(InputRequiredResult::from_input_requests(requests).into());
         };
         let result: ElicitResult = parse_response(&responses, "review")?;
 
-        Ok(Elicited::Done(Json(review_decision(&result))))
+        Ok(Json(review_decision(&result)).into_call_tool_result()?)
     }
 
     fn build_elicitation_form(plan: &Plan) -> Result<ElicitRequestParams, String> {

--- a/crates/mcp-servers/src/plan/server.rs
+++ b/crates/mcp-servers/src/plan/server.rs
@@ -182,9 +182,7 @@ impl PlanMcp {
             };
         }
 
-        let responses = if let Some(responses) = responses.0 {
-            responses
-        } else {
+        let Some(responses) = responses.0 else {
             let params = Self::build_elicitation_form(&plan).map_err(|e| McpError::internal_error(e, None))?;
             let requests =
                 InputRequests::from([("review".to_string(), InputRequest::Elicitation(ElicitRequest::new(params)))]);
@@ -195,7 +193,7 @@ impl PlanMcp {
         };
         let result: ElicitResult = parse_response(&responses, "review")?;
 
-        Ok(Json(review_decision(&result)).into_call_tool_result()?)
+        Json(review_decision(&result)).into_call_tool_result()
     }
 
     fn build_elicitation_form(plan: &Plan) -> Result<ElicitRequestParams, String> {

--- a/crates/mcp-servers/src/plan/server.rs
+++ b/crates/mcp-servers/src/plan/server.rs
@@ -3,7 +3,7 @@ use crate::file_ops::{FileEdit, FileError, apply_edits, read_text_file, write_te
 use crate::workspace_paths::resolve_path;
 use clap::Parser;
 use mcp_utils::display_meta::{FileDiff, ToolDisplayMeta, ToolResultMeta, basename};
-use mcp_utils::server::mrtr::{ELICITATION_UNSUPPORTED, parse_response, validate_input_requests};
+use mcp_utils::server::mrtr::{ELICITATION_UNSUPPORTED, input_requests_supported, parse_response};
 use rmcp::{
     ErrorData as McpError, RoleServer, ServerHandler,
     handler::server::{
@@ -186,7 +186,7 @@ impl PlanMcp {
             let params = Self::build_elicitation_form(&plan).map_err(|e| McpError::internal_error(e, None))?;
             let requests =
                 InputRequests::from([("review".to_string(), InputRequest::Elicitation(ElicitRequest::new(params)))]);
-            if validate_input_requests(context.client_capabilities().as_ref(), &requests).is_err() {
+            if !input_requests_supported(context.client_capabilities().as_ref(), &requests) {
                 return Ok(CallToolResult::error(vec![ContentBlock::text(ELICITATION_UNSUPPORTED)]).into());
             }
             return Ok(InputRequiredResult::from_input_requests(requests).into());

--- a/crates/mcp-servers/src/survey/server.rs
+++ b/crates/mcp-servers/src/survey/server.rs
@@ -1,4 +1,4 @@
-use mcp_utils::server::mrtr::{ELICITATION_UNSUPPORTED, parse_response, validate_input_requests};
+use mcp_utils::server::mrtr::{ELICITATION_UNSUPPORTED, input_requests_supported, parse_response};
 use rmcp::{
     ErrorData, RoleServer, ServerHandler,
     handler::server::{
@@ -95,7 +95,7 @@ impl SurveyMcp {
             let params = ElicitRequestParams::FormElicitationParams { meta: None, message, requested_schema: schema };
             let requests =
                 InputRequests::from([("answer".to_string(), InputRequest::Elicitation(ElicitRequest::new(params)))]);
-            if validate_input_requests(context.client_capabilities().as_ref(), &requests).is_err() {
+            if !input_requests_supported(context.client_capabilities().as_ref(), &requests) {
                 return Ok(CallToolResult::error(vec![ContentBlock::text(ELICITATION_UNSUPPORTED)]).into());
             }
             return Ok(rmcp::model::InputRequiredResult::from_input_requests(requests).into());

--- a/crates/mcp-servers/src/survey/server.rs
+++ b/crates/mcp-servers/src/survey/server.rs
@@ -91,9 +91,7 @@ impl SurveyMcp {
         let schema =
             parse_schema(schema).map_err(|e| ErrorData::invalid_params(format!("invalid schema: {e}"), None))?;
 
-        let responses = if let Some(responses) = responses.0 {
-            responses
-        } else {
+        let Some(responses) = responses.0 else {
             let params = ElicitRequestParams::FormElicitationParams { meta: None, message, requested_schema: schema };
             let requests =
                 InputRequests::from([("answer".to_string(), InputRequest::Elicitation(ElicitRequest::new(params)))]);
@@ -104,8 +102,8 @@ impl SurveyMcp {
         };
         let result: ElicitResult = parse_response(&responses, "answer")?;
 
-        Ok(Json(AskUserOutput { accepted: result.action == ElicitationAction::Accept, data: result.content })
-            .into_call_tool_result()?)
+        Json(AskUserOutput { accepted: result.action == ElicitationAction::Accept, data: result.content })
+            .into_call_tool_result()
     }
 }
 

--- a/crates/mcp-servers/src/survey/server.rs
+++ b/crates/mcp-servers/src/survey/server.rs
@@ -1,14 +1,15 @@
-use mcp_utils::server::mrtr::{ELICITATION_UNSUPPORTED, Elicited, MrtrAction, get_next_mrtr_action, parse_response};
+use mcp_utils::server::mrtr::{ELICITATION_UNSUPPORTED, parse_response, validate_input_requests};
 use rmcp::{
     ErrorData, RoleServer, ServerHandler,
     handler::server::{
         router::tool::ToolRouter,
-        tool::{InputResponses, schema_for_output},
+        tool::{InputResponses, IntoCallToolResult, RequestState, schema_for_output},
         wrapper::{Json, Parameters},
     },
     model::{
-        ElicitRequest, ElicitRequestParams, ElicitResult, ElicitationAction, ElicitationSchema, Implementation,
-        InputRequest, InputRequests, ServerCapabilities, ServerInfo,
+        CallToolResponse, CallToolResult, ContentBlock, ElicitRequest, ElicitRequestParams, ElicitResult,
+        ElicitationAction, ElicitationSchema, Implementation, InputRequest, InputRequests, ServerCapabilities,
+        ServerInfo,
     },
     service::RequestContext,
     tool, tool_handler, tool_router,
@@ -83,28 +84,28 @@ impl SurveyMcp {
         &self,
         request: Parameters<AskUserInput>,
         responses: InputResponses,
+        _request_state: RequestState,
         context: RequestContext<RoleServer>,
-    ) -> Result<Elicited<Json<AskUserOutput>>, ErrorData> {
+    ) -> Result<CallToolResponse, ErrorData> {
         let Parameters(AskUserInput { message, schema }) = request;
         let schema =
             parse_schema(schema).map_err(|e| ErrorData::invalid_params(format!("invalid schema: {e}"), None))?;
 
-        let action = get_next_mrtr_action(responses.0.as_ref(), || {
+        let responses = if let Some(responses) = responses.0 {
+            responses
+        } else {
             let params = ElicitRequestParams::FormElicitationParams { meta: None, message, requested_schema: schema };
-            Ok(InputRequests::from([("answer".to_string(), InputRequest::Elicitation(ElicitRequest::new(params)))]))
-        })?
-        .validate_for_client(&context);
-        let responses = match action {
-            MrtrAction::Request(request) => return Ok(Elicited::Respond(request.into())),
-            MrtrAction::Abort(_) => return Ok(Elicited::error(ELICITATION_UNSUPPORTED)),
-            MrtrAction::Resume(responses) => responses,
+            let requests =
+                InputRequests::from([("answer".to_string(), InputRequest::Elicitation(ElicitRequest::new(params)))]);
+            if validate_input_requests(context.client_capabilities().as_ref(), &requests).is_err() {
+                return Ok(CallToolResult::error(vec![ContentBlock::text(ELICITATION_UNSUPPORTED)]).into());
+            }
+            return Ok(rmcp::model::InputRequiredResult::from_input_requests(requests).into());
         };
         let result: ElicitResult = parse_response(&responses, "answer")?;
 
-        Ok(Elicited::Done(Json(AskUserOutput {
-            accepted: result.action == ElicitationAction::Accept,
-            data: result.content,
-        })))
+        Ok(Json(AskUserOutput { accepted: result.action == ElicitationAction::Accept, data: result.content })
+            .into_call_tool_result()?)
     }
 }
 

--- a/crates/mcp-utils/src/client/connection.rs
+++ b/crates/mcp-utils/src/client/connection.rs
@@ -118,12 +118,10 @@ impl McpServerConnection {
     }
 
     pub(super) async fn list_tools(&self) -> Result<Vec<RmcpTool>> {
-        let response = self
-            .client
-            .list_tools(None)
+        self.client
+            .list_all_tools()
             .await
-            .map_err(|e| McpError::ToolDiscoveryFailed(format!("Failed to list tools: {e}")))?;
-        Ok(response.tools)
+            .map_err(|e| McpError::ToolDiscoveryFailed(format!("Failed to list tools: {e}")))
     }
 
     fn from_parts(

--- a/crates/mcp-utils/src/client/manager.rs
+++ b/crates/mcp-utils/src/client/manager.rs
@@ -52,9 +52,8 @@ impl ToolListChangedRequest {
     pub async fn refresh(self) -> ToolListRefresh {
         let result = self
             .peer
-            .list_tools(None)
+            .list_all_tools()
             .await
-            .map(|response| response.tools)
             .map_err(|error| McpError::ToolDiscoveryFailed(format!("Failed to refresh tools: {error}")));
         ToolListRefresh { server: self.server, generation: self.generation, result }
     }
@@ -318,12 +317,11 @@ impl McpManager {
                 let server_name = server_name.clone();
                 let client = conn.client.clone();
                 Some(async move {
-                    let prompts_response = client.list_prompts(None).await.map_err(|e| {
+                    let prompts = client.list_all_prompts().await.map_err(|e| {
                         McpError::PromptListFailed(format!("Failed to list prompts for {server_name}: {e}"))
                     })?;
 
-                    let namespaced_prompts: Vec<rmcp::model::Prompt> = prompts_response
-                        .prompts
+                    let namespaced_prompts: Vec<rmcp::model::Prompt> = prompts
                         .into_iter()
                         .map(|prompt| {
                             let namespaced_name = create_namespaced_tool_name(&server_name, &prompt.name);

--- a/crates/mcp-utils/src/client/manager.rs
+++ b/crates/mcp-utils/src/client/manager.rs
@@ -16,10 +16,9 @@ use aether_auth::{OAuthCredentialStorage, OAuthHandler};
 use futures::future::join_all;
 use rmcp::{
     Peer, RoleClient, RoleServer,
-    model::{ClientInfo, ElicitRequestParams, ElicitResult, ElicitationAction, Implementation, Tool as RmcpTool},
+    model::{ClientCapabilities, ClientInfo, ElicitRequestParams, ElicitResult, Implementation, Tool as RmcpTool},
     service::DynService,
 };
-use serde_json::Value;
 use std::collections::{BTreeMap, HashMap};
 use std::future::Future;
 use std::num::NonZeroU16;
@@ -98,18 +97,13 @@ pub struct ElicitationRequest {
     pub response_sender: oneshot::Sender<ElicitResult>,
 }
 
-#[derive(Debug, Clone)]
-pub struct ElicitationResponse {
-    pub action: ElicitationAction,
-    pub content: Option<Value>,
-}
-
 /// Events emitted by MCP clients that require attention from the host
 /// (e.g. the relay or TUI). Flows through a single channel from `McpManager`
 /// to the consumer.
 #[derive(Debug)]
 pub enum McpClientEvent {
     Elicitation(Box<ElicitationRequest>),
+    ElicitationComplete { server_name: String, elicitation_id: String },
     ServerStatusesChanged(Vec<McpServerStatusEntry>),
     AuthenticationFailed { server: String, error: String },
     ConnectionReady(McpConnectionDetails),
@@ -156,6 +150,11 @@ impl McpManager {
 
     pub fn take_tool_refresh_receiver(&mut self) -> mpsc::Receiver<ToolListChangedRequest> {
         self.tool_refresh_receiver.take().expect("tool refresh receiver can only be taken once")
+    }
+
+    pub fn with_client_capabilities(mut self, capabilities: ClientCapabilities) -> Self {
+        self.client_info.capabilities = capabilities;
+        self
     }
 
     pub fn with_progressive_discovery_instructions(mut self, instructions: impl Into<String>) -> Self {

--- a/crates/mcp-utils/src/client/mcp_client.rs
+++ b/crates/mcp-utils/src/client/mcp_client.rs
@@ -3,8 +3,9 @@ use rmcp::{
     ClientHandler, RoleClient,
     handler::client::progress::ProgressDispatcher,
     model::{
-        ClientCapabilities, ClientInfo, ElicitRequestParams, ElicitResult, ElicitationAction, ErrorData,
-        FormElicitationCapability, ProgressNotificationParam, UrlElicitationCapability,
+        ClientCapabilities, ClientInfo, CustomNotification, ElicitRequestParams, ElicitResult, ElicitationAction,
+        ElicitationCapability, ErrorData, FormElicitationCapability, ProgressNotificationParam,
+        UrlElicitationCapability,
     },
     service::{NotificationContext, RequestContext},
 };
@@ -69,10 +70,16 @@ pub fn cancel_result() -> ElicitResult {
 }
 
 pub fn client_capabilities() -> ClientCapabilities {
-    let mut capabilities = ClientCapabilities::builder().enable_elicitation().enable_tasks().build();
-    if let Some(elicitation) = capabilities.elicitation.as_mut() {
-        elicitation.form = Some(FormElicitationCapability::default());
-        elicitation.url = Some(UrlElicitationCapability::default());
+    client_capabilities_for(true, true)
+}
+
+pub fn client_capabilities_for(form: bool, url: bool) -> ClientCapabilities {
+    let mut capabilities = ClientCapabilities::builder().enable_tasks().build();
+    if form || url {
+        let mut elicitation = ElicitationCapability::new();
+        elicitation.form = form.then(FormElicitationCapability::default);
+        elicitation.url = url.then(UrlElicitationCapability::default);
+        capabilities.elicitation = Some(elicitation);
     }
     capabilities
 }
@@ -94,6 +101,29 @@ impl ClientHandler for McpClient {
         Ok(self.dispatch_elicitation(request).await)
     }
 
+    async fn on_custom_notification(
+        &self,
+        notification: CustomNotification,
+        _context: NotificationContext<RoleClient>,
+    ) {
+        if notification.method != "notifications/elicitation/complete" {
+            return;
+        }
+        let params: Option<ElicitationCompleteParams> =
+            notification.params.and_then(|params| serde_json::from_value(params).ok());
+        let Some(params) = params else {
+            tracing::warn!("Ignoring malformed MCP elicitation completion notification");
+            return;
+        };
+        let _ = self
+            .event_sender
+            .send(McpClientEvent::ElicitationComplete {
+                server_name: self.server_name.clone(),
+                elicitation_id: params.elicitation_id,
+            })
+            .await;
+    }
+
     async fn on_tool_list_changed(&self, context: NotificationContext<RoleClient>) {
         let Some(sender) = &self.tool_refresh_sender else {
             return;
@@ -103,6 +133,12 @@ impl ClientHandler for McpClient {
             tracing::debug!(server = %self.server_name, "MCP tool refresh receiver closed");
         }
     }
+}
+
+#[derive(serde::Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct ElicitationCompleteParams {
+    elicitation_id: String,
 }
 
 #[cfg(test)]

--- a/crates/mcp-utils/src/client/mod.rs
+++ b/crates/mcp-utils/src/client/mod.rs
@@ -29,7 +29,7 @@ pub use manager::{
     ElicitationRequest, McpClientEvent, McpConnectionDetails, McpManager, McpServerStatus, McpServerStatusEntry,
     OAuthHandlerContext, OAuthHandlerFactory, RuntimeMcpServer, RuntimeMcpTransport,
 };
-pub use mcp_client::{McpClient, cancel_result, client_capabilities};
+pub use mcp_client::{McpClient, cancel_result, client_capabilities, client_capabilities_for};
 pub use mcp_snapshot::McpSnapshot;
 pub use mrtr::AbortReason;
 pub use naming::{SERVERNAME_DELIMITER, split_on_server_name};

--- a/crates/mcp-utils/src/client/oauth_handler.rs
+++ b/crates/mcp-utils/src/client/oauth_handler.rs
@@ -55,7 +55,7 @@ impl OAuthHandler for ElicitingOAuthHandler {
                 .await
                 .map_err(|_| OAuthError::Rmcp("OAuth prompt channel closed".to_string()))?;
 
-            tokio::select! {
+            let result = tokio::select! {
                 callback = accept_oauth_callback(&self.listener) => callback,
                 response = response_rx => match response {
                     Ok(result) if matches!(result.action, ElicitationAction::Decline | ElicitationAction::Cancel) => {
@@ -63,7 +63,17 @@ impl OAuthHandler for ElicitingOAuthHandler {
                     }
                     Ok(_) | Err(_) => accept_oauth_callback(&self.listener).await,
                 },
+            };
+            if !matches!(result, Err(OAuthError::UserCancelled)) {
+                let _ = self
+                    .event_sender
+                    .send(McpClientEvent::ElicitationComplete {
+                        server_name: self.server_name.clone(),
+                        elicitation_id: AETHER_OAUTH_ELICITATION_ID.to_string(),
+                    })
+                    .await;
             }
+            result
         })
     }
 }

--- a/crates/mcp-utils/src/server/mod.rs
+++ b/crates/mcp-utils/src/server/mod.rs
@@ -1,3 +1,2 @@
 pub mod mrtr;
 pub mod tasks;
-pub mod tool;

--- a/crates/mcp-utils/src/server/mrtr.rs
+++ b/crates/mcp-utils/src/server/mrtr.rs
@@ -1,92 +1,11 @@
-use rmcp::RoleServer;
-use rmcp::model::{
-    ClientCapabilities, ElicitRequestParams, ErrorData, InputRequest, InputRequests, InputRequiredResult,
-    InputResponses,
-};
-use rmcp::service::RequestContext;
+use rmcp::model::{ClientCapabilities, ElicitRequestParams, ErrorData, InputRequest, InputRequests, InputResponses};
 use serde::de::DeserializeOwned;
 
 pub const ELICITATION_UNSUPPORTED: &str = "This tool needs to ask the user for input, but the connected client does not support \
      interactive input (MCP elicitation over protocol 2026-07-28 or newer).";
 
-/// The next action in a server-side MRTR round.
-#[derive(Debug)]
-pub enum MrtrAction {
-    /// Ask the client for a batch of inputs and end the current tool call.
-    Request(InputRequiredResult),
-    /// Resume the tool call with the complete response batch.
-    Resume(InputResponses),
-    /// End the tool call because the client cannot fulfill an input request.
-    Abort(AbortReason),
-}
-
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub enum AbortReason {
-    UnsupportedInput { key: String, kind: InputKind },
-}
-
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum InputKind {
-    FormElicitation,
-    UrlElicitation,
-    Sampling,
-    Roots,
-    Unknown,
-}
-
-impl MrtrAction {
-    /// Validate an outgoing request batch against the negotiated client.
-    /// Responses bypass validation because the prior batch was already fulfilled.
-    pub fn validate_for_client(self, context: &RequestContext<RoleServer>) -> Self {
-        let Self::Request(result) = &self else {
-            return self;
-        };
-        let Some(requests) = result.input_requests.as_ref() else {
-            return self;
-        };
-        let capabilities = context.client_capabilities();
-        match validate_input_requests(capabilities.as_ref(), requests) {
-            Ok(()) => self,
-            Err(reason) => Self::Abort(reason),
-        }
-    }
-}
-
-impl AbortReason {
-    pub fn message(&self) -> String {
-        match self {
-            Self::UnsupportedInput { key, kind } => {
-                format!("Client does not support {kind} required by input request '{key}'")
-            }
-        }
-    }
-}
-
-impl std::fmt::Display for InputKind {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        let name = match self {
-            Self::FormElicitation => "form elicitation",
-            Self::UrlElicitation => "URL elicitation",
-            Self::Sampling => "sampling",
-            Self::Roots => "roots",
-            Self::Unknown => "this input kind",
-        };
-        f.write_str(name)
-    }
-}
-
-pub fn validate_input_requests(
-    capabilities: Option<&ClientCapabilities>,
-    requests: &InputRequests,
-) -> Result<(), AbortReason> {
-    for (key, request) in requests {
-        let kind = input_kind(request);
-        let supported = capabilities.is_some_and(|capabilities| supports_input(capabilities, kind));
-        if !supported {
-            return Err(AbortReason::UnsupportedInput { key: key.clone(), kind });
-        }
-    }
-    Ok(())
+pub fn input_requests_supported(capabilities: Option<&ClientCapabilities>, requests: &InputRequests) -> bool {
+    requests.values().all(|request| capabilities.is_some_and(|capabilities| supports_input(capabilities, request)))
 }
 
 /// Deserialize one keyed response from a complete MRTR response batch.
@@ -98,37 +17,27 @@ pub fn parse_response<T: DeserializeOwned>(responses: &InputResponses, key: &str
         .map_err(|e| ErrorData::invalid_params(format!("invalid input response for '{key}': {e}"), None))
 }
 
-fn supports_input(capabilities: &ClientCapabilities, kind: InputKind) -> bool {
-    match kind {
-        InputKind::FormElicitation => capabilities
+fn supports_input(capabilities: &ClientCapabilities, request: &InputRequest) -> bool {
+    #[allow(unreachable_patterns)]
+    match request {
+        InputRequest::CreateMessage(_) => capabilities.sampling.is_some(),
+        InputRequest::Elicitation(request) => supports_elicitation(capabilities, &request.params),
+        InputRequest::ListRoots(_) => capabilities.roots.is_some(),
+        _ => false,
+    }
+}
+
+fn supports_elicitation(capabilities: &ClientCapabilities, params: &ElicitRequestParams) -> bool {
+    #[allow(unreachable_patterns)]
+    match params {
+        ElicitRequestParams::FormElicitationParams { .. } => capabilities
             .elicitation
             .as_ref()
             .is_some_and(|elicitation| elicitation.form.is_some() || elicitation.url.is_none()),
-        InputKind::UrlElicitation => {
+        ElicitRequestParams::UrlElicitationParams { .. } => {
             capabilities.elicitation.as_ref().is_some_and(|elicitation| elicitation.url.is_some())
         }
-        InputKind::Sampling => capabilities.sampling.is_some(),
-        InputKind::Roots => capabilities.roots.is_some(),
-        InputKind::Unknown => false,
-    }
-}
-
-fn input_kind(request: &InputRequest) -> InputKind {
-    #[allow(unreachable_patterns)]
-    match request {
-        InputRequest::CreateMessage(_) => InputKind::Sampling,
-        InputRequest::Elicitation(request) => elicitation_kind(&request.params),
-        InputRequest::ListRoots(_) => InputKind::Roots,
-        _ => InputKind::Unknown,
-    }
-}
-
-fn elicitation_kind(params: &ElicitRequestParams) -> InputKind {
-    #[allow(unreachable_patterns)]
-    match params {
-        ElicitRequestParams::FormElicitationParams { .. } => InputKind::FormElicitation,
-        ElicitRequestParams::UrlElicitationParams { .. } => InputKind::UrlElicitation,
-        _ => InputKind::Unknown,
+        _ => false,
     }
 }
 
@@ -150,9 +59,7 @@ mod tests {
         let mut capabilities = ClientCapabilities::default();
         capabilities.elicitation = Some(ElicitationCapability::new().with_form(FormElicitationCapability::new()));
 
-        let error = validate_input_requests(Some(&capabilities), &requests).unwrap_err();
-
-        assert_eq!(error, AbortReason::UnsupportedInput { key: "url".to_string(), kind: InputKind::UrlElicitation });
+        assert!(!input_requests_supported(Some(&capabilities), &requests));
     }
 
     #[test]
@@ -168,7 +75,7 @@ mod tests {
                 .with_url(UrlElicitationCapability::new()),
         );
 
-        validate_input_requests(Some(&capabilities), &requests).unwrap();
+        assert!(input_requests_supported(Some(&capabilities), &requests));
     }
 
     #[test]

--- a/crates/mcp-utils/src/server/mrtr.rs
+++ b/crates/mcp-utils/src/server/mrtr.rs
@@ -1,8 +1,7 @@
 use rmcp::RoleServer;
-use rmcp::handler::server::tool::IntoCallToolResult;
 use rmcp::model::{
-    CallToolResponse, CallToolResult, ClientCapabilities, ContentBlock, ElicitRequestParams, ErrorData, InputRequest,
-    InputRequests, InputRequiredResult, InputResponses, ProtocolVersion,
+    ClientCapabilities, ElicitRequestParams, ErrorData, InputRequest, InputRequests, InputRequiredResult,
+    InputResponses,
 };
 use rmcp::service::RequestContext;
 use serde::de::DeserializeOwned;
@@ -46,7 +45,7 @@ impl MrtrAction {
             return self;
         };
         let capabilities = context.client_capabilities();
-        match validate_input_requests(context.protocol_version().as_ref(), capabilities.as_ref(), requests) {
+        match validate_input_requests(capabilities.as_ref(), requests) {
             Ok(()) => self,
             Err(reason) => Self::Abort(reason),
         }
@@ -76,61 +75,13 @@ impl std::fmt::Display for InputKind {
     }
 }
 
-/// Tool-method return value for MRTR tools: either a mid-flight response or the
-/// tool's final output.
-#[allow(clippy::large_enum_variant)]
-pub enum Elicited<T> {
-    Respond(CallToolResponse),
-    Done(T),
-}
-
-impl<T> Elicited<T> {
-    /// A user-visible tool error (`is_error: true`), not a protocol failure.
-    pub fn error(message: impl Into<String>) -> Self {
-        Self::Respond(CallToolResult::error(vec![ContentBlock::text(message.into())]).into())
-    }
-}
-
-impl<T: IntoCallToolResult> IntoCallToolResult for Elicited<T> {
-    fn into_call_tool_result(self) -> Result<CallToolResponse, ErrorData> {
-        match self {
-            Self::Respond(response) => Ok(response),
-            Self::Done(value) => value.into_call_tool_result(),
-        }
-    }
-}
-
-/// Run one batch-oriented MRTR step.
-///
-/// A retry resumes with the complete response map. An initial call lazily builds
-/// the complete request map and returns it as one `InputRequiredResult`.
-pub fn get_next_mrtr_action(
-    responses: Option<&InputResponses>,
-    make_requests: impl FnOnce() -> Result<InputRequests, ErrorData>,
-) -> Result<MrtrAction, ErrorData> {
-    if let Some(responses) = responses {
-        return Ok(MrtrAction::Resume(responses.clone()));
-    }
-
-    let requests = make_requests()?;
-    if requests.is_empty() {
-        return Err(ErrorData::internal_error("MRTR request batch must not be empty", None));
-    }
-    Ok(MrtrAction::Request(InputRequiredResult::from_input_requests(requests)))
-}
-
-/// Validate every request in an MRTR batch against the negotiated protocol and
-/// client capabilities.
 pub fn validate_input_requests(
-    protocol_version: Option<&ProtocolVersion>,
     capabilities: Option<&ClientCapabilities>,
     requests: &InputRequests,
 ) -> Result<(), AbortReason> {
-    let version_supported = protocol_version.is_some_and(|version| version >= &ProtocolVersion::V_2026_07_28);
     for (key, request) in requests {
         let kind = input_kind(request);
-        let supported =
-            version_supported && capabilities.is_some_and(|capabilities| supports_input(capabilities, kind));
+        let supported = capabilities.is_some_and(|capabilities| supports_input(capabilities, kind));
         if !supported {
             return Err(AbortReason::UnsupportedInput { key: key.clone(), kind });
         }
@@ -191,52 +142,6 @@ mod tests {
     use serde_json::json;
 
     #[test]
-    fn mrtr_step_requests_the_complete_batch() {
-        let requests = InputRequests::from([
-            ("first".to_string(), elicitation("First")),
-            ("second".to_string(), elicitation("Second")),
-        ]);
-
-        let action = get_next_mrtr_action(None, || Ok::<_, ErrorData>(requests)).unwrap();
-
-        let MrtrAction::Request(result) = action else {
-            panic!("expected an input request batch");
-        };
-        let requests = result.input_requests.expect("requests should be present");
-        assert_eq!(requests.len(), 2);
-        assert!(requests.contains_key("first"));
-        assert!(requests.contains_key("second"));
-    }
-
-    #[test]
-    fn mrtr_step_resumes_with_the_complete_batch_without_building_requests() {
-        let responses = InputResponses::from([
-            ("first".to_string(), json!({ "value": 1 })),
-            ("second".to_string(), json!({ "value": 2 })),
-        ]);
-
-        let action = get_next_mrtr_action(Some(&responses), || -> Result<InputRequests, ErrorData> {
-            panic!("request construction should be lazy on a retry")
-        })
-        .unwrap();
-
-        let MrtrAction::Resume(actual) = action else {
-            panic!("expected the complete response batch");
-        };
-        assert_eq!(actual, responses);
-    }
-
-    #[test]
-    fn an_empty_response_batch_is_still_a_retry() {
-        let action = get_next_mrtr_action(Some(&InputResponses::new()), || -> Result<InputRequests, ErrorData> {
-            panic!("an empty retry must not issue the requests again")
-        })
-        .unwrap();
-
-        assert!(matches!(action, MrtrAction::Resume(responses) if responses.is_empty()));
-    }
-
-    #[test]
     fn validates_capabilities_against_every_request_in_the_batch() {
         let requests = InputRequests::from([
             ("form".to_string(), elicitation("Form")),
@@ -245,8 +150,7 @@ mod tests {
         let mut capabilities = ClientCapabilities::default();
         capabilities.elicitation = Some(ElicitationCapability::new().with_form(FormElicitationCapability::new()));
 
-        let error =
-            validate_input_requests(Some(&ProtocolVersion::V_2026_07_28), Some(&capabilities), &requests).unwrap_err();
+        let error = validate_input_requests(Some(&capabilities), &requests).unwrap_err();
 
         assert_eq!(error, AbortReason::UnsupportedInput { key: "url".to_string(), kind: InputKind::UrlElicitation });
     }
@@ -264,19 +168,7 @@ mod tests {
                 .with_url(UrlElicitationCapability::new()),
         );
 
-        validate_input_requests(Some(&ProtocolVersion::V_2026_07_28), Some(&capabilities), &requests).unwrap();
-    }
-
-    #[test]
-    fn rejects_input_requests_for_an_old_protocol_version() {
-        let requests = InputRequests::from([("form".to_string(), elicitation("Form"))]);
-        let mut capabilities = ClientCapabilities::default();
-        capabilities.elicitation = Some(ElicitationCapability::new().with_form(FormElicitationCapability::new()));
-
-        let error =
-            validate_input_requests(Some(&ProtocolVersion::V_2025_11_25), Some(&capabilities), &requests).unwrap_err();
-
-        assert_eq!(error, AbortReason::UnsupportedInput { key: "form".to_string(), kind: InputKind::FormElicitation });
+        validate_input_requests(Some(&capabilities), &requests).unwrap();
     }
 
     #[test]

--- a/crates/mcp-utils/src/server/tool.rs
+++ b/crates/mcp-utils/src/server/tool.rs
@@ -1,9 +1,0 @@
-use rmcp::model::{CallToolRequestParams, ErrorData};
-use serde::de::DeserializeOwned;
-
-/// Deserialize a tool call's arguments into a typed input
-pub fn parse_arguments<T: DeserializeOwned>(request: &CallToolRequestParams) -> Result<T, ErrorData> {
-    let arguments = request.arguments.clone().unwrap_or_default();
-    serde_json::from_value(serde_json::Value::Object(arguments))
-        .map_err(|e| ErrorData::invalid_params(format!("invalid arguments: {e}"), None))
-}

--- a/crates/mcp-utils/src/testing/fake_mcp.rs
+++ b/crates/mcp-utils/src/testing/fake_mcp.rs
@@ -2,10 +2,10 @@ use crate::client::{RuntimeMcpServer, RuntimeMcpTransport, ToolExposure};
 use rmcp::{
     ErrorData as McpError, Peer, RoleServer, ServerHandler,
     model::{
-        CacheScope, CallToolRequestParams, CallToolResponse, CallToolResult, CancelTaskParams, ContentBlock,
-        CreateTaskResult, DetailedTask, GetTaskParams, GetTaskResult, Implementation, ListToolsResult,
-        PaginatedRequestParams, ProgressNotificationParam, ProtocolVersion, ResultType, ServerCapabilities, ServerInfo,
-        Tool, UpdateTaskParams,
+        CacheScope, CallToolRequestParams, CallToolResponse, CallToolResult, CancelTaskParams, ClientCapabilities,
+        ContentBlock, CreateTaskResult, DetailedTask, DiscoverResult, GetTaskParams, GetTaskResult, Implementation,
+        ListToolsResult, PaginatedRequestParams, ProgressNotificationParam, ProtocolVersion, ResultType,
+        ServerCapabilities, ServerInfo, Tool, UpdateTaskParams,
     },
     service::{DynService, RequestContext},
 };
@@ -106,6 +106,10 @@ impl FakeMcpState {
 
     pub fn task_cancel_ids(&self) -> Vec<String> {
         self.lock().task_cancel_ids.clone()
+    }
+
+    pub fn client_capabilities(&self) -> Option<ClientCapabilities> {
+        self.lock().client_capabilities.clone()
     }
 
     pub fn script_task(&self, task_id: impl Into<String>, states: impl IntoIterator<Item = DetailedTask>) {
@@ -284,6 +288,17 @@ impl Default for FakeMcpServer {
 }
 
 impl ServerHandler for FakeMcpServer {
+    fn discover(
+        &self,
+        context: RequestContext<RoleServer>,
+    ) -> impl Future<Output = Result<DiscoverResult, McpError>> + Send + '_ {
+        self.state.lock().client_capabilities = context.meta.client_capabilities();
+        std::future::ready(Ok(DiscoverResult::from_server_info(
+            ServerHandler::supported_protocol_versions(self).into_owned(),
+            ServerHandler::get_info(self),
+        )))
+    }
+
     fn get_info(&self) -> ServerInfo {
         ServerInfo::new(ServerCapabilities::builder().enable_tools().enable_tasks().build())
             .with_server_info(
@@ -402,6 +417,7 @@ type ToolHandler = Arc<dyn Fn(&CallToolRequestParams) -> FakeToolResponse + Send
 struct FakeMcpStateInner {
     tools: BTreeMap<String, FakeTool>,
     calls: Vec<CapturedToolCall>,
+    client_capabilities: Option<ClientCapabilities>,
     tasks: HashMap<String, VecDeque<DetailedTask>>,
     task_get_ids: Vec<String>,
     task_updates: Vec<CapturedTaskUpdate>,

--- a/crates/mcp-utils/tests/elicitation_notifications.rs
+++ b/crates/mcp-utils/tests/elicitation_notifications.rs
@@ -1,0 +1,38 @@
+use mcp_utils::client::{McpClient, McpClientEvent, client_capabilities};
+use mcp_utils::testing::connect;
+use rmcp::ServerHandler;
+use rmcp::model::{ClientInfo, CustomNotification, Implementation, ServerNotification};
+use tokio::sync::mpsc;
+
+#[derive(Clone)]
+struct CompletionServer;
+
+impl ServerHandler for CompletionServer {}
+
+#[tokio::test]
+async fn custom_completion_notification_includes_the_source_server() {
+    let (event_tx, mut event_rx) = mpsc::channel(1);
+    let client = McpClient::new(
+        ClientInfo::new(client_capabilities(), Implementation::new("test-client", "1.0.0")),
+        "linear".to_string(),
+        event_tx,
+    );
+    let (server, client) = connect(CompletionServer, client).await.expect("connect MCP peers");
+
+    server
+        .send_notification(ServerNotification::CustomNotification(CustomNotification::new(
+            "notifications/elicitation/complete",
+            Some(serde_json::json!({ "elicitationId": "oauth-1" })),
+        )))
+        .await
+        .expect("send completion notification");
+
+    let event = event_rx.recv().await.expect("receive completion event");
+    assert!(matches!(
+        event,
+        McpClientEvent::ElicitationComplete { server_name, elicitation_id }
+            if server_name == "linear" && elicitation_id == "oauth-1"
+    ));
+
+    client.cancel().await.expect("close MCP client");
+}

--- a/crates/utils/src/plan_review.rs
+++ b/crates/utils/src/plan_review.rs
@@ -1,5 +1,5 @@
 use serde::{Deserialize, Serialize};
-use serde_json::{Map, Value, json};
+use serde_json::{Map, Value};
 use std::path::Path;
 
 pub const PLAN_REVIEW_UI_KIND: &str = "planReview";
@@ -16,13 +16,6 @@ impl PlanReviewDecision {
         match self {
             Self::Approve => "approve",
             Self::Deny => "deny",
-        }
-    }
-
-    pub fn response_content(self, feedback: Option<&str>) -> Value {
-        match (self, feedback) {
-            (Self::Deny, Some(feedback)) => json!({ "decision": self.as_str(), "feedback": feedback }),
-            _ => json!({ "decision": self.as_str() }),
         }
     }
 }

--- a/crates/wisp/src/app/acp_reducer.rs
+++ b/crates/wisp/src/app/acp_reducer.rs
@@ -42,14 +42,6 @@ impl App {
                 self.finish_prompt(&ToolStatus::Error(format!("failed: {error}")));
                 self.notify(&format!("Prompt failed: {error}"));
             }
-            AcpEvent::ContextUsage(params) => {
-                self.conversation.turn_mut().set_context_usage(
-                    params.usage.context_limit.map(|limit| ContextUsageDisplay {
-                        used_tokens: params.usage.input_tokens,
-                        limit_tokens: limit,
-                    }),
-                );
-            }
             AcpEvent::ContextCompaction(params) => {
                 self.conversation.turn_mut().set_compaction_active(params.active);
             }
@@ -283,6 +275,12 @@ impl App {
             acp::SessionUpdate::Plan(plan) => {
                 self.conversation.plan_tracker_mut().replace(plan.entries.clone(), Instant::now());
                 self.conversation.finish_current_block();
+            }
+            acp::SessionUpdate::UsageUpdate(usage) => {
+                self.conversation.turn_mut().set_context_usage(Some(ContextUsageDisplay {
+                    used_tokens: u32::try_from(usage.used).unwrap_or(u32::MAX),
+                    limit_tokens: u32::try_from(usage.size).unwrap_or(u32::MAX),
+                }));
             }
             _ => {
                 self.conversation.finish_current_block();

--- a/crates/wisp/src/app/acp_reducer.rs
+++ b/crates/wisp/src/app/acp_reducer.rs
@@ -11,7 +11,7 @@ use crate::surfaces::session_picker::SessionPicker;
 use crate::surfaces::workspace_picker::WorkspacePicker;
 use acp_utils::client::AcpEvent;
 use acp_utils::notifications::McpNotification;
-use agent_client_protocol::schema::v1::{self as acp, SessionId};
+use agent_client_protocol::schema::v1::{self as acp, CreateElicitationRequest, ElicitationMode, SessionId};
 use std::time::Instant;
 
 impl App {
@@ -49,6 +49,7 @@ impl App {
                 self.reset_conversation();
             }
             AcpEvent::ElicitationRequest { params, responder } => {
+                let params = *params;
                 self.close_elicitation_owner();
                 if let Some(meta) = plan_review_meta(&params) {
                     self.open_route(Route::PlanReview(Box::new(PlanReviewScreen::new(meta, responder))));
@@ -65,12 +66,14 @@ impl App {
                     );
                     return;
                 }
-                self.open_overlay(Overlay::Elicitation(ElicitationModal::with_url_handlers(
+                if let Some(modal) = ElicitationModal::with_url_handlers(
                     params,
                     responder,
                     self.browser_opener.clone(),
                     self.clipboard_writer.clone(),
-                )));
+                ) {
+                    self.open_overlay(Overlay::Elicitation(modal));
+                }
             }
             AcpEvent::McpNotification(notification) => self.on_mcp_notification(&notification),
             AcpEvent::AuthMethodsUpdated(params) => {
@@ -301,12 +304,10 @@ impl App {
 }
 
 pub(super) fn plan_review_meta(
-    params: &acp_utils::notifications::ElicitationParams,
+    params: &CreateElicitationRequest,
 ) -> Option<utils::plan_review::PlanReviewElicitationMeta> {
-    match &params.request {
-        acp_utils::notifications::ElicitRequestParams::FormElicitationParams { meta, .. } => {
-            utils::plan_review::PlanReviewElicitationMeta::parse(meta.as_ref().map(|meta| &**meta).map(|meta| &**meta))
-        }
-        _ => None,
+    if !matches!(params.mode, ElicitationMode::Form(_)) {
+        return None;
     }
+    utils::plan_review::PlanReviewElicitationMeta::parse(params.meta.as_ref())
 }

--- a/crates/wisp/src/screens/plan_review/screen.rs
+++ b/crates/wisp/src/screens/plan_review/screen.rs
@@ -1,4 +1,3 @@
-use acp_utils::notifications::ElicitationAction;
 use crossterm::event::{KeyCode, KeyEvent};
 use ratatui::buffer::Buffer;
 use ratatui::layout::{Constraint, Layout, Position, Rect};
@@ -135,16 +134,13 @@ impl PlanReviewScreen {
                 ReviewOutcome::Cancelled
             }
             KeyCode::Char('a') => {
-                self.responder
-                    .respond(ElicitationAction::Accept, Some(PlanReviewDecision::Approve.response_content(None)));
+                self.responder.accept_strings([("decision", PlanReviewDecision::Approve.as_str())]);
                 ReviewOutcome::Submitted("Approved the plan".to_string())
             }
             KeyCode::Char('r') => {
                 let feedback = compile_feedback(&self.document, &self.comments);
-                self.responder.respond(
-                    ElicitationAction::Accept,
-                    Some(PlanReviewDecision::Deny.response_content(Some(&feedback))),
-                );
+                self.responder
+                    .accept_strings([("decision", PlanReviewDecision::Deny.as_str()), ("feedback", &feedback)]);
                 ReviewOutcome::Submitted("Requested changes to the plan".to_string())
             }
             KeyCode::Char('u') => {

--- a/crates/wisp/src/session/mod.rs
+++ b/crates/wisp/src/session/mod.rs
@@ -10,8 +10,9 @@ use crate::session::workspace_status::WorkspaceStatus;
 use acp_utils::client::{AcpClientError, AcpEvent, AcpPromptHandle, TokioAcpAgent, spawn_acp_session};
 use agent_client_protocol::schema::ProtocolVersion;
 use agent_client_protocol::schema::v1::{
-    AuthMethod, Implementation, InitializeRequest, NewSessionRequest, PromptCapabilities, SessionCapabilities,
-    SessionConfigOption, SessionId,
+    AuthMethod, ClientCapabilities, ElicitationCapabilities, ElicitationFormCapabilities, ElicitationUrlCapabilities,
+    Implementation, InitializeRequest, NewSessionRequest, PromptCapabilities, SessionCapabilities, SessionConfigOption,
+    SessionId,
 };
 use std::env::current_dir;
 use std::path::PathBuf;
@@ -37,6 +38,7 @@ impl Session {
         let workspace_status = WorkspaceStatus::initial(&working_dir);
         let agent = TokioAcpAgent::from_str(agent_command).map_err(AcpClientError::InvalidAgentCommand)?;
         let init_request = InitializeRequest::new(ProtocolVersion::LATEST)
+            .client_capabilities(client_capabilities())
             .client_info(Implementation::new("wisp", env!("CARGO_PKG_VERSION")));
         let acp_session = spawn_acp_session(agent, init_request, NewSessionRequest::new(working_dir.clone())).await?;
 
@@ -53,4 +55,12 @@ impl Session {
             workspace_status,
         })
     }
+}
+
+fn client_capabilities() -> ClientCapabilities {
+    ClientCapabilities::new().elicitation(
+        ElicitationCapabilities::new()
+            .form(ElicitationFormCapabilities::new())
+            .url(ElicitationUrlCapabilities::new()),
+    )
 }

--- a/crates/wisp/src/settings/overlay/mod.rs
+++ b/crates/wisp/src/settings/overlay/mod.rs
@@ -18,9 +18,9 @@ use crate::theme::Theme;
 use crate::view::selection::Direction;
 use crate::view::widgets::key_hints;
 use acp_utils::config_meta::SelectOptionMeta;
-use acp_utils::notifications::{ElicitationParams, ElicitationResponse, McpServerStatusEntry};
+use acp_utils::notifications::McpServerStatusEntry;
 use agent_client_protocol::Responder;
-use agent_client_protocol::schema::v1::AuthMethod;
+use agent_client_protocol::schema::v1::{AuthMethod, CreateElicitationRequest, CreateElicitationResponse};
 use crossterm::event::{KeyCode, KeyEvent};
 use ratatui::buffer::Buffer;
 use ratatui::layout::{Constraint, Layout, Position, Rect};
@@ -214,13 +214,13 @@ impl SettingsOverlay {
     /// host handlers so tests observe URL opens without spawning a browser.
     pub fn on_elicitation_request(
         &mut self,
-        params: ElicitationParams,
-        responder: Responder<ElicitationResponse>,
+        params: CreateElicitationRequest,
+        responder: Responder<CreateElicitationResponse>,
         browser_opener: BrowserOpener,
         clipboard_writer: ClipboardWriter,
     ) {
         self.pending_elicitation =
-            Some(ElicitationModal::with_url_handlers(params, responder, browser_opener, clipboard_writer));
+            ElicitationModal::with_url_handlers(params, responder, browser_opener, clipboard_writer);
     }
 
     /// Drops an unanswered request, which cancels it.

--- a/crates/wisp/src/surfaces/elicitation.rs
+++ b/crates/wisp/src/surfaces/elicitation.rs
@@ -1,35 +1,44 @@
-use acp_utils::notifications::{ElicitationAction, ElicitationResponse};
 use agent_client_protocol::Responder;
-use serde_json::Value;
+use agent_client_protocol::schema::v1::{
+    CreateElicitationResponse, ElicitationAcceptAction, ElicitationAction, ElicitationContentValue,
+};
+use std::collections::BTreeMap;
 
-/// Answers one elicitation, exactly once.
-///
-/// Dropping it unanswered cancels, so tearing navigation down can never leave the
-/// agent waiting on a reply that will not come. Every route or overlay that holds an
-/// elicitation goes through this instead of writing its own `Drop`.
-pub struct ElicitationResponder(Option<Box<dyn FnOnce(ElicitationResponse) + Send>>);
+pub struct ElicitationResponder(Option<Box<dyn FnOnce(CreateElicitationResponse) + Send>>);
 
 impl ElicitationResponder {
-    pub fn new(responder: Responder<ElicitationResponse>) -> Self {
+    pub fn new(responder: Responder<CreateElicitationResponse>) -> Self {
         Self::from_fn(move |response| {
             let _ = responder.respond(response);
         })
     }
 
     /// For tests, which observe the answer without an ACP connection.
-    pub fn from_fn(respond: impl FnOnce(ElicitationResponse) + Send + 'static) -> Self {
+    pub fn from_fn(respond: impl FnOnce(CreateElicitationResponse) + Send + 'static) -> Self {
         Self(Some(Box::new(respond)))
     }
 
-    /// Sends `action`, or does nothing when this elicitation is already answered.
-    pub fn respond(&mut self, action: ElicitationAction, content: Option<Value>) {
-        if let Some(respond) = self.0.take() {
-            respond(ElicitationResponse { action, content });
-        }
+    pub fn accept(&mut self, content: Option<BTreeMap<String, ElicitationContentValue>>) {
+        self.respond(ElicitationAction::Accept(ElicitationAcceptAction::new().content(content)));
+    }
+
+    pub fn accept_strings<const T: usize>(&mut self, content: [(&str, &str); T]) {
+        self.accept(Some(
+            content
+                .into_iter()
+                .map(|(name, value)| (name.to_string(), ElicitationContentValue::String(value.to_string())))
+                .collect(),
+        ));
     }
 
     pub fn cancel(&mut self) {
-        self.respond(ElicitationAction::Cancel, None);
+        self.respond(ElicitationAction::Cancel);
+    }
+
+    fn respond(&mut self, action: ElicitationAction) {
+        if let Some(respond) = self.0.take() {
+            respond(CreateElicitationResponse::new(action));
+        }
     }
 
     pub fn is_answered(&self) -> bool {
@@ -43,8 +52,8 @@ impl Drop for ElicitationResponder {
     }
 }
 
-impl From<Responder<ElicitationResponse>> for ElicitationResponder {
-    fn from(responder: Responder<ElicitationResponse>) -> Self {
+impl From<Responder<CreateElicitationResponse>> for ElicitationResponder {
+    fn from(responder: Responder<CreateElicitationResponse>) -> Self {
         Self::new(responder)
     }
 }

--- a/crates/wisp/src/surfaces/modal/form.rs
+++ b/crates/wisp/src/surfaces/modal/form.rs
@@ -1,5 +1,6 @@
-use acp_utils::{
-    ConstTitle, ElicitationSchema, EnumSchema, MultiSelectEnumSchema, PrimitiveSchemaDefinition, SingleSelectEnumSchema,
+use agent_client_protocol::schema::v1::{
+    ElicitationContentValue, ElicitationPropertySchema, ElicitationSchema, EnumOption, MultiSelectItems,
+    MultiSelectPropertySchema, StringPropertySchema,
 };
 use crossterm::event::{KeyCode, KeyEvent};
 use ratatui::buffer::Buffer;
@@ -7,13 +8,13 @@ use ratatui::layout::{Position, Rect};
 use ratatui::style::{Modifier, Style};
 use ratatui::text::{Line, Span};
 use ratatui::widgets::Widget;
-use serde_json::{Map, Value};
+use std::collections::BTreeMap;
 use unicode_width::UnicodeWidthStr;
 
 use crate::surfaces::input::is_composed_char;
+use crate::theme::Theme;
 use crate::view::edit_buffer::{EditBuffer, apply_edit_key};
 use crate::view::selection::{Direction, scroll_into_view, step_clamped};
-use crate::theme::Theme;
 use crate::view::widgets::{KeyHint, RowsView, render_vertical_scrollbar, rows_and_track, visible_window};
 use crate::view::wrap::{as_u16, fit_line, wrap_line};
 
@@ -89,7 +90,7 @@ pub(super) struct SelectOption {
 pub(super) enum FormAction {
     None,
     Cancel,
-    Accept(Value),
+    Accept(BTreeMap<String, ElicitationContentValue>),
 }
 
 /// The rows of one page, with everything a click or the terminal cursor needs
@@ -129,11 +130,22 @@ impl PageRows {
 }
 
 impl FormModal {
-    pub(super) fn new(server_name: String, message: String, schema: &ElicitationSchema) -> Self {
+    pub(super) fn new(server_name: String, message: String, schema: &ElicitationSchema) -> Option<Self> {
         let required: Vec<&str> = schema.required.as_deref().unwrap_or(&[]).iter().map(String::as_str).collect();
-        let fields: Vec<FormField> =
-            schema.properties.iter().map(|(name, prop)| FormField::from_primitive(name, prop, &required)).collect();
-        Self { server_name, message, fields, page: 0, confirming_cancel: false, validation_error: None, body: BodyView::default() }
+        let fields = schema
+            .properties
+            .iter()
+            .map(|(name, prop)| FormField::from_schema(name, prop, &required))
+            .collect::<Option<Vec<_>>>()?;
+        Some(Self {
+            server_name,
+            message,
+            fields,
+            page: 0,
+            confirming_cancel: false,
+            validation_error: None,
+            body: BodyView::default(),
+        })
     }
 
     pub(super) fn server_name(&self) -> &str {
@@ -348,22 +360,21 @@ impl FormModal {
     }
 
     fn submit(&mut self) -> FormAction {
-        let mut content = Map::new();
+        let mut content = BTreeMap::new();
         let mut first_error = None;
         for (index, field) in self.fields.iter().enumerate() {
             match field.value() {
-                Ok(value) => {
-                    if !value.is_null() {
-                        content.insert(field.name.clone(), value);
-                    }
+                Ok(Some(value)) => {
+                    content.insert(field.name.clone(), value);
                 }
+                Ok(None) => {}
                 Err(error) => {
                     first_error.get_or_insert((index, error));
                 }
             }
         }
         match first_error {
-            None => FormAction::Accept(Value::Object(content)),
+            None => FormAction::Accept(content),
             Some((index, error)) => {
                 // Send the user to the first thing standing between them and
                 // submitting, with the complaint right beside it.
@@ -411,10 +422,8 @@ impl FormModal {
         let mut rows = PageRows::default();
 
         if !self.message.is_empty() {
-            let headline = Line::styled(
-                self.message.clone(),
-                Style::new().fg(theme.heading).add_modifier(Modifier::BOLD),
-            );
+            let headline =
+                Line::styled(self.message.clone(), Style::new().fg(theme.heading).add_modifier(Modifier::BOLD));
             for line in wrap_line(headline, width) {
                 rows.row(line);
             }
@@ -457,28 +466,22 @@ impl FormModal {
 
     fn review_rows(&self, theme: &Theme, width: u16, rows: &mut PageRows) {
         rows.blank();
-        let headline = Line::styled("Review your answers", Style::new().fg(theme.text_primary).add_modifier(Modifier::BOLD));
+        let headline =
+            Line::styled("Review your answers", Style::new().fg(theme.text_primary).add_modifier(Modifier::BOLD));
         for line in wrap_line(headline, width) {
             rows.row(line);
         }
         rows.blank();
 
-        let label_width = self
-            .fields
-            .iter()
-            .map(|field| field.label.width())
-            .max()
-            .unwrap_or(0)
-            .min(usize::from(width) * 2 / 5);
+        let label_width =
+            self.fields.iter().map(|field| field.label.width()).max().unwrap_or(0).min(usize::from(width) * 2 / 5);
         for (index, field) in self.fields.iter().enumerate() {
             let value = field.display_value();
             let value = if value.is_empty() { "—".to_string() } else { value };
-            let style = if field.value().is_err() {
-                Style::new().fg(theme.error)
-            } else {
-                Style::new().fg(theme.text_primary)
-            };
-            let prefix = vec![Span::styled(format!("{:<label_width$}  ", field.label), Style::new().fg(theme.text_secondary))];
+            let style =
+                if field.value().is_err() { Style::new().fg(theme.error) } else { Style::new().fg(theme.text_primary) };
+            let prefix =
+                vec![Span::styled(format!("{:<label_width$}  ", field.label), Style::new().fg(theme.text_secondary))];
             for line in wrapped_row(&prefix, &value, style, width) {
                 rows.site(line, RowSite::Review { field: index });
             }
@@ -586,7 +589,8 @@ impl FormModal {
 
     pub(super) fn render(&mut self, area: Rect, buf: &mut Buffer, theme: &Theme) -> Option<Position> {
         let (rows_area, track_area) = rows_and_track(area, true);
-        let rows_area = Rect { x: rows_area.x.saturating_add(1), width: rows_area.width.saturating_sub(1), ..rows_area };
+        let rows_area =
+            Rect { x: rows_area.x.saturating_add(1), width: rows_area.width.saturating_sub(1), ..rows_area };
 
         let page = self.page_rows(theme, rows_area.width);
         let height = usize::from(rows_area.height);
@@ -783,7 +787,11 @@ fn input_rows(buffer: &EditBuffer, theme: &Theme, width: u16, rows: &mut PageRow
     rows.blank();
     let border = Style::new().fg(theme.muted);
     let rule = "─".repeat(usize::from(width.saturating_sub(2)));
-    rows.row(Line::from(vec![Span::styled("╭", border), Span::styled(rule.clone(), border), Span::styled("╮", border)]));
+    rows.row(Line::from(vec![
+        Span::styled("╭", border),
+        Span::styled(rule.clone(), border),
+        Span::styled("╮", border),
+    ]));
 
     let content = usize::from(width.saturating_sub(4));
     let (visible, cursor_column) = visible_window(buffer, content.max(1));
@@ -831,64 +839,78 @@ fn boolean_index(value: bool) -> usize {
 }
 
 impl FormField {
-    fn from_primitive(name: &str, prop: &PrimitiveSchemaDefinition, required: &[&str]) -> Self {
-        use FormFieldKind::{Boolean, Number, Text};
+    fn from_schema(name: &str, prop: &ElicitationPropertySchema, required: &[&str]) -> Option<Self> {
+        use FormFieldKind::{Boolean, Number};
         let (labelling, kind) = match prop {
-            PrimitiveSchemaDefinition::Boolean(b) => {
-                (labelling(b.title.as_deref(), b.description.as_deref(), name), Boolean(b.default.unwrap_or(false)))
+            ElicitationPropertySchema::Boolean(value) => (
+                labelling(value.title.as_deref(), value.description.as_deref(), name),
+                Boolean(value.default.unwrap_or(false)),
+            ),
+            ElicitationPropertySchema::Integer(value) => (
+                labelling(value.title.as_deref(), value.description.as_deref(), name),
+                Number(stringified_default(value.default).into()),
+            ),
+            ElicitationPropertySchema::Number(value) => (
+                labelling(value.title.as_deref(), value.description.as_deref(), name),
+                Number(stringified_default(value.default).into()),
+            ),
+            ElicitationPropertySchema::String(value) => {
+                (labelling(value.title.as_deref(), value.description.as_deref(), name), string_kind(value))
             }
-            PrimitiveSchemaDefinition::Integer(i) => (
-                labelling(i.title.as_deref(), i.description.as_deref(), name),
-                Number(stringified_default(i.default).into()),
-            ),
-            PrimitiveSchemaDefinition::Number(n) => (
-                labelling(n.title.as_deref(), n.description.as_deref(), name),
-                Number(stringified_default(n.default).into()),
-            ),
-            PrimitiveSchemaDefinition::String(s) => (
-                labelling(s.title.as_deref(), s.description.as_deref(), name),
-                Text(s.default.clone().unwrap_or_default().into()),
-            ),
-            PrimitiveSchemaDefinition::Enum(e) => (enum_labelling(e, name), parse_enum_kind(e)),
-            _ => unreachable!("unsupported primitive elicitation schema"),
+            ElicitationPropertySchema::Array(value) => {
+                (labelling(value.title.as_deref(), value.description.as_deref(), name), multi_kind(value)?)
+            }
+            _ => return None,
         };
         let (label, description) = labelling;
-        Self { name: name.to_string(), label, description, required: required.contains(&name), touched: false, kind }
+        Some(Self {
+            name: name.to_string(),
+            label,
+            description,
+            required: required.contains(&name),
+            touched: false,
+            kind,
+        })
     }
 
-    fn value(&self) -> Result<Value, String> {
+    fn value(&self) -> Result<Option<ElicitationContentValue>, String> {
         let missing = || format!("{} is required", self.label);
         match &self.kind {
             FormFieldKind::Text(value) => {
                 if self.required && value.is_empty() {
                     Err(missing())
                 } else {
-                    Ok(if value.is_empty() { Value::Null } else { Value::String(value.text().to_string()) })
+                    Ok((!value.is_empty()).then(|| ElicitationContentValue::String(value.text().to_string())))
                 }
             }
             FormFieldKind::Number(value) => {
                 if value.is_empty() {
-                    return if self.required { Err(missing()) } else { Ok(Value::Null) };
+                    return if self.required { Err(missing()) } else { Ok(None) };
                 }
-                serde_json::from_str(value.text()).map_err(|_| format!("{} must be a number", self.label))
+                let invalid = || format!("{} must be a number", self.label);
+                let number: serde_json::Number = serde_json::from_str(value.text()).map_err(|_| invalid())?;
+                Ok(Some(match number.as_i64() {
+                    Some(integer) => ElicitationContentValue::Integer(integer),
+                    None => ElicitationContentValue::Number(number.as_f64().ok_or_else(invalid)?),
+                }))
             }
-            FormFieldKind::Boolean(value) => Ok(Value::Bool(*value)),
+            FormFieldKind::Boolean(value) => Ok(Some(ElicitationContentValue::Boolean(*value))),
             FormFieldKind::Single { options, selected } => {
-                let value = options.get(*selected).map(|o| o.value.clone());
+                let value = options.get(*selected).map(|option| option.value.clone());
                 if self.required && value.is_none() {
                     Err(missing())
                 } else {
-                    Ok(value.map_or(Value::Null, Value::String))
+                    Ok(value.map(ElicitationContentValue::String))
                 }
             }
-            FormFieldKind::Multi { options, selected, .. } => Ok(Value::Array(
+            FormFieldKind::Multi { options, selected, .. } => Ok(Some(ElicitationContentValue::StringArray(
                 options
                     .iter()
                     .zip(selected)
                     .filter(|(_, selected)| **selected)
-                    .map(|(opt, _)| Value::String(opt.value.clone()))
+                    .map(|(option, _)| option.value.clone())
                     .collect(),
-            )),
+            ))),
         }
     }
 
@@ -916,34 +938,23 @@ fn labelling(title: Option<&str>, description: Option<&str>, name: &str) -> Labe
     (title.unwrap_or(name).to_string(), description.map(str::to_string))
 }
 
-/// Every enum variant carries its title and description in the same two fields,
-/// just at a different depth.
-fn enum_labelling(e: &EnumSchema, name: &str) -> Labelling {
-    let (title, description) = match e {
-        EnumSchema::Single(SingleSelectEnumSchema::Untitled(s)) => (s.title.as_deref(), s.description.as_deref()),
-        EnumSchema::Single(SingleSelectEnumSchema::Titled(s)) => (s.title.as_deref(), s.description.as_deref()),
-        EnumSchema::Multi(MultiSelectEnumSchema::Untitled(m)) => (m.title.as_deref(), m.description.as_deref()),
-        EnumSchema::Multi(MultiSelectEnumSchema::Titled(m)) => (m.title.as_deref(), m.description.as_deref()),
-        EnumSchema::Legacy(l) => (l.title.as_deref(), l.description.as_deref()),
-        _ => (None, None),
-    };
-    labelling(title, description, name)
+fn string_kind(schema: &StringPropertySchema) -> FormFieldKind {
+    if let Some(options) = &schema.one_of {
+        single(options_from_enum_options(options), schema.default.as_deref())
+    } else if let Some(options) = &schema.enum_values {
+        single(options_from_strings(options), schema.default.as_deref())
+    } else {
+        FormFieldKind::Text(schema.default.clone().unwrap_or_default().into())
+    }
 }
 
-fn parse_enum_kind(e: &EnumSchema) -> FormFieldKind {
-    match e {
-        EnumSchema::Single(SingleSelectEnumSchema::Untitled(s)) => {
-            single(options_from_strings(&s.enum_), s.default.as_deref())
-        }
-        EnumSchema::Single(SingleSelectEnumSchema::Titled(s)) => {
-            single(options_from_const_titles(&s.one_of), s.default.as_deref())
-        }
-        EnumSchema::Legacy(l) => single(options_from_strings(&l.enum_), None),
-        EnumSchema::Multi(MultiSelectEnumSchema::Untitled(m)) => {
-            multi(options_from_strings(&m.items.enum_), m.default.as_deref())
-        }
-        _ => single(Vec::new(), None),
-    }
+fn multi_kind(schema: &MultiSelectPropertySchema) -> Option<FormFieldKind> {
+    let options = match &schema.items {
+        MultiSelectItems::String(items) => options_from_strings(&items.values),
+        MultiSelectItems::Titled(items) => options_from_enum_options(&items.options),
+        _ => return None,
+    };
+    Some(multi(options, schema.default.as_deref()))
 }
 
 /// A single-select focused on `default`, or on the first option when the
@@ -963,12 +974,23 @@ fn options_from_strings(values: &[String]) -> Vec<SelectOption> {
     values.iter().map(|s| SelectOption { value: s.clone(), title: s.clone() }).collect()
 }
 
-fn options_from_const_titles(items: &[ConstTitle]) -> Vec<SelectOption> {
-    items.iter().map(|ct| SelectOption { value: ct.const_.clone(), title: ct.title.clone() }).collect()
+fn options_from_enum_options(items: &[EnumOption]) -> Vec<SelectOption> {
+    items.iter().map(|item| SelectOption { value: item.value.clone(), title: item.title.clone() }).collect()
 }
 
 fn stringified_default<T: std::fmt::Display>(default: Option<T>) -> String {
     default.map(|value| value.to_string()).unwrap_or_default()
+}
+
+/// The single-question decision form a permission prompt sends, shared with
+/// the modal tests one level up.
+#[cfg(test)]
+pub(super) fn permission_like_schema() -> ElicitationSchema {
+    ElicitationSchema::new().property(
+        "decision",
+        StringPropertySchema::new().enum_values(vec!["allow".into(), "deny".into()]).default_value("deny"),
+        true,
+    )
 }
 
 #[cfg(test)]
@@ -976,49 +998,39 @@ fn stringified_default<T: std::fmt::Display>(default: Option<T>) -> String {
 mod tests {
     use super::*;
     use crate::testing::{buffer_text, row_containing};
+    use agent_client_protocol::schema::v1::{BooleanPropertySchema, IntegerPropertySchema, NumberPropertySchema};
     use crossterm::event::KeyModifiers;
+    use serde_json::Value;
 
     const WIDTH: u16 = 64;
     const HEIGHT: u16 = 24;
 
-    fn permission_like_schema() -> ElicitationSchema {
-        ElicitationSchema::builder()
-            .required_enum_schema(
-                "decision",
-                EnumSchema::builder(vec!["allow".into(), "deny".into()])
-                    .untitled()
-                    .with_default(String::from("deny"))
-                    .unwrap()
-                    .build(),
-            )
-            .build()
-            .unwrap()
+    fn test_modal(server_name: String, message: String, schema: &ElicitationSchema) -> FormModal {
+        FormModal::new(server_name, message, schema).unwrap()
+    }
+
+    fn required(name: &str, property: impl Into<ElicitationPropertySchema>) -> ElicitationSchema {
+        ElicitationSchema::new().property(name, property, true)
+    }
+
+    fn optional(name: &str, property: impl Into<ElicitationPropertySchema>) -> ElicitationSchema {
+        ElicitationSchema::new().property(name, property, false)
     }
 
     fn multi_schema() -> ElicitationSchema {
-        ElicitationSchema::builder()
-            .required_enum_schema(
-                "tags",
-                EnumSchema::builder(vec!["fast".into(), "reliable".into(), "cheap".into()]).multiselect().build(),
-            )
-            .build()
-            .unwrap()
+        required("tags", MultiSelectPropertySchema::new(vec!["fast".into(), "reliable".into(), "cheap".into()]))
     }
 
     fn survey_schema() -> ElicitationSchema {
-        ElicitationSchema::builder()
-            .required_string_with("team", |field| field.title("Team"))
-            .optional_enum_schema(
+        ElicitationSchema::new()
+            .property("team", StringPropertySchema::new().title("Team"), true)
+            .property(
                 "urgency",
-                EnumSchema::builder(vec!["low".into(), "high".into()])
-                    .untitled()
-                    .enum_titles(vec!["Low".into(), "High".into()])
-                    .unwrap()
-                    .build(),
+                StringPropertySchema::new()
+                    .one_of(vec![EnumOption::new("low", "Low"), EnumOption::new("high", "High")]),
+                false,
             )
-            .optional_bool("notify", false)
-            .build()
-            .unwrap()
+            .property("notify", BooleanPropertySchema::new().default_value(false), false)
     }
 
     fn key(code: KeyCode) -> KeyEvent {
@@ -1047,12 +1059,10 @@ mod tests {
         panic!("{needle:?} should be on screen");
     }
 
-    /// Submits with the keys a user would press: `Enter` walks to the review
-    /// page and submits from there.
     fn submitted(form: &mut FormModal) -> Value {
         for _ in 0..16 {
-            if let FormAction::Accept(value) = form.on_key(key(KeyCode::Enter)) {
-                return value;
+            if let FormAction::Accept(content) = form.on_key(key(KeyCode::Enter)) {
+                return serde_json::to_value(content).expect("elicitation content serializes");
             }
         }
         panic!("Enter never submitted the form");
@@ -1060,11 +1070,9 @@ mod tests {
 
     #[test]
     fn parses_string_field_with_title_and_description() {
-        let schema = ElicitationSchema::builder()
-            .required_string_with("name", |s| s.title("Your Name").description("Enter your full name"))
-            .build()
-            .unwrap();
-        let form = FormModal::new("test".into(), String::new(), &schema);
+        let schema =
+            required("name", StringPropertySchema::new().title("Your Name").description("Enter your full name"));
+        let form = test_modal("test".into(), String::new(), &schema);
         assert_eq!(form.fields.len(), 1);
         assert_eq!(form.fields[0].label, "Your Name");
         assert_eq!(form.fields[0].description.as_deref(), Some("Enter your full name"));
@@ -1074,20 +1082,18 @@ mod tests {
 
     #[test]
     fn parses_boolean_field_with_default() {
-        let schema = ElicitationSchema::builder().optional_bool("approved", true).build().unwrap();
-        let form = FormModal::new("test".into(), String::new(), &schema);
+        let schema = optional("approved", BooleanPropertySchema::new().default_value(true));
+        let form = test_modal("test".into(), String::new(), &schema);
         assert_eq!(form.fields.len(), 1);
         assert!(matches!(form.fields[0].kind, FormFieldKind::Boolean(true)));
     }
 
     #[test]
     fn parses_integer_and_number_fields() {
-        let schema = ElicitationSchema::builder()
-            .required_integer("age", 0, 150)
-            .required_number("rating", 0.0, 5.0)
-            .build()
-            .unwrap();
-        let form = FormModal::new("test".into(), String::new(), &schema);
+        let schema = ElicitationSchema::new()
+            .property("age", IntegerPropertySchema::new().minimum(0).maximum(150), true)
+            .property("rating", NumberPropertySchema::new().minimum(0.0).maximum(5.0), true);
+        let form = test_modal("test".into(), String::new(), &schema);
         assert_eq!(form.fields.len(), 2);
         assert!(matches!(form.fields[0].kind, FormFieldKind::Number(_)));
         assert!(matches!(form.fields[1].kind, FormFieldKind::Number(_)));
@@ -1095,11 +1101,8 @@ mod tests {
 
     #[test]
     fn integer_field_respects_default() {
-        let schema = ElicitationSchema::builder()
-            .required_integer_with("count", |i| i.range(0, 100).with_default(42))
-            .build()
-            .unwrap();
-        let form = FormModal::new("test".into(), String::new(), &schema);
+        let schema = required("count", IntegerPropertySchema::new().minimum(0).maximum(100).default_value(42));
+        let form = test_modal("test".into(), String::new(), &schema);
         match &form.fields[0].kind {
             FormFieldKind::Number(value) => assert_eq!(value, "42"),
             _ => panic!("expected Number"),
@@ -1108,11 +1111,8 @@ mod tests {
 
     #[test]
     fn number_field_respects_default() {
-        let schema = ElicitationSchema::builder()
-            .required_number_with("score", |n| n.range(0.0, 100.0).with_default(2.5))
-            .build()
-            .unwrap();
-        let form = FormModal::new("test".into(), String::new(), &schema);
+        let schema = required("score", NumberPropertySchema::new().minimum(0.0).maximum(100.0).default_value(2.5));
+        let form = test_modal("test".into(), String::new(), &schema);
         match &form.fields[0].kind {
             FormFieldKind::Number(value) => {
                 let parsed: f64 = value.parse().unwrap();
@@ -1124,9 +1124,8 @@ mod tests {
 
     #[test]
     fn string_field_respects_default() {
-        let schema =
-            ElicitationSchema::builder().required_string_with("greeting", |s| s.with_default("hello")).build().unwrap();
-        let form = FormModal::new("test".into(), String::new(), &schema);
+        let schema = required("greeting", StringPropertySchema::new().default_value("hello"));
+        let form = test_modal("test".into(), String::new(), &schema);
         match &form.fields[0].kind {
             FormFieldKind::Text(value) => assert_eq!(value, "hello"),
             _ => panic!("expected Text"),
@@ -1135,14 +1134,11 @@ mod tests {
 
     #[test]
     fn parses_single_select_enum_from_schema() {
-        let schema = ElicitationSchema::builder()
-            .required_enum_schema(
-                "color",
-                EnumSchema::builder(vec!["red".into(), "green".into(), "blue".into()]).untitled().build(),
-            )
-            .build()
-            .unwrap();
-        let form = FormModal::new("test".into(), String::new(), &schema);
+        let schema = required(
+            "color",
+            StringPropertySchema::new().enum_values(vec!["red".into(), "green".into(), "blue".into()]),
+        );
+        let form = test_modal("test".into(), String::new(), &schema);
         match &form.fields[0].kind {
             FormFieldKind::Single { options, selected } => {
                 assert_eq!(options.len(), 3);
@@ -1155,18 +1151,11 @@ mod tests {
 
     #[test]
     fn parses_single_select_with_default() {
-        let schema = ElicitationSchema::builder()
-            .required_enum_schema(
-                "color",
-                EnumSchema::builder(vec!["red".into(), "green".into()])
-                    .untitled()
-                    .with_default("green".to_string())
-                    .unwrap()
-                    .build(),
-            )
-            .build()
-            .unwrap();
-        let form = FormModal::new("test".into(), String::new(), &schema);
+        let schema = required(
+            "color",
+            StringPropertySchema::new().enum_values(vec!["red".into(), "green".into()]).default_value("green"),
+        );
+        let form = test_modal("test".into(), String::new(), &schema);
         match &form.fields[0].kind {
             FormFieldKind::Single { options, selected } => {
                 assert_eq!(*selected, 1);
@@ -1178,17 +1167,15 @@ mod tests {
 
     #[test]
     fn parses_titled_single_select_with_const_titles() {
-        let schema = ElicitationSchema::builder()
-            .required_enum_schema(
-                "size",
-                EnumSchema::builder(vec!["s".into(), "m".into(), "l".into()])
-                    .enum_titles(vec!["Small".into(), "Medium".into(), "Large".into()])
-                    .unwrap()
-                    .build(),
-            )
-            .build()
-            .unwrap();
-        let form = FormModal::new("test".into(), String::new(), &schema);
+        let schema = required(
+            "size",
+            StringPropertySchema::new().one_of(vec![
+                EnumOption::new("s", "Small"),
+                EnumOption::new("m", "Medium"),
+                EnumOption::new("l", "Large"),
+            ]),
+        );
+        let form = test_modal("test".into(), String::new(), &schema);
         match &form.fields[0].kind {
             FormFieldKind::Single { options, .. } => {
                 assert_eq!(options.len(), 3);
@@ -1202,7 +1189,7 @@ mod tests {
     #[test]
     fn parses_multi_select_enum() {
         let schema = multi_schema();
-        let form = FormModal::new("test".into(), String::new(), &schema);
+        let form = test_modal("test".into(), String::new(), &schema);
         match &form.fields[0].kind {
             FormFieldKind::Multi { options, selected, cursor } => {
                 assert_eq!(options.len(), 3);
@@ -1216,18 +1203,12 @@ mod tests {
 
     #[test]
     fn parses_multi_select_with_defaults() {
-        let schema = ElicitationSchema::builder()
-            .required_enum_schema(
-                "tags",
-                EnumSchema::builder(vec!["fast".into(), "reliable".into(), "cheap".into()])
-                    .multiselect()
-                    .with_default(vec!["reliable".to_string()])
-                    .unwrap()
-                    .build(),
-            )
-            .build()
-            .unwrap();
-        let form = FormModal::new("test".into(), String::new(), &schema);
+        let schema = required(
+            "tags",
+            MultiSelectPropertySchema::new(vec!["fast".into(), "reliable".into(), "cheap".into()])
+                .default_value(vec!["reliable".to_string()]),
+        );
+        let form = test_modal("test".into(), String::new(), &schema);
         match &form.fields[0].kind {
             FormFieldKind::Multi { selected, .. } => {
                 assert!(!selected[0]);
@@ -1240,80 +1221,60 @@ mod tests {
 
     #[test]
     fn empty_schema_produces_no_fields() {
-        let schema = ElicitationSchema::builder().build().unwrap();
-        let form = FormModal::new("test".into(), String::new(), &schema);
+        let schema = ElicitationSchema::new();
+        let form = test_modal("test".into(), String::new(), &schema);
         assert!(form.fields.is_empty());
     }
 
     #[test]
     fn text_field_default_submits_as_a_string() {
-        let schema =
-            ElicitationSchema::builder().optional_string_with("greeting", |s| s.with_default("hello")).build().unwrap();
-        let mut form = FormModal::new("test".into(), String::new(), &schema);
+        let schema = optional("greeting", StringPropertySchema::new().default_value("hello"));
+        let mut form = test_modal("test".into(), String::new(), &schema);
         assert_eq!(submitted(&mut form), serde_json::json!({"greeting": "hello"}));
     }
 
     #[test]
     fn number_field_default_submits_as_a_parsed_number() {
-        let schema = ElicitationSchema::builder()
-            .optional_integer_with("count", |i| i.range(0, 100).with_default(42))
-            .build()
-            .unwrap();
-        let mut form = FormModal::new("test".into(), String::new(), &schema);
+        let schema = optional("count", IntegerPropertySchema::new().minimum(0).maximum(100).default_value(42));
+        let mut form = test_modal("test".into(), String::new(), &schema);
         assert_eq!(submitted(&mut form), serde_json::json!({"count": 42}));
     }
 
     #[test]
     fn boolean_and_single_select_defaults_submit_as_typed_values() {
-        let schema = ElicitationSchema::builder()
-            .optional_bool("approved", true)
-            .optional_enum_schema(
+        let schema = ElicitationSchema::new()
+            .property("approved", BooleanPropertySchema::new().default_value(true), false)
+            .property(
                 "color",
-                EnumSchema::builder(vec!["red".into(), "green".into()])
-                    .untitled()
-                    .with_default("green".to_string())
-                    .unwrap()
-                    .build(),
-            )
-            .build()
-            .unwrap();
-        let mut form = FormModal::new("test".into(), String::new(), &schema);
+                StringPropertySchema::new().enum_values(vec!["red".into(), "green".into()]).default_value("green"),
+                false,
+            );
+        let mut form = test_modal("test".into(), String::new(), &schema);
         assert_eq!(submitted(&mut form), serde_json::json!({"approved": true, "color": "green"}));
     }
 
     #[test]
     fn multi_select_defaults_submit_as_the_selected_array() {
-        let schema = ElicitationSchema::builder()
-            .required_enum_schema(
-                "tags",
-                EnumSchema::builder(vec!["fast".into(), "reliable".into(), "cheap".into()])
-                    .multiselect()
-                    .with_default(vec!["reliable".to_string()])
-                    .unwrap()
-                    .build(),
-            )
-            .build()
-            .unwrap();
-        let mut form = FormModal::new("test".into(), String::new(), &schema);
+        let schema = required(
+            "tags",
+            MultiSelectPropertySchema::new(vec!["fast".into(), "reliable".into(), "cheap".into()])
+                .default_value(vec!["reliable".to_string()]),
+        );
+        let mut form = test_modal("test".into(), String::new(), &schema);
         assert_eq!(submitted(&mut form), serde_json::json!({"tags": ["reliable"]}));
     }
 
     #[test]
     fn accept_produces_correct_json() {
-        let schema = ElicitationSchema::builder()
-            .optional_string_with("name", |s| s.title("Name"))
-            .optional_bool("approved", true)
-            .optional_enum_schema(
+        let schema = ElicitationSchema::new()
+            .property("name", StringPropertySchema::new().title("Name"), false)
+            .property("approved", BooleanPropertySchema::new().default_value(true), false)
+            .property(
                 "color",
-                EnumSchema::builder(vec!["red".into(), "green".into()])
-                    .untitled()
-                    .with_default("green".to_string())
-                    .unwrap()
-                    .build(),
-            )
-            .build()
-            .unwrap();
-        let mut form = FormModal::new("test".into(), "Test".into(), &schema);
+                StringPropertySchema::new().enum_values(vec!["red".into(), "green".into()]).default_value("green"),
+                false,
+            );
+        let mut form = test_modal("test".into(), "Test".into(), &schema);
         let value = submitted(&mut form);
         let object = value.as_object().unwrap();
         assert!(!object.contains_key("name"), "empty optional text should be omitted");
@@ -1323,22 +1284,22 @@ mod tests {
 
     #[test]
     fn submit_rejects_required_field() {
-        let schema = ElicitationSchema::builder().required_string("name").build().unwrap();
-        let mut form = FormModal::new("test".into(), String::new(), &schema);
+        let schema = required("name", StringPropertySchema::new());
+        let mut form = test_modal("test".into(), String::new(), &schema);
         assert!(matches!(form.on_key(key(KeyCode::Enter)), FormAction::None));
     }
 
     #[test]
     fn permission_like_form_submit_returns_default_deny() {
         let schema = permission_like_schema();
-        let mut form = FormModal::new("coding".into(), "Allow bash: rm -rf /tmp?".into(), &schema);
+        let mut form = test_modal("coding".into(), "Allow bash: rm -rf /tmp?".into(), &schema);
         assert_eq!(submitted(&mut form)["decision"], "deny");
     }
 
     #[test]
     fn number_field_rejects_non_numeric_input() {
-        let schema = ElicitationSchema::builder().optional_number("score", 0.0, 5.0).build().unwrap();
-        let mut form = FormModal::new("test".into(), String::new(), &schema);
+        let schema = optional("score", NumberPropertySchema::new().minimum(0.0).maximum(5.0));
+        let mut form = test_modal("test".into(), String::new(), &schema);
 
         form.on_key(key(KeyCode::Char('4')));
         form.on_key(key(KeyCode::Char('a')));
@@ -1351,7 +1312,7 @@ mod tests {
     #[test]
     fn single_field_form_submits_directly_on_enter() {
         let schema = permission_like_schema();
-        let mut form = FormModal::new("coding".into(), "Allow bash?".into(), &schema);
+        let mut form = test_modal("coding".into(), "Allow bash?".into(), &schema);
         assert!(matches!(form.on_key(key(KeyCode::Enter)), FormAction::Accept(_)));
     }
 
@@ -1360,7 +1321,7 @@ mod tests {
         let schema = survey_schema();
         // `properties` arrives as a sorted map, so the pages run notify, team,
         // urgency — alphabetical by name.
-        let mut form = FormModal::new("survey".into(), "Help us route this".into(), &schema);
+        let mut form = test_modal("survey".into(), "Help us route this".into(), &schema);
 
         form.on_key(key(KeyCode::Down));
         assert!(matches!(form.on_key(key(KeyCode::Enter)), FormAction::None), "the notify page advances");
@@ -1374,9 +1335,10 @@ mod tests {
         assert!(matches!(form.on_key(key(KeyCode::Enter)), FormAction::None), "the last question advances to review");
         assert!(draw(&mut form).contains("Review your answers"), "the review page");
 
-        let FormAction::Accept(value) = form.on_key(key(KeyCode::Enter)) else {
+        let FormAction::Accept(content) = form.on_key(key(KeyCode::Enter)) else {
             panic!("a complete form submits from review")
         };
+        let value = serde_json::to_value(content).unwrap();
         assert_eq!(value["notify"], true);
         assert_eq!(value["team"], "team");
         assert_eq!(value["urgency"], "high");
@@ -1385,7 +1347,7 @@ mod tests {
     #[test]
     fn tab_and_backtab_walk_pages_without_wraparound() {
         let schema = survey_schema();
-        let mut form = FormModal::new("survey".into(), String::new(), &schema);
+        let mut form = test_modal("survey".into(), String::new(), &schema);
 
         form.on_key(key(KeyCode::BackTab));
         assert!(draw(&mut form).contains("1  Yes"), "BackTab stops at the first page");
@@ -1399,12 +1361,12 @@ mod tests {
 
     #[test]
     fn submit_failure_jumps_to_the_first_invalid_field() {
-        let schema = ElicitationSchema::builder()
-            .required_string("first")
-            .required_string("second")
-            .build()
-            .unwrap();
-        let mut form = FormModal::new("test".into(), String::new(), &schema);
+        let schema = ElicitationSchema::new().property("first", StringPropertySchema::new(), true).property(
+            "second",
+            StringPropertySchema::new(),
+            true,
+        );
+        let mut form = test_modal("test".into(), String::new(), &schema);
         form.on_key(key(KeyCode::Tab));
         form.on_key(key(KeyCode::Tab));
         assert!(matches!(form.on_key(key(KeyCode::Enter)), FormAction::None));
@@ -1415,19 +1377,15 @@ mod tests {
 
     #[test]
     fn arrows_answer_choice_pages_immediately() {
-        let schema = ElicitationSchema::builder()
-            .optional_enum_schema(
+        let schema = ElicitationSchema::new()
+            .property(
                 "urgency",
-                EnumSchema::builder(vec!["low".into(), "high".into()])
-                    .untitled()
-                    .enum_titles(vec!["Low".into(), "High".into()])
-                    .unwrap()
-                    .build(),
+                StringPropertySchema::new()
+                    .one_of(vec![EnumOption::new("low", "Low"), EnumOption::new("high", "High")]),
+                false,
             )
-            .optional_bool("notify", false)
-            .build()
-            .unwrap();
-        let mut form = FormModal::new("survey".into(), String::new(), &schema);
+            .property("notify", BooleanPropertySchema::new().default_value(false), false);
+        let mut form = test_modal("survey".into(), String::new(), &schema);
         form.on_key(key(KeyCode::Tab));
         assert!(draw(&mut form).contains("1  Low"), "the urgency question is a choice page");
 
@@ -1435,7 +1393,7 @@ mod tests {
         assert!(draw(&mut form).contains("1 / 2"), "answering marks the page answered");
         assert_eq!(submitted(&mut form)["urgency"], "high", "Down answers High");
 
-        let mut form = FormModal::new("survey".into(), String::new(), &schema);
+        let mut form = test_modal("survey".into(), String::new(), &schema);
         form.on_key(key(KeyCode::Tab));
         form.on_key(key(KeyCode::Down));
         form.on_key(key(KeyCode::Up));
@@ -1444,8 +1402,8 @@ mod tests {
 
     #[test]
     fn boolean_page_answers_through_its_two_options() {
-        let schema = ElicitationSchema::builder().optional_bool("notify", false).build().unwrap();
-        let mut form = FormModal::new("test".into(), String::new(), &schema);
+        let schema = optional("notify", BooleanPropertySchema::new().default_value(false));
+        let mut form = test_modal("test".into(), String::new(), &schema);
         form.on_key(key(KeyCode::Down));
         assert_eq!(submitted(&mut form)["notify"], true, "Down selects Yes");
         form.on_key(key(KeyCode::Char('2')));
@@ -1456,18 +1414,14 @@ mod tests {
 
     #[test]
     fn digit_keys_pick_single_and_toggle_multi_options() {
-        let schema = ElicitationSchema::builder()
-            .optional_enum_schema(
+        let schema = ElicitationSchema::new()
+            .property(
                 "color",
-                EnumSchema::builder(vec!["red".into(), "green".into(), "blue".into()]).untitled().build(),
+                StringPropertySchema::new().enum_values(vec!["red".into(), "green".into(), "blue".into()]),
+                false,
             )
-            .required_enum_schema(
-                "tags",
-                EnumSchema::builder(vec!["fast".into(), "reliable".into()]).multiselect().build(),
-            )
-            .build()
-            .unwrap();
-        let mut form = FormModal::new("test".into(), String::new(), &schema);
+            .property("tags", MultiSelectPropertySchema::new(vec!["fast".into(), "reliable".into()]), true);
+        let mut form = test_modal("test".into(), String::new(), &schema);
 
         form.on_key(key(KeyCode::Char('3')));
         form.on_key(key(KeyCode::Tab));
@@ -1478,15 +1432,14 @@ mod tests {
     }
     #[test]
     fn multi_select_cursor_moves_without_answering() {
-        let schema = ElicitationSchema::builder()
-            .required_enum_schema(
+        let schema = ElicitationSchema::new()
+            .property(
                 "tags",
-                EnumSchema::builder(vec!["fast".into(), "reliable".into(), "cheap".into()]).multiselect().build(),
+                MultiSelectPropertySchema::new(vec!["fast".into(), "reliable".into(), "cheap".into()]),
+                true,
             )
-            .optional_bool("verify", false)
-            .build()
-            .unwrap();
-        let mut form = FormModal::new("test".into(), String::new(), &schema);
+            .property("verify", BooleanPropertySchema::new().default_value(false), false);
+        let mut form = test_modal("test".into(), String::new(), &schema);
 
         form.on_key(key(KeyCode::Down));
         assert!(draw(&mut form).contains("0 / 2"), "moving the cursor is not an answer");
@@ -1500,7 +1453,7 @@ mod tests {
     #[test]
     fn multi_select_space_toggles_the_focused_option() {
         let schema = multi_schema();
-        let mut form = FormModal::new("test".into(), String::new(), &schema);
+        let mut form = test_modal("test".into(), String::new(), &schema);
         form.on_key(key(KeyCode::Char(' ')));
         assert_eq!(submitted(&mut form)["tags"], serde_json::json!(["fast"]));
     }
@@ -1508,7 +1461,7 @@ mod tests {
     #[test]
     fn multi_select_up_saturates_at_zero() {
         let schema = multi_schema();
-        let mut form = FormModal::new("test".into(), String::new(), &schema);
+        let mut form = test_modal("test".into(), String::new(), &schema);
         form.on_key(key(KeyCode::Up));
         form.on_key(key(KeyCode::Char(' ')));
         assert_eq!(submitted(&mut form)["tags"], serde_json::json!(["fast"]));
@@ -1517,7 +1470,7 @@ mod tests {
     #[test]
     fn select_all_flips_every_checkbox() {
         let schema = multi_schema();
-        let mut form = FormModal::new("test".into(), String::new(), &schema);
+        let mut form = test_modal("test".into(), String::new(), &schema);
         form.on_key(key(KeyCode::Char('a')));
         assert_eq!(submitted(&mut form)["tags"], serde_json::json!(["fast", "reliable", "cheap"]));
         form.on_key(key(KeyCode::Char('a')));
@@ -1526,8 +1479,8 @@ mod tests {
 
     #[test]
     fn digits_still_type_into_text_fields() {
-        let schema = ElicitationSchema::builder().optional_string("name").build().unwrap();
-        let mut form = FormModal::new("test".into(), String::new(), &schema);
+        let schema = optional("name", StringPropertySchema::new());
+        let mut form = test_modal("test".into(), String::new(), &schema);
         form.on_key(key(KeyCode::Char('4')));
         form.on_key(key(KeyCode::Char('2')));
         assert_eq!(submitted(&mut form)["name"], "42");
@@ -1536,7 +1489,7 @@ mod tests {
     #[test]
     fn esc_confirms_when_more_than_one_answer_would_be_lost() {
         let schema = survey_schema();
-        let mut form = FormModal::new("survey".into(), String::new(), &schema);
+        let mut form = test_modal("survey".into(), String::new(), &schema);
         form.on_key(key(KeyCode::Down));
         form.on_key(key(KeyCode::Tab));
         form.on_key(key(KeyCode::Char('t')));
@@ -1556,7 +1509,7 @@ mod tests {
     #[test]
     fn esc_cancels_immediately_when_barely_anything_was_answered() {
         let schema = survey_schema();
-        let mut form = FormModal::new("survey".into(), String::new(), &schema);
+        let mut form = test_modal("survey".into(), String::new(), &schema);
         form.on_key(key(KeyCode::Down));
         assert!(matches!(form.on_key(key(KeyCode::Esc)), FormAction::Cancel), "one answer needs no ceremony");
     }
@@ -1564,7 +1517,7 @@ mod tests {
     #[test]
     fn wizard_pages_show_a_tab_strip_and_progress_counter() {
         let schema = survey_schema();
-        let mut form = FormModal::new("survey".into(), "Help us route this".into(), &schema);
+        let mut form = test_modal("survey".into(), "Help us route this".into(), &schema);
 
         let screen = draw(&mut form);
         assert!(screen.contains("notify"), "the first question is the page headline: {screen}");
@@ -1581,7 +1534,7 @@ mod tests {
     #[test]
     fn single_question_forms_skip_the_tab_strip() {
         let schema = permission_like_schema();
-        let mut form = FormModal::new("coding".into(), "Allow bash: rm -rf /tmp?".into(), &schema);
+        let mut form = test_modal("coding".into(), "Allow bash: rm -rf /tmp?".into(), &schema);
         let screen = draw(&mut form);
         assert!(!screen.contains("/ 1"), "no progress counter for one question: {screen}");
         assert!(screen.contains("Allow bash: rm -rf /tmp?"));
@@ -1591,7 +1544,7 @@ mod tests {
     #[test]
     fn choice_pages_list_every_option_with_its_ordinal() {
         let schema = survey_schema();
-        let mut form = FormModal::new("survey".into(), String::new(), &schema);
+        let mut form = test_modal("survey".into(), String::new(), &schema);
         form.on_key(key(KeyCode::Tab));
         form.on_key(key(KeyCode::Tab));
         let screen = draw(&mut form);
@@ -1602,7 +1555,7 @@ mod tests {
     #[test]
     fn text_pages_draw_an_input_and_place_the_terminal_cursor() {
         let schema = survey_schema();
-        let mut form = FormModal::new("survey".into(), String::new(), &schema);
+        let mut form = test_modal("survey".into(), String::new(), &schema);
         form.on_key(key(KeyCode::Tab));
         form.on_key(key(KeyCode::Char('a')));
         form.on_key(key(KeyCode::Char('b')));
@@ -1618,7 +1571,7 @@ mod tests {
     #[test]
     fn review_page_lists_every_answer_and_marks_missing_ones() {
         let schema = survey_schema();
-        let mut form = FormModal::new("survey".into(), String::new(), &schema);
+        let mut form = test_modal("survey".into(), String::new(), &schema);
         for _ in 0..3 {
             form.on_key(key(KeyCode::Tab));
         }
@@ -1630,12 +1583,10 @@ mod tests {
 
     #[test]
     fn clicking_an_option_answers_the_field_under_the_pointer() {
-        let schema = ElicitationSchema::builder()
-            .optional_bool("alpha", false)
-            .optional_bool("bravo", false)
-            .build()
-            .unwrap();
-        let mut form = FormModal::new("test".into(), String::new(), &schema);
+        let schema = ElicitationSchema::new()
+            .property("alpha", BooleanPropertySchema::new().default_value(false), false)
+            .property("bravo", BooleanPropertySchema::new().default_value(false), false);
+        let mut form = test_modal("test".into(), String::new(), &schema);
 
         let (column, yes) = cell_of(&mut form, "1  Yes");
         form.click(column, yes);
@@ -1651,7 +1602,7 @@ mod tests {
     #[test]
     fn clicking_a_tab_or_a_review_row_jumps_to_its_page() {
         let schema = survey_schema();
-        let mut form = FormModal::new("survey".into(), String::new(), &schema);
+        let mut form = test_modal("survey".into(), String::new(), &schema);
 
         let (column, row) = cell_of(&mut form, "✓");
         form.click(column, row);
@@ -1664,12 +1615,11 @@ mod tests {
 
     #[test]
     fn long_forms_window_the_tab_strip_around_the_current_page() {
-        let mut builder = ElicitationSchema::builder();
+        let mut schema = ElicitationSchema::new();
         for index in 0..40 {
-            builder = builder.optional_bool(format!("field_{index:02}"), false);
+            schema = schema.property(format!("field_{index:02}"), BooleanPropertySchema::new(), false);
         }
-        let schema = builder.build().unwrap();
-        let mut form = FormModal::new("survey".into(), String::new(), &schema);
+        let mut form = test_modal("survey".into(), String::new(), &schema);
 
         for _ in 0..20 {
             form.on_key(key(KeyCode::Tab));
@@ -1687,7 +1637,7 @@ mod tests {
     #[test]
     fn scrolling_answers_on_choice_pages_and_walks_pages_elsewhere() {
         let schema = survey_schema();
-        let mut form = FormModal::new("survey".into(), String::new(), &schema);
+        let mut form = test_modal("survey".into(), String::new(), &schema);
 
         form.vertical(Direction::Forward);
         assert!(draw(&mut form).contains("1  Yes"), "vertical motion on a choice page answers instead of paging");
@@ -1704,7 +1654,7 @@ mod tests {
     #[test]
     fn hints_follow_the_page_in_focus() {
         let schema = survey_schema();
-        let mut form = FormModal::new("survey".into(), String::new(), &schema);
+        let mut form = test_modal("survey".into(), String::new(), &schema);
 
         let hints = |form: &FormModal| form.hints().iter().map(|(key, _)| *key).collect::<Vec<_>>();
         assert_eq!(hints(&form), vec!["↑↓", "1-9", "Tab", "Enter", "Esc"], "a choice page picks");
@@ -1715,4 +1665,3 @@ mod tests {
         assert_eq!(hints(&form), vec!["Enter", "Esc"], "the review page submits");
     }
 }
-

--- a/crates/wisp/src/surfaces/modal/form.rs
+++ b/crates/wisp/src/surfaces/modal/form.rs
@@ -73,6 +73,7 @@ pub(super) struct FormField {
 
 pub(super) enum FormFieldKind {
     Text(EditBuffer),
+    Integer(EditBuffer),
     Number(EditBuffer),
     Boolean(bool),
     Single { options: Vec<SelectOption>, selected: usize },
@@ -198,7 +199,7 @@ impl FormModal {
 
     fn text_buffer(&mut self) -> Option<&mut EditBuffer> {
         match self.focused_kind()? {
-            FormFieldKind::Text(buffer) | FormFieldKind::Number(buffer) => Some(buffer),
+            FormFieldKind::Text(buffer) | FormFieldKind::Integer(buffer) | FormFieldKind::Number(buffer) => Some(buffer),
             _ => None,
         }
     }
@@ -738,7 +739,9 @@ fn question_rows(field: &FormField, theme: &Theme, width: u16, rows: &mut PageRo
         FormFieldKind::Boolean(value) => {
             option_rows(&boolean_options(), boolean_index(*value), None, theme, width, rows);
         }
-        FormFieldKind::Text(buffer) | FormFieldKind::Number(buffer) => input_rows(buffer, theme, width, rows),
+        FormFieldKind::Text(buffer) | FormFieldKind::Integer(buffer) | FormFieldKind::Number(buffer) => {
+            input_rows(buffer, theme, width, rows);
+        }
     }
 }
 
@@ -840,7 +843,7 @@ fn boolean_index(value: bool) -> usize {
 
 impl FormField {
     fn from_schema(name: &str, prop: &ElicitationPropertySchema, required: &[&str]) -> Option<Self> {
-        use FormFieldKind::{Boolean, Number};
+        use FormFieldKind::{Boolean, Integer, Number};
         let (labelling, kind) = match prop {
             ElicitationPropertySchema::Boolean(value) => (
                 labelling(value.title.as_deref(), value.description.as_deref(), name),
@@ -848,7 +851,7 @@ impl FormField {
             ),
             ElicitationPropertySchema::Integer(value) => (
                 labelling(value.title.as_deref(), value.description.as_deref(), name),
-                Number(stringified_default(value.default).into()),
+                Integer(stringified_default(value.default).into()),
             ),
             ElicitationPropertySchema::Number(value) => (
                 labelling(value.title.as_deref(), value.description.as_deref(), name),
@@ -883,16 +886,31 @@ impl FormField {
                     Ok((!value.is_empty()).then(|| ElicitationContentValue::String(value.text().to_string())))
                 }
             }
+            FormFieldKind::Integer(value) => {
+                if value.is_empty() {
+                    return if self.required { Err(missing()) } else { Ok(None) };
+                }
+                let invalid = || format!("{} must be an integer", self.label);
+                value
+                    .text()
+                    .parse::<i64>()
+                    .map(ElicitationContentValue::Integer)
+                    .map(Some)
+                    .map_err(|_| invalid())
+            }
             FormFieldKind::Number(value) => {
                 if value.is_empty() {
                     return if self.required { Err(missing()) } else { Ok(None) };
                 }
                 let invalid = || format!("{} must be a number", self.label);
-                let number: serde_json::Number = serde_json::from_str(value.text()).map_err(|_| invalid())?;
-                Ok(Some(match number.as_i64() {
-                    Some(integer) => ElicitationContentValue::Integer(integer),
-                    None => ElicitationContentValue::Number(number.as_f64().ok_or_else(invalid)?),
-                }))
+                value
+                    .text()
+                    .parse::<f64>()
+                    .ok()
+                    .filter(|number| number.is_finite())
+                    .map(ElicitationContentValue::Number)
+                    .map(Some)
+                    .ok_or_else(invalid)
             }
             FormFieldKind::Boolean(value) => Ok(Some(ElicitationContentValue::Boolean(*value))),
             FormFieldKind::Single { options, selected } => {
@@ -916,7 +934,9 @@ impl FormField {
 
     fn display_value(&self) -> String {
         match &self.kind {
-            FormFieldKind::Text(value) | FormFieldKind::Number(value) => value.text().to_string(),
+            FormFieldKind::Text(value) | FormFieldKind::Integer(value) | FormFieldKind::Number(value) => {
+                value.text().to_string()
+            }
             FormFieldKind::Boolean(value) => if *value { "Yes" } else { "No" }.to_string(),
             FormFieldKind::Single { options, selected } => {
                 options.get(*selected).map(|o| o.title.clone()).unwrap_or_default()
@@ -982,8 +1002,6 @@ fn stringified_default<T: std::fmt::Display>(default: Option<T>) -> String {
     default.map(|value| value.to_string()).unwrap_or_default()
 }
 
-/// The single-question decision form a permission prompt sends, shared with
-/// the modal tests one level up.
 #[cfg(test)]
 pub(super) fn permission_like_schema() -> ElicitationSchema {
     ElicitationSchema::new().property(
@@ -1095,7 +1113,7 @@ mod tests {
             .property("rating", NumberPropertySchema::new().minimum(0.0).maximum(5.0), true);
         let form = test_modal("test".into(), String::new(), &schema);
         assert_eq!(form.fields.len(), 2);
-        assert!(matches!(form.fields[0].kind, FormFieldKind::Number(_)));
+        assert!(matches!(form.fields[0].kind, FormFieldKind::Integer(_)));
         assert!(matches!(form.fields[1].kind, FormFieldKind::Number(_)));
     }
 
@@ -1104,8 +1122,8 @@ mod tests {
         let schema = required("count", IntegerPropertySchema::new().minimum(0).maximum(100).default_value(42));
         let form = test_modal("test".into(), String::new(), &schema);
         match &form.fields[0].kind {
-            FormFieldKind::Number(value) => assert_eq!(value, "42"),
-            _ => panic!("expected Number"),
+            FormFieldKind::Integer(value) => assert_eq!(value, "42"),
+            _ => panic!("expected Integer"),
         }
     }
 
@@ -1297,7 +1315,19 @@ mod tests {
     }
 
     #[test]
-    fn number_field_rejects_non_numeric_input() {
+    fn integer_field_rejects_fractional_input() {
+        let schema = optional("count", IntegerPropertySchema::new());
+        let mut form = test_modal("test".into(), String::new(), &schema);
+
+        form.on_key(key(KeyCode::Char('1')));
+        form.on_key(key(KeyCode::Char('.')));
+        form.on_key(key(KeyCode::Char('5')));
+
+        assert!(matches!(form.on_key(key(KeyCode::Enter)), FormAction::None));
+    }
+
+    #[test]
+    fn number_field_rejects_non_numeric_input_and_preserves_number_type() {
         let schema = optional("score", NumberPropertySchema::new().minimum(0.0).maximum(5.0));
         let mut form = test_modal("test".into(), String::new(), &schema);
 
@@ -1306,7 +1336,7 @@ mod tests {
         assert!(matches!(form.on_key(key(KeyCode::Enter)), FormAction::None), "letters block submit");
 
         form.on_key(key(KeyCode::Backspace));
-        assert_eq!(submitted(&mut form), serde_json::json!({"score": 4}));
+        assert_eq!(submitted(&mut form), serde_json::json!({"score": 4.0}));
     }
 
     #[test]

--- a/crates/wisp/src/surfaces/modal/mod.rs
+++ b/crates/wisp/src/surfaces/modal/mod.rs
@@ -4,8 +4,9 @@ mod url;
 
 use crate::renderer::DrawContext;
 use crate::surfaces::elicitation::ElicitationResponder;
-use acp_utils::notifications::{ElicitRequestParams, ElicitationAction, ElicitationParams, ElicitationResponse};
+use acp_utils::elicitation::source_mcp_server_name;
 use agent_client_protocol::Responder;
+use agent_client_protocol::schema::v1::{CreateElicitationRequest, CreateElicitationResponse, ElicitationMode};
 use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
 use ratatui::buffer::Buffer;
 use ratatui::layout::{Constraint, Position, Rect};
@@ -35,21 +36,22 @@ enum ModalKind {
 
 impl ElicitationModal {
     pub fn with_url_handlers(
-        params: ElicitationParams,
-        responder: Responder<ElicitationResponse>,
+        params: CreateElicitationRequest,
+        responder: Responder<CreateElicitationResponse>,
         browser_opener: BrowserOpener,
         clipboard_writer: ClipboardWriter,
-    ) -> Self {
-        let kind = match params.request {
-            ElicitRequestParams::FormElicitationParams { message, requested_schema, .. } => {
-                ModalKind::Form(FormModal::new(params.server_name, message, &requested_schema))
+    ) -> Option<Self> {
+        let server_name = source_mcp_server_name(params.meta.as_ref()).unwrap_or("Agent").to_string();
+        let message = params.message;
+        let responder = ElicitationResponder::new(responder);
+        let kind = match params.mode {
+            ElicitationMode::Form(form) => {
+                ModalKind::Form(FormModal::new(server_name, message, &form.requested_schema)?)
             }
-            ElicitRequestParams::UrlElicitationParams { message, url, .. } => {
-                ModalKind::Url(UrlModal::new(params.server_name, message, url))
-            }
-            _ => unreachable!("unsupported elicitation request"),
+            ElicitationMode::Url(url) => ModalKind::Url(UrlModal::new(server_name, message, url.url)),
+            _ => return None,
         };
-        Self { kind, responder: ElicitationResponder::new(responder), browser_opener, clipboard_writer }
+        Some(Self { kind, responder, browser_opener, clipboard_writer })
     }
 
     /// Draws the request inside a host that keeps its own chrome, rather than as
@@ -97,7 +99,7 @@ impl ElicitationModal {
                 if let Err(error) = (self.browser_opener)(&url.url) {
                     url.launch_error = Some(format!("Failed to open browser: {error}"));
                 } else {
-                    self.responder.respond(ElicitationAction::Accept, None);
+                    self.responder.accept(None);
                     return vec![ElicitationOutput::Close];
                 }
             }
@@ -154,7 +156,7 @@ impl ElicitationModal {
                 vec![ElicitationOutput::Close]
             }
             FormAction::Accept(content) => {
-                self.responder.respond(ElicitationAction::Accept, Some(content));
+                self.responder.accept(Some(content));
                 vec![ElicitationOutput::Close]
             }
         }
@@ -212,26 +214,15 @@ impl ElicitationModal {
 #[cfg(test)]
 #[allow(clippy::absolute_paths, clippy::similar_names)]
 mod tests {
+    use super::form::permission_like_schema;
     use super::*;
     use acp_utils::testing::test_connection;
-    use acp_utils::{ElicitationSchema, EnumSchema};
+    use agent_client_protocol::schema::v1::{
+        ElicitationAction, ElicitationFormMode, ElicitationSchema, ElicitationSessionScope, ElicitationUrlMode,
+    };
     use std::sync::Arc;
     use std::sync::atomic::{AtomicBool, Ordering};
     use tokio::task::LocalSet;
-
-    fn permission_like_schema() -> ElicitationSchema {
-        ElicitationSchema::builder()
-            .required_enum_schema(
-                "decision",
-                EnumSchema::builder(vec!["allow".into(), "deny".into()])
-                    .untitled()
-                    .with_default(String::from("deny"))
-                    .unwrap()
-                    .build(),
-            )
-            .build()
-            .unwrap()
-    }
 
     /// Whether the modal asked to be dismissed.
     fn closes(messages: &[ElicitationOutput]) -> bool {
@@ -249,37 +240,36 @@ mod tests {
         )
     }
 
-    async fn make_modal_for_schema(
-        schema: ElicitationSchema,
-    ) -> (ElicitationModal, tokio::sync::oneshot::Receiver<ElicitationResponse>) {
-        let (cx, mut peer) = test_connection().await;
-        let (responder, rx) = peer.fake_elicitation(&cx).await;
-        let params = ElicitationParams {
-            server_name: "test".into(),
-            request: ElicitRequestParams::FormElicitationParams {
-                meta: None,
-                message: String::new(),
-                requested_schema: schema,
-            },
-        };
-        let (opener, writer) = noop_handlers();
-        (ElicitationModal::with_url_handlers(params, responder, opener, writer), rx)
+    fn form_request(schema: ElicitationSchema) -> CreateElicitationRequest {
+        CreateElicitationRequest::new(
+            ElicitationFormMode::new(ElicitationSessionScope::new("session-1"), schema),
+            String::new(),
+        )
     }
 
-    async fn make_url_modal(url: &str) -> (ElicitationModal, tokio::sync::oneshot::Receiver<ElicitationResponse>) {
+    fn url_request(url: &str) -> CreateElicitationRequest {
+        CreateElicitationRequest::new(
+            ElicitationUrlMode::new(ElicitationSessionScope::new("session-1"), "el-1", url),
+            "Authorize GitHub",
+        )
+    }
+
+    async fn make_modal_for_schema(
+        schema: ElicitationSchema,
+    ) -> (ElicitationModal, tokio::sync::oneshot::Receiver<CreateElicitationResponse>) {
         let (cx, mut peer) = test_connection().await;
         let (responder, rx) = peer.fake_elicitation(&cx).await;
-        let params = ElicitationParams {
-            server_name: "github".into(),
-            request: ElicitRequestParams::UrlElicitationParams {
-                meta: None,
-                message: "Authorize GitHub".into(),
-                url: url.into(),
-                elicitation_id: "el-1".into(),
-            },
-        };
         let (opener, writer) = noop_handlers();
-        (ElicitationModal::with_url_handlers(params, responder, opener, writer), rx)
+        (ElicitationModal::with_url_handlers(form_request(schema), responder, opener, writer).unwrap(), rx)
+    }
+
+    async fn make_url_modal(
+        url: &str,
+    ) -> (ElicitationModal, tokio::sync::oneshot::Receiver<CreateElicitationResponse>) {
+        let (cx, mut peer) = test_connection().await;
+        let (responder, rx) = peer.fake_elicitation(&cx).await;
+        let (opener, writer) = noop_handlers();
+        (ElicitationModal::with_url_handlers(url_request(url), responder, opener, writer).unwrap(), rx)
     }
 
     async fn make_url_modal_with_handlers(
@@ -289,16 +279,7 @@ mod tests {
     ) -> ElicitationModal {
         let (cx, mut peer) = test_connection().await;
         let (responder, _rx) = peer.fake_elicitation(&cx).await;
-        let params = ElicitationParams {
-            server_name: "github".into(),
-            request: ElicitRequestParams::UrlElicitationParams {
-                meta: None,
-                message: "Authorize GitHub".into(),
-                url: url.into(),
-                elicitation_id: "el-1".into(),
-            },
-        };
-        ElicitationModal::with_url_handlers(params, responder, opener, writer)
+        ElicitationModal::with_url_handlers(url_request(url), responder, opener, writer).unwrap()
     }
     #[tokio::test(flavor = "current_thread")]
     async fn permission_like_form_returns_default_on_enter() {
@@ -308,8 +289,8 @@ mod tests {
                 let (mut modal, rx) = make_modal_for_schema(schema).await;
                 assert!(closes(&modal.on_key(KeyEvent::new(KeyCode::Enter, KeyModifiers::NONE))));
                 let response = rx.await.unwrap();
-                assert_eq!(response.action, ElicitationAction::Accept);
-                assert_eq!(response.content.unwrap()["decision"], "deny");
+                let ElicitationAction::Accept(accept) = response.action else { panic!("expected accept") };
+                assert_eq!(accept.content.unwrap()["decision"], "deny".into());
             })
             .await;
     }
@@ -317,11 +298,11 @@ mod tests {
     async fn esc_returns_cancel() {
         LocalSet::new()
             .run_until(async {
-                let schema = ElicitationSchema::builder().build().unwrap();
+                let schema = ElicitationSchema::new();
                 let (mut modal, rx) = make_modal_for_schema(schema).await;
                 assert!(closes(&modal.on_key(KeyEvent::new(KeyCode::Esc, KeyModifiers::NONE))));
                 let response = rx.await.unwrap();
-                assert_eq!(response.action, ElicitationAction::Cancel);
+                assert!(matches!(response.action, ElicitationAction::Cancel));
             })
             .await;
     }
@@ -330,16 +311,16 @@ mod tests {
     async fn dropping_modal_responds_cancel() {
         LocalSet::new()
             .run_until(async {
-                let schema = ElicitationSchema::builder().build().unwrap();
+                let schema = ElicitationSchema::new();
                 let (modal, rx) = make_modal_for_schema(schema).await;
                 drop(modal);
                 let response = rx.await.unwrap();
-                assert_eq!(response.action, ElicitationAction::Cancel);
+                assert!(matches!(response.action, ElicitationAction::Cancel));
             })
             .await;
     }
     #[tokio::test(flavor = "current_thread")]
-    async fn url_enter_opens_browser_and_keeps_modal_open() {
+    async fn url_enter_opens_browser_and_accepts_request() {
         LocalSet::new()
             .run_until(async {
                 let opened = Arc::new(AtomicBool::new(false));
@@ -426,7 +407,7 @@ mod tests {
                 let (mut modal, rx) = make_url_modal("https://github.com/login").await;
                 assert!(closes(&modal.on_key(KeyEvent::new(KeyCode::Esc, KeyModifiers::NONE))));
                 let response = rx.await.unwrap();
-                assert_eq!(response.action, ElicitationAction::Cancel);
+                assert!(matches!(response.action, ElicitationAction::Cancel));
             })
             .await;
     }
@@ -438,7 +419,7 @@ mod tests {
                 let (modal, rx) = make_url_modal("https://github.com/login").await;
                 drop(modal);
                 let response = rx.await.unwrap();
-                assert_eq!(response.action, ElicitationAction::Cancel);
+                assert!(matches!(response.action, ElicitationAction::Cancel));
             })
             .await;
     }

--- a/crates/wisp/tests/tui/configuration.rs
+++ b/crates/wisp/tests/tui/configuration.rs
@@ -11,15 +11,41 @@ fn required_elicitation_field_must_be_completed() {
         }))
         .unwrap();
 
-        let mut response_rx = with_elicitation(&mut app, form_elicitation("", schema)).await;
+        let mut response_rx = with_elicitation(&mut app, form_elicitation("test", "", schema)).await;
         app.key(key(KeyCode::Enter));
         assert!(response_rx.try_recv().is_err());
         app.type_text("Ada");
         app.key(key(KeyCode::Enter));
 
         let response = response_rx.await.unwrap();
-        assert_eq!(response.action, ElicitationAction::Accept);
-        assert_eq!(response.content, Some(serde_json::json!({ "name": "Ada" })));
+        assert_eq!(accepted_content(&response), serde_json::json!({ "name": "Ada" }));
+    });
+}
+
+#[test]
+fn form_with_unsupported_required_field_is_cancelled() {
+    block_on_local(async {
+        let mut app = make_app();
+        let request: CreateElicitationRequest = serde_json::from_value(serde_json::json!({
+            "mode": "form",
+            "sessionId": "test-session",
+            "message": "Mixed schema",
+            "requestedSchema": {
+                "type": "object",
+                "properties": {
+                    "name": { "type": "string" },
+                    "future": { "type": "future_widget" }
+                },
+                "required": ["future"]
+            }
+        }))
+        .unwrap();
+
+        let response_rx = with_elicitation(&mut app, request).await;
+
+        let response = response_rx.await.unwrap();
+        assert!(matches!(response.action, ElicitationAction::Cancel));
+        assert!(!app.app().has_modal());
     });
 }
 
@@ -28,25 +54,15 @@ fn elicitation_request_is_accepted_interactively() {
     block_on_local(async {
         let mut app = make_app();
 
-        let response_rx = with_elicitation(
-            &mut app,
-            ElicitationParams {
-                server_name: "test-server".to_string(),
-                request: ElicitRequestParams::FormElicitationParams {
-                    meta: None,
-                    message: "Confirm the action".to_string(),
-                    requested_schema: ElicitationSchema::builder().build().unwrap(),
-                },
-            },
-        )
-        .await;
+        let response_rx =
+            with_elicitation(&mut app, form_elicitation("test-server", "Confirm the action", ElicitationSchema::new()))
+                .await;
         assert!(app.app().has_modal());
 
         app.key(KeyEvent::new(KeyCode::Enter, KeyModifiers::NONE));
 
         let response = response_rx.await.unwrap();
-        assert_eq!(response.action, ElicitationAction::Accept);
-        assert_eq!(response.content, Some(serde_json::json!({})));
+        assert_eq!(accepted_content(&response), serde_json::json!({}));
         assert!(!app.app().has_modal());
     });
 }
@@ -170,18 +186,7 @@ fn double_ctrl_c_exits_over_elicitation_modal() {
     block_on_local(async {
         let mut app = make_app();
 
-        with_elicitation(
-            &mut app,
-            ElicitationParams {
-                server_name: "test-server".to_string(),
-                request: ElicitRequestParams::FormElicitationParams {
-                    meta: None,
-                    message: String::new(),
-                    requested_schema: ElicitationSchema::builder().build().unwrap(),
-                },
-            },
-        )
-        .await;
+        with_elicitation(&mut app, form_elicitation("test-server", "", ElicitationSchema::new())).await;
         assert!(app.app().has_modal());
         assert_ctrl_c_exits(&mut app);
     });
@@ -194,14 +199,11 @@ fn form_modal_composed_space_does_not_answer() {
 
         let response_rx = with_elicitation(
             &mut app,
-            ElicitationParams {
-                server_name: "test-server".to_string(),
-                request: ElicitRequestParams::FormElicitationParams {
-                    meta: None,
-                    message: String::new(),
-                    requested_schema: ElicitationSchema::builder().optional_bool("approved", false).build().unwrap(),
-                },
-            },
+            form_elicitation(
+                "test-server",
+                "",
+                ElicitationSchema::new().property("approved", BooleanPropertySchema::new().default_value(false), false),
+            ),
         )
         .await;
         assert!(app.app().has_modal());
@@ -212,10 +214,9 @@ fn form_modal_composed_space_does_not_answer() {
         app.key(key(KeyCode::Enter));
 
         let response = response_rx.await.unwrap();
-        assert_eq!(response.action, ElicitationAction::Accept);
         assert_eq!(
-            response.content,
-            Some(serde_json::json!({ "approved": false })),
+            accepted_content(&response),
+            serde_json::json!({ "approved": false }),
             "composed spaces must not answer a choice page; only the arrows do"
         );
     });

--- a/crates/wisp/tests/tui/foundation.rs
+++ b/crates/wisp/tests/tui/foundation.rs
@@ -670,13 +670,7 @@ fn status_line_is_never_inserted_into_scrollback() {
 #[test]
 fn scrollback_insertion_does_not_duplicate_status_line() {
     let mut ui = TestUi::with_backend(RecordingBackend::new(120, 15));
-    ui.acp_event(AcpEvent::ContextUsage(acp_utils::notifications::ContextUsageParams {
-        usage: acp_utils::notifications::ContextUsage {
-            input_tokens: 20_000,
-            context_limit: Some(200_000),
-            ..Default::default()
-        },
-    }));
+    ui.acp_event(session_update(acp::SessionUpdate::UsageUpdate(acp::UsageUpdate::new(20_000, 200_000))));
     ui.draw();
 
     let mut response = String::new();
@@ -686,13 +680,7 @@ fn scrollback_insertion_does_not_duplicate_status_line() {
     ui.submit("hello");
     ui.acp_event(text_chunk(&response));
     ui.acp_event(AcpEvent::PromptDone(acp::StopReason::EndTurn));
-    ui.acp_event(AcpEvent::ContextUsage(acp_utils::notifications::ContextUsageParams {
-        usage: acp_utils::notifications::ContextUsage {
-            input_tokens: 40_000,
-            context_limit: Some(200_000),
-            ..Default::default()
-        },
-    }));
+    ui.acp_event(session_update(acp::SessionUpdate::UsageUpdate(acp::UsageUpdate::new(40_000, 200_000))));
 
     ui.draw();
 

--- a/crates/wisp/tests/tui/plan_review.rs
+++ b/crates/wisp/tests/tui/plan_review.rs
@@ -1,4 +1,3 @@
-use acp_utils::notifications::{ElicitationAction, ElicitationResponse};
 use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
 use ratatui::TerminalOptions;
 use ratatui::backend::TestBackend;
@@ -18,18 +17,18 @@ use wisp::view::generation::Generation;
 use wisp::view::syntax::SyntaxHighlighter;
 
 use super::support::{
-    ElicitRequestParams, ElicitationParams, ElicitationSchema, assert_ctrl_c_exits, block_on_local, make_app,
-    with_elicitation,
+    CreateElicitationResponse, ElicitationAction, ElicitationSchema, accepted_content, assert_ctrl_c_exits,
+    block_on_local, form_elicitation, make_app, with_elicitation,
 };
 
 fn make_meta(markdown: &str) -> PlanReviewElicitationMeta {
     PlanReviewElicitationMeta::new(&PathBuf::from("/tmp/plan.md"), markdown)
 }
 
-fn make_screen(markdown: &str) -> (PlanReviewScreen, oneshot::Receiver<ElicitationResponse>) {
+fn make_screen(markdown: &str) -> (PlanReviewScreen, oneshot::Receiver<CreateElicitationResponse>) {
     let meta = make_meta(markdown);
     let (tx, rx) = oneshot::channel();
-    let responder = ElicitationResponder::from_fn(move |response: ElicitationResponse| {
+    let responder = ElicitationResponder::from_fn(move |response: CreateElicitationResponse| {
         let _ = tx.send(response);
     });
     (PlanReviewScreen::new(meta, responder), rx)
@@ -136,7 +135,7 @@ fn comment_submit_at_first_line() {
     // Request changes - should include the comment
     assert!(closes(&mut screen, key(KeyCode::Char('r'))));
     let response = rx.try_recv().expect("responder should have been called");
-    let content = response.content.expect("content should be present");
+    let content = accepted_content(&response);
     assert!(content["feedback"].as_str().unwrap().contains("needs work"));
 }
 
@@ -157,8 +156,7 @@ fn comment_cancel_with_escape() {
     // Submit request-changes — canceled draft must not leak
     assert!(closes(&mut screen, key(KeyCode::Char('r'))));
     let response = rx.try_recv().expect("responder should have been called");
-    assert_eq!(response.action, ElicitationAction::Accept);
-    let content = response.content.expect("content should be present");
+    let content = accepted_content(&response);
     let feedback = content["feedback"].as_str().unwrap();
     assert!(!feedback.contains("should be discarded"), "canceled draft must not leak into feedback: {feedback}");
     assert!(feedback.contains("no inline comments"), "should return no-inline-comments fallback: {feedback}");
@@ -288,8 +286,7 @@ fn approve_sends_correct_payload() {
     assert!(closes(&mut screen, key(KeyCode::Char('a'))));
 
     let response = rx.try_recv().expect("responder should have been called");
-    assert_eq!(response.action, ElicitationAction::Accept);
-    let content = response.content.expect("content should be present");
+    let content = accepted_content(&response);
     assert_eq!(content["decision"].as_str().unwrap(), "approve");
 }
 
@@ -308,8 +305,7 @@ fn request_changes_sends_feedback_in_payload() {
     assert!(closes(&mut screen, key(KeyCode::Char('r'))));
 
     let response = rx.try_recv().expect("responder should have been called");
-    assert_eq!(response.action, ElicitationAction::Accept);
-    let content = response.content.expect("content should be present");
+    let content = accepted_content(&response);
     assert_eq!(content["decision"].as_str().unwrap(), "deny");
     assert!(content["feedback"].as_str().unwrap().contains("this is wrong"));
 }
@@ -322,7 +318,7 @@ fn cancel_sends_correct_payload() {
     assert!(closes(&mut screen, key(KeyCode::Esc)));
 
     let response = rx.try_recv().expect("responder should have been called");
-    assert_eq!(response.action, ElicitationAction::Cancel);
+    assert!(matches!(&response.action, ElicitationAction::Cancel));
 }
 
 #[test]
@@ -378,8 +374,7 @@ fn modified_chars_do_not_approve_or_reject_the_plan() {
 
     assert!(closes(&mut screen, key(KeyCode::Char('a'))));
     let response = rx.try_recv().expect("plain 'a' should approve");
-    assert_eq!(response.action, ElicitationAction::Accept);
-    assert_eq!(response.content.unwrap()["decision"], "approve");
+    assert_eq!(accepted_content(&response)["decision"], "approve");
 }
 
 #[test]
@@ -401,24 +396,9 @@ fn double_ctrl_c_exits_over_plan_review() {
     block_on_local(async {
         let mut app = make_app();
 
-        // Build the plan-review elicitation meta without a direct rmcp dependency:
-        // round-trip the metadata through serde into the field's `Meta` type.
-        let meta = serde_json::from_value(serde_json::Value::Object(
-            PlanReviewElicitationMeta::new(&PathBuf::from("/tmp/plan.md"), "# Plan\nbody").to_json().unwrap(),
-        ))
-        .unwrap();
-        with_elicitation(
-            &mut app,
-            ElicitationParams {
-                server_name: "plan".to_string(),
-                request: ElicitRequestParams::FormElicitationParams {
-                    meta: Some(meta),
-                    message: "Approve plan?".to_string(),
-                    requested_schema: ElicitationSchema::builder().build().unwrap(),
-                },
-            },
-        )
-        .await;
+        let meta = PlanReviewElicitationMeta::new(&PathBuf::from("/tmp/plan.md"), "# Plan\nbody").to_json().unwrap();
+        with_elicitation(&mut app, form_elicitation("plan", "Approve plan?", ElicitationSchema::new()).meta(meta))
+            .await;
         assert!(app.app().full_screen_active());
         assert_ctrl_c_exits(&mut app);
     });

--- a/crates/wisp/tests/tui/progress_indicator.rs
+++ b/crates/wisp/tests/tui/progress_indicator.rs
@@ -1,5 +1,5 @@
 use acp_utils::client::AcpEvent;
-use acp_utils::notifications::{ContextCompactionParams, ContextUsage, ContextUsageParams};
+use acp_utils::notifications::ContextCompactionParams;
 use agent_client_protocol::schema::v1 as acp;
 
 use super::support::*;
@@ -22,10 +22,8 @@ fn running_tool(id: &str, title: &str) -> AcpEvent {
     session_update(acp::SessionUpdate::ToolCall(acp::ToolCall::new(id.to_string(), title)))
 }
 
-fn context_usage(used: u32, limit: u32) -> AcpEvent {
-    AcpEvent::ContextUsage(ContextUsageParams {
-        usage: ContextUsage { input_tokens: used, context_limit: Some(limit), ..ContextUsage::default() },
-    })
+fn context_usage(used: u64, limit: u64) -> AcpEvent {
+    session_update(acp::SessionUpdate::UsageUpdate(acp::UsageUpdate::new(used, limit)))
 }
 
 fn activity_row(ui: &mut TestUi, label: &str) -> String {

--- a/crates/wisp/tests/tui/prompt_search.rs
+++ b/crates/wisp/tests/tui/prompt_search.rs
@@ -331,18 +331,7 @@ fn prompt_search_ctrl_r_does_not_steal_from_modal() {
     let mut app = make_app_with_prompt_search();
 
     block_on_local(async {
-        with_elicitation(
-            &mut app,
-            ElicitationParams {
-                server_name: "test".to_string(),
-                request: ElicitRequestParams::FormElicitationParams {
-                    meta: None,
-                    message: String::new(),
-                    requested_schema: ElicitationSchema::builder().build().unwrap(),
-                },
-            },
-        )
-        .await;
+        with_elicitation(&mut app, form_elicitation("test", "", ElicitationSchema::new())).await;
     });
 
     assert!(app.app().has_modal());

--- a/crates/wisp/tests/tui/sessions.rs
+++ b/crates/wisp/tests/tui/sessions.rs
@@ -467,18 +467,7 @@ fn new_modal_replaces_session_picker() {
     assert!(app.app().has_session_picker());
 
     block_on_local(async {
-        with_elicitation(
-            &mut app,
-            ElicitationParams {
-                server_name: "test".to_string(),
-                request: ElicitRequestParams::FormElicitationParams {
-                    meta: None,
-                    message: String::new(),
-                    requested_schema: ElicitationSchema::builder().build().unwrap(),
-                },
-            },
-        )
-        .await;
+        with_elicitation(&mut app, form_elicitation("test", "", ElicitationSchema::new())).await;
     });
 
     assert!(!app.app().has_session_picker());

--- a/crates/wisp/tests/tui/settings.rs
+++ b/crates/wisp/tests/tui/settings.rs
@@ -33,18 +33,6 @@ fn auth_methods_updated(methods: Vec<acp::AuthMethod>) -> AcpEvent {
     AcpEvent::AuthMethodsUpdated(AuthMethodsUpdatedParams { auth_methods: methods })
 }
 
-fn url_elicitation(server_name: &str, url: &str, elicitation_id: &str) -> ElicitationParams {
-    ElicitationParams {
-        server_name: server_name.to_string(),
-        request: ElicitRequestParams::UrlElicitationParams {
-            meta: None,
-            message: "Open this URL to authorize MCP server access.".to_string(),
-            url: url.to_string(),
-            elicitation_id: elicitation_id.to_string(),
-        },
-    }
-}
-
 /// Walks settings down to the MCP servers pane and authenticates the selected
 /// server: the flow that makes the agent hand back an OAuth URL.
 fn authenticate_selected_oauth_server(ui: &mut TestUi) {
@@ -303,7 +291,7 @@ fn esc_on_settings_elicitation_cancels_it_and_keeps_the_overlay_open() {
         ui.key(key(KeyCode::Esc));
 
         let response = response_rx.await.unwrap();
-        assert_eq!(response.action, ElicitationAction::Cancel);
+        assert!(matches!(&response.action, ElicitationAction::Cancel));
         assert!(ui.app().has_modal(), "cancelling the request should leave the settings overlay open");
 
         ui.key(key(KeyCode::Esc));
@@ -374,7 +362,7 @@ fn url_elicitation_enter_accepts_and_clears_settings_prompt() {
         assert_eq!(ui.opened_urls(), vec!["https://linear.app/oauth"], "Enter should open the OAuth URL");
 
         let response = response_rx.await.unwrap();
-        assert_eq!(response.action, ElicitationAction::Accept);
+        assert!(matches!(&response.action, ElicitationAction::Accept(_)));
 
         ui.draw();
         let viewport = ui.viewport_text();
@@ -392,14 +380,11 @@ fn form_elicitation_is_answered_inside_the_settings_overlay() {
 
         let response_rx = with_elicitation(
             &mut ui,
-            ElicitationParams {
-                server_name: "linear".to_string(),
-                request: ElicitRequestParams::FormElicitationParams {
-                    meta: None,
-                    message: "Paste an API token".to_string(),
-                    requested_schema: ElicitationSchema::builder().required_string("token").build().unwrap(),
-                },
-            },
+            form_elicitation(
+                "linear",
+                "Paste an API token",
+                ElicitationSchema::new().property("token", StringPropertySchema::new(), true),
+            ),
         )
         .await;
 
@@ -411,8 +396,7 @@ fn form_elicitation_is_answered_inside_the_settings_overlay() {
         ui.key(key(KeyCode::Enter));
 
         let response = response_rx.await.unwrap();
-        assert_eq!(response.action, ElicitationAction::Accept);
-        assert_eq!(response.content.unwrap()["token"], "secret");
+        assert_eq!(accepted_content(&response)["token"], "secret");
         assert!(ui.app().has_modal(), "answering the request should leave the settings overlay open");
     });
 }
@@ -664,24 +648,13 @@ fn connection_closed_cancels_settings_elicitation() {
         ui.key(key(KeyCode::Tab));
         assert!(ui.app().has_modal());
 
-        let response_rx = with_elicitation(
-            &mut ui,
-            ElicitationParams {
-                server_name: "test".to_string(),
-                request: ElicitRequestParams::UrlElicitationParams {
-                    meta: None,
-                    message: "auth".to_string(),
-                    url: "https://example.com".to_string(),
-                    elicitation_id: "el-conn-closed".to_string(),
-                },
-            },
-        )
-        .await;
+        let response_rx =
+            with_elicitation(&mut ui, url_elicitation("test", "https://example.com", "el-conn-closed")).await;
 
         ui.acp_event(AcpEvent::ConnectionClosed);
 
         let response = response_rx.await.unwrap();
-        assert_eq!(response.action, ElicitationAction::Cancel);
+        assert!(matches!(&response.action, ElicitationAction::Cancel));
     });
 }
 
@@ -694,24 +667,13 @@ fn new_session_created_cancels_settings_elicitation() {
         ui.key(key(KeyCode::Tab));
         assert!(ui.app().has_modal());
 
-        let response_rx = with_elicitation(
-            &mut ui,
-            ElicitationParams {
-                server_name: "test".to_string(),
-                request: ElicitRequestParams::UrlElicitationParams {
-                    meta: None,
-                    message: "auth".to_string(),
-                    url: "https://example.com".to_string(),
-                    elicitation_id: "el-new-session".to_string(),
-                },
-            },
-        )
-        .await;
+        let response_rx =
+            with_elicitation(&mut ui, url_elicitation("test", "https://example.com", "el-new-session")).await;
 
         ui.acp_event(AcpEvent::NewSessionCreated { session_id: SessionId::new("new"), config_options: vec![] });
 
         let response = response_rx.await.unwrap();
-        assert_eq!(response.action, ElicitationAction::Cancel);
+        assert!(matches!(&response.action, ElicitationAction::Cancel));
     });
 }
 

--- a/crates/wisp/tests/tui/status_line.rs
+++ b/crates/wisp/tests/tui/status_line.rs
@@ -1,5 +1,5 @@
 use acp_utils::client::AcpEvent;
-use acp_utils::notifications::{ContextUsage, ContextUsageParams, McpServerStatus, McpServerStatusEntry};
+use acp_utils::notifications::{McpServerStatus, McpServerStatusEntry};
 use agent_client_protocol::schema::v1::{self as acp, SessionId};
 use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
 use std::time::{Duration, Instant};
@@ -55,10 +55,8 @@ fn type_and_submit(ui: &mut TestUi, text: &str) {
     ui.key(KeyEvent::new(KeyCode::Enter, KeyModifiers::NONE));
 }
 
-fn context_usage(used: u32, limit: u32) -> AcpEvent {
-    AcpEvent::ContextUsage(ContextUsageParams {
-        usage: ContextUsage { input_tokens: used, context_limit: Some(limit), ..ContextUsage::default() },
-    })
+fn context_usage(used: u64, limit: u64) -> AcpEvent {
+    session_update(acp::SessionUpdate::UsageUpdate(acp::UsageUpdate::new(used, limit)))
 }
 
 #[test]

--- a/crates/wisp/tests/tui/support.rs
+++ b/crates/wisp/tests/tui/support.rs
@@ -1,16 +1,18 @@
-pub(crate) use acp_utils::ElicitationSchema;
 pub(crate) use acp_utils::client::AcpEvent;
 pub(crate) use acp_utils::config_meta::SelectOptionMeta;
 pub(crate) use acp_utils::config_option_id::ConfigOptionId;
 pub(crate) use acp_utils::notifications::{
-    AuthMethodsUpdatedParams, ContextClearedParams, ContextCompactionParams, ElicitRequestParams, ElicitationAction,
-    ElicitationParams, ElicitationResponse, McpNotification, McpServerAuthCapability, McpServerStatus,
-    McpServerStatusEntry, SessionPreviewResponse, SessionPreviewRole, SessionPreviewTurn, SubAgentEvent,
-    SubAgentProgressParams, SubAgentToolRequest, SubAgentToolResult, WorkspaceEntry, WorkspaceListResponse,
-    WorkspaceMoveResponse,
+    AuthMethodsUpdatedParams, ContextClearedParams, ContextCompactionParams, McpNotification, McpServerAuthCapability,
+    McpServerStatus, McpServerStatusEntry, SessionPreviewResponse, SessionPreviewRole, SessionPreviewTurn,
+    SubAgentEvent, SubAgentProgressParams, SubAgentToolRequest, SubAgentToolResult, WorkspaceEntry,
+    WorkspaceListResponse, WorkspaceMoveResponse,
 };
 pub(crate) use acp_utils::testing::test_connection;
-pub(crate) use agent_client_protocol::schema::v1::{self as acp, SessionId};
+pub(crate) use agent_client_protocol::schema::v1::{
+    self as acp, BooleanPropertySchema, CreateElicitationRequest, CreateElicitationResponse, ElicitationAction,
+    ElicitationFormMode, ElicitationSchema, ElicitationSessionScope, ElicitationUrlMode, SessionId,
+    StringPropertySchema,
+};
 pub(crate) use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
 pub(crate) use ratatui::buffer::{Buffer, Cell};
 pub(crate) use ratatui::layout::Position;
@@ -45,35 +47,56 @@ pub(crate) use wisp::theme::Theme;
 pub(crate) use wisp::view::generation::Generation;
 pub(crate) use wisp::view::syntax::SyntaxHighlighter;
 
-/// Runs `body` on a current-thread runtime inside a `LocalSet`: the ACP test
-/// connection spawns `!Send` tasks, so they need a local set to live in.
 pub(crate) fn block_on_local<F: std::future::Future>(body: F) -> F::Output {
     let runtime = tokio::runtime::Builder::new_current_thread().enable_all().build().unwrap();
     LocalSet::new().block_on(&runtime, body)
 }
 
-/// A form elicitation carrying `schema`, as an MCP server would send one.
-pub(crate) fn form_elicitation(message: &str, schema: ElicitationSchema) -> ElicitationParams {
-    ElicitationParams {
-        server_name: "test".to_string(),
-        request: ElicitRequestParams::FormElicitationParams {
-            meta: None,
-            message: message.to_string(),
-            requested_schema: schema,
-        },
-    }
+pub(crate) fn form_elicitation(
+    server_name: &str,
+    message: &str,
+    schema: ElicitationSchema,
+) -> CreateElicitationRequest {
+    CreateElicitationRequest::new(
+        ElicitationFormMode::new(ElicitationSessionScope::new("test-session"), schema),
+        message,
+    )
+    .meta(server_meta(server_name))
 }
 
-/// Hands `ui` an elicitation request over a live test connection and returns the
-/// channel the agent's answer comes back on. Must run inside [`block_on_local`].
+pub(crate) fn url_elicitation(server_name: &str, url: &str, elicitation_id: &str) -> CreateElicitationRequest {
+    CreateElicitationRequest::new(
+        ElicitationUrlMode::new(ElicitationSessionScope::new("test-session"), elicitation_id.to_string(), url),
+        "Open this URL to authorize MCP server access.",
+    )
+    .meta(server_meta(server_name))
+}
+
+fn server_meta(server_name: &str) -> acp::Meta {
+    acp::Meta::from_iter([(
+        acp_utils::notifications::AETHER_META_NAMESPACE.to_string(),
+        serde_json::json!({ "mcpServer": server_name }),
+    )])
+}
+
 pub(crate) async fn with_elicitation(
     ui: &mut TestUi,
-    params: ElicitationParams,
-) -> tokio::sync::oneshot::Receiver<ElicitationResponse> {
+    params: CreateElicitationRequest,
+) -> tokio::sync::oneshot::Receiver<CreateElicitationResponse> {
     let (cx, mut peer) = test_connection().await;
     let (responder, response_rx) = peer.fake_elicitation(&cx).await;
-    ui.acp_event(AcpEvent::ElicitationRequest { params, responder });
+    ui.acp_event(AcpEvent::ElicitationRequest { params: Box::new(params), responder });
     response_rx
+}
+
+pub(crate) fn accepted_content(response: &CreateElicitationResponse) -> serde_json::Value {
+    let ElicitationAction::Accept(accept) = &response.action else {
+        panic!("expected an accepted elicitation, got {:?}", response.action);
+    };
+    match &accept.content {
+        Some(content) => serde_json::to_value(content).expect("elicitation content is JSON-serializable"),
+        None => serde_json::Value::Null,
+    }
 }
 
 pub(crate) fn message_texts(app: &TestUi) -> impl Iterator<Item = &str> {

--- a/crates/wisp/tests/tui/terminal_interaction.rs
+++ b/crates/wisp/tests/tui/terminal_interaction.rs
@@ -5,7 +5,10 @@ use ratatui::buffer::Buffer;
 use wisp::app::WorkspaceMoveState;
 use wisp::command::{AgentCommand, Command, GitCommand, TerminalCommand};
 
-use super::support::{TestUi, TestUiBuilder, block_on_local, buffer_text, form_elicitation, with_elicitation};
+use super::support::{
+    BooleanPropertySchema, ElicitationSchema, StringPropertySchema, TestUi, TestUiBuilder, accepted_content,
+    block_on_local, buffer_text, form_elicitation, with_elicitation,
+};
 
 /// Whether the app asked the terminal to ring the bell, draining whatever else
 /// it had queued along with it.
@@ -587,13 +590,13 @@ mod event_routing {
     fn form_modal_scroll_changes_field() {
         block_on_local(async {
             let mut ui = make_ui();
-            let schema = acp_utils::ElicitationSchema::builder()
-                .required_string("field1")
-                .required_string("field2")
-                .build()
-                .unwrap();
+            let schema = ElicitationSchema::new().property("field1", StringPropertySchema::new(), true).property(
+                "field2",
+                StringPropertySchema::new(),
+                true,
+            );
 
-            with_elicitation(&mut ui, form_elicitation("Test", schema)).await;
+            with_elicitation(&mut ui, form_elicitation("test", "Test", schema)).await;
 
             assert!(ui.app().needs_mouse_capture());
 
@@ -613,12 +616,12 @@ mod event_routing {
             const QUESTIONS: usize = 40;
 
             let mut ui = make_ui();
-            let mut builder = acp_utils::ElicitationSchema::builder();
+            let mut schema = ElicitationSchema::new();
             for index in 0..QUESTIONS {
-                builder = builder.optional_bool(format!("question_{index:02}"), false);
+                schema = schema.property(format!("question_{index:02}"), BooleanPropertySchema::new(), false);
             }
 
-            with_elicitation(&mut ui, form_elicitation("Pick some", builder.build().unwrap())).await;
+            with_elicitation(&mut ui, form_elicitation("test", "Pick some", schema)).await;
 
             ui.draw();
             let shows = |ui: &mut TestUi, needle: &str| screen_rows(ui).iter().any(|row| row.contains(needle));
@@ -643,13 +646,11 @@ mod event_routing {
             const OPTIONS: usize = 40;
 
             let values = (0..OPTIONS).map(|index| format!("option_{index:02}")).collect::<Vec<_>>();
-            let schema = acp_utils::ElicitationSchema::builder()
-                .optional_enum_schema("choice", acp_utils::EnumSchema::builder(values).untitled().build())
-                .build()
-                .unwrap();
+            let schema =
+                ElicitationSchema::new().property("choice", StringPropertySchema::new().enum_values(values), false);
 
             let mut ui = make_ui();
-            with_elicitation(&mut ui, form_elicitation("Pick one", schema)).await;
+            with_elicitation(&mut ui, form_elicitation("test", "Pick one", schema)).await;
 
             ui.draw();
             let shows = |ui: &mut TestUi, needle: &str| screen_rows(ui).iter().any(|row| row.contains(needle));
@@ -673,13 +674,11 @@ mod event_routing {
     fn form_modal_click_answers_the_option_under_the_pointer() {
         block_on_local(async {
             let mut ui = make_ui();
-            let schema = acp_utils::ElicitationSchema::builder()
-                .optional_bool("alpha", false)
-                .optional_bool("bravo", false)
-                .build()
-                .unwrap();
+            let schema = ElicitationSchema::new()
+                .property("alpha", BooleanPropertySchema::new().default_value(false), false)
+                .property("bravo", BooleanPropertySchema::new().default_value(false), false);
 
-            let response_rx = with_elicitation(&mut ui, form_elicitation("Pick one", schema)).await;
+            let response_rx = with_elicitation(&mut ui, form_elicitation("test", "Pick one", schema)).await;
 
             ui.draw();
 
@@ -694,7 +693,7 @@ mod event_routing {
             ui.key(key(KeyCode::Enter));
 
             let response = response_rx.await.unwrap();
-            assert_eq!(response.content, Some(serde_json::json!({ "alpha": true, "bravo": false })));
+            assert_eq!(accepted_content(&response), serde_json::json!({ "alpha": true, "bravo": false }));
         });
     }
 
@@ -704,20 +703,16 @@ mod event_routing {
     fn form_modal_click_hits_every_row_an_option_occupies() {
         block_on_local(async {
             let mut ui = make_ui();
-            let schema = acp_utils::ElicitationSchema::builder()
-                .optional_enum_schema(
-                    "choice",
-                    acp_utils::EnumSchema::builder(vec![
-                        "a-very-long-option-title-that-certainly-wraps-onto-a-second-row".to_string(),
-                        "short".to_string(),
-                    ])
-                    .untitled()
-                    .build(),
-                )
-                .build()
-                .unwrap();
+            let schema = ElicitationSchema::new().property(
+                "choice",
+                StringPropertySchema::new().enum_values(vec![
+                    "a-very-long-option-title-that-certainly-wraps-onto-a-second-row".to_string(),
+                    "short".to_string(),
+                ]),
+                false,
+            );
 
-            let response_rx = with_elicitation(&mut ui, form_elicitation("Pick one", schema)).await;
+            let response_rx = with_elicitation(&mut ui, form_elicitation("test", "Pick one", schema)).await;
 
             ui.draw();
 
@@ -735,10 +730,10 @@ mod event_routing {
 
             let response = response_rx.await.unwrap();
             assert_eq!(
-                response.content,
-                Some(serde_json::json!({
+                accepted_content(&response),
+                serde_json::json!({
                     "choice": "a-very-long-option-title-that-certainly-wraps-onto-a-second-row"
-                }))
+                })
             );
         });
     }

--- a/packages/aether-sdk/README.md
+++ b/packages/aether-sdk/README.md
@@ -60,18 +60,18 @@ yourself in a `finally` block.
 
 `AetherSessionOptions` lets you pick the initial agent or model:
 
-| Option               | Notes                                                                                                                         |
-| -------------------- | ----------------------------------------------------------------------------------------------------------------------------- |
-| `agent`              | Mode name from `.aether/settings.json` (e.g. `planner`).                                                                      |
-| `model`              | Direct model id (e.g. `anthropic:claude-sonnet-4-5`).                                                                         |
-| `reasoningEffort`    | `"low"`, `"medium"`, `"high"`, `"xhigh"`.                                                                                     |
-| `settings`           | Inline Aether settings object using the `.aether/settings.json` shape. SDK-hosted tools live here under `mcps`.                                  |
-| `settingsFile`       | Path to an alternate settings JSON file.                                                                                      |
-| `cwd`                | Working directory for the spawned `aether acp` process.                                                                       |
-| `binaryPath`         | Override the bundled `@aether-agent/cli` binary (absolute path or name on `PATH`).                                            |
-| `providers`          | Provider connection overrides, keyed by provider (for example `{ bedrock: { url: "http://127.0.0.1:8787", auth: "none" } }`). |
-| `traceContext`       | A remote W3C `traceparent` with optional `tracestate`, or a standalone `traceId` for root spans without a parent.                 |
-| `abortSignal`        | Cancel the active session and tear the subprocess down.                                                                       |
+| Option            | Notes                                                                                                                         |
+| ----------------- | ----------------------------------------------------------------------------------------------------------------------------- |
+| `agent`           | Mode name from `.aether/settings.json` (e.g. `planner`).                                                                      |
+| `model`           | Direct model id (e.g. `anthropic:claude-sonnet-4-5`).                                                                         |
+| `reasoningEffort` | `"low"`, `"medium"`, `"high"`, `"xhigh"`.                                                                                     |
+| `settings`        | Inline Aether settings object using the `.aether/settings.json` shape. SDK-hosted tools live here under `mcps`.               |
+| `settingsFile`    | Path to an alternate settings JSON file.                                                                                      |
+| `cwd`             | Working directory for the spawned `aether acp` process.                                                                       |
+| `binaryPath`      | Override the bundled `@aether-agent/cli` binary (absolute path or name on `PATH`).                                            |
+| `providers`       | Provider connection overrides, keyed by provider (for example `{ bedrock: { url: "http://127.0.0.1:8787", auth: "none" } }`). |
+| `traceContext`    | A remote W3C `traceparent` with optional `tracestate`, or a standalone `traceId` for root spans without a parent.             |
+| `abortSignal`     | Cancel the active session and tear the subprocess down.                                                                       |
 
 `agent` and `model` are mutually exclusive. `settings` and `settingsFile` are
 mutually exclusive. These are forwarded to the spawned `aether acp` process as
@@ -109,8 +109,7 @@ await AetherSession.start({
 ```ts
 await using continuedSession = await AetherSession.start({
   traceContext: {
-    traceparent:
-      "00-00112233445566778899aabbccddeeff-0123456789abcdef-01",
+    traceparent: "00-00112233445566778899aabbccddeeff-0123456789abcdef-01",
     tracestate: "vendor=value",
   },
 });
@@ -136,7 +135,7 @@ for await (const m of session.prompt("Follow-up")) console.log(m);
 
 `mcp()` creates a TypeScript MCP server. Tools run **in the calling Node process**, so closures, in-memory state, file handles, and database connections all work as you'd expect.
 
-The returned handle implements `Symbol.asyncDispose`, so `await using` tears the server down on scope exit. 
+The returned handle implements `Symbol.asyncDispose`, so `await using` tears the server down on scope exit.
 
 ```ts
 import { AetherSession, mcp, tool } from "@aether-agent/sdk";
@@ -183,7 +182,7 @@ console.log(submit.getResult());
 ### Per-agent tools
 
 A spec on the top-level `mcps` is available to every agent. Put it on a single
-agent's `mcps` instead to scope those tools to that agent. 
+agent's `mcps` instead to scope those tools to that agent.
 
 ```ts
 await using planner = await mcp({ name: "planner-tools", tools: [plan] });
@@ -256,8 +255,7 @@ await AetherSession.start({
 });
 ```
 
-`onElicitation` handles Aether's `_aether/elicitation` extension request.
-
-```
-
-See the [`@aether-agent/evals` README](../aether-evals/README.md) for usage.
+`onElicitation` handles native ACP `elicitation/create` requests in form or URL
+mode. It returns an ACP accept, decline, or cancel response. Without a handler,
+the SDK does not advertise elicitation support. URL completion notifications
+appear in the prompt stream as `elicitation_complete` messages.

--- a/packages/aether-sdk/src/index.ts
+++ b/packages/aether-sdk/src/index.ts
@@ -28,8 +28,6 @@ export { mcp } from "./mcp/index.js";
 export type { McpHandle, InlineMcpSource } from "./mcp/index.js";
 export { AetherSdkError } from "./errors.js";
 export type {
-  AetherElicitationRequest,
-  AetherElicitationResponse,
   AgentSelection,
   AetherMessage,
   SdkMcpToolDefinition,

--- a/packages/aether-sdk/src/session.ts
+++ b/packages/aether-sdk/src/session.ts
@@ -191,8 +191,10 @@ export class AetherSession {
     let completed = false;
     const promptPromise = this.connection
       .prompt({ sessionId: this.sessionId, prompt })
-      .then((response) => {
+      .then(async (response) => {
         completed = true;
+        // ACP routes session responses and connection notifications independently.
+        await new Promise<void>((resolve) => setImmediate(resolve));
         this.events.push({
           type: "result",
           sessionId: this.sessionId,

--- a/packages/aether-sdk/src/session.ts
+++ b/packages/aether-sdk/src/session.ts
@@ -9,12 +9,7 @@ import {
   type SettingsSelection,
 } from "./agentProcess.js";
 import { AetherSdkError, throwIfAborted } from "./errors.js";
-import type {
-  AetherElicitationRequest,
-  AetherElicitationResponse,
-  AetherMessage,
-  AgentSelection,
-} from "./types.js";
+import type { AetherMessage, AgentSelection } from "./types.js";
 
 const SDK_VERSION = "0.3.6";
 
@@ -32,9 +27,14 @@ export type CommonAetherSessionOptions = Pick<
   abortSignal?: AbortSignal;
   /** Defaults to {@link autoApprovePermissions}. */
   onPermissionRequest?: PermissionRequestHandler;
+  /**
+   * Handles native ACP `elicitation/create` requests from the agent. When
+   * omitted, the SDK responds with `{ action: "cancel" }` and does not
+   * advertise the `elicitation` client capability.
+   */
   onElicitation?: (
-    request: AetherElicitationRequest,
-  ) => Promise<AetherElicitationResponse>;
+    request: acp.CreateElicitationRequest,
+  ) => Promise<acp.CreateElicitationResponse>;
 };
 
 export type AetherSessionOptions = CommonAetherSessionOptions &
@@ -100,6 +100,7 @@ export class AetherSession {
       clientCapabilities: {
         fs: { readTextFile: false, writeTextFile: false },
         terminal: false,
+        ...(onElicitation ? { elicitation: { form: {}, url: {} } } : {}),
       },
     });
 
@@ -258,18 +259,20 @@ function createAcpClient(
       return onPermissionRequest(request);
     },
 
-    async extMethod(
-      method: string,
-      params: Record<string, unknown>,
-    ): Promise<Record<string, unknown>> {
-      if (method === "_aether/elicitation" && onElicitation) {
-        return (await onElicitation({
-          method: "_aether/elicitation",
-          params,
-        })) as unknown as Record<string, unknown>;
-      }
-      if (method === "_aether/elicitation") return { action: "cancel" };
-      throw new acp.RequestError(-32601, `Unknown extMethod: ${method}`);
+    async unstable_createElicitation(
+      request: acp.CreateElicitationRequest,
+    ): Promise<acp.CreateElicitationResponse> {
+      if (!onElicitation) return { action: "cancel" };
+      return onElicitation(request);
+    },
+
+    async unstable_completeElicitation(
+      notification: acp.CompleteElicitationNotification,
+    ): Promise<void> {
+      events.push({
+        type: "elicitation_complete",
+        elicitationId: notification.elicitationId,
+      });
     },
 
     async extNotification(

--- a/packages/aether-sdk/src/types.ts
+++ b/packages/aether-sdk/src/types.ts
@@ -11,16 +11,6 @@ export type AgentSelection =
   | { agent?: never; model: string; reasoningEffort?: ReasoningEffort }
   | { agent?: never; model?: never; reasoningEffort?: never };
 
-export interface AetherElicitationRequest {
-  method: "_aether/elicitation";
-  params: Record<string, unknown>;
-}
-
-export interface AetherElicitationResponse {
-  action: "accept" | "decline" | "cancel";
-  content?: Record<string, unknown>;
-}
-
 export interface SdkMcpToolDefinition<Schema extends z.ZodRawShape> {
   name: string;
   description: string;
@@ -41,5 +31,6 @@ export type AetherMessage =
       method: string;
       params: Record<string, unknown>;
     }
+  | { type: "elicitation_complete"; elicitationId: string }
   | { type: "result"; sessionId: string; stopReason: acp.StopReason }
   | { type: "error"; error: unknown };

--- a/packages/aether-sdk/test/fakeAether.mjs
+++ b/packages/aether-sdk/test/fakeAether.mjs
@@ -5,7 +5,8 @@
 //   - initialize -> respond with V1 capabilities.
 //   - newSession -> echo session id, store settings + _meta to log file.
 //   - prompt -> emit a session_update chunk, optionally request a permission
-//     decision and/or call a custom MCP tool, then return stopReason="end_turn".
+//     decision, request an elicitation, and/or call a custom MCP tool, then
+//     return stopReason="end_turn".
 //
 // Configurable via env:
 //   FAKE_AETHER_CALL_MCP_SERVER   Name of the SDK-supplied MCP server to call
@@ -13,6 +14,7 @@
 //   FAKE_AETHER_TOOL_ARGS         JSON-encoded args (default {"value":"hi"})
 //   FAKE_AETHER_REQUEST_PERMISSION  If set, send a requestPermission RPC and
 //                                 echo the chosen outcome as the chunk text.
+//   FAKE_AETHER_REQUEST_ELICITATION  If set, exercise ACP elicitation.
 //   FAKE_AETHER_LOG_FILE          Optional path; debug events written there.
 
 import { Readable, Writable } from "node:stream";
@@ -132,6 +134,20 @@ const agent = {
         ],
       });
       chunkText = JSON.stringify(decision.outcome);
+    }
+
+    if (process.env.FAKE_AETHER_REQUEST_ELICITATION) {
+      const response = await conn.unstable_createElicitation({
+        mode: "form",
+        sessionId: params.sessionId,
+        requestedSchema: {
+          type: "object",
+          properties: { name: { type: "string", title: "Name" } },
+        },
+        message: "What is your name?",
+      });
+      chunkText = JSON.stringify(response);
+      await conn.unstable_completeElicitation({ elicitationId: "elicit-1" });
     }
 
     await conn.sessionUpdate({

--- a/packages/aether-sdk/test/session.integration.test.ts
+++ b/packages/aether-sdk/test/session.integration.test.ts
@@ -165,7 +165,11 @@ describe("AetherSession with a fake ACP agent", () => {
 
     expect(session.sessionId).toMatch(/^fake-session-/);
     const types = messages.map((m) => m.type);
-    expect(types).toEqual(["elicitation_complete", "session_update", "result"]);
+    expect(types.slice(0, -1).sort()).toEqual([
+      "elicitation_complete",
+      "session_update",
+    ]);
+    expect(types.at(-1)).toBe("result");
     expect(requests).toMatchObject([
       { mode: "form", message: "What is your name?" },
     ]);

--- a/packages/aether-sdk/test/session.integration.test.ts
+++ b/packages/aether-sdk/test/session.integration.test.ts
@@ -143,9 +143,15 @@ describe("AetherSession with a fake ACP agent", () => {
     }
   });
 
-  it("starts an explicit session and streams a final result", async () => {
+  it("starts a session and handles native ACP elicitation", async () => {
+    const requests: unknown[] = [];
     const session = await AetherSession.start({
       binaryPath: FAKE_AETHER,
+      env: { PATH: process.env.PATH, FAKE_AETHER_REQUEST_ELICITATION: "1" },
+      onElicitation: async (request) => {
+        requests.push(request);
+        return { action: "accept", content: { name: "Ada" } };
+      },
     });
 
     const messages: AetherMessage[] = [];
@@ -159,7 +165,10 @@ describe("AetherSession with a fake ACP agent", () => {
 
     expect(session.sessionId).toMatch(/^fake-session-/);
     const types = messages.map((m) => m.type);
-    expect(types).toEqual(["session_update", "result"]);
+    expect(types).toEqual(["elicitation_complete", "session_update", "result"]);
+    expect(requests).toMatchObject([
+      { mode: "form", message: "What is your name?" },
+    ]);
     const result = messages.find((m) => m.type === "result");
     if (result?.type === "result") {
       expect(result.stopReason).toBe("end_turn");

--- a/packages/website/src/content/docs/libraries/typescript-sdk.mdx
+++ b/packages/website/src/content/docs/libraries/typescript-sdk.mdx
@@ -55,22 +55,22 @@ await AetherSession.start({
 
 ## Session options
 
-| Option                | Description                                                                           |
-| --------------------- | ------------------------------------------------------------------------------------- |
-| `cwd`                 | Working directory for the spawned `aether acp` process. Defaults to `process.cwd()`.  |
-| `agent`               | Agent name from `.aether/settings.json`.                                              |
-| `model`               | Direct model id, such as `anthropic:claude-sonnet-4-5`.                               |
-| `reasoningEffort`     | `"minimal"`, `"low"`, `"medium"`, `"high"`, `"xhigh"`, or `"max"` when using a direct model. |
-| `settings`            | Inline Aether settings object using the `.aether/settings.json` shape. SDK-hosted and external MCP servers live here under `mcps`. |
-| `settingsFile`        | Path to an alternate settings JSON file.                                              |
-| `binaryPath`          | Override the bundled CLI binary with an absolute path or command available on `PATH`. |
-| `env`                 | Environment variables for the spawned `aether acp` process.                            |
-| `logDir`              | Custom directory for ACP logs.                                                         |
-| `providers`           | Provider connection overrides, such as custom Bedrock endpoints or auth behavior.     |
+| Option                | Description                                                                                                                                                                                                                |
+| --------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `cwd`                 | Working directory for the spawned `aether acp` process. Defaults to `process.cwd()`.                                                                                                                                       |
+| `agent`               | Agent name from `.aether/settings.json`.                                                                                                                                                                                   |
+| `model`               | Direct model id, such as `anthropic:claude-sonnet-4-5`.                                                                                                                                                                    |
+| `reasoningEffort`     | `"minimal"`, `"low"`, `"medium"`, `"high"`, `"xhigh"`, or `"max"` when using a direct model.                                                                                                                               |
+| `settings`            | Inline Aether settings object using the `.aether/settings.json` shape. SDK-hosted and external MCP servers live here under `mcps`.                                                                                         |
+| `settingsFile`        | Path to an alternate settings JSON file.                                                                                                                                                                                   |
+| `binaryPath`          | Override the bundled CLI binary with an absolute path or command available on `PATH`.                                                                                                                                      |
+| `env`                 | Environment variables for the spawned `aether acp` process.                                                                                                                                                                |
+| `logDir`              | Custom directory for ACP logs.                                                                                                                                                                                             |
+| `providers`           | Provider connection overrides, such as custom Bedrock endpoints or auth behavior.                                                                                                                                          |
 | `traceContext`        | A remote W3C `traceparent` with optional `tracestate`, or a standalone `traceId` for root spans without a parent. See [Telemetry](/aether/settings/telemetry/#correlating-sdk-runs) for validation and sampling semantics. |
-| `abortSignal`         | Cancel the active session and tear down the subprocess.                               |
-| `onPermissionRequest` | Custom policy for ACP permission requests. Defaults to `autoApprovePermissions`.      |
-| `onElicitation`       | Handler for Aether's `_aether/elicitation` extension request.                         |
+| `abortSignal`         | Cancel the active session and tear down the subprocess.                                                                                                                                                                    |
+| `onPermissionRequest` | Custom policy for ACP permission requests. Defaults to `autoApprovePermissions`.                                                                                                                                           |
+| `onElicitation`       | Handler for native ACP `elicitation/create` requests (form or URL mode).                                                                                                                                                   |
 
 `settings` and `settingsFile` are mutually exclusive.
 
@@ -112,12 +112,12 @@ console.log(result.stdout);
 
 `runHeadless()` resolves to an `AetherHeadlessResult`:
 
-| Field       | Type                  | Description                                                                 |
-| ----------- | --------------------- | --------------------------------------------------------------------------- |
-| `stdout`    | `string`              | Captured stdout from the `aether headless` process.                         |
-| `stderr`    | `string`              | Captured stderr (diagnostics/tracing).                                      |
-| `exitCode`  | `number`              | Process exit code. `0` on success; non-zero when the turn ends with a failed outcome. |
-| `signal`    | `NodeJS.Signals \| null` | Termination signal, if the process was killed instead of exiting normally. |
+| Field      | Type                     | Description                                                                           |
+| ---------- | ------------------------ | ------------------------------------------------------------------------------------- |
+| `stdout`   | `string`                 | Captured stdout from the `aether headless` process.                                   |
+| `stderr`   | `string`                 | Captured stderr (diagnostics/tracing).                                                |
+| `exitCode` | `number`                 | Process exit code. `0` on success; non-zero when the turn ends with a failed outcome. |
+| `signal`   | `NodeJS.Signals \| null` | Termination signal, if the process was killed instead of exiting normally.            |
 
 Because `aether headless` exits non-zero on a failed turn, `runHeadless()` **rejects** with an `AetherSdkError` (`code: "process_exited"`) in that case instead of resolving. Wrap the call in `try`/`catch` (or read the error's details) when a failed turn is an expected outcome.
 
@@ -125,25 +125,25 @@ Because `aether headless` exits non-zero on a failed turn, `runHeadless()` **rej
 
 `AetherHeadlessOptions` mirrors the [headless CLI flags](/aether/running/headless/#flags) plus SDK process controls:
 
-| Option          | Description                                                                                          |
-| --------------- | ---------------------------------------------------------------------------------------------------- |
-| `prompt`        | Required. Prompt text to run.                                                                        |
-| `agent`         | Named agent from `.aether/settings.json`. Mutually exclusive with `model`.                           |
-| `model`         | Direct model id, such as `anthropic:claude-sonnet-4-5`. Mutually exclusive with `agent`.             |
-| `cwd`           | Working directory. Defaults to `process.cwd()`.                                                      |
-| `settings`      | Inline Aether settings object. Mutually exclusive with `settingsFile`.                               |
-| `settingsFile`  | Path to an alternate settings JSON file.                                                             |
-| `systemPrompt`  | Additional system prompt text.                                                                       |
-| `output`        | `"text"`, `"pretty"`, or `"json"`. Defaults to `"text"`. See [output formats](/aether/running/headless/#output-formats). |
-| `events`        | Event kinds to emit (applies to any output format). See [event filtering](/aether/running/headless/#event-filtering).   |
-| `verbose`       | Verbose diagnostic logging to stderr.                                                                |
-| `providers`     | Provider connection overrides, such as custom Bedrock endpoints or auth behavior.                    |
-| `traceContext`  | A remote W3C `traceparent` with optional `tracestate`, or a standalone `traceId`. See [Telemetry](/aether/settings/telemetry/#correlating-sdk-runs). |
-| `binaryPath`    | Override the bundled CLI binary with an absolute path or command available on `PATH`.                |
-| `env`           | Environment variables for the spawned `aether headless` process.                                     |
-| `stdout`        | `"pipe"` (capture, the default) or `"inherit"` (write directly to the parent stdio).                 |
-| `stderr`        | `"pipe"` (the default) or `"inherit"`.                                                                |
-| `abortSignal`   | Cancel the run and tear down the subprocess.                                                         |
+| Option         | Description                                                                                                                                          |
+| -------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `prompt`       | Required. Prompt text to run.                                                                                                                        |
+| `agent`        | Named agent from `.aether/settings.json`. Mutually exclusive with `model`.                                                                           |
+| `model`        | Direct model id, such as `anthropic:claude-sonnet-4-5`. Mutually exclusive with `agent`.                                                             |
+| `cwd`          | Working directory. Defaults to `process.cwd()`.                                                                                                      |
+| `settings`     | Inline Aether settings object. Mutually exclusive with `settingsFile`.                                                                               |
+| `settingsFile` | Path to an alternate settings JSON file.                                                                                                             |
+| `systemPrompt` | Additional system prompt text.                                                                                                                       |
+| `output`       | `"text"`, `"pretty"`, or `"json"`. Defaults to `"text"`. See [output formats](/aether/running/headless/#output-formats).                             |
+| `events`       | Event kinds to emit (applies to any output format). See [event filtering](/aether/running/headless/#event-filtering).                                |
+| `verbose`      | Verbose diagnostic logging to stderr.                                                                                                                |
+| `providers`    | Provider connection overrides, such as custom Bedrock endpoints or auth behavior.                                                                    |
+| `traceContext` | A remote W3C `traceparent` with optional `tracestate`, or a standalone `traceId`. See [Telemetry](/aether/settings/telemetry/#correlating-sdk-runs). |
+| `binaryPath`   | Override the bundled CLI binary with an absolute path or command available on `PATH`.                                                                |
+| `env`          | Environment variables for the spawned `aether headless` process.                                                                                     |
+| `stdout`       | `"pipe"` (capture, the default) or `"inherit"` (write directly to the parent stdio).                                                                 |
+| `stderr`       | `"pipe"` (the default) or `"inherit"`.                                                                                                               |
+| `abortSignal`  | Cancel the run and tear down the subprocess.                                                                                                         |
 
 Unlike `AetherSession.start()`, headless runs are non-interactive, so there are no permission or elicitation handlers.
 
@@ -151,12 +151,13 @@ Unlike `AetherSession.start()`, headless runs are non-interactive, so there are 
 
 `session.prompt()` yields `AetherMessage` objects. Each has a `type` discriminator:
 
-| Type                | Description                                                                                     |
-| ------------------- | -------------------------------------------------------------------------------------------- |
-| `session_update`    | An ACP session update (agent text, tool calls, tool results, progress, etc.). Access `.update`. |
-| `ext_notification`  | A custom extension notification (e.g. plan or task updates). Access `.method` and `.params`.  |
-| `result`            | The prompt finished. `.stopReason` describes why (e.g. `end_turn`, `cancelled`).              |
-| `error`             | An unrecoverable error occurred. Access `.error`.                                             |
+| Type                   | Description                                                                                     |
+| ---------------------- | ----------------------------------------------------------------------------------------------- |
+| `session_update`       | An ACP session update (agent text, tool calls, tool results, progress, etc.). Access `.update`. |
+| `ext_notification`     | A custom extension notification (e.g. plan or task updates). Access `.method` and `.params`.    |
+| `elicitation_complete` | A URL-mode elicitation finished. Access `.elicitationId`.                                       |
+| `result`               | The prompt finished. `.stopReason` describes why (e.g. `end_turn`, `cancelled`).                |
+| `error`                | An unrecoverable error occurred. Access `.error`.                                               |
 
 A `result` message is always emitted last (unless the stream errors), so it is a reliable place to stop consuming the iterator.
 
@@ -200,8 +201,6 @@ for await (const _message of session.prompt(
 
 console.log(submitted);
 ```
-
-
 
 The handle implements `Symbol.asyncDispose`, so `await using` stops the server on
 scope exit.
@@ -283,11 +282,16 @@ await AetherSession.start({
       : { outcome: { outcome: "cancelled" } };
   },
   onElicitation: async (request) => {
-    console.log(request.params);
+    // Native ACP request: `mode` is "form" or "url".
+    console.log(request.mode, request.message);
     return { action: "cancel" };
   },
 });
 ```
+
+The hook receives native ACP form or URL elicitation requests and returns an
+ACP accept, decline, or cancel response. Without the hook, the SDK does not
+advertise elicitation support.
 
 ## Provider overrides
 
@@ -306,5 +310,3 @@ await AetherSession.start({
 ```
 
 Set `auth: "none"` only when a trusted proxy injects or signs provider authentication.
-
-The `onElicitation` response `action` may be `"accept"` (with optional `content`), `"decline"`, or `"cancel"`. When `onElicitation` is omitted, the SDK cancels by default.


### PR DESCRIPTION
This PR does 3 things:

1. Uses the ACP crate's new type for context usage
2. Uses RMCP's list_all methods for tools and prompts, which handles auto pagination 
3. Switches to using ACP-native elicitation (ACP protocol recently added support for elicitation)