### PR TITLE
ci: fail zizmor job when SARIF contains findings

### DIFF
--- a/.github/actions/fetch-release-secrets/action.yml
+++ b/.github/actions/fetch-release-secrets/action.yml
@@ -18,7 +18,7 @@ runs:
   using: "composite"
   steps:
     - name: Configure AWS credentials
-      uses: ./.github/actions/configure-aws-credentials
+      uses: $/.github/actions/configure-aws-credentials
       with:
         role-to-assume: ${{ inputs.role-to-assume }}
         aws-region: ${{ inputs.aws-region }}

--- a/.github/workflows/aether-agent.yml
+++ b/.github/workflows/aether-agent.yml
@@ -78,7 +78,7 @@ jobs:
           persist-credentials: false
 
       - name: Configure Bedrock credentials
-        uses: ./.github/actions/configure-aws-credentials
+        uses: $/.github/actions/configure-aws-credentials
         with:
           role-to-assume: arn:aws:iam::212467111133:role/GitHubActionsBedrockInference-aether
           role-duration-seconds: "7200"

--- a/.github/workflows/scheduled-aether-prompts.yml
+++ b/.github/workflows/scheduled-aether-prompts.yml
@@ -84,7 +84,7 @@ jobs:
           token: ${{ steps.app-token.outputs.token }}
 
       - name: Configure Bedrock credentials
-        uses: ./.github/actions/configure-aws-credentials
+        uses: $/.github/actions/configure-aws-credentials
         with:
           role-to-assume: arn:aws:iam::212467111133:role/GitHubActionsBedrockInference-aether
 

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -55,3 +55,11 @@ jobs:
         with:
           sarif_file: zizmor.sarif
           category: zizmor
+
+      # zizmor always exits 0 in SARIF mode, so fail here (after the upload
+      # so findings still reach code scanning) when the SARIF has results.
+      - name: Fail on findings
+        if: steps.changes.outputs.github == 'true'
+        run: |
+          jq -r '.runs[].results[] | "\(.level): \(.ruleId) — \(.locations[0].physicalLocation.artifactLocation.uri):\(.locations[0].physicalLocation.region.startLine // "?") \(.message.text)"' zizmor.sarif
+          jq -e '[.runs[].results[]] | length == 0' zizmor.sarif > /dev/null


### PR DESCRIPTION
## Summary

zizmor always exits 0 in SARIF mode, so findings only ever showed up in the code scanning tab and never failed the check. Adds a step after the SARIF upload that fails the job when the SARIF has any results, so findings still reach code scanning but also block the PR. The first run on this PR failed as expected on `self-repository` findings; the second commit fixes them and the check went green. Same change as contextbridge/planbridge#288.

## Review focus

Ordering: the fail step runs after the upload on purpose so results still land in code scanning on failure.

## Commits

- [`dc73a1f`](https://github.com/contextbridge/aether/commit/dc73a1feff19e92f2b4dbd0d538bb315a7e36fcf) — fail zizmor job when SARIF contains findings
- [`d199e28`](https://github.com/contextbridge/aether/commit/d199e28d88dacccd7b5ea93641407711594734a5) — use $/ self-repository syntax for local action references
