### PR TITLE
feat: enable Bedrock access for GitHub agents

### DIFF
--- a/.github/actions/configure-aws-credentials/action.yml
+++ b/.github/actions/configure-aws-credentials/action.yml
@@ -1,0 +1,28 @@
+name: Configure AWS credentials
+description: Assumes an IAM role with GitHub OIDC and exports temporary AWS credentials
+
+inputs:
+  aws-region:
+    description: AWS region for the session
+    required: false
+    default: us-west-2
+  role-to-assume:
+    description: IAM role ARN to assume
+    required: true
+  role-duration-seconds:
+    description: Duration of the assumed role session
+    required: false
+    default: "3600"
+
+runs:
+  using: composite
+  steps:
+    - name: Configure AWS credentials
+      uses: aws-actions/configure-aws-credentials@e6de054238d6b7531b4efff3b6587d9aade6a06c # v6.2.3
+      with:
+        role-to-assume: ${{ inputs.role-to-assume }}
+        aws-region: ${{ inputs.aws-region }}
+        role-duration-seconds: ${{ inputs.role-duration-seconds }}
+        role-session-name: github-actions-${{ github.run_id }}
+        mask-aws-account-id: true
+        output-env-credentials: true

--- a/.github/actions/fetch-release-secrets/action.yml
+++ b/.github/actions/fetch-release-secrets/action.yml
@@ -3,22 +3,22 @@ description: Fetches release environment variables from AWS SSM Parameter Store
 
 inputs:
   aws-region:
-    description: 'AWS region where secrets are stored'
+    description: "AWS region where secrets are stored"
     required: false
-    default: 'us-west-2'
+    default: "us-west-2"
   role-to-assume:
-    description: 'IAM role ARN to assume for secrets access'
+    description: "IAM role ARN to assume for secrets access"
     required: true
   parameter-path:
-    description: 'SSM parameter path prefix'
+    description: "SSM parameter path prefix"
     required: false
-    default: '/aether/ci/release/env-vars'
+    default: "/aether/ci/release/env-vars"
 
 runs:
-  using: 'composite'
+  using: "composite"
   steps:
-    - name: Configure AWS Credentials
-      uses: aws-actions/configure-aws-credentials@e6de054238d6b7531b4efff3b6587d9aade6a06c # v6.2.3
+    - name: Configure AWS credentials
+      uses: ./.github/actions/configure-aws-credentials
       with:
         role-to-assume: ${{ inputs.role-to-assume }}
         aws-region: ${{ inputs.aws-region }}

--- a/.github/actions/fetch-release-secrets/action.yml
+++ b/.github/actions/fetch-release-secrets/action.yml
@@ -18,7 +18,7 @@ runs:
   using: "composite"
   steps:
     - name: Configure AWS credentials
-      uses: ./.github/actions/configure-aws-credentials
+      uses: $/.github/actions/configure-aws-credentials
       with:
         role-to-assume: ${{ inputs.role-to-assume }}
         aws-region: ${{ inputs.aws-region }}

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -42,7 +42,7 @@ updates:
     ignore:
       - dependency-name: actions/upload-artifact
       - dependency-name: actions/download-artifact
-    directory: /.github/actions/fetch-release-secrets
+    directory: /.github/actions/configure-aws-credentials
     cooldown:
       default-days: 7
     groups:

--- a/.github/workflows/aether-agent.yml
+++ b/.github/workflows/aether-agent.yml
@@ -21,6 +21,9 @@ concurrency:
 jobs:
   agent:
     name: Aether agent
+    permissions:
+      contents: read
+      id-token: write
     if: >-
       (github.event_name == 'issues'
        && github.event.label.name == 'assign-agent') ||
@@ -73,6 +76,12 @@ jobs:
           ref: ${{ github.event.repository.default_branch }}
           token: ${{ steps.app-token.outputs.token }}
           persist-credentials: false
+
+      - name: Configure Bedrock credentials
+        uses: ./.github/actions/configure-aws-credentials
+        with:
+          role-to-assume: arn:aws:iam::412795048087:role/GitHubActionsBedrockInference-contextbridge
+          role-duration-seconds: "7200"
 
       - name: Stage trusted automation scripts
         run: |

--- a/.github/workflows/aether-agent.yml
+++ b/.github/workflows/aether-agent.yml
@@ -78,9 +78,9 @@ jobs:
           persist-credentials: false
 
       - name: Configure Bedrock credentials
-        uses: ./.github/actions/configure-aws-credentials
+        uses: $/.github/actions/configure-aws-credentials
         with:
-          role-to-assume: arn:aws:iam::412795048087:role/GitHubActionsBedrockInference-contextbridge
+          role-to-assume: arn:aws:iam::212467111133:role/GitHubActionsBedrockInference-aether
           role-duration-seconds: "7200"
 
       - name: Stage trusted automation scripts

--- a/.github/workflows/scheduled-aether-prompts.yml
+++ b/.github/workflows/scheduled-aether-prompts.yml
@@ -84,9 +84,9 @@ jobs:
           token: ${{ steps.app-token.outputs.token }}
 
       - name: Configure Bedrock credentials
-        uses: ./.github/actions/configure-aws-credentials
+        uses: $/.github/actions/configure-aws-credentials
         with:
-          role-to-assume: arn:aws:iam::412795048087:role/GitHubActionsBedrockInference-contextbridge
+          role-to-assume: arn:aws:iam::212467111133:role/GitHubActionsBedrockInference-aether
 
       - name: Install system dependencies
         run: sudo apt-get update && sudo apt-get install -y libdbus-1-dev

--- a/.github/workflows/scheduled-aether-prompts.yml
+++ b/.github/workflows/scheduled-aether-prompts.yml
@@ -50,6 +50,9 @@ jobs:
   run-prompt:
     name: Run ${{ matrix.prompt.id }}
     needs: discover-prompts
+    permissions:
+      contents: read
+      id-token: write
     runs-on: ubuntu-latest
     timeout-minutes: 45
     environment: ci
@@ -79,6 +82,11 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
           token: ${{ steps.app-token.outputs.token }}
+
+      - name: Configure Bedrock credentials
+        uses: ./.github/actions/configure-aws-credentials
+        with:
+          role-to-assume: arn:aws:iam::412795048087:role/GitHubActionsBedrockInference-contextbridge
 
       - name: Install system dependencies
         run: sudo apt-get update && sudo apt-get install -y libdbus-1-dev


### PR DESCRIPTION
## Summary

- add a reusable GitHub OIDC credential action that exports temporary AWS credentials
- assume the shared Bedrock inference role in interactive and scheduled agent workflows
- request `id-token: write` only on jobs that need AWS access
- reuse the credential action when fetching release secrets

## Dependency

Depends on contextbridge/infrastructure#254 being merged and deployed so `arn:aws:iam::412795048087:role/GitHubActionsBedrockInference-contextbridge` exists.

This only supplies Bedrock credentials through the default AWS credential provider chain. Agent model selections remain unchanged.

## Testing

- `just automation-check`
- Prettier checks for changed actions and workflows