### PR TITLE
fix(aether-sdk): Codegenerate sdk version at build time instead of im…

### DIFF
--- a/packages/aether-sdk/package.json
+++ b/packages/aether-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aether-agent/sdk",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "description": "TypeScript SDK for the Aether agent CLI",
   "repository": {
     "type": "git",

--- a/packages/aether-sdk/scripts/generate-types.mjs
+++ b/packages/aether-sdk/scripts/generate-types.mjs
@@ -1,5 +1,5 @@
 import { execFileSync } from "node:child_process";
-import { mkdirSync, writeFileSync } from "node:fs";
+import { mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import { dirname, resolve } from "node:path";
 import { compile } from "json-schema-to-typescript";
 
@@ -24,6 +24,7 @@ await generateEvalTypes(document);
 await generateSettingsTypes(document.AetherSettings);
 await generateAcpOptionsTypes(document.AcpOptions);
 await generateHeadlessOptionsTypes(document.HeadlessOptions);
+generateSdkVersion();
 
 async function generateEvalTypes(document) {
   const canonicalSchemaPath = resolve(
@@ -107,6 +108,18 @@ async function generateHeadlessOptionsTypes(schema) {
 
   writeGenerated(
     resolve(import.meta.dirname, "../src/generated/aether-headless-options.ts"),
+    content,
+  );
+}
+
+function generateSdkVersion() {
+  const packageJson = JSON.parse(
+    readFileSync(resolve(import.meta.dirname, "../package.json"), "utf8"),
+  );
+  const content = `// @generated ${GENERATED_NOTICE}\n// Source: packages/aether-sdk/package.json.\n\nexport const SDK_VERSION = ${JSON.stringify(packageJson.version)};\n`;
+
+  writeGenerated(
+    resolve(import.meta.dirname, "../src/generated/sdk-version.ts"),
     content,
   );
 }

--- a/packages/aether-sdk/src/session.ts
+++ b/packages/aether-sdk/src/session.ts
@@ -1,7 +1,6 @@
 import type { AetherAcpOptions } from "./generated/aether-acp-options.js";
 import type { SessionUsageEvent } from "./generated/eval-types.js";
 import { addAbortListener } from "node:events";
-import { createRequire } from "node:module";
 import path from "node:path";
 import * as acp from "@agentclientprotocol/sdk";
 import { AsyncQueue } from "./asyncQueue.js";
@@ -11,11 +10,8 @@ import {
   type SettingsSelection,
 } from "./agentProcess.js";
 import { AetherSdkError, throwIfAborted } from "./errors.js";
+import { SDK_VERSION } from "./generated/sdk-version.js";
 import type { AetherMessage, AgentSelection } from "./types.js";
-
-const { version: SDK_VERSION } = createRequire(import.meta.url)(
-  "../package.json",
-) as { version: string };
 
 export type PermissionRequestHandler = (
   request: acp.RequestPermissionRequest,


### PR DESCRIPTION
This PR fixes an issue in the TS SDK where we were importing a `package.json` at runtime to pull out the current version of the SDK package. 

Here, we make a change to code-generate it at compile time so it doesn't cause issues with consuming code. 