### PR TITLE
feat(aether-sdk): Expose token and cost estimates via TS SDK messages

### DIFF
--- a/packages/aether-sdk/README.md
+++ b/packages/aether-sdk/README.md
@@ -149,6 +149,26 @@ await using rootSession = await AetherSession.start({
 
 `traceContext` is also accepted by `runHeadless` and the lower-level ACP process options. A `traceparent` makes every turn a child of the propagated span. A standalone `traceId` instead creates root turn spans with that trace ID and no parent span. Telemetry must still be enabled in Aether settings.
 
+## Tracking token usage and cost
+
+Each provider call emits a typed `usage` message with per-call usage and the
+cumulative session totals:
+
+```ts
+for await (const message of session.prompt("Implement the feature")) {
+  if (message.type === "usage") {
+    console.log(message.usage.tokens);
+    console.log(message.usage.estimated_cost?.total_usd);
+    console.log(message.usage.totals.estimated_usd);
+  }
+}
+```
+
+Costs are catalog-based USD estimates. `totals.estimated_usd` excludes calls
+whose model pricing is unknown; `totals.unpriced_calls` reports how many were
+excluded. Sub-agent usage includes agent and task identity in
+`message.usage.source`.
+
 ## Multi-turn usage
 
 ```ts

--- a/packages/aether-sdk/README.md
+++ b/packages/aether-sdk/README.md
@@ -104,6 +104,32 @@ await AetherSession.start({
 });
 ```
 
+## Configuring telemetry
+
+Telemetry content is opt-in per OpenTelemetry GenAI attribute:
+
+```ts
+await using session = await AetherSession.start({
+  settings: {
+    telemetry: {
+      content: {
+        systemInstructions: true,
+        inputMessages: true,
+        outputMessages: true,
+        toolDefinitions: true,
+        toolCalls: true,
+      },
+      otlp: { endpoint: "http://localhost:4318" },
+    },
+    agents: [],
+  },
+});
+```
+
+All content flags default to `false`. This replaces the former
+`telemetry.captureContent` setting. See the [telemetry documentation](https://aether-agent.io/aether/settings/telemetry/)
+for signal toggles, endpoint overrides, headers, validation, and sampling semantics.
+
 ## Correlating telemetry traces
 
 ```ts
@@ -121,7 +147,7 @@ await using rootSession = await AetherSession.start({
 });
 ```
 
-`traceContext` is also accepted by `runHeadless` and the lower-level ACP process options. A `traceparent` makes every turn a child of the propagated span. A standalone `traceId` instead creates root turn spans with that trace ID and no parent span. Telemetry must still be enabled in Aether settings. See the [telemetry documentation](https://aether-agent.io/aether/settings/telemetry/) for validation and sampling semantics.
+`traceContext` is also accepted by `runHeadless` and the lower-level ACP process options. A `traceparent` makes every turn a child of the propagated span. A standalone `traceId` instead creates root turn spans with that trace ID and no parent span. Telemetry must still be enabled in Aether settings.
 
 ## Multi-turn usage
 

--- a/packages/aether-sdk/package.json
+++ b/packages/aether-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aether-agent/sdk",
-  "version": "0.4.1",
+  "version": "0.5.0",
   "description": "TypeScript SDK for the Aether agent CLI",
   "repository": {
     "type": "git",
@@ -27,7 +27,7 @@
     "e2e": "node scripts/e2e.mjs"
   },
   "dependencies": {
-    "@aether-agent/cli": "^0.7.35",
+    "@aether-agent/cli": "^0.8.0",
     "@agentclientprotocol/sdk": "^1.3.0",
     "@modelcontextprotocol/sdk": "^1.30.0",
     "express": "^5.1.0",
@@ -36,6 +36,7 @@
   "devDependencies": {
     "@types/express": "^5.0.0",
     "@types/node": "^26.4.0",
+    "fishery": "^2.4.0",
     "json-schema-to-typescript": "^15.0.4",
     "typescript": "^6.0.3",
     "vitest": "^4.1.11"

--- a/packages/aether-sdk/src/docs/basic_session.md
+++ b/packages/aether-sdk/src/docs/basic_session.md
@@ -4,6 +4,21 @@ import { AetherSession, type AetherSettings } from "@aether-agent/sdk";
 async function example() {
   const settings: AetherSettings = {
     agent: "Example",
+    telemetry: {
+      content: {
+        systemInstructions: true,
+        inputMessages: true,
+        outputMessages: true,
+        toolDefinitions: true,
+        toolCalls: true,
+      },
+      traces: { enabled: true },
+      metrics: { enabled: true },
+      otlp: {
+        endpoint: "http://localhost:4318",
+        headers: { Authorization: "Bearer $OTEL_TOKEN" },
+      },
+    },
     agents: [
       {
         name: "Example",

--- a/packages/aether-sdk/src/errors.ts
+++ b/packages/aether-sdk/src/errors.ts
@@ -6,6 +6,7 @@ export type AetherSdkErrorCode =
   | "session_not_started"
   | "prompt_in_progress"
   | "invalid_options"
+  | "invalid_protocol_message"
   | "execution_failed"
   | "generate_command_failed"
   | "aborted";

--- a/packages/aether-sdk/src/session.ts
+++ b/packages/aether-sdk/src/session.ts
@@ -1,5 +1,7 @@
 import type { AetherAcpOptions } from "./generated/aether-acp-options.js";
+import type { SessionUsageEvent } from "./generated/eval-types.js";
 import { addAbortListener } from "node:events";
+import { createRequire } from "node:module";
 import path from "node:path";
 import * as acp from "@agentclientprotocol/sdk";
 import { AsyncQueue } from "./asyncQueue.js";
@@ -11,7 +13,9 @@ import {
 import { AetherSdkError, throwIfAborted } from "./errors.js";
 import type { AetherMessage, AgentSelection } from "./types.js";
 
-const SDK_VERSION = "0.3.6";
+const { version: SDK_VERSION } = createRequire(import.meta.url)(
+  "../package.json",
+) as { version: string };
 
 export type PermissionRequestHandler = (
   request: acp.RequestPermissionRequest,
@@ -281,9 +285,31 @@ function createAcpClient(
       method: string,
       params: Record<string, unknown>,
     ): Promise<void> {
-      events.push({ type: "ext_notification", method, params });
+      try {
+        const usage = parseUsageNotification(method, params);
+        if (usage) events.push({ type: "usage", usage });
+      } catch (error) {
+        events.fail(error);
+      }
     },
   } satisfies acp.Client;
+}
+
+function parseUsageNotification(
+  method: string,
+  params: Record<string, unknown>,
+): SessionUsageEvent | undefined {
+  if (method !== "_aether/session_usage") return undefined;
+
+  const usage = params.usage;
+  if (!usage || typeof usage !== "object") {
+    throw new AetherSdkError(
+      "invalid_protocol_message",
+      "Aether CLI sent an invalid session usage update",
+    );
+  }
+
+  return usage as SessionUsageEvent;
 }
 
 function normalizePrompt(

--- a/packages/aether-sdk/src/types.ts
+++ b/packages/aether-sdk/src/types.ts
@@ -5,6 +5,7 @@ import type {
 } from "@modelcontextprotocol/sdk/types.js";
 import type { z } from "zod";
 import type { ReasoningEffort } from "./generated/aether-settings.js";
+import type { SessionUsageEvent } from "./generated/eval-types.js";
 
 export type AgentSelection =
   | { agent: string; model?: never; reasoningEffort?: never }
@@ -26,11 +27,7 @@ export type AetherMessage =
       update: acp.SessionUpdate;
       raw: acp.SessionNotification;
     }
-  | {
-      type: "ext_notification";
-      method: string;
-      params: Record<string, unknown>;
-    }
+  | { type: "usage"; usage: SessionUsageEvent }
   | { type: "elicitation_complete"; elicitationId: string }
   | { type: "result"; sessionId: string; stopReason: acp.StopReason }
   | { type: "error"; error: unknown };

--- a/packages/aether-sdk/test/agentProcess.test.ts
+++ b/packages/aether-sdk/test/agentProcess.test.ts
@@ -22,7 +22,19 @@ describe("buildAetherAcpCommand()", () => {
   it("adds ACP options JSON for settings, model, reasoning effort, providers, and log dir", () => {
     const command = buildAetherAcpCommand({
       binaryPath: FAKE_AETHER,
-      settings: { credentialsStore: { type: "memory" }, agents: [] },
+      settings: {
+        credentialsStore: { type: "memory" },
+        telemetry: {
+          content: {
+            systemInstructions: true,
+            inputMessages: true,
+            outputMessages: true,
+            toolDefinitions: true,
+            toolCalls: true,
+          },
+        },
+        agents: [],
+      },
       model: "anthropic:claude-sonnet-4-5",
       reasoningEffort: "high",
       traceContext: TRACE_CONTEXT,
@@ -50,6 +62,15 @@ describe("buildAetherAcpCommand()", () => {
       },
       settings: {
         credentialsStore: { type: "memory" },
+        telemetry: {
+          content: {
+            systemInstructions: true,
+            inputMessages: true,
+            outputMessages: true,
+            toolDefinitions: true,
+            toolCalls: true,
+          },
+        },
         agents: [],
       },
       model: "anthropic:claude-sonnet-4-5",

--- a/packages/aether-sdk/test/factories/sessionUsage.ts
+++ b/packages/aether-sdk/test/factories/sessionUsage.ts
@@ -1,0 +1,47 @@
+import { Factory } from "fishery";
+
+import type { SessionUsageEvent } from "../../src/generated/eval-types.js";
+
+export const sessionUsageFactory = Factory.define<SessionUsageEvent>(() => ({
+  sequence: 10,
+  source: {
+    agent_id: "agent-child",
+    parent_agent_id: "agent-root",
+    task_id: "task-2",
+    agent_name: "Explore",
+  },
+  purpose: "chat",
+  model: {
+    provider: "anthropic",
+    model_id: "claude-sonnet-4-5",
+    pricing: {
+      input_per_million: 10,
+      output_per_million: 20,
+      cache_read_per_million: 30,
+      cache_write_per_million: 40,
+    },
+  },
+  tokens: {
+    input_tokens: 10,
+    output_tokens: 20,
+    cache_read_tokens: 30,
+    cache_creation_tokens: null,
+    reasoning_tokens: 40,
+  },
+  estimated_cost: {
+    input_usd: 10,
+    output_usd: 20,
+    cache_read_usd: 30,
+    cache_creation_usd: 40,
+    total_usd: 100,
+  },
+  totals: {
+    tokens: {
+      input_tokens: 100,
+      output_tokens: 200,
+      cache_read_tokens: 300,
+    },
+    estimated_usd: 400,
+    unpriced_calls: 10,
+  },
+}));

--- a/packages/aether-sdk/test/fakeAether.mjs
+++ b/packages/aether-sdk/test/fakeAether.mjs
@@ -169,6 +169,11 @@ const agent = {
       });
     }
 
+    if (process.env.FAKE_AETHER_EXT_NOTIFICATION) {
+      const notification = JSON.parse(process.env.FAKE_AETHER_EXT_NOTIFICATION);
+      await conn.extNotification(notification.method, notification.params);
+    }
+
     const callName = process.env.FAKE_AETHER_CALL_MCP_SERVER;
     if (callName) {
       const server = inlineServers.get(callName);

--- a/packages/aether-sdk/test/session.integration.test.ts
+++ b/packages/aether-sdk/test/session.integration.test.ts
@@ -7,6 +7,7 @@ import { describe, expect, it } from "vitest";
 import { z } from "zod";
 
 import { AetherSession, mcp, type AetherMessage, tool } from "../src/index.js";
+import { sessionUsageFactory } from "./factories/sessionUsage.js";
 import { TRACE_CONTEXT } from "./traceContext.js";
 
 const FAKE_AETHER = path.resolve(
@@ -176,6 +177,89 @@ describe("AetherSession with a fake ACP agent", () => {
     const result = messages.find((m) => m.type === "result");
     if (result?.type === "result") {
       expect(result.stopReason).toBe("end_turn");
+    }
+  });
+
+  it("exposes session usage", async () => {
+    const session = await AetherSession.start({
+      binaryPath: FAKE_AETHER,
+      env: {
+        PATH: process.env.PATH,
+        FAKE_AETHER_EXT_NOTIFICATION: JSON.stringify({
+          method: "_aether/session_usage",
+          params: { usage: sessionUsageFactory.build() },
+        }),
+      },
+    });
+
+    try {
+      const messages: AetherMessage[] = [];
+      for await (const message of session.prompt("test prompt")) {
+        messages.push(message);
+      }
+
+      expect(messages.map((message) => message.type)).toEqual([
+        "session_update",
+        "usage",
+        "result",
+      ]);
+
+      expect(messages.find((message) => message.type === "usage")).toEqual({
+        type: "usage",
+        usage: sessionUsageFactory.build(),
+      });
+    } finally {
+      await session.close();
+    }
+  });
+
+  it("ignores unknown ACP extension notifications", async () => {
+    const notification = {
+      method: "example.com/status",
+      params: { status: "ready" },
+    };
+    const session = await AetherSession.start({
+      binaryPath: FAKE_AETHER,
+      env: {
+        PATH: process.env.PATH,
+        FAKE_AETHER_EXT_NOTIFICATION: JSON.stringify(notification),
+      },
+    });
+
+    try {
+      const messages: AetherMessage[] = [];
+      for await (const message of session.prompt("test prompt")) {
+        messages.push(message);
+      }
+      expect(messages.map((message) => message.type)).toEqual([
+        "session_update",
+        "result",
+      ]);
+    } finally {
+      await session.close();
+    }
+  });
+
+  it("rejects malformed session usage notifications", async () => {
+    const session = await AetherSession.start({
+      binaryPath: FAKE_AETHER,
+      env: {
+        PATH: process.env.PATH,
+        FAKE_AETHER_EXT_NOTIFICATION: JSON.stringify({
+          method: "_aether/session_usage",
+          params: {},
+        }),
+      },
+    });
+
+    try {
+      await expect(async () => {
+        for await (const _message of session.prompt("test prompt")) {
+          void _message;
+        }
+      }).rejects.toMatchObject({ code: "invalid_protocol_message" });
+    } finally {
+      await session.close();
     }
   });
 

--- a/packages/website/src/content/docs/libraries/typescript-sdk.mdx
+++ b/packages/website/src/content/docs/libraries/typescript-sdk.mdx
@@ -154,12 +154,33 @@ Unlike `AetherSession.start()`, headless runs are non-interactive, so there are 
 | Type                   | Description                                                                                     |
 | ---------------------- | ----------------------------------------------------------------------------------------------- |
 | `session_update`       | An ACP session update (agent text, tool calls, tool results, progress, etc.). Access `.update`. |
-| `ext_notification`     | A custom extension notification (e.g. plan or task updates). Access `.method` and `.params`.    |
+| `usage`                | Per-call token usage and estimated cost, plus cumulative session totals. Access `.usage`.       |
 | `elicitation_complete` | A URL-mode elicitation finished. Access `.elicitationId`.                                       |
 | `result`               | The prompt finished. `.stopReason` describes why (e.g. `end_turn`, `cancelled`).                |
 | `error`                | An unrecoverable error occurred. Access `.error`.                                               |
 
 A `result` message is always emitted last (unless the stream errors), so it is a reliable place to stop consuming the iterator.
+
+### Token usage and estimated cost
+
+Aether exposes accounting as a domain-level `usage` message rather than an ACP
+extension notification:
+
+```ts
+for await (const message of session.prompt("Implement the feature")) {
+  if (message.type === "usage") {
+    console.log(message.usage.tokens);
+    console.log(message.usage.estimated_cost?.total_usd);
+    console.log(message.usage.totals.estimated_usd);
+  }
+}
+```
+
+`tokens` and `estimated_cost` describe the provider call that produced the
+update. `totals` contains cumulative usage after that call. Costs are
+catalog-based USD estimates; `totals.estimated_usd` excludes calls whose model
+pricing is unknown, and `totals.unpriced_calls` reports how many were excluded.
+Sub-agent calls include agent and task attribution in `source`.
 
 ## TypeScript tools
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -43,8 +43,8 @@ importers:
   packages/aether-sdk:
     dependencies:
       '@aether-agent/cli':
-        specifier: ^0.7.35
-        version: 0.7.35
+        specifier: ^0.8.0
+        version: 0.8.0
       '@agentclientprotocol/sdk':
         specifier: ^1.3.0
         version: 1.3.0(zod@4.4.3)
@@ -64,6 +64,9 @@ importers:
       '@types/node':
         specifier: ^26.4.0
         version: 26.4.0
+      fishery:
+        specifier: ^2.4.0
+        version: 2.4.0
       json-schema-to-typescript:
         specifier: ^15.0.4
         version: 15.0.4
@@ -153,6 +156,11 @@ packages:
 
   '@aether-agent/cli@0.7.35':
     resolution: {integrity: sha512-Xme2xrRU46zPrgXzC1HAv1LKSB2A7j35xNuMT/cLQZ+rD3Bf+fgZ7fnVQP46wWfgnuLOpmEKJNjmidVcCK6RcQ==}
+    engines: {node: '>=14', npm: '>=6'}
+    hasBin: true
+
+  '@aether-agent/cli@0.8.0':
+    resolution: {integrity: sha512-WQklT8QDdUSaJHMIoJcEY06Q5GXiJNaBx3fkFp8M3PYWk8w45AbJ8xRAk7Gl0+LxDdTO/2NZ+VG9+HzfO7hMiA==}
     engines: {node: '>=14', npm: '>=6'}
     hasBin: true
 
@@ -2673,6 +2681,9 @@ packages:
     resolution: {integrity: sha512-SrQDx3QhlmHM90iqn9rdjCQcw/T+WlpOkHFsjoRgB+zTpDfltNA1VSNYeYELwhUTJy12UFxqjWhmhOrJc+o4sA==}
     hasBin: true
 
+  fishery@2.4.0:
+    resolution: {integrity: sha512-QgeTlvgNhVGuMztrfAhlSIBs3rD3l9RMjl9I15yb/lnrx3njrOhvegr2L3LWdqvXwYfQjdQGpglyAfHH2J8DRA==}
+
   flattie@1.1.1:
     resolution: {integrity: sha512-9UbaD6XdAL97+k/n+N7JwX46K/M6Zc6KcFYskrYL8wbBV/Uyk0CTAMY0VT+qiK5PM7AIc9aTWYtq65U7T+aCNQ==}
     engines: {node: '>=8'}
@@ -3185,6 +3196,9 @@ packages:
 
   lodash.camelcase@4.3.0:
     resolution: {integrity: sha512-TwuEnCnxbc3rAvhf/LbG7tJUDzhqXyFnv3dtzLOPgCG/hODL7WFnsbwktkD7yUV0RrreP/l1PALq/YSg6VvjlA==}
+
+  lodash.mergewith@4.6.2:
+    resolution: {integrity: sha512-GK3g5RPZWTRSeLSpgP8Xhra+pnjBC56q9FZYe1d5RN3TJ35dbkGy3YqBSMbyCrlbi+CM9Z3Jk5yTL7RCsqboyQ==}
 
   lodash@4.18.1:
     resolution: {integrity: sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==}
@@ -4668,6 +4682,17 @@ snapshots:
       - supports-color
 
   '@aether-agent/cli@0.7.35':
+    dependencies:
+      axios: 1.19.0
+      axios-proxy-builder: 0.1.2
+      console.table: 0.10.0
+      detect-libc: 2.1.2
+      rimraf: 6.1.3
+    transitivePeerDependencies:
+      - debug
+      - supports-color
+
+  '@aether-agent/cli@0.8.0':
     dependencies:
       axios: 1.19.0
       axios-proxy-builder: 0.1.2
@@ -7247,6 +7272,10 @@ snapshots:
       commander: 14.0.3
       loglevel: 1.9.2
 
+  fishery@2.4.0:
+    dependencies:
+      lodash.mergewith: 4.6.2
+
   flattie@1.1.1: {}
 
   follow-redirects@1.16.0: {}
@@ -7813,6 +7842,8 @@ snapshots:
   lodash-es@4.18.1: {}
 
   lodash.camelcase@4.3.0: {}
+
+  lodash.mergewith@4.6.2: {}
 
   lodash@4.18.1: {}
 


### PR DESCRIPTION
## Summary

This PR upgrades our TS SDK to expose the `SessionUsage` type emitted by aether's CLI to consumers of the SDK. Now when SDK users consume an agent's message stream, they'll get a `usage` type they can optionally choose to process. 