### PR TITLE
fix(wisp): preserve prompt completion ordering

### DIFF
--- a/crates/acp-utils/src/client/event.rs
+++ b/crates/acp-utils/src/client/event.rs
@@ -16,6 +16,6 @@ pub enum AcpEvent {
     AuthMethodsUpdated(AuthMethodsUpdatedParams),
     McpNotification(McpNotification),
     ElicitationRequest { params: Box<CreateElicitationRequest>, responder: Responder<CreateElicitationResponse> },
-    PromptDone(StopReason),
+    PromptCompleted(StopReason),
     ConnectionClosed,
 }

--- a/crates/acp-utils/src/client/session.rs
+++ b/crates/acp-utils/src/client/session.rs
@@ -390,7 +390,7 @@ async fn run_prompt(
             result = &mut prompt_fut => {
                 match result {
                     Ok(prompt_response) => {
-                        let _ = event_tx.send(AcpEvent::PromptDone(prompt_response.stop_reason));
+                        let _ = event_tx.send(AcpEvent::PromptCompleted(prompt_response.stop_reason));
                         let _ = response.send(Ok(prompt_response));
                     }
                     Err(error) => {

--- a/crates/acp-utils/tests/client_session.rs
+++ b/crates/acp-utils/tests/client_session.rs
@@ -7,9 +7,9 @@ use agent_client_protocol::schema::ProtocolVersion;
 use agent_client_protocol::schema::v1::{
     CancelNotification, CloseSessionRequest, CloseSessionResponse, ContentBlock, ContentChunk, Implementation,
     InitializeRequest, InitializeResponse, ListSessionsRequest, ListSessionsResponse, LoadSessionRequest,
-    LoadSessionResponse, NewSessionRequest, NewSessionResponse, PromptRequest, ResumeSessionRequest,
+    LoadSessionResponse, NewSessionRequest, NewSessionResponse, PromptRequest, PromptResponse, ResumeSessionRequest,
     ResumeSessionResponse, SessionId, SessionInfo, SessionNotification, SessionUpdate, SetSessionConfigOptionRequest,
-    TextContent,
+    StopReason, TextContent,
 };
 use agent_client_protocol::{self as acp, Agent};
 use std::path::PathBuf;
@@ -97,6 +97,50 @@ async fn cancel_reaches_the_agent_while_a_config_response_is_outstanding() {
             client.handle.cancel(CancelNotification::new(session_id)).await.expect("cancel queues");
 
             cancelled.notified().await;
+        })
+        .await;
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn prompt_completion_follows_session_updates_on_the_event_stream() {
+    LocalSet::new()
+        .run_until(async {
+            let (agent_transport, client_transport) = duplex_pair();
+            let agent_builder = Agent
+                .builder()
+                .on_receive_request(
+                    async |_request: InitializeRequest, responder, _cx| {
+                        responder.respond(InitializeResponse::new(ProtocolVersion::V1))
+                    },
+                    acp::on_receive_request!(),
+                )
+                .on_receive_request(
+                    async |request: PromptRequest, responder, cx| {
+                        cx.send_notification(SessionNotification::new(
+                            request.session_id,
+                            SessionUpdate::AgentMessageChunk(ContentChunk::new(ContentBlock::Text(TextContent::new(
+                                "final answer",
+                            )))),
+                        ))?;
+                        responder.respond(PromptResponse::new(StopReason::EndTurn))
+                    },
+                    acp::on_receive_request!(),
+                );
+            spawn_local(async move {
+                let _ = agent_builder.connect_to(agent_transport).await;
+            });
+
+            let mut client = connect_acp_client(client_transport, InitializeRequest::new(ProtocolVersion::V1))
+                .await
+                .expect("initialization succeeds");
+            client
+                .handle
+                .prompt(PromptRequest::new("session", vec![ContentBlock::Text(TextContent::new("hello"))]))
+                .await
+                .expect("prompt succeeds");
+
+            assert!(matches!(client.event_rx.recv().await, Some(AcpEvent::SessionUpdate { .. })));
+            assert!(matches!(client.event_rx.recv().await, Some(AcpEvent::PromptCompleted(StopReason::EndTurn))));
         })
         .await;
 }

--- a/crates/wisp/src/app/acp_reducer.rs
+++ b/crates/wisp/src/app/acp_reducer.rs
@@ -22,7 +22,7 @@ impl App {
                     self.on_session_update(&update);
                 }
             }
-            AcpEvent::PromptDone(stop_reason) => {
+            AcpEvent::PromptCompleted(stop_reason) => {
                 let status = match stop_reason {
                     acp::StopReason::Cancelled => ToolStatus::Error("cancelled".to_string()),
                     _ => ToolStatus::Success,
@@ -30,7 +30,9 @@ impl App {
                 self.finish_prompt(&status);
             }
             AcpEvent::ContextCompaction(params) => {
-                self.conversation.turn_mut().set_compaction_active(params.active);
+                if self.conversation.progress_indicator().accepts_activity() {
+                    self.conversation.turn_mut().set_compaction_active(params.active);
+                }
             }
             AcpEvent::ContextCleared(_) => {
                 self.reset_conversation();
@@ -71,7 +73,9 @@ impl App {
             }
             AcpEvent::ConnectionClosed => self.on_connection_closed(),
             AcpEvent::SubAgentProgress(progress) => {
-                self.conversation.on_sub_agent_progress(&progress);
+                if self.conversation.progress_indicator().accepts_activity() {
+                    self.conversation.on_sub_agent_progress(&progress);
+                }
             }
         }
     }
@@ -148,6 +152,9 @@ impl App {
     }
 
     fn on_session_update(&mut self, update: &acp::SessionUpdate) {
+        if is_agent_activity(update) && !self.conversation.progress_indicator().accepts_activity() {
+            return;
+        }
         match update {
             acp::SessionUpdate::UserMessageChunk(chunk) => {
                 if let Some(text) = match &chunk.content {
@@ -232,6 +239,16 @@ impl App {
             self.queue(Command::Terminal(TerminalCommand::RingBell));
         }
     }
+}
+
+fn is_agent_activity(update: &acp::SessionUpdate) -> bool {
+    matches!(
+        update,
+        acp::SessionUpdate::AgentMessageChunk(_)
+            | acp::SessionUpdate::AgentThoughtChunk(_)
+            | acp::SessionUpdate::ToolCall(_)
+            | acp::SessionUpdate::ToolCallUpdate(_)
+    )
 }
 
 pub(super) fn plan_review_meta(

--- a/crates/wisp/src/app/mod.rs
+++ b/crates/wisp/src/app/mod.rs
@@ -1,4 +1,4 @@
-use crate::command::{Command, CommandResult, FailedCommand};
+use crate::command::{AgentCommand, Command, CommandResult, FailedCommand};
 use crate::app::keybindings::Keybindings;
 use crate::app::message::Message;
 use crate::conversation::items::{Conversation, ConversationItem};
@@ -281,6 +281,16 @@ impl App {
             FailedCommand::Other(_) => {}
         }
         self.notify(&format!("Failed to {}: {error}", command.describe()));
+    }
+
+    fn start_prompt(&mut self, text: String, content: Option<Vec<acp::ContentBlock>>) {
+        self.conversation.turn_mut().set_prompt_in_flight(true);
+        self.conversation.progress_indicator_mut().prompt_started();
+        self.queue(Command::Agent(AgentCommand::Prompt {
+            session_id: self.session.session_id().clone(),
+            text,
+            content,
+        }));
     }
 
     fn queue(&mut self, command: Command) {

--- a/crates/wisp/src/app/session.rs
+++ b/crates/wisp/src/app/session.rs
@@ -204,13 +204,8 @@ impl App {
         if self.waiting_for_response() {
             return;
         }
-        self.conversation.turn_mut().set_prompt_in_flight(true);
         self.conversation.append_notice(format!("[wisp] Submitted review of working tree diff.\n{prompt}"));
-        self.queue(Command::Agent(AgentCommand::Prompt {
-            session_id: self.session.session_id().clone(),
-            text: prompt.to_string(),
-            content: None,
-        }));
+        self.start_prompt(prompt.to_string(), None);
         self.close_active();
     }
 

--- a/crates/wisp/src/app/submission.rs
+++ b/crates/wisp/src/app/submission.rs
@@ -66,14 +66,8 @@ impl App {
             return;
         }
 
-        self.conversation.turn_mut().set_prompt_in_flight(true);
-        self.conversation.progress_indicator_mut().prompt_started();
         let content = (!outcome.blocks.is_empty()).then_some(outcome.blocks);
-        self.queue(Command::Agent(AgentCommand::Prompt {
-            session_id: self.session.session_id().clone(),
-            text,
-            content,
-        }));
+        self.start_prompt(text, content);
     }
     fn media_support_error(&self, blocks: &[acp::ContentBlock]) -> Option<String> {
         let requires_image = blocks.iter().any(|block| matches!(block, acp::ContentBlock::Image(_)));

--- a/crates/wisp/src/conversation/progress_indicator.rs
+++ b/crates/wisp/src/conversation/progress_indicator.rs
@@ -49,6 +49,7 @@ pub struct ProgressIndicator {
     phase: ProgressPhase,
     agent_phase: ProgressPhase,
     interruptible: bool,
+    accepts_activity: bool,
     now: Instant,
     phase_started_at: Instant,
     thought: String,
@@ -61,6 +62,7 @@ impl Default for ProgressIndicator {
             phase: ProgressPhase::Idle,
             agent_phase: ProgressPhase::Idle,
             interruptible: false,
+            accepts_activity: true,
             now,
             phase_started_at: now,
             thought: String::new(),
@@ -69,8 +71,13 @@ impl Default for ProgressIndicator {
 }
 
 impl ProgressIndicator {
+    pub(crate) fn accepts_activity(&self) -> bool {
+        self.accepts_activity
+    }
+
     pub(crate) fn prompt_started(&mut self) {
         self.thought.clear();
+        self.accepts_activity = true;
         self.set_agent_phase(ProgressPhase::Thinking);
     }
 
@@ -85,6 +92,7 @@ impl ProgressIndicator {
     pub(crate) fn prompt_finished(&mut self) {
         self.thought.clear();
         self.set_agent_phase(ProgressPhase::Idle);
+        self.accepts_activity = false;
     }
 
     pub(crate) fn refresh(&mut self, override_phase: Option<ProgressPhase>, interruptible: bool) {
@@ -97,6 +105,9 @@ impl ProgressIndicator {
     }
 
     pub(crate) fn record_thought(&mut self, chunk: &str) {
+        if !self.accepts_activity {
+            return;
+        }
         self.set_agent_phase(ProgressPhase::Thinking);
         for character in chunk.chars() {
             if character.is_whitespace() {
@@ -119,6 +130,9 @@ impl ProgressIndicator {
     }
 
     fn set_agent_phase(&mut self, phase: ProgressPhase) {
+        if phase != ProgressPhase::Idle && !self.accepts_activity {
+            return;
+        }
         if self.agent_phase == ProgressPhase::Thinking && phase != ProgressPhase::Thinking {
             self.thought.clear();
         }

--- a/crates/wisp/src/testing.rs
+++ b/crates/wisp/src/testing.rs
@@ -869,7 +869,7 @@ where
                 self.seed_sub_agent_tree(turn);
             }
             self.acp_event(text_chunk(SEED_CLOSING));
-            self.acp_event(AcpEvent::PromptDone(acp::StopReason::EndTurn));
+            self.complete_prompt(acp::StopReason::EndTurn);
             self.draw();
         }
     }
@@ -932,7 +932,7 @@ where
     /// Finishes the in-flight turn and advances synthetic time past every
     /// grace period, leaving a session that owes the event loop nothing.
     pub fn settle(&mut self) {
-        self.acp_event(AcpEvent::PromptDone(acp::StopReason::EndTurn));
+        self.complete_prompt(acp::StopReason::EndTurn);
         let mut now = Instant::now();
         // The plan tracker's grace period (3s) is the longest deadline a
         // settled session can still be waiting on.
@@ -975,6 +975,10 @@ where
 
     pub fn acp_event(&mut self, event: AcpEvent) {
         self.deliver(Message::Agent(Box::new(event)));
+    }
+
+    pub fn complete_prompt(&mut self, stop_reason: acp::StopReason) {
+        self.acp_event(AcpEvent::PromptCompleted(stop_reason));
     }
 
     pub fn tick(&mut self, now: Instant) {

--- a/crates/wisp/tests/tui/conversation.rs
+++ b/crates/wisp/tests/tui/conversation.rs
@@ -203,7 +203,7 @@ fn overflowing_single_paragraph_stream_enters_scrollback_before_completion() {
     ui.draw();
     assert_eq!(ui.history_text().matches("stream-line-0").count(), 1, "unchanged redraw duplicated history");
 
-    ui.acp_event(AcpEvent::PromptDone(acp::StopReason::EndTurn));
+    ui.complete_prompt(acp::StopReason::EndTurn);
     ui.draw();
     let completed_conversation = ui.conversation_text();
     assert_eq!(
@@ -246,7 +246,7 @@ fn stream_after_a_completed_tool_commits_incrementally() {
     ui.assert_viewport_not_contains("after-tool-line-0");
     ui.assert_viewport_contains("after-tool-line-29");
 
-    ui.acp_event(AcpEvent::PromptDone(acp::StopReason::EndTurn));
+    ui.complete_prompt(acp::StopReason::EndTurn);
     ui.draw();
     let conversation = ui.conversation_text();
     assert_eq!(conversation.matches("after-tool-line-0").count(), 1, "completed conversation:\n{conversation}");
@@ -317,7 +317,7 @@ fn resizing_a_partially_committed_stream_keeps_new_content_visible() {
 
     ui.assert_viewport_contains("after-resize");
 
-    ui.acp_event(AcpEvent::PromptDone(acp::StopReason::EndTurn));
+    ui.complete_prompt(acp::StopReason::EndTurn);
     ui.draw();
     let conversation = ui.conversation_text();
     assert_eq!(conversation.matches("resize-line-0").count(), 1, "completed conversation:\n{conversation}");
@@ -336,7 +336,7 @@ fn completed_streaming_text_remains_adjacent_to_the_composer_once() {
     ui.assert_viewport_contains("streamed answer");
     ui.assert_history_not_contains("streamed answer");
 
-    ui.acp_event(AcpEvent::PromptDone(acp::StopReason::EndTurn));
+    ui.complete_prompt(acp::StopReason::EndTurn);
     ui.draw();
     ui.draw();
 
@@ -353,7 +353,7 @@ fn streamed_markdown_blocks_keep_blank_separators() {
     for chunk in ["### Root\n", "\n", "Keep this paragraph separate.\n", "\n", "- first item\n"] {
         ui.acp_event(text_chunk(chunk));
     }
-    ui.acp_event(AcpEvent::PromptDone(acp::StopReason::EndTurn));
+    ui.complete_prompt(acp::StopReason::EndTurn);
     ui.draw();
 
     let conversation = ui.conversation();
@@ -379,7 +379,7 @@ fn running_tool_holds_later_content_out_of_committed_history() {
     assert!(!ui.history_text().contains("Reading main.rs"));
 
     ui.acp_event(tool_completed("tool-1"));
-    ui.acp_event(AcpEvent::PromptDone(acp::StopReason::EndTurn));
+    ui.complete_prompt(acp::StopReason::EndTurn);
     ui.draw();
 
     let conversation = ui.conversation_text();
@@ -394,7 +394,7 @@ fn cancelled_prompt_marks_running_tool_as_error() {
     app.submit("run a tool");
     app.acp_event(tool_call("tool-1", "Slow tool"));
 
-    app.acp_event(AcpEvent::PromptDone(acp::StopReason::Cancelled));
+    app.complete_prompt(acp::StopReason::Cancelled);
 
     let cancelled = app.app().conversation_items().iter().any(|item| {
         matches!(item.content(), ConversationContent::Tool(tool) if tool.status == ToolStatus::Error("cancelled".to_string()))
@@ -687,7 +687,7 @@ fn truncation_preserved_in_scrollback() {
     let long = "x".repeat(300);
     ui.acp_event(tool_call_with_raw("tool-1", "Long arg", serde_json::Value::String(long)));
     ui.acp_event(tool_completed_status("tool-1"));
-    ui.acp_event(AcpEvent::PromptDone(acp::StopReason::EndTurn));
+    ui.complete_prompt(acp::StopReason::EndTurn);
 
     ui.draw();
     ui.draw();
@@ -703,7 +703,7 @@ fn tool_arguments_preserved_in_scrollback_exactly_once() {
     ui.submit("run tool");
     ui.acp_event(tool_call_with_raw("tool-1", "Read file", raw));
     ui.acp_event(tool_completed_status("tool-1"));
-    ui.acp_event(AcpEvent::PromptDone(acp::StopReason::EndTurn));
+    ui.complete_prompt(acp::StopReason::EndTurn);
 
     ui.draw();
     ui.draw();
@@ -749,7 +749,7 @@ fn diff_not_rendered_after_failed_status() {
             .status(acp::ToolCallStatus::Failed),
     );
     ui.acp_event(session_update(acp::SessionUpdate::ToolCallUpdate(update)));
-    ui.acp_event(AcpEvent::PromptDone(acp::StopReason::EndTurn));
+    ui.complete_prompt(acp::StopReason::EndTurn);
 
     ui.draw();
     ui.draw();

--- a/crates/wisp/tests/tui/foundation.rs
+++ b/crates/wisp/tests/tui/foundation.rs
@@ -202,7 +202,7 @@ fn markdown_styles_stream_live_and_finalize_once() {
     assert!(has_cell(&conversation, "b", |cell| cell.modifier.contains(Modifier::BOLD)));
     assert!(has_cell(&conversation, "i", |cell| cell.modifier.contains(Modifier::ITALIC)));
 
-    ui.acp_event(AcpEvent::PromptDone(acp::StopReason::EndTurn));
+    ui.complete_prompt(acp::StopReason::EndTurn);
     ui.draw();
     ui.draw();
 
@@ -217,7 +217,7 @@ fn fenced_code_info_string_is_syntax_highlighted_with_token_colors() {
     let code_background = ui.app().theme().code_bg;
     ui.submit("show code");
     ui.acp_event(text_chunk("```rust title=\"example.rs\"\nfn highlighted() {}\n```"));
-    ui.acp_event(AcpEvent::PromptDone(acp::StopReason::EndTurn));
+    ui.complete_prompt(acp::StopReason::EndTurn);
 
     ui.draw();
 
@@ -254,7 +254,7 @@ fn fenced_code_streamed_across_chunks_is_syntax_highlighted() {
     assert!(has_cell(&ui.viewport(), "f", |cell| cell.bg == code_background));
 
     ui.acp_event(text_chunk("```\n"));
-    ui.acp_event(AcpEvent::PromptDone(acp::StopReason::EndTurn));
+    ui.complete_prompt(acp::StopReason::EndTurn);
     ui.draw();
     ui.draw();
 
@@ -276,7 +276,7 @@ fn fenced_code_line_comment_does_not_consume_following_code() {
     let code_background = ui.app().theme().code_bg;
     ui.submit("show documented code");
     ui.acp_event(text_chunk("```python\n# Documentation\nif condition:\n    pass\n```"));
-    ui.acp_event(AcpEvent::PromptDone(acp::StopReason::EndTurn));
+    ui.complete_prompt(acp::StopReason::EndTurn);
 
     ui.draw();
 
@@ -347,7 +347,7 @@ fn markdown_blockquote_prefixes_inline_code_first_content() {
     let code_background = ui.app().theme().code_bg;
     ui.submit("quote this");
     ui.acp_event(text_chunk("> `quoted`"));
-    ui.acp_event(AcpEvent::PromptDone(acp::StopReason::EndTurn));
+    ui.complete_prompt(acp::StopReason::EndTurn);
     ui.draw();
 
     let conversation = ui.conversation();
@@ -364,7 +364,7 @@ fn markdown_horizontal_rule_uses_available_width() {
     let mut ui = TestUi::with_dimensions(24, 15);
     ui.submit("add a rule");
     ui.acp_event(text_chunk("---"));
-    ui.acp_event(AcpEvent::PromptDone(acp::StopReason::EndTurn));
+    ui.complete_prompt(acp::StopReason::EndTurn);
     ui.draw();
 
     let conversation = ui.conversation();
@@ -377,7 +377,7 @@ fn transcript_markdown_wraps_at_word_boundaries() {
     let mut ui = TestUi::with_dimensions(13, 15);
     ui.submit("wrap words");
     ui.acp_event(text_chunk("alpha beta gamma"));
-    ui.acp_event(AcpEvent::PromptDone(acp::StopReason::EndTurn));
+    ui.complete_prompt(acp::StopReason::EndTurn);
     ui.draw();
 
     let conversation = ui.conversation();
@@ -394,7 +394,7 @@ fn transcript_markdown_separates_a_heading_from_its_paragraph() {
     let mut ui = TestUi::with_dimensions(44, 15);
     ui.submit("heading test");
     ui.acp_event(text_chunk("# Heading\n\nParagraph text."));
-    ui.acp_event(AcpEvent::PromptDone(acp::StopReason::EndTurn));
+    ui.complete_prompt(acp::StopReason::EndTurn);
     ui.draw();
 
     let conversation = ui.conversation();
@@ -410,7 +410,7 @@ fn transcript_wrapping_expands_tabs() {
     let mut ui = TestUi::with_dimensions(8, 15);
     ui.submit("hello");
     ui.acp_event(text_chunk("a\tb"));
-    ui.acp_event(AcpEvent::PromptDone(acp::StopReason::EndTurn));
+    ui.complete_prompt(acp::StopReason::EndTurn);
     ui.draw();
 
     let conversation = ui.conversation();
@@ -425,7 +425,7 @@ fn transcript_wrapping_never_exceeds_a_one_column_allocation() {
     let mut ui = TestUi::with_dimensions(5, 15);
     ui.submit("x");
     ui.acp_event(text_chunk("界"));
-    ui.acp_event(AcpEvent::PromptDone(acp::StopReason::EndTurn));
+    ui.complete_prompt(acp::StopReason::EndTurn);
     ui.draw();
 
     let conversation = ui.conversation();
@@ -454,7 +454,7 @@ fn markdown_renders_lists_strikethrough_and_tables() {
     let markdown = "- first\n- second\n\n~~removed~~\n\n| Name | Value |\n| --- | --- |\n| alpha | beta |";
     ui.submit("render table");
     ui.acp_event(text_chunk(markdown));
-    ui.acp_event(AcpEvent::PromptDone(acp::StopReason::EndTurn));
+    ui.complete_prompt(acp::StopReason::EndTurn);
     ui.draw();
 
     let conversation = ui.conversation();
@@ -491,7 +491,7 @@ fn streaming_markdown_reuses_unchanged_renders_and_finalizes_once() {
     ui.draw();
     assert_eq!(ui.viewport_text(), before);
 
-    ui.acp_event(AcpEvent::PromptDone(acp::StopReason::EndTurn));
+    ui.complete_prompt(acp::StopReason::EndTurn);
     ui.draw();
     ui.draw();
 
@@ -536,7 +536,7 @@ fn markdown_rendering_preserves_semantic_content_and_styles() {
     let mut ui = TestUi::new();
     ui.submit("markdown rendering");
     ui.acp_event(text_chunk("# Heading\n\n**bold** and `code`"));
-    ui.acp_event(AcpEvent::PromptDone(acp::StopReason::EndTurn));
+    ui.complete_prompt(acp::StopReason::EndTurn);
 
     ui.draw();
 
@@ -589,7 +589,7 @@ fn large_markdown_history_preserves_order_across_scrollback_and_viewport() {
     }
     ui.submit("long response");
     ui.acp_event(text_chunk(&markdown));
-    ui.acp_event(AcpEvent::PromptDone(acp::StopReason::EndTurn));
+    ui.complete_prompt(acp::StopReason::EndTurn);
 
     ui.draw();
 
@@ -639,7 +639,7 @@ fn history_is_inserted_before_the_live_viewport_is_drawn() {
     }
     ui.submit("hello");
     ui.acp_event(text_chunk(&response));
-    ui.acp_event(AcpEvent::PromptDone(acp::StopReason::EndTurn));
+    ui.complete_prompt(acp::StopReason::EndTurn);
     ui.draw();
 
     let events: Vec<BackendEvent> = ui.backend().events().to_vec();
@@ -679,7 +679,7 @@ fn scrollback_insertion_does_not_duplicate_status_line() {
     }
     ui.submit("hello");
     ui.acp_event(text_chunk(&response));
-    ui.acp_event(AcpEvent::PromptDone(acp::StopReason::EndTurn));
+    ui.complete_prompt(acp::StopReason::EndTurn);
     ui.acp_event(session_update(acp::SessionUpdate::UsageUpdate(acp::UsageUpdate::new(40_000, 200_000))));
 
     ui.draw();

--- a/crates/wisp/tests/tui/frame.rs
+++ b/crates/wisp/tests/tui/frame.rs
@@ -34,7 +34,7 @@ fn resize_growth_preserves_native_history_without_duplication() {
         reply.push('\n');
     }
     ui.acp_event(text_chunk(&reply));
-    ui.acp_event(AcpEvent::PromptDone(acp::StopReason::EndTurn));
+    ui.complete_prompt(acp::StopReason::EndTurn);
     ui.draw();
     assert!(
         ui.app()
@@ -110,7 +110,7 @@ fn completed_turn_settles_into_a_stable_viewport() {
     let mut ui = TestUi::with_dimensions(40, 15);
     ui.submit("hi");
     ui.acp_event(text_chunk("final answer"));
-    ui.acp_event(AcpEvent::PromptDone(acp::StopReason::EndTurn));
+    ui.complete_prompt(acp::StopReason::EndTurn);
     ui.draw();
     ui.draw();
 
@@ -168,7 +168,7 @@ fn resize_growth_keeps_canonical_history_visible() {
         reply.push('\n');
     }
     ui.acp_event(text_chunk(&reply));
-    ui.acp_event(AcpEvent::PromptDone(acp::StopReason::EndTurn));
+    ui.complete_prompt(acp::StopReason::EndTurn);
     ui.draw();
 
     ui.assert_history_contains("queued-line-0");

--- a/crates/wisp/tests/tui/plans.rs
+++ b/crates/wisp/tests/tui/plans.rs
@@ -148,7 +148,7 @@ fn plan_not_in_scrollback() {
 
     ui.submit("hello");
     ui.acp_event(text_chunk("response text"));
-    ui.acp_event(AcpEvent::PromptDone(acp::StopReason::EndTurn));
+    ui.complete_prompt(acp::StopReason::EndTurn);
 
     ui.draw();
     let scrollback = ui.history_text();

--- a/crates/wisp/tests/tui/progress_indicator.rs
+++ b/crates/wisp/tests/tui/progress_indicator.rs
@@ -33,7 +33,7 @@ fn activity_row(ui: &mut TestUi, label: &str) -> String {
 }
 
 #[test]
-fn keeps_status_segments_visible_until_prompt_done() {
+fn keeps_status_segments_visible_until_prompt_completes() {
     let (mut ui, _) = progress_ui();
     ui.acp_event(context_usage(100_000, 200_000));
 
@@ -42,10 +42,41 @@ fn keeps_status_segments_visible_until_prompt_done() {
         assert!(text.contains(expected), "missing {expected:?}:\n{text}");
     }
 
-    ui.acp_event(AcpEvent::PromptDone(acp::StopReason::EndTurn));
+    ui.complete_prompt(acp::StopReason::EndTurn);
     let text = ui.viewport_text();
     assert!(!text.contains("esc to interrupt"), "{text}");
     assert!(text.contains("Claude Sonnet"), "{text}");
+}
+
+#[test]
+fn prompt_completion_event_clears_responding_state() {
+    let (mut ui, _) = progress_ui();
+    ui.acp_event(text_chunk("final answer"));
+    ui.assert_viewport_contains("Responding…");
+
+    ui.acp_event(AcpEvent::PromptCompleted(acp::StopReason::EndTurn));
+
+    assert!(!ui.app().waiting_for_response());
+    assert!(!ui.app().is_agent_busy());
+    ui.assert_viewport_not_contains("Responding…");
+}
+
+#[test]
+fn activity_after_prompt_completion_is_ignored() {
+    let (mut ui, _) = progress_ui();
+    ui.acp_event(text_chunk("final answer"));
+    ui.complete_prompt(acp::StopReason::EndTurn);
+
+    ui.acp_event(text_chunk("late chunk"));
+    ui.acp_event(thought_chunk("late thought"));
+    ui.acp_event(tool_call("late-tool", "Late tool"));
+    ui.acp_event(AcpEvent::ContextCompaction(ContextCompactionParams { active: true }));
+
+    ui.assert_viewport_not_contains("late chunk");
+    ui.assert_viewport_not_contains("late thought");
+    ui.assert_viewport_not_contains("Late tool");
+    ui.assert_viewport_not_contains("Responding…");
+    assert!(!ui.app().wants_tick());
 }
 
 #[test]
@@ -84,7 +115,7 @@ fn reasoning_is_ephemeral_and_scoped_to_thinking() {
     ui.assert_viewport_contains("fresh reasoning");
     ui.assert_viewport_not_contains("first thought");
 
-    ui.acp_event(AcpEvent::PromptDone(acp::StopReason::EndTurn));
+    ui.complete_prompt(acp::StopReason::EndTurn);
     ui.submit("again");
     ui.tick(t0 + Duration::from_millis(300));
     ui.assert_viewport_not_contains("fresh reasoning");

--- a/crates/wisp/tests/tui/scrollback.rs
+++ b/crates/wisp/tests/tui/scrollback.rs
@@ -24,7 +24,7 @@ fn commit_overflowing_reply(ui: &mut TestUi) {
         "precondition: a prior reply must have been committed to scrollback"
     );
     // Complete the turn so the app is idle and later commands (e.g. /move) are not blocked.
-    ui.acp_event(AcpEvent::PromptDone(acp::StopReason::EndTurn));
+    ui.complete_prompt(acp::StopReason::EndTurn);
 }
 
 #[test]

--- a/crates/wisp/tests/tui/settings.rs
+++ b/crates/wisp/tests/tui/settings.rs
@@ -853,7 +853,7 @@ fn settings_overlay_uses_borderless_modal_chrome_and_padded_highlights() {
 fn settings_overlay_clears_conversation_content_behind_it() {
     let mut ui = TestUiBuilder::new().config_options(vec![select_option("model", "gpt-4o")]).build();
     ui.submit("CHAT_CONTENT_MUST_NOT_SHOW_THROUGH_SETTINGS");
-    ui.acp_event(AcpEvent::PromptDone(acp::StopReason::EndTurn));
+    ui.complete_prompt(acp::StopReason::EndTurn);
 
     ui.draw();
 
@@ -879,7 +879,7 @@ fn settings_overlay_still_valid_after_scrollback() {
     for i in 0..30 {
         ui.acp_event(text_chunk(&format!("line {i}")));
     }
-    ui.acp_event(AcpEvent::PromptDone(acp::StopReason::EndTurn));
+    ui.complete_prompt(acp::StopReason::EndTurn);
 
     ui.draw();
     ui.draw();

--- a/crates/wisp/tests/tui/subagents.rs
+++ b/crates/wisp/tests/tui/subagents.rs
@@ -82,7 +82,7 @@ fn sub_agent_parent_stays_live_while_child_running() {
 
     // parent completed, no sub-agents → should drain
     app.acp_event(text_chunk("Done"));
-    app.acp_event(AcpEvent::PromptDone(acp::StopReason::EndTurn));
+    app.complete_prompt(acp::StopReason::EndTurn);
     assert!(
         app.app().conversation_items().iter().any(|item| {
             matches!(item.content(), ConversationContent::Tool(tool) if tool.title == "spawn_subagent")
@@ -123,7 +123,7 @@ fn sub_agent_wants_tick_while_running() {
     assert!(app.app().wants_tick());
 
     app.acp_event(sub_agent_done("parent-1", "task-a", "explorer"));
-    app.acp_event(AcpEvent::PromptDone(acp::StopReason::EndTurn));
+    app.complete_prompt(acp::StopReason::EndTurn);
 
     // after finalization, sub-agent tools are finalized
     assert!(!app.app().wants_tick());
@@ -210,7 +210,7 @@ fn sub_agent_drain_includes_sub_agents_in_history_items() {
 
     // End prompt to finalize everything
     app.acp_event(text_chunk("Done"));
-    app.acp_event(AcpEvent::PromptDone(acp::StopReason::EndTurn));
+    app.complete_prompt(acp::StopReason::EndTurn);
 
     let tool_item = app.app().conversation_items().iter().find_map(|item| match item.content() {
         ConversationContent::Tool(tool) if tool.title == "spawn_subagent" => Some(tool),
@@ -244,7 +244,7 @@ fn sub_agent_prompt_cancelled_finalizes_sub_agents() {
     app.acp_event(tool_call("parent-1", "spawn_subagent"));
     app.acp_event(sub_agent_tool_call("parent-1", "task-a", "explorer", "c1", "grep", "{}"));
 
-    app.acp_event(AcpEvent::PromptDone(acp::StopReason::Cancelled));
+    app.complete_prompt(acp::StopReason::Cancelled);
 
     assert!(!app.app().wants_tick());
 }
@@ -301,11 +301,11 @@ mod progress_indicator_tests {
     }
 
     #[test]
-    fn prompt_done_hides_progress() {
+    fn completed_prompt_hides_progress() {
         let mut ui = TestUi::new();
         ui.submit("hello");
         ui.acp_event(text_chunk("response"));
-        ui.acp_event(AcpEvent::PromptDone(acp::StopReason::EndTurn));
+        ui.complete_prompt(acp::StopReason::EndTurn);
         ui.draw();
         let full = ui.viewport_text();
         assert!(!full.contains("esc to interrupt"), "{full}");
@@ -463,7 +463,7 @@ mod progress_indicator_tests {
         let mut app = make_app();
         app.submit("hello");
         app.acp_event(text_chunk("done"));
-        app.acp_event(AcpEvent::PromptDone(acp::StopReason::EndTurn));
+        app.complete_prompt(acp::StopReason::EndTurn);
         assert!(!app.app().wants_tick(), "wants_tick should be false after prompt completes and no other activity");
     }
 
@@ -498,7 +498,7 @@ mod progress_indicator_tests {
 
         // Complete the prompt
         ui.acp_event(text_chunk("response"));
-        ui.acp_event(AcpEvent::PromptDone(acp::StopReason::EndTurn));
+        ui.complete_prompt(acp::StopReason::EndTurn);
         // Tick while idle — should not change
         ui.tick(now);
         ui.resize(120, 30);
@@ -517,7 +517,7 @@ mod progress_indicator_tests {
             writeln!(response, "line-{i}").unwrap();
         }
         ui.acp_event(text_chunk(&response));
-        ui.acp_event(AcpEvent::PromptDone(acp::StopReason::EndTurn));
+        ui.complete_prompt(acp::StopReason::EndTurn);
 
         // Submit another prompt so we can see progress indicator
         ui.submit("another");

--- a/crates/wisp/tests/tui/terminal_interaction.rs
+++ b/crates/wisp/tests/tui/terminal_interaction.rs
@@ -255,7 +255,7 @@ mod bell {
         app.submit("hello");
         assert!(app.app().waiting_for_response());
 
-        app.acp_event(AcpEvent::PromptDone(acp::StopReason::EndTurn));
+        app.complete_prompt(acp::StopReason::EndTurn);
 
         assert!(rang_bell(&mut app));
     }
@@ -265,7 +265,7 @@ mod bell {
         let mut app = make_app();
 
         app.submit("hello");
-        app.acp_event(AcpEvent::PromptDone(acp::StopReason::Cancelled));
+        app.complete_prompt(acp::StopReason::Cancelled);
 
         assert!(!rang_bell(&mut app));
     }
@@ -291,11 +291,10 @@ mod bell {
     }
 
     #[test]
-    fn no_bell_on_unsolicited_prompt_done() {
+    fn no_bell_on_unsolicited_prompt_completion() {
         let mut app = make_app();
 
-        // No prompt in flight — PromptDone is unsolicited
-        app.acp_event(AcpEvent::PromptDone(acp::StopReason::EndTurn));
+        app.complete_prompt(acp::StopReason::EndTurn);
 
         assert!(!rang_bell(&mut app));
     }
@@ -305,7 +304,7 @@ mod bell {
         let mut app = make_app();
 
         app.submit("first");
-        app.acp_event(AcpEvent::PromptDone(acp::StopReason::EndTurn));
+        app.complete_prompt(acp::StopReason::EndTurn);
 
         assert!(rang_bell(&mut app));
         assert!(!rang_bell(&mut app));


### PR DESCRIPTION
## Summary

- keep prompt completion on the ordered ACP event stream
- ignore invalid agent activity that arrives after prompt completion
- centralize prompt lifecycle startup across regular and review submissions
- rename prompt completion test terminology and add ordering regressions

## Testing

- `just fmt`
- `just lint`
- `just test` (2,681 passed, 15 skipped)
- `git diff --check`