### PR TITLE
feat: add persistent codex websocket sessions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -215,6 +215,7 @@ dependencies = [
  "futures",
  "oauth2",
  "reqwest 0.13.4",
+ "reqwest-websocket",
  "schemars 1.2.2",
  "secrecy",
  "serde",
@@ -904,6 +905,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "async-tungstenite"
+version = "0.32.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8acc405d38be14342132609f06f02acaf825ddccfe76c4824a69281e0458ebd4"
+dependencies = [
+ "atomic-waker",
+ "futures-core",
+ "futures-io",
+ "futures-task",
+ "futures-util",
+ "log",
+ "pin-project-lite",
+ "tungstenite 0.28.0",
+]
+
+[[package]]
 name = "atoi"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1389,6 +1406,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "31b698c5f9a010f6573133b09e0de5408834d0c82f8d7475a89fc1867a71cd90"
 dependencies = [
  "axum-core",
+ "base64 0.22.1",
  "bytes",
  "form_urlencoded",
  "futures-util",
@@ -1407,8 +1425,10 @@ dependencies = [
  "serde_json",
  "serde_path_to_error",
  "serde_urlencoded",
+ "sha1 0.10.7",
  "sync_wrapper",
  "tokio",
+ "tokio-tungstenite",
  "tower",
  "tower-layer",
  "tower-service",
@@ -2325,6 +2345,12 @@ dependencies = [
  "quote",
  "syn 3.0.4",
 ]
+
+[[package]]
+name = "data-encoding"
+version = "2.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4583a4551df46e2792f82ceeac45e850d2e2d5debba0b91f102385cda5b11f06"
 
 [[package]]
 name = "dbus"
@@ -5857,6 +5883,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "reqwest-websocket"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7705b649c3b66b85c4e9c304a6898b1ae3eecb880c474720ebf925e4a932ae02"
+dependencies = [
+ "async-tungstenite",
+ "bytes",
+ "futures-util",
+ "reqwest 0.13.4",
+ "thiserror 2.0.20",
+ "tokio",
+ "tokio-util",
+ "tracing",
+ "tungstenite 0.28.0",
+ "web-sys",
+]
+
+[[package]]
 name = "ring"
 version = "0.17.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7272,6 +7316,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-tungstenite"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f72a05e828585856dacd553fba484c242c46e391fb0e58917c942ee9202915c"
+dependencies = [
+ "futures-util",
+ "log",
+ "tokio",
+ "tungstenite 0.29.0",
+]
+
+[[package]]
 name = "tokio-util"
 version = "0.7.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7798,6 +7854,39 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
+name = "tungstenite"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8628dcc84e5a09eb3d8423d6cb682965dea9133204e8fb3efee74c2a0c259442"
+dependencies = [
+ "bytes",
+ "data-encoding",
+ "http 1.5.0",
+ "httparse",
+ "log",
+ "rand 0.9.5",
+ "sha1 0.10.7",
+ "thiserror 2.0.20",
+ "utf-8",
+]
+
+[[package]]
+name = "tungstenite"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c01152af293afb9c7c2a57e4b559c5620b421f6d133261c60dd2d0cdb38e6b8"
+dependencies = [
+ "bytes",
+ "data-encoding",
+ "http 1.5.0",
+ "httparse",
+ "log",
+ "rand 0.9.5",
+ "sha1 0.10.7",
+ "thiserror 2.0.20",
+]
+
+[[package]]
 name = "two-face"
 version = "0.5.2+bat-0.26.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7944,6 +8033,12 @@ name = "urlencoding"
 version = "2.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "daf8dba3b7eb870caf1ddeed7bc9d2a049f3cfdfae7cb521b087cc33ae4c49da"
+
+[[package]]
+name = "utf-8"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09cc8ee72d2a9becf2f2febe0205bbed8fc6615b7cb429ad062dc7b7ddd036a9"
 
 [[package]]
 name = "utf8_iter"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -52,6 +52,7 @@ agent-client-protocol = { version = "2.0.0", features = ["unstable_elicitation"]
 rmcp = { version = "^3.1.1", default-features = false }
 async-openai = { version = "^0.41.0", features = ["byot", "chat-completion", "responses"] }
 reqwest = { version = "^0.13.4", default-features = false, features = ["json", "query", "rustls", "http2", "stream"] }
+reqwest-websocket = { version = "0.6", default-features = false }
 oauth2 = "5.0"
 keyring-core = "1.0.0"
 apple-native-keyring-store = { version = "1.0.0", features = ["keychain"] }

--- a/crates/aether-core/src/core/agent.rs
+++ b/crates/aether-core/src/core/agent.rs
@@ -28,6 +28,7 @@ use tokio::time::sleep;
 use tokio_stream::StreamExt;
 use tokio_stream::StreamMap;
 use tokio_stream::wrappers::ReceiverStream;
+use uuid::Uuid;
 
 /// Internal event type for merging LLM and tool result streams
 #[derive(Debug)]
@@ -326,6 +327,7 @@ impl Agent {
         *state = IterationState::default();
         self.auto_continue.reset();
         self.turn_active = true;
+        self.context.set_turn_id(Some(Uuid::new_v4().to_string()));
         let content = input.content_blocks();
         self.emit(AgentEvent::Turn(TurnEvent::Started { content })).await;
         self.queued_inputs.push_back(input);
@@ -748,6 +750,7 @@ impl Agent {
     }
 
     async fn finish_turn(&mut self, outcome: TurnOutcome) {
+        self.context.set_turn_id(None);
         if std::mem::take(&mut self.turn_active) {
             self.emit(AgentEvent::turn_ended(outcome)).await;
         }

--- a/crates/aether-core/tests/agent.rs
+++ b/crates/aether-core/tests/agent.rs
@@ -12,5 +12,6 @@ mod agent {
     mod replace_conversation_tests;
     mod retry_tests;
     mod trace_tests;
+    mod turn_identity_tests;
     mod usage_tests;
 }

--- a/crates/aether-core/tests/agent/turn_identity_tests.rs
+++ b/crates/aether-core/tests/agent/turn_identity_tests.rs
@@ -1,0 +1,103 @@
+use std::time::Duration;
+
+use aether_core::context::CompactionConfig;
+use aether_core::core::RetryConfig;
+use aether_core::testing::{FakeMcpServer, FakeTool, TestScenario, test_agent};
+use llm::ProviderError;
+use llm::testing::llm_response;
+
+#[tokio::test]
+async fn tool_iterations_share_identity_but_next_user_turn_does_not() {
+    let result = test_agent()
+        .fake_mcp_server("tools", FakeMcpServer::new().with_tool(FakeTool::new("read")))
+        .llm_responses(&[
+            llm_response("first").tool_call("call-1", "tools__read", &["{}"]).build(),
+            llm_response("second").text(&["done"]).build(),
+            llm_response("third").text(&["next"]).build(),
+        ])
+        .scenario(TestScenario::new().user_text("first").wait_for_turn_end().user_text("second").wait_for_turn_end())
+        .run_with_context()
+        .await
+        .unwrap();
+    let contexts = result.captured_contexts.lock().unwrap();
+    assert_eq!(contexts.len(), 3);
+    assert!(contexts[0].turn_id().is_some());
+    assert_eq!(contexts[0].turn_id(), contexts[1].turn_id());
+    assert_ne!(contexts[1].turn_id(), contexts[2].turn_id());
+}
+
+#[tokio::test]
+async fn cancellation_and_replacement_start_fresh_turn_identities() {
+    for replace in [false, true] {
+        let blocked = std::sync::Arc::new(tokio::sync::Notify::new());
+        let mut scenario = TestScenario::new().user_text("first").wait_for(|event| {
+            matches!(
+                event,
+                aether_core::events::AgentEvent::Message(aether_core::events::MessageEvent::Text {
+                    is_complete: false,
+                    ..
+                })
+            )
+        });
+        scenario = if replace {
+            scenario.replace_conversation(vec![llm::ChatMessage::user("replacement")])
+        } else {
+            scenario.cancel()
+        };
+        let result = test_agent()
+            .without_mcp()
+            .llm_responses(&[
+                llm_response("one").text(&["partial", "blocked"]).build(),
+                llm_response("two").text(&["done"]).build(),
+            ])
+            .pause_turn_after(0, 2, blocked)
+            .scenario(scenario.wait_for_turn_end().user_text("next").wait_for_turn_end())
+            .run_with_context()
+            .await
+            .unwrap();
+        let contexts = result.captured_contexts.lock().unwrap();
+        assert_eq!(contexts.len(), 2);
+        assert!(contexts[0].turn_id().is_some());
+        assert_ne!(contexts[0].turn_id(), contexts[1].turn_id());
+    }
+}
+
+#[tokio::test]
+async fn compaction_preserves_active_turn_identity() {
+    let result = test_agent()
+        .without_mcp()
+        .llm_responses(&[
+            llm_response("summary").text(&["summary"]).build(),
+            llm_response("answer").text(&["hello"]).build(),
+        ])
+        .context_window_override(100)
+        .compaction_config(CompactionConfig::with_threshold(0.85))
+        .messages(vec![llm::ChatMessage::user("x".repeat(400))])
+        .user_text("go")
+        .run_with_context()
+        .await
+        .unwrap();
+    let contexts = result.captured_contexts.lock().unwrap();
+    assert_eq!(contexts.len(), 2);
+    assert!(contexts[0].turn_id().is_some());
+    assert_eq!(contexts[0].turn_id(), contexts[1].turn_id());
+}
+
+#[tokio::test(start_paused = true)]
+async fn retry_keeps_turn_identity() {
+    let result = test_agent()
+        .without_mcp()
+        .retry_config(RetryConfig { max_attempts: 1, base_delay: Duration::ZERO, max_delay: Duration::ZERO })
+        .llm_result_responses(&[
+            vec![Err(ProviderError::server("retry").into())],
+            llm_response("retry").text(&["done"]).build().into_iter().map(Ok).collect(),
+        ])
+        .user_text("go")
+        .run_with_context()
+        .await
+        .unwrap();
+    let contexts = result.captured_contexts.lock().unwrap();
+    assert_eq!(contexts.len(), 2);
+    assert!(contexts[0].turn_id().is_some());
+    assert_eq!(contexts[0].turn_id(), contexts[1].turn_id());
+}

--- a/crates/llm/Cargo.toml
+++ b/crates/llm/Cargo.toml
@@ -2,6 +2,7 @@
 name = "aether-llm"
 version = "0.8.1"
 edition = "2024"
+rust-version = "1.98"
 description = "Multi-provider LLM abstraction layer for the Aether AI agent framework"
 license = "MIT"
 repository = "https://github.com/contextbridge/aether"
@@ -35,7 +36,7 @@ bedrock = [
     "dep:base64",
     "dep:time",
 ]
-codex = ["dep:aether-auth", "dep:oauth2", "dep:base64", "dep:url"]
+codex = ["dep:aether-auth", "dep:oauth2", "dep:base64", "dep:url", "dep:reqwest-websocket"]
 
 [dependencies]
 async-openai = { workspace = true }
@@ -50,6 +51,7 @@ base64 = { workspace = true, optional = true }
 chrono = { workspace = true }
 eventsource-stream = { workspace = true }
 reqwest = { workspace = true }
+reqwest-websocket = { workspace = true, optional = true }
 futures = { workspace = true }
 thiserror = { workspace = true }
 time = { workspace = true, optional = true }
@@ -78,7 +80,8 @@ llm-codegen = { package = "aether-llm-codegen", path = "../llm-codegen", version
 
 [dev-dependencies]
 aether-doctest = { path = "../doctest" }
-axum = { workspace = true }
+axum = { workspace = true, features = ["ws"] }
+tokio = { workspace = true, features = ["test-util"] }
 tempfile = { workspace = true }
 tracing-subscriber = { workspace = true }
 
@@ -89,3 +92,7 @@ required-features = ["bedrock"]
 [[example]]
 name = "bedrock_mantle"
 required-features = ["bedrock"]
+
+[[example]]
+name = "codex_websocket"
+required-features = ["codex", "aether-auth/keyring"]

--- a/crates/llm/README.md
+++ b/crates/llm/README.md
@@ -163,6 +163,24 @@ context.set_model_settings(ModelSettings {
 # }
 ```
 
+### Codex WebSocket lifecycle
+
+With the `codex` feature, each `CodexProvider::new(oauth_store, connection, model)?`
+owns one conversation over a persistent Responses `WebSocket`. Reuse that
+provider for sequential requests; create separate providers for concurrent
+conversations. Clones share the same session. Overlapping calls are serialized
+through a bounded request channel; consume or drop the active stream before
+awaiting the next one.
+
+The first request's nonempty `Context::set_session_affinity_key` binds the
+conversation's routing ID; without one, the provider generates a stable ID.
+A later request cannot bind the provider to a different conversation. Set a
+fresh `Context::set_turn_id` per user turn; Aether's core agent does both
+automatically. Dropping an active stream before its terminal result discards
+the socket; dropping a queued stream cancels only that request. Once `Done`
+is yielded the session is ready for the next request.
+Idle sockets expire even while the provider remains alive.
+
 ## Providers
 
 | Provider | Example model string | Env var |

--- a/crates/llm/examples/codex_websocket.rs
+++ b/crates/llm/examples/codex_websocket.rs
@@ -1,0 +1,78 @@
+//! Live Codex WebSocket smoke test using Aether's existing OS-keychain credentials.
+//!
+//! ```bash
+//! cargo run -p aether-llm --features codex,aether-auth/keyring --example codex_websocket
+//! ```
+//!
+//! Optionally pass a model ID as the first argument (default: `gpt-5.6-luna`).
+//! Requires an existing Codex login; expired credentials may be refreshed and saved.
+//! Inference uses WebSocket only: the provider has no HTTP/SSE fallback.
+use std::process::ExitCode;
+use std::sync::Arc;
+
+use aether_auth::OsKeyringStore;
+use futures::StreamExt;
+use llm::providers::codex::CodexProvider;
+use llm::{
+    ChatMessage, Context, LlmResponse, ProviderConnectionConfig, ReasoningEffort, StopReason, StreamingModelProvider,
+};
+
+#[tokio::main]
+async fn main() -> ExitCode {
+    tracing_subscriber::fmt()
+        .with_writer(std::io::stderr)
+        .with_ansi(false)
+        .with_env_filter("llm::providers::codex=debug")
+        .init();
+
+    match run().await {
+        Ok(()) => ExitCode::SUCCESS,
+        Err(error) => {
+            eprintln!("FAIL: {error}");
+            ExitCode::FAILURE
+        }
+    }
+}
+
+async fn run() -> llm::Result<()> {
+    let model = std::env::args().nth(1).unwrap_or_else(|| "gpt-5.6-luna".into());
+    let store = Arc::new(OsKeyringStore::with_platform_store());
+    let provider = CodexProvider::new(store, ProviderConnectionConfig::default(), &model)?;
+    let mut context = Context::new(
+        vec![
+            ChatMessage::system("Follow the user's instructions exactly."),
+            ChatMessage::user("Reply with exactly: Hello, world!"),
+        ],
+        vec![],
+    );
+    context.set_reasoning_effort(Some(ReasoningEffort::Low));
+    context.set_session_affinity_key(Some(uuid::Uuid::new_v4().to_string()));
+    context.set_turn_id(Some(uuid::Uuid::new_v4().to_string()));
+
+    println!("Testing {} via WebSocket with OS-keychain authentication", provider.display_name());
+    let mut stream = provider.stream_response(&context);
+    let mut text = String::new();
+    let mut completed = false;
+    while let Some(event) = stream.next().await {
+        match event? {
+            LlmResponse::Text { chunk } => text.push_str(&chunk),
+            LlmResponse::Usage { tokens } => {
+                println!("Usage: input={} output={}", tokens.input_tokens, tokens.output_tokens);
+            }
+            LlmResponse::Done { stop_reason } => {
+                println!("Done: {stop_reason:?}");
+                completed = stop_reason == Some(StopReason::EndTurn);
+            }
+            LlmResponse::Error { message } => return Err(llm::LlmError::ProviderRequest(message)),
+            _ => {}
+        }
+    }
+    println!("Response: {text:?}");
+    if !completed || text.trim() != "Hello, world!" {
+        return Err(llm::LlmError::ProviderRequest(
+            "Expected a completed EndTurn response containing exactly 'Hello, world!'".into(),
+        ));
+    }
+    println!("PASS: received the expected completed response over Codex WebSocket (no SSE fallback)");
+    Ok(())
+}

--- a/crates/llm/src/context.rs
+++ b/crates/llm/src/context.rs
@@ -21,6 +21,8 @@ pub struct Context {
     prompt_cache_key: Option<String>,
     #[serde(skip)]
     session_affinity_key: Option<String>,
+    #[serde(skip)]
+    turn_id: Option<String>,
 }
 
 impl Context {
@@ -32,6 +34,7 @@ impl Context {
             model_settings: ModelSettings::default(),
             prompt_cache_key: None,
             session_affinity_key: None,
+            turn_id: None,
         }
     }
 
@@ -49,6 +52,15 @@ impl Context {
 
     pub fn set_session_affinity_key(&mut self, key: Option<String>) {
         self.session_affinity_key = key;
+    }
+
+    /// Runtime identity shared by inference requests within one user turn.
+    pub fn turn_id(&self) -> Option<&str> {
+        self.turn_id.as_deref()
+    }
+
+    pub fn set_turn_id(&mut self, id: Option<String>) {
+        self.turn_id = id;
     }
 
     pub fn reasoning_effort(&self) -> Option<ReasoningEffort> {
@@ -225,6 +237,23 @@ mod tests {
 
     use crate::ToolCallResult;
     use crate::catalog::LlmModel;
+
+    #[test]
+    fn turn_identity_is_runtime_only_and_survives_transformations() {
+        let mut context = Context::new(vec![ChatMessage::user("Hello")], vec![]);
+        assert_eq!(context.turn_id(), None);
+        context.set_turn_id(Some("turn-1".into()));
+        assert_eq!(context.clone().turn_id(), Some("turn-1"));
+        assert_eq!(context.filter_encrypted_reasoning(None).turn_id(), Some("turn-1"));
+        assert_eq!(context.with_compacted_summary("summary").turn_id(), Some("turn-1"));
+        context.replace_conversation(vec![ChatMessage::user("replacement")]);
+        assert_eq!(context.turn_id(), Some("turn-1"));
+        let json = serde_json::to_value(&context).unwrap();
+        assert!(json.get("turn_id").is_none());
+        assert_eq!(serde_json::from_value::<Context>(json).unwrap().turn_id(), None);
+        context.set_turn_id(None);
+        assert_eq!(context.turn_id(), None);
+    }
 
     fn create_test_context() -> Context {
         let messages = vec![

--- a/crates/llm/src/docs/llm_error.md
+++ b/crates/llm/src/docs/llm_error.md
@@ -24,7 +24,7 @@ Errors that can occur when interacting with LLM providers.
 - **`InvalidModelSpec`** -- A `provider:model` identity could not be parsed.
 - **`MissingProviderUrl`** -- Provider endpoint URL has not been configured.
 - **`ProviderRequest`** -- A provider request, header, or signature could not be constructed (e.g. an SDK builder rejected the input or contained malformed data).
-- **`InvalidArgument`** -- An upstream client library rejected an argument as invalid.
+- **`InvalidArgument`** -- A caller or upstream client library supplied an invalid argument, such as reusing a Codex provider for a different conversation.
 
 
 # Type alias

--- a/crates/llm/src/error.rs
+++ b/crates/llm/src/error.rs
@@ -51,7 +51,7 @@ pub enum LlmError {
     /// rejected the input or contained malformed data).
     #[error("Failed to build provider request: {0}")]
     ProviderRequest(String),
-    /// An upstream client library rejected an argument as invalid.
+    /// A caller or upstream client library supplied an invalid argument.
     #[error("Invalid argument: {0}")]
     InvalidArgument(String),
 }
@@ -69,6 +69,28 @@ pub enum ProviderErrorKind {
 }
 
 impl ProviderErrorKind {
+    pub fn from_http_status(status: u16) -> Self {
+        match status {
+            401 | 403 => Self::Authentication,
+            408 | 504 => Self::Timeout,
+            429 => Self::RateLimit,
+            500..600 => Self::Server,
+            _ => Self::Api,
+        }
+    }
+
+    /// The kind implied by an `OpenAI`-style error code, when the code is recognized.
+    pub(crate) fn from_code(code: &str) -> Option<Self> {
+        match code {
+            "invalid_api_key" | "invalid_authentication" | "authentication_error" | "token_expired" => {
+                Some(Self::Authentication)
+            }
+            "rate_limit_exceeded" => Some(Self::RateLimit),
+            "server_error" => Some(Self::Server),
+            _ => None,
+        }
+    }
+
     pub fn is_retryable(&self) -> bool {
         matches!(
             self,
@@ -120,14 +142,7 @@ impl ProviderError {
     }
 
     pub fn from_http_status(status: u16, message: impl Into<String>) -> Self {
-        match status {
-            401 | 403 => Self::authentication(message),
-            408 | 504 => Self::timeout(message),
-            429 => Self::rate_limit(message),
-            s if (500..600).contains(&s) => Self::server(message),
-            _ => Self::api(message),
-        }
-        .with_http_status(status)
+        Self::new(ProviderErrorKind::from_http_status(status), message).with_http_status(status)
     }
 
     pub fn with_http_status(mut self, status: u16) -> Self {

--- a/crates/llm/src/parser.rs
+++ b/crates/llm/src/parser.rs
@@ -89,9 +89,7 @@ impl ModelProviderParser {
             Box::new(move |model: &str, connection: ProviderConnectionConfig| {
                 let store = Arc::clone(&store);
                 let model = model.to_string();
-                Box::pin(async move {
-                    Ok(Box::new(CodexProvider::new(store).with_connection(connection).with_model(&model)) as _)
-                })
+                Box::pin(async move { Ok(Box::new(CodexProvider::new(store, connection, &model)?) as _) })
             }),
         );
         self

--- a/crates/llm/src/providers/codex/continuation.rs
+++ b/crates/llm/src/providers/codex/continuation.rs
@@ -1,0 +1,136 @@
+use std::collections::HashSet;
+
+use async_openai::types::responses::{CreateResponse, InputItem, InputParam, Item, OutputItem, OutputMessageContent};
+
+use crate::providers::openai_responses::mappers::map_messages;
+use crate::providers::openai_responses::streaming::ResponsesCompleted;
+use crate::types::IsoString;
+use crate::{
+    AssistantReasoning, ChatMessage, EncryptedReasoningContent, LlmModel, LlmResponse, ReasoningEffort, ToolCallRequest,
+};
+
+pub(super) struct ContinuationCheckpoint {
+    response_id: String,
+    properties: CreateResponse,
+    effort: Option<ReasoningEffort>,
+    expected_prefix: Vec<InputItem>,
+}
+
+#[derive(Default, PartialEq)]
+pub(super) struct DeliveredResponse {
+    text: String,
+    encrypted: Vec<(String, String)>,
+    tools: Vec<ToolCallRequest>,
+}
+
+impl ContinuationCheckpoint {
+    pub fn prepare(&self, mut request: CreateResponse, effort: Option<ReasoningEffort>) -> CreateResponse {
+        let mut input = std::mem::replace(&mut request.input, InputParam::Items(Vec::new()));
+        if request == self.properties
+            && effort == self.effort
+            && let InputParam::Items(items) = &mut input
+            && items.starts_with(&self.expected_prefix)
+            && items.len() > self.expected_prefix.len()
+        {
+            items.drain(..self.expected_prefix.len());
+            request.previous_response_id = Some(self.response_id.clone());
+        }
+        request.input = input;
+        request
+    }
+
+    pub fn capture(
+        mut full: CreateResponse,
+        effort: Option<ReasoningEffort>,
+        completed: ResponsesCompleted,
+        delivered: &DeliveredResponse,
+        model: Option<LlmModel>,
+    ) -> Option<Self> {
+        let response_id = completed.id.filter(|id| !id.is_empty())?;
+        let projected = project_completed_response(&completed.output?, delivered, model)?;
+        let InputParam::Items(mut expected_prefix) = std::mem::replace(&mut full.input, InputParam::Items(Vec::new()))
+        else {
+            return None;
+        };
+        expected_prefix.extend(projected);
+        Some(Self { response_id, properties: full, effort, expected_prefix })
+    }
+}
+
+impl DeliveredResponse {
+    pub fn observe(&mut self, response: &LlmResponse) {
+        match response {
+            LlmResponse::Text { chunk } => self.text.push_str(chunk),
+            LlmResponse::EncryptedReasoning { id, content } => self.encrypted.push((id.clone(), content.clone())),
+            LlmResponse::ToolRequestComplete { tool_call } => self.tools.push(tool_call.clone()),
+            _ => {}
+        }
+    }
+}
+
+fn project_completed_response(
+    output: &[OutputItem],
+    delivered: &DeliveredResponse,
+    model: Option<LlmModel>,
+) -> Option<Vec<InputItem>> {
+    let mut projected = DeliveredResponse::default();
+    let mut call_ids = HashSet::new();
+    let mut has_message = false;
+    for item in output {
+        match item {
+            OutputItem::Message(message) => {
+                if std::mem::replace(&mut has_message, true) {
+                    return None;
+                }
+                for part in &message.content {
+                    let OutputMessageContent::OutputText(text) = part else {
+                        return None;
+                    };
+                    projected.text.push_str(&text.text);
+                }
+            }
+            OutputItem::Reasoning(reasoning) => {
+                if !projected.encrypted.is_empty() {
+                    return None;
+                }
+                projected.encrypted.push((reasoning.id.clone()?, reasoning.encrypted_content.clone()?));
+            }
+            OutputItem::FunctionCall(call) => {
+                if call.call_id.is_empty() || !call_ids.insert(call.call_id.clone()) {
+                    return None;
+                }
+                projected.tools.push(ToolCallRequest {
+                    id: call.call_id.clone(),
+                    name: call.name.clone(),
+                    arguments: call.arguments.clone(),
+                });
+            }
+            _ => return None,
+        }
+    }
+    if &projected != delivered {
+        return None;
+    }
+    let encrypted_content = if let Some((id, content)) = projected.encrypted.pop() {
+        Some(EncryptedReasoningContent { id, content, model: model? })
+    } else {
+        None
+    };
+    let assistant = ChatMessage::Assistant {
+        content: projected.text,
+        reasoning: AssistantReasoning { summary_text: None, encrypted_content },
+        tool_calls: projected.tools,
+        timestamp: IsoString::now(),
+    };
+    let (_, items) = map_messages(&[assistant]).ok()?;
+    let same_order = items.len() == output.len()
+        && items.iter().zip(output).all(|(input, output)| {
+            matches!(
+                (input, output),
+                (InputItem::EasyMessage(_), OutputItem::Message(_))
+                    | (InputItem::Item(Item::Reasoning(_)), OutputItem::Reasoning(_))
+                    | (InputItem::Item(Item::FunctionCall(_)), OutputItem::FunctionCall(_))
+            )
+        });
+    same_order.then_some(items)
+}

--- a/crates/llm/src/providers/codex/mod.rs
+++ b/crates/llm/src/providers/codex/mod.rs
@@ -1,9 +1,17 @@
 #![doc = include_str!(concat!(env!("OUT_DIR"), "/docs/codex.md"))]
 
+mod continuation;
 pub mod oauth;
 pub mod provider;
+mod session;
+mod websocket;
 
 pub const PROVIDER_ID: &str = "codex";
 
 pub use oauth::perform_codex_oauth_flow;
 pub use provider::CodexProvider;
+
+#[cfg(test)]
+mod test_server;
+#[cfg(test)]
+mod tests;

--- a/crates/llm/src/providers/codex/provider.rs
+++ b/crates/llm/src/providers/codex/provider.rs
@@ -1,99 +1,52 @@
-use super::oauth::CodexTokenManager;
-use crate::provider::{LlmResponseStream, StreamingModelProvider, get_context_window, stream_from};
-use crate::providers::openai_responses::mappers::{ResponsesRequestPolicy, build_wire_request};
-use crate::providers::openai_responses::transport::{ResponsesConnection, process_connection, send};
-use crate::{Context, LlmError, Result};
-use aether_auth::OAuthCredentialStorage;
-use reqwest::header::{AUTHORIZATION, HeaderMap, HeaderValue};
 use std::sync::Arc;
-use tracing::debug;
 
-const CODEX_API_BASE: &str = "https://chatgpt.com/backend-api/codex";
-const CODEX_CLIENT_VERSION: &str = "0.153.4";
+use aether_auth::OAuthCredentialStorage;
+use reqwest::header::{AUTHORIZATION, HeaderMap, HeaderName, HeaderValue};
+use reqwest::redirect::Policy;
+use uuid::Uuid;
 
+use super::oauth::CodexTokenManager;
+use super::session::{Credentials, InferenceRequest, SessionClient, SessionHandle};
+use super::websocket::responses_url;
+use crate::provider::{LlmResponseStream, StreamingModelProvider, get_context_window};
+use crate::providers::openai_responses::mappers::{ResponsesRequestPolicy, build_typed_request};
+use crate::{Context, LlmError, LlmModel, ProviderConnectionConfig, Result};
+
+/// One conversation with at most one active inference request.
+///
+/// Clones share the same session and overlapping calls are serialized. Consume
+/// or drop the active stream before awaiting the next one. Construct a new
+/// provider for an independent conversation.
 #[derive(Clone)]
 pub struct CodexProvider {
-    base_url: String,
-    client: reqwest::Client,
     model: String,
-    token_manager: Arc<CodexTokenManager>,
+    session: Arc<SessionHandle>,
 }
 
 impl CodexProvider {
-    pub fn new(store: Arc<dyn OAuthCredentialStorage>) -> Self {
-        let token_manager = CodexTokenManager::new(store, super::PROVIDER_ID);
-        Self {
-            base_url: CODEX_API_BASE.to_string(),
-            client: reqwest::Client::new(),
-            model: "gpt-5.5".to_string(),
-            token_manager: Arc::new(token_manager),
-        }
-    }
-
-    pub fn with_connection(mut self, connection: crate::ProviderConnectionConfig) -> Self {
-        if let Some(base_url) = connection.base_url {
-            self.base_url = base_url.trim_end_matches('/').to_string();
-        }
-        self
-    }
-
-    pub fn with_model(mut self, model: &str) -> Self {
-        self.model = model.to_string();
-        self
-    }
-
-    fn build_wire_request(&self, context: &Context) -> Result<serde_json::Value> {
-        build_wire_request(&self.model, context, &ResponsesRequestPolicy::codex())
-    }
-
-    async fn build_headers(&self) -> Result<HeaderMap> {
-        let (access_token, account_id) = self.token_manager.get_valid_token().await?;
-
-        let mut headers = HeaderMap::new();
-        headers.insert(
-            AUTHORIZATION,
-            HeaderValue::from_str(&format!("Bearer {access_token}"))
-                .map_err(|e| LlmError::ProviderRequest(e.to_string()))?,
-        );
-        headers.insert(
-            "chatgpt-account-id",
-            HeaderValue::from_str(&account_id).map_err(|e| LlmError::ProviderRequest(e.to_string()))?,
-        );
-        headers.insert("originator", HeaderValue::from_static("codex_cli_rs"));
-        headers.insert("version", HeaderValue::from_static(CODEX_CLIENT_VERSION));
-
-        Ok(headers)
-    }
-
-    /// Send the request and return a stream of SSE lines parsed into typed events.
-    ///
-    /// Uses manual SSE parsing because the Codex API does not return a
-    /// `Content-Type: text/event-stream` header, which `reqwest_eventsource`
-    /// (used by `async-openai`'s `create_stream`) requires.
-    async fn send_request(&self, request: serde_json::Value, headers: HeaderMap) -> Result<ResponsesConnection> {
-        let url = format!("{}/responses", self.base_url);
-
-        debug!("Sending request to Codex API: {url}");
-        debug!(
-            "Codex request body: {}",
-            serde_json::to_string(&request).unwrap_or_else(|_| "<failed to serialize>".to_string())
-        );
-
-        match send(&self.client, &url, headers, request).await {
-            Ok(connection) => Ok(connection),
-            Err(error) => {
-                if error.provider().map(|provider| provider.kind) == Some(crate::ProviderErrorKind::Authentication) {
-                    self.token_manager.clear_cache().await;
-                }
-                Err(error)
-            }
-        }
+    pub fn new(
+        store: Arc<dyn OAuthCredentialStorage>,
+        connection: ProviderConnectionConfig,
+        model: &str,
+    ) -> Result<Self> {
+        let client = reqwest::Client::builder()
+            .http1_only()
+            .redirect(Policy::none())
+            .build()
+            .map_err(|error| LlmError::HttpClientCreation(error.to_string()))?;
+        let endpoint = SessionClient {
+            client,
+            url: responses_url(&connection.base_url.unwrap_or_else(|| CODEX_API_BASE.to_string()))?,
+            model: format!("{}:{model}", super::PROVIDER_ID).parse().ok(),
+            token_manager: Arc::new(CodexTokenManager::new(store, super::PROVIDER_ID)),
+        };
+        Ok(Self { model: model.to_string(), session: Arc::new(SessionHandle::new(endpoint)) })
     }
 }
 
 impl StreamingModelProvider for CodexProvider {
-    fn model(&self) -> Option<crate::LlmModel> {
-        format!("{}:{}", super::PROVIDER_ID, self.model).parse().ok()
+    fn model(&self) -> Option<LlmModel> {
+        self.session.endpoint().model.clone()
     }
 
     fn context_window(&self) -> Option<u32> {
@@ -101,17 +54,22 @@ impl StreamingModelProvider for CodexProvider {
     }
 
     fn stream_response(&self, context: &Context) -> LlmResponseStream {
-        let provider = self.clone();
+        let session = Arc::clone(&self.session);
+        let model = self.model.clone();
         let context = context.clone();
-
-        stream_from(
-            async move {
-                let headers = provider.build_headers().await?;
-                let request = provider.build_wire_request(&context)?;
-                provider.send_request(request, headers).await
-            },
-            process_connection,
-        )
+        self.session.stream(async move {
+            let session_id = session.id(context.session_affinity_key())?;
+            let (access_token, account_id) = session.endpoint().token_manager.get_valid_token().await?;
+            let policy = ResponsesRequestPolicy::codex();
+            let request = build_typed_request(&model, &context, &policy)?;
+            Ok(InferenceRequest {
+                headers: build_headers(&access_token, &account_id, session_id)?,
+                full: request,
+                effort: policy.effort(&context),
+                identity: Credentials { access_token, account_id },
+                turn_id: context.turn_id().map_or_else(new_id, str::to_owned),
+            })
+        })
     }
 
     fn display_name(&self) -> String {
@@ -119,102 +77,30 @@ impl StreamingModelProvider for CodexProvider {
     }
 }
 
-#[cfg(test)]
-mod tests {
-    use super::*;
-    use crate::ChatMessage;
-    use crate::ToolDefinition;
-    use crate::providers::test_capture_server::CaptureServer;
-    use aether_auth::{FakeOAuthCredentialStore, OAuthCredential};
-    use base64::Engine;
-    use base64::engine::general_purpose::URL_SAFE_NO_PAD;
-    use futures::StreamExt;
+const CODEX_API_BASE: &str = "https://chatgpt.com/backend-api/codex";
+const CODEX_CLIENT_VERSION: &str = "0.153.4";
 
-    #[test]
-    fn context_window_uses_codex_subscription_limit() {
-        let provider = create_test_provider();
-        assert_eq!(provider.context_window(), Some(272_000));
-    }
+fn new_id() -> String {
+    Uuid::new_v4().to_string()
+}
 
-    #[test]
-    fn display_name_includes_model() {
-        let provider = create_test_provider();
-        assert_eq!(provider.display_name(), "Codex (gpt-5.5)");
-    }
-
-    #[tokio::test]
-    async fn stream_response_sends_supported_protocol_version_for_gpt_5_6_luna() {
-        let mut server = CaptureServer::start_responses().await;
-        let provider = server_backed_provider(&server).with_model("gpt-5.6-luna");
-        let mut context = Context::new(
-            vec![ChatMessage::system("You are helpful"), ChatMessage::user("Think harder")],
-            vec![ToolDefinition::new(
-                "bash",
-                "Run a command",
-                serde_json::from_str(r#"{"type": "object", "properties": {"cmd": {"type": "string"}}}"#).unwrap(),
-            )],
+fn build_headers(access_token: &str, account_id: &str, session_id: &str) -> Result<HeaderMap> {
+    let mut headers = HeaderMap::new();
+    for (name, value) in [
+        (AUTHORIZATION.as_str(), format!("Bearer {access_token}")),
+        ("chatgpt-account-id", account_id.into()),
+        ("session-id", session_id.into()),
+        ("thread-id", session_id.into()),
+        ("x-client-request-id", new_id()),
+    ] {
+        headers.insert(
+            HeaderName::from_static(name),
+            HeaderValue::from_str(&value)
+                .map_err(|_| LlmError::ProviderRequest("Invalid Codex header value".into()))?,
         );
-        context.set_reasoning_effort(Some(crate::ReasoningEffort::Max));
-        context.set_prompt_cache_key(Some("session-abc".to_string()));
-
-        let responses = provider.stream_response(&context).collect::<Vec<_>>().await;
-        let captured = server.captured().await;
-
-        assert!(responses.iter().all(Result::is_ok), "{responses:?}");
-        assert_eq!(captured.body["reasoning"]["effort"], "max");
-        assert!(captured.body["reasoning"].get("context").is_none());
-        assert_eq!(captured.body["model"], "gpt-5.6-luna");
-        assert_eq!(captured.body["instructions"], "You are helpful");
-        assert_eq!(captured.body["tools"].as_array().unwrap().len(), 1);
-        assert!(captured.body.get("parallel_tool_calls").is_none());
-        assert_eq!(captured.body["input"][0]["role"], "user");
-        assert_eq!(captured.body["prompt_cache_key"], "session-abc");
-        assert_eq!(captured.body["store"], false);
-        assert_eq!(captured.body["stream"], true);
-        assert_eq!(captured.headers["chatgpt-account-id"], "account-1");
-        assert_eq!(captured.headers["version"], "0.153.4");
-        assert_eq!(captured.headers["accept"], "text/event-stream");
-        assert!(captured.headers.get("x-openai-internal-codex-responses-lite").is_none());
-        assert!(captured.headers.get("OpenAI-Beta").is_none());
     }
-
-    #[tokio::test]
-    async fn stream_response_defaults_to_medium_effort_on_the_wire() {
-        let mut server = CaptureServer::start_responses().await;
-        let provider = server_backed_provider(&server);
-        let context = Context::new(vec![ChatMessage::user("Hello")], vec![]);
-
-        let responses = provider.stream_response(&context).collect::<Vec<_>>().await;
-        let captured = server.captured().await;
-
-        assert!(responses.iter().all(Result::is_ok), "{responses:?}");
-        assert_eq!(captured.body["reasoning"]["effort"], "medium");
-    }
-
-    fn server_backed_provider(server: &CaptureServer) -> CodexProvider {
-        let credential = OAuthCredential {
-            client_id: "test".to_string(),
-            access_token: test_jwt("account-1"),
-            refresh_token: None,
-            expires_at: Some(u64::MAX),
-        };
-        let store: Arc<dyn OAuthCredentialStorage> =
-            Arc::new(FakeOAuthCredentialStore::new().with_credential("codex", credential));
-        CodexProvider::new(store).with_connection(crate::ProviderConnectionConfig {
-            base_url: Some(server.base_url.clone()),
-            ..Default::default()
-        })
-    }
-
-    fn test_jwt(account_id: &str) -> String {
-        let header = URL_SAFE_NO_PAD.encode(r#"{"alg":"none"}"#);
-        let payload = URL_SAFE_NO_PAD
-            .encode(serde_json::json!({"https://api.openai.com/auth": {"chatgpt_account_id": account_id}}).to_string());
-        format!("{header}.{payload}.signature")
-    }
-
-    fn create_test_provider() -> CodexProvider {
-        let store: Arc<dyn OAuthCredentialStorage> = Arc::new(FakeOAuthCredentialStore::new());
-        CodexProvider::new(store).with_model("gpt-5.5")
-    }
+    headers.insert("originator", HeaderValue::from_static("codex_cli_rs"));
+    headers.insert("version", HeaderValue::from_static(CODEX_CLIENT_VERSION));
+    headers.insert("openai-beta", HeaderValue::from_static("responses_websockets=2026-02-06"));
+    Ok(headers)
 }

--- a/crates/llm/src/providers/codex/session.rs
+++ b/crates/llm/src/providers/codex/session.rs
@@ -1,0 +1,334 @@
+use std::future::Future;
+use std::sync::{Arc, OnceLock};
+
+use async_openai::types::responses::{CreateResponse, InputParam, Status};
+use futures::{Stream, StreamExt, future::BoxFuture};
+use reqwest::{Client, Url, header::HeaderMap};
+use tokio::sync::{mpsc, oneshot};
+use tokio::time::Instant;
+use uuid::Uuid;
+
+use super::continuation::{ContinuationCheckpoint, DeliveredResponse};
+use super::oauth::CodexTokenManager;
+use super::websocket::Connection;
+use crate::provider::LlmResponseStream;
+use crate::providers::openai_responses::streaming::{
+    ResponsesCompleted, ResponsesStreamEvent, process_response_stream,
+};
+use crate::{LlmError, LlmModel, LlmResponse, ProviderError, ProviderErrorKind, ReasoningEffort, Result};
+
+pub(super) struct SessionHandle {
+    client: Arc<SessionClient>,
+    request_tx: OnceLock<mpsc::Sender<Request>>,
+    id: OnceLock<String>,
+}
+
+pub(super) struct SessionClient {
+    pub client: Client,
+    pub url: Url,
+    pub model: Option<LlmModel>,
+    pub token_manager: Arc<CodexTokenManager>,
+}
+
+pub(super) struct InferenceRequest {
+    pub headers: HeaderMap,
+    pub full: CreateResponse,
+    pub effort: Option<ReasoningEffort>,
+    pub identity: Credentials,
+    pub turn_id: String,
+}
+
+#[derive(Clone, PartialEq, Eq)]
+pub(super) struct Credentials {
+    pub access_token: String,
+    pub account_id: String,
+}
+
+impl SessionHandle {
+    pub fn new(client: SessionClient) -> Self {
+        Self { client: Arc::new(client), request_tx: OnceLock::new(), id: OnceLock::new() }
+    }
+
+    pub fn endpoint(&self) -> &SessionClient {
+        &self.client
+    }
+
+    pub fn id(&self, affinity: Option<&str>) -> Result<&str> {
+        let affinity = affinity.filter(|key| !key.is_empty());
+        let id = self.id.get_or_init(|| affinity.map_or_else(|| Uuid::new_v4().to_string(), str::to_owned));
+        if affinity.is_some_and(|key| key != id) {
+            return Err(LlmError::InvalidArgument(
+                "CodexProvider already belongs to another conversation; construct a new provider".into(),
+            ));
+        }
+        Ok(id)
+    }
+
+    pub fn stream(
+        self: &Arc<Self>,
+        prepare: impl Future<Output = Result<InferenceRequest>> + Send + 'static,
+    ) -> LlmResponseStream {
+        let handle = Arc::clone(self);
+        Box::pin(async_stream::try_stream! {
+            let (responses, mut receiver) = mpsc::channel(1);
+            let (finished, acknowledged) = oneshot::channel();
+            let requests = handle.request_tx.get_or_init(|| {
+                let (sender, receiver) = mpsc::channel(1);
+                tokio::spawn(Session::default().run(Arc::clone(&handle.client), receiver));
+                sender
+            });
+            requests.send(Request { prepare: Box::pin(prepare), responses, acknowledged }).await
+                .map_err(|_| ProviderError::stream_interrupted("Codex session task stopped"))?;
+            while let Some(response) = receiver.recv().await {
+                if response.is_err() || matches!(response, Ok(LlmResponse::Done { .. })) {
+                    let _ = finished.send(());
+                    yield response?;
+                    return;
+                }
+                yield response?;
+            }
+            Err(ProviderError::stream_interrupted("Codex session task stopped"))?;
+        })
+    }
+}
+
+struct Request {
+    prepare: BoxFuture<'static, Result<InferenceRequest>>,
+    responses: mpsc::Sender<Result<LlmResponse>>,
+    acknowledged: oneshot::Receiver<()>,
+}
+
+#[derive(Default)]
+struct Session {
+    link: Option<Link>,
+    identity: Option<Credentials>,
+    turn: Turn,
+}
+
+/// A live socket and the server-side response lineage it carries.
+struct Link {
+    connection: Connection,
+    checkpoint: Option<ContinuationCheckpoint>,
+}
+
+/// The user turn being served and the routing token the server issued for it.
+#[derive(Default)]
+struct Turn {
+    id: String,
+    routing_token: Option<String>,
+}
+
+impl Session {
+    async fn run(mut self, endpoint: Arc<SessionClient>, mut requests: mpsc::Receiver<Request>) {
+        loop {
+            let request = tokio::select! {
+                biased;
+                request = requests.recv() => match request {
+                    Some(request) => request,
+                    None => return,
+                },
+                () = self.idle(), if self.link.is_some() => continue,
+            };
+            let Request { prepare, responses, acknowledged } = request;
+            if responses.is_closed() {
+                continue;
+            }
+            let outcome = tokio::select! {
+                biased;
+                () = responses.closed() => {
+                    self.link = None;
+                    continue;
+                }
+                outcome = self.infer(&endpoint, prepare, &responses) => outcome,
+            };
+            if self.link.as_ref().is_some_and(|link| !link.connection.reusable()) {
+                self.link = None;
+            }
+            // Queuing Done is not delivery: only its consumption permits socket reuse.
+            if responses.send(outcome).await.is_err() || acknowledged.await.is_err() {
+                self.link = None;
+            }
+        }
+    }
+
+    async fn infer(
+        &mut self,
+        endpoint: &SessionClient,
+        prepare: BoxFuture<'static, Result<InferenceRequest>>,
+        responses: &mpsc::Sender<Result<LlmResponse>>,
+    ) -> Result<LlmResponse> {
+        let exchange = prepare.await?;
+        self.begin(&exchange);
+        let mut delivered = DeliveredResponse::default();
+        let mut completed = None;
+        let outcome = {
+            let events = std::pin::pin!(self.events(endpoint, &exchange, &mut completed));
+            let mut stream = std::pin::pin!(process_response_stream(events));
+            loop {
+                match stream.next().await {
+                    Some(Ok(done @ LlmResponse::Done { .. })) => break Ok(done),
+                    Some(Ok(response)) => {
+                        delivered.observe(&response);
+                        responses
+                            .send(Ok(response))
+                            .await
+                            .map_err(|_| ProviderError::stream_interrupted("Codex response consumer dropped"))?;
+                    }
+                    Some(Err(error)) => break Err(error),
+                    None => break Err(ProviderError::stream_interrupted("Codex stream ended without Done").into()),
+                }
+            }
+        };
+        self.finish(endpoint, exchange, outcome, completed, &delivered).await
+    }
+
+    fn begin(&mut self, exchange: &InferenceRequest) {
+        let same_identity = self.identity.as_ref() == Some(&exchange.identity);
+        if !same_identity || self.turn.id != exchange.turn_id {
+            self.turn = Turn { id: exchange.turn_id.clone(), routing_token: None };
+        }
+        if !same_identity || self.link.as_ref().is_some_and(|link| !link.connection.reusable()) {
+            self.link = None;
+        }
+        if !same_identity {
+            self.identity = Some(exchange.identity.clone());
+        }
+    }
+
+    fn events<'a>(
+        &'a mut self,
+        endpoint: &'a SessionClient,
+        exchange: &'a InferenceRequest,
+        completed: &'a mut Option<ResponsesCompleted>,
+    ) -> impl Stream<Item = Result<ResponsesStreamEvent>> + Send + 'a {
+        async_stream::try_stream! {
+            self.send(endpoint, exchange).await?;
+            let mut recovered = false;
+            let mut saw_event = false;
+            let mut created_id = None;
+            loop {
+                let link = self.link.as_mut().expect("sent request has a connection");
+                let event = match link.connection.receive().await?.into_result() {
+                    Ok(event) => event,
+                    Err(mut error) => {
+                        error.request_id = error.request_id.or_else(|| link.connection.request_id().map(str::to_owned));
+                        let recoverable = recovery_code(error.code.as_deref());
+                        if recoverable && !saw_event && !recovered {
+                            tracing::debug!(reason = error.code.as_deref(), "Codex WebSocket full-context recovery");
+                            self.link = None;
+                            recovered = true;
+                            self.send(endpoint, exchange).await?;
+                            continue;
+                        }
+                        if recoverable {
+                            error.kind = ProviderErrorKind::StreamInterrupted;
+                        }
+                        Err(error)?
+                    }
+                };
+                match &event {
+                    ResponsesStreamEvent::Metadata(metadata) => {
+                        self.capture_token(metadata.headers.get("x-codex-turn-state"));
+                        continue;
+                    }
+                    ResponsesStreamEvent::Created(created)
+                        if created_id.replace(created.response.id.clone()).is_some() =>
+                    {
+                        Err(ProviderError::stream_interrupted("Duplicate Codex response.created"))?;
+                    }
+                    ResponsesStreamEvent::Completed(event)
+                        if matches!(event.response.status, Some(Status::Completed)) =>
+                    {
+                        let mut response = event.response.clone();
+                        response.id = response.id.filter(|id| Some(id.as_str()) == created_id.as_deref());
+                        *completed = Some(response);
+                    }
+                    _ => {}
+                }
+                saw_event = true;
+                let terminal = event.ends_response();
+                yield event;
+                if terminal {
+                    return;
+                }
+            }
+        }
+    }
+
+    async fn send(&mut self, endpoint: &SessionClient, exchange: &InferenceRequest) -> Result<()> {
+        let started = Instant::now();
+        let reused = self.link.is_some();
+        if self.link.is_none() {
+            let (connection, token) =
+                Connection::open(&endpoint.client, endpoint.url.clone(), exchange.headers.clone()).await?;
+            self.capture_token(token.as_deref());
+            self.link = Some(Link { connection, checkpoint: None });
+        }
+        let link = self.link.as_mut().expect("connection opened above");
+        tracing::debug!(reused, connect_ms = started.elapsed().as_millis(), "Codex WebSocket connection ready");
+        let mut body = exchange.full.clone();
+        if let Some(checkpoint) = &link.checkpoint {
+            body = checkpoint.prepare(body, exchange.effort);
+        }
+        tracing::debug!(
+            transport = "websocket",
+            continuation = body.previous_response_id.is_some(),
+            sent_items = match &body.input {
+                InputParam::Items(items) => items.len(),
+                InputParam::Text(_) => 1,
+            },
+            "Codex response.create"
+        );
+        link.connection.send(&body, exchange.effort, &self.turn.id, self.turn.routing_token.as_deref()).await
+    }
+
+    async fn finish(
+        &mut self,
+        endpoint: &SessionClient,
+        exchange: InferenceRequest,
+        outcome: Result<LlmResponse>,
+        completed: Option<ResponsesCompleted>,
+        delivered: &DeliveredResponse,
+    ) -> Result<LlmResponse> {
+        let authentication_failed = outcome
+            .as_ref()
+            .err()
+            .and_then(LlmError::provider)
+            .is_some_and(|error| error.kind == ProviderErrorKind::Authentication);
+        if authentication_failed {
+            self.turn.routing_token = None;
+            endpoint.token_manager.clear_cache().await;
+        }
+        if outcome.is_ok()
+            && let Some(completed) = completed
+            && let Some(link) = &mut self.link
+        {
+            link.checkpoint = ContinuationCheckpoint::capture(
+                exchange.full,
+                exchange.effort,
+                completed,
+                delivered,
+                endpoint.model.clone(),
+            );
+        }
+        outcome
+    }
+
+    /// Service the socket until it sees the idle deadline or unexpected traffic.
+    async fn idle(&mut self) {
+        if let Some(link) = &mut self.link {
+            link.connection.idle().await;
+        }
+        self.link = None;
+    }
+
+    fn capture_token(&mut self, token: Option<&str>) {
+        if self.turn.routing_token.is_none() {
+            self.turn.routing_token = token.map(str::to_owned);
+        }
+    }
+}
+
+fn recovery_code(code: Option<&str>) -> bool {
+    matches!(code, Some("previous_response_not_found" | "websocket_connection_limit_reached"))
+}

--- a/crates/llm/src/providers/codex/test_server.rs
+++ b/crates/llm/src/providers/codex/test_server.rs
@@ -1,0 +1,242 @@
+use std::collections::{HashMap, VecDeque};
+use std::sync::{Arc, Mutex};
+
+use axum::extract::State;
+use axum::extract::ws::{Message, WebSocket, WebSocketUpgrade};
+use axum::http::{HeaderMap, Uri};
+use axum::routing::get;
+use futures::SinkExt;
+use serde_json::{Value, json};
+use tokio::sync::{mpsc, oneshot};
+use tokio::task::JoinHandle;
+use tokio_util::sync::CancellationToken;
+
+pub(super) struct FakeResponsesWebsocketServer {
+    pub base_url: String,
+    requests: mpsc::UnboundedReceiver<CapturedRequest>,
+    state: Arc<ServerState>,
+    closed: mpsc::UnboundedReceiver<usize>,
+    pongs: mpsc::UnboundedReceiver<()>,
+    task: JoinHandle<()>,
+}
+
+pub(super) struct CapturedRequest {
+    pub connection: usize,
+    pub headers: HeaderMap,
+    pub uri: Uri,
+    pub body: Value,
+    pub effective_input: Vec<Value>,
+}
+
+pub(super) struct Reply {
+    pub frames: Vec<Message>,
+    pub release: Option<oneshot::Receiver<()>>,
+}
+
+impl Reply {
+    pub fn events(events: Vec<Value>) -> Self {
+        Self {
+            frames: events.into_iter().map(|event| Message::Text(event.to_string().into())).collect(),
+            release: None,
+        }
+    }
+}
+
+impl FakeResponsesWebsocketServer {
+    pub async fn start(replies: Vec<Reply>) -> Self {
+        let (sender, requests) = mpsc::unbounded_channel();
+        let (close_sender, closed) = mpsc::unbounded_channel();
+        let (pong_sender, pongs) = mpsc::unbounded_channel();
+        let state = Arc::new(ServerState {
+            closed: close_sender,
+            pongs: pong_sender,
+            handshake_token: Mutex::new(None),
+            requests: sender,
+            replies: Mutex::new(replies.into()),
+            connections: Mutex::new(0),
+            shutdown: CancellationToken::new(),
+        });
+        let router = axum::Router::new()
+            .route("/responses", get(upgrade))
+            .route("/base/responses", get(upgrade))
+            .route("/reject/{status}/responses", get(reject))
+            .route("/reject-body/{mode}/responses", get(reject_body))
+            .with_state(state.clone());
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let base_url = format!("http://{}", listener.local_addr().unwrap());
+        let task = tokio::spawn(async move {
+            axum::serve(listener, router).await.unwrap();
+        });
+        Self { base_url, requests, state, closed, pongs, task }
+    }
+
+    pub fn handshake_token(&self, token: &str) {
+        *self.state.handshake_token.lock().unwrap() = Some(token.into());
+    }
+
+    pub async fn closed(&mut self) -> usize {
+        self.closed.recv().await.unwrap()
+    }
+
+    pub async fn pong(&mut self) {
+        self.pongs.recv().await.unwrap();
+    }
+
+    pub async fn captured(&mut self) -> CapturedRequest {
+        self.requests.recv().await.expect("fake server stopped before receiving request")
+    }
+}
+
+impl Drop for FakeResponsesWebsocketServer {
+    fn drop(&mut self) {
+        self.state.shutdown.cancel();
+        self.task.abort();
+    }
+}
+
+pub(super) fn text_events(id: &str, text: &str) -> Vec<Value> {
+    vec![
+        json!({"type":"response.created", "response":{"id":id}}),
+        json!({"type":"response.output_text.delta", "delta":text}),
+        json!({"type":"response.completed", "response":{"id":id,"status":"completed", "output":[
+            {"type":"message","id":"msg_1","role":"assistant","status":"completed","content":[{"type":"output_text","text":text,"annotations":[]}]}
+        ]}}),
+    ]
+}
+
+struct ServerState {
+    requests: mpsc::UnboundedSender<CapturedRequest>,
+    replies: Mutex<VecDeque<Reply>>,
+    connections: Mutex<usize>,
+    shutdown: CancellationToken,
+    closed: mpsc::UnboundedSender<usize>,
+    pongs: mpsc::UnboundedSender<()>,
+    handshake_token: Mutex<Option<String>>,
+}
+
+async fn upgrade(
+    State(state): State<Arc<ServerState>>,
+    headers: HeaderMap,
+    uri: Uri,
+    ws: WebSocketUpgrade,
+) -> axum::response::Response {
+    let connection = {
+        let mut count = state.connections.lock().unwrap();
+        *count += 1;
+        *count
+    };
+    let token = state.handshake_token.lock().unwrap().clone();
+    let mut response = ws.on_upgrade(move |socket| async move {
+        tokio::select! {
+            () = state.shutdown.cancelled() => {},
+            () = serve(socket, &state, connection, headers, uri) => {},
+        }
+        let _ = state.closed.send(connection);
+    });
+    response.headers_mut().insert("x-request-id", "upgrade-request".parse().unwrap());
+    if let Some(token) = token {
+        response.headers_mut().insert("x-codex-turn-state", token.parse().unwrap());
+    }
+    response
+}
+
+async fn reject(axum::extract::Path(status): axum::extract::Path<u16>) -> impl axum::response::IntoResponse {
+    (
+        axum::http::StatusCode::from_u16(status).unwrap(),
+        [("x-request-id", "upgrade-rejected")],
+        axum::Json(json!({"error":{"code":"rejected","message":"Upgrade rejected"}})),
+    )
+}
+
+async fn reject_body(axum::extract::Path(mode): axum::extract::Path<String>) -> impl axum::response::IntoResponse {
+    let body = if mode == "large" {
+        json!({"error":{"code":"oversized","message":"sensitive".repeat(10000)}}).to_string()
+    } else {
+        "sensitive proxy response".into()
+    };
+    (axum::http::StatusCode::TOO_MANY_REQUESTS, [("x-request-id", "upgrade-rejected")], body)
+}
+
+async fn serve(mut socket: WebSocket, state: &ServerState, connection: usize, headers: HeaderMap, uri: Uri) {
+    let mut lineage: HashMap<String, Vec<Value>> = HashMap::new();
+    let mut sequence = 0;
+    while let Some(Ok(message)) = socket.recv().await {
+        if matches!(message, Message::Pong(_)) {
+            let _ = state.pongs.send(());
+        }
+        let Message::Text(text) = message else {
+            continue;
+        };
+        let body: Value = serde_json::from_str(&text).unwrap();
+        let mut effective = if let Some(id) = body["previous_response_id"].as_str() {
+            let Some(prefix) = lineage.get(id) else {
+                let error =
+                    json!({"type":"error","error":{"code":"previous_response_not_found","message":"Unknown response"}});
+                if socket.send(Message::Text(error.to_string().into())).await.is_err() {
+                    return;
+                }
+                continue;
+            };
+            prefix.clone()
+        } else {
+            Vec::new()
+        };
+        effective.extend(body["input"].as_array().unwrap().clone());
+        let invalid_call = effective.iter().any(|item| {
+            item["type"] == "function_call_output"
+                && !effective.iter().any(|call| call["type"] == "function_call" && call["call_id"] == item["call_id"])
+        });
+        if invalid_call {
+            let error =
+                json!({"type":"error","status":400,"error":{"code":"invalid_call_id","message":"Unknown tool call"}});
+            let _ = socket.send(Message::Text(error.to_string().into())).await;
+            continue;
+        }
+        let _ = state.requests.send(CapturedRequest {
+            connection,
+            headers: headers.clone(),
+            uri: uri.clone(),
+            body,
+            effective_input: effective.clone(),
+        });
+        sequence += 1;
+        let reply = state
+            .replies
+            .lock()
+            .unwrap()
+            .pop_front()
+            .unwrap_or_else(|| Reply::events(text_events(&format!("resp_{connection}_{sequence}"), "Hello")));
+        if let Some(release) = reply.release {
+            let _ = release.await;
+        }
+        for frame in reply.frames {
+            if let Message::Text(text) = &frame {
+                let event: Value = serde_json::from_str(text).unwrap_or(Value::Null);
+                if event["type"] == "response.completed"
+                    && let (Some(id), Some(output)) =
+                        (event["response"]["id"].as_str(), event["response"]["output"].as_array())
+                {
+                    let mut prefix = effective.clone();
+                    for item in output {
+                        match item["type"].as_str() {
+                                Some("message") => {
+                                    let text: String = item["content"].as_array().unwrap().iter().filter_map(|part| part["text"].as_str()).collect();
+                                    prefix.push(json!({"type":"message","role":"assistant","content":text}));
+                                }
+                                Some("function_call") => prefix.push(json!({"type":"function_call","name":item["name"],"call_id":item["call_id"],"arguments":item["arguments"]})),
+                                Some("reasoning") => prefix.push(json!({"type":"reasoning","id":item["id"],"encrypted_content":item["encrypted_content"],"summary":[]})),
+                                _ => {},
+                            }
+                    }
+                    lineage.insert(id.into(), prefix);
+                }
+            }
+            if socket.send(frame).await.is_err() {
+                return;
+            }
+        }
+        if socket.flush().await.is_err() {
+            return;
+        }
+    }
+}

--- a/crates/llm/src/providers/codex/tests/continuation.rs
+++ b/crates/llm/src/providers/codex/tests/continuation.rs
@@ -1,0 +1,370 @@
+use super::test_server::{FakeResponsesWebsocketServer, Reply, text_events};
+use super::{collect, context, full_history, provider};
+use crate::{ChatMessage, LlmResponse, StreamingModelProvider};
+use futures::StreamExt;
+use tokio::sync::oneshot;
+
+#[tokio::test]
+async fn three_requests_chain_from_full_history_not_previous_delta() {
+    let mut server = FakeResponsesWebsocketServer::start(vec![
+        Reply::events(text_events("one", "Hello")),
+        Reply::events(text_events("two", "Again")),
+        Reply::events(text_events("three", "Bye")),
+    ])
+    .await;
+    let provider = provider(&server);
+    let mut context = context("same");
+    for (index, text) in ["Hello", "Again", "Bye"].into_iter().enumerate() {
+        let responses = provider.stream_response(&context).collect::<Vec<_>>().await;
+        assert!(responses.iter().all(Result::is_ok), "{responses:?}");
+        let request = server.captured().await;
+        assert_eq!(request.effective_input, full_history(&context));
+        if index > 0 {
+            assert_eq!(request.body["input"].as_array().unwrap().len(), 1);
+            assert_eq!(request.body["previous_response_id"], if index == 1 { "one" } else { "two" });
+        }
+        context.push_assistant_turn(text, crate::AssistantReasoning::default(), vec![]);
+        context.add_message(ChatMessage::user("next"));
+    }
+}
+
+#[tokio::test]
+async fn tool_results_chain_with_call_id_and_exact_arguments_and_reasoning() {
+    let events =
+        serde_json::from_str(include_str!("../../../../tests/fixtures/codex_websocket/tool_reasoning.json")).unwrap();
+    let mut server = FakeResponsesWebsocketServer::start(vec![Reply::events(events)]).await;
+    let provider = provider(&server);
+    let mut context = context("same");
+    let responses = collect(&provider, &context).await;
+    let call = responses
+        .iter()
+        .find_map(|response| match response {
+            LlmResponse::ToolRequestComplete { tool_call } => Some(tool_call.clone()),
+            _ => None,
+        })
+        .unwrap();
+    assert_eq!(call.id, "call_1");
+    assert_eq!(call.arguments, "{ \"path\" : \"file\" }");
+    assert!(
+        responses.iter().any(|response| matches!(response, LlmResponse::Reasoning { chunk } if chunk == "Checking"))
+    );
+    assert!(responses.iter().any(
+        |response| matches!(response, LlmResponse::Usage { tokens } if tokens.reasoning_tokens.unwrap().get() == 3)
+    ));
+    let encrypted = responses.iter().find_map(|response| match response {
+        LlmResponse::EncryptedReasoning { id, content } => Some(crate::EncryptedReasoningContent {
+            id: id.clone(),
+            content: content.clone(),
+            model: provider.model().unwrap(),
+        }),
+        _ => None,
+    });
+    context.push_assistant_turn(
+        "",
+        crate::AssistantReasoning { summary_text: Some("Checking".into()), encrypted_content: encrypted },
+        vec![Ok(crate::ToolCallResult {
+            id: call.id,
+            name: call.name,
+            arguments: call.arguments,
+            result: "file contents".into(),
+        })],
+    );
+    collect(&provider, &context).await;
+    let first = server.captured().await;
+    let second = server.captured().await;
+    assert_eq!(first.connection, second.connection);
+    assert_eq!(second.body["previous_response_id"], "tool-response");
+    assert_eq!(second.body["input"].as_array().unwrap().len(), 1);
+    assert_eq!(second.body["input"][0]["call_id"], "call_1");
+    assert_eq!(second.effective_input, full_history(&context));
+    assert_eq!(
+        second.effective_input[1],
+        serde_json::json!({
+            "type":"reasoning", "id":"reasoning-1", "encrypted_content":"opaque-content", "summary":[]
+        })
+    );
+    assert_eq!(
+        second.effective_input[2],
+        serde_json::json!({
+            "type":"function_call", "call_id":"call_1", "name":"read", "arguments":"{ \"path\" : \"file\" }"
+        })
+    );
+    assert_eq!(
+        second.effective_input[3],
+        serde_json::json!({
+            "type":"function_call_output", "call_id":"call_1", "output":"file contents"
+        })
+    );
+}
+
+#[tokio::test]
+async fn reasoning_then_text_chains_with_history_matching_full_replay() {
+    let events =
+        serde_json::from_str(include_str!("../../../../tests/fixtures/codex_websocket/reasoning_text.json")).unwrap();
+    let mut server = FakeResponsesWebsocketServer::start(vec![Reply::events(events)]).await;
+    let provider = provider(&server);
+    let mut context = context("same");
+    let responses = collect(&provider, &context).await;
+    let encrypted = responses.iter().find_map(|response| match response {
+        LlmResponse::EncryptedReasoning { id, content } => Some(crate::EncryptedReasoningContent {
+            id: id.clone(),
+            content: content.clone(),
+            model: provider.model().unwrap(),
+        }),
+        _ => None,
+    });
+    context.push_assistant_turn(
+        "Hello",
+        crate::AssistantReasoning { summary_text: None, encrypted_content: encrypted },
+        vec![],
+    );
+    context.add_message(ChatMessage::user("next"));
+    collect(&provider, &context).await;
+    server.captured().await;
+    let second = server.captured().await;
+    assert_eq!(second.body["previous_response_id"], "mixed-response");
+    assert_eq!(second.body["input"].as_array().unwrap().len(), 1);
+    assert_eq!(second.effective_input, full_history(&context));
+}
+
+#[tokio::test]
+async fn reordered_parallel_tool_calls_reset_continuation() {
+    for reverse in [false, true] {
+        let mut events = vec![serde_json::json!({"type":"response.created","response":{"id":"parallel"}})];
+        let mut output = Vec::new();
+        for index in 0..2 {
+            let item = serde_json::json!({"type":"function_call","id":format!("item-{index}"),"call_id":format!("call-{index}"),"name":"read","arguments":"{}","status":"completed"});
+            let mut started = item.clone();
+            started["arguments"] = "".into();
+            started["status"] = "in_progress".into();
+            events.push(serde_json::json!({"type":"response.output_item.added","output_index":index,"item":started}));
+            events.push(
+                serde_json::json!({"type":"response.function_call_arguments.delta","output_index":index,"delta":"{}"}),
+            );
+            events.push(serde_json::json!({"type":"response.function_call_arguments.done","output_index":index}));
+            output.push(item);
+        }
+        events.push(serde_json::json!({"type":"response.completed","response":{"id":"parallel","status":"completed","output":output}}));
+        let mut server = FakeResponsesWebsocketServer::start(vec![Reply::events(events)]).await;
+        let provider = provider(&server);
+        let mut context = context("same");
+        let responses = collect(&provider, &context).await;
+        let mut results = responses
+            .into_iter()
+            .filter_map(|response| match response {
+                LlmResponse::ToolRequestComplete { tool_call } => Some(Ok(crate::ToolCallResult {
+                    id: tool_call.id,
+                    name: tool_call.name,
+                    arguments: tool_call.arguments,
+                    result: "contents".into(),
+                })),
+                _ => None,
+            })
+            .collect::<Vec<_>>();
+        assert_eq!(results.len(), 2);
+        if reverse {
+            results.reverse();
+        }
+        context.push_assistant_turn("", crate::AssistantReasoning::default(), results);
+        collect(&provider, &context).await;
+        let first = server.captured().await;
+        let second = server.captured().await;
+        assert_eq!(first.connection, second.connection);
+        assert_eq!(second.body.get("previous_response_id").is_none(), reverse);
+    }
+}
+
+#[tokio::test]
+async fn continuation_preserves_wire_settings_and_effective_effort() {
+    for (first_effort, next_effort, continues) in [
+        (Some(crate::ReasoningEffort::Max), Some(crate::ReasoningEffort::Max), true),
+        (Some(crate::ReasoningEffort::Max), Some(crate::ReasoningEffort::High), false),
+        (Some(crate::ReasoningEffort::High), Some(crate::ReasoningEffort::Max), false),
+        (None, Some(crate::ReasoningEffort::Medium), true),
+    ] {
+        let mut server = FakeResponsesWebsocketServer::start(vec![Reply::events(text_events("one", "Hello"))]).await;
+        let provider = provider(&server);
+        let mut context = context("same");
+        context.set_reasoning_effort(first_effort);
+        context.set_system_content("Instructions".into());
+        context.set_prompt_cache_key(Some("cache".into()));
+        context.set_tools(vec![crate::ToolDefinition::new("read", "Read", serde_json::json!({"type":"object"}))]);
+        collect(&provider, &context).await;
+        context.push_assistant_turn("Hello", crate::AssistantReasoning::default(), vec![]);
+        context.add_message(ChatMessage::user("next"));
+        context.set_reasoning_effort(next_effort);
+        collect(&provider, &context).await;
+        let first = server.captured().await;
+        let second = server.captured().await;
+        assert_eq!(second.body.get("previous_response_id").is_some(), continues);
+        assert_eq!(second.body["reasoning"]["effort"], next_effort.unwrap().as_str());
+        assert_eq!(second.effective_input, full_history(&context));
+        for (key, value) in first.body.as_object().unwrap() {
+            if !matches!(key.as_str(), "input" | "reasoning" | "client_metadata") {
+                assert_eq!(&second.body[key], value, "{key}");
+            }
+        }
+    }
+}
+
+#[tokio::test]
+async fn history_and_settings_changes_disable_continuation() {
+    for change in ["repeat", "edit", "compact", "tools", "effort", "instructions", "cache-key"] {
+        let mut server = FakeResponsesWebsocketServer::start(vec![]).await;
+        let provider = provider(&server);
+        let mut context = context("same");
+        collect(&provider, &context).await;
+        if change != "repeat" {
+            context.push_assistant_turn("Hello", crate::AssistantReasoning::default(), vec![]);
+            context.add_message(ChatMessage::user("next"));
+        }
+        match change {
+            "edit" => context.replace_conversation(vec![ChatMessage::user("edited")]),
+            "compact" => context = context.with_compacted_summary("summary"),
+            "tools" => context.set_tools(vec![crate::ToolDefinition::new(
+                "read",
+                "read",
+                serde_json::json!({"type":"object"}),
+            )]),
+            "effort" => context.set_reasoning_effort(Some(crate::ReasoningEffort::High)),
+            "instructions" => context.set_system_content("new instruction".into()),
+            "cache-key" => context.set_prompt_cache_key(Some("different".into())),
+            _ => {}
+        }
+        collect(&provider, &context).await;
+        let first = server.captured().await;
+        let second = server.captured().await;
+        assert_eq!(first.connection, second.connection);
+        assert!(second.body.get("previous_response_id").is_none(), "{change}");
+    }
+}
+
+#[tokio::test]
+async fn mismatched_missing_unsupported_or_malformed_output_sends_full_context() {
+    for variant in [
+        "mismatch",
+        "missing",
+        "wrong-id",
+        "missing-id",
+        "empty-id",
+        "missing-status",
+        "phase",
+        "namespace",
+        "unsupported",
+        "future",
+        "refusal",
+        "malformed",
+    ] {
+        let mut events = text_events("one", "Hello");
+        let response = &mut events[2]["response"];
+        match variant {
+            "mismatch" => response["output"][0]["content"][0]["text"] = "different".into(),
+            "missing" => {
+                response.as_object_mut().unwrap().remove("output");
+            }
+            "wrong-id" => response["id"] = "other".into(),
+            "missing-id" => {
+                response.as_object_mut().unwrap().remove("id");
+            }
+            "empty-id" => response["id"] = "".into(),
+            "missing-status" => {
+                response.as_object_mut().unwrap().remove("status");
+            }
+            "phase" => response["output"][0]["phase"] = "commentary".into(),
+            "namespace" => response["output"][0]["namespace"] = "tools".into(),
+            "unsupported" => response["output"] = serde_json::json!([{"type":"web_search_call"}]),
+            "future" => response["output"] = serde_json::json!([{"type":"future_output"}]),
+            "refusal" => response["output"][0]["content"][0] = serde_json::json!({"type":"refusal","refusal":"no"}),
+            "malformed" => {
+                response["output"] = serde_json::json!([{"type":"function_call","name":"read","arguments":"{}"}]);
+            }
+            _ => unreachable!(),
+        }
+        let mut server = FakeResponsesWebsocketServer::start(vec![Reply::events(events)]).await;
+        let provider = provider(&server);
+        let mut context = context("same");
+        collect(&provider, &context).await;
+        context.push_assistant_turn("Hello", crate::AssistantReasoning::default(), vec![]);
+        context.add_message(ChatMessage::user("next"));
+        collect(&provider, &context).await;
+        server.captured().await;
+        assert!(server.captured().await.body.get("previous_response_id").is_none(), "{variant}");
+    }
+}
+
+#[tokio::test]
+async fn queued_request_uses_checkpoint_from_completed_request() {
+    let (release, wait) = oneshot::channel();
+    let mut reply = Reply::events(text_events("one", "Hello"));
+    reply.release = Some(wait);
+    let mut server = FakeResponsesWebsocketServer::start(vec![reply]).await;
+    let provider = provider(&server);
+    let mut context = context("same");
+    let first = tokio::spawn(provider.stream_response(&context).collect::<Vec<_>>());
+    let first_request = server.captured().await;
+    context.push_assistant_turn("Hello", crate::AssistantReasoning::default(), vec![]);
+    context.add_message(ChatMessage::user("next"));
+    let mut queued = provider.clone().stream_response(&context);
+    assert!(futures::poll!(queued.next()).is_pending());
+    release.send(()).unwrap();
+    assert!(first.await.unwrap().iter().all(Result::is_ok));
+    assert!(queued.collect::<Vec<_>>().await.iter().all(Result::is_ok));
+    let continued = server.captured().await;
+    assert_eq!(continued.connection, first_request.connection);
+    assert_eq!(continued.body["previous_response_id"], "one");
+    assert_eq!(continued.body["input"].as_array().unwrap().len(), 1);
+    assert_eq!(continued.effective_input, full_history(&context));
+}
+
+#[tokio::test]
+async fn pre_creation_recovery_reopens_once_with_full_context() {
+    let rejection = serde_json::json!({"type":"error","status":400,"error":{"code":"previous_response_not_found","message":"expired"}});
+    let mut server = FakeResponsesWebsocketServer::start(vec![
+        Reply::events(text_events("one", "Hello")),
+        Reply::events(vec![rejection]),
+        Reply::events(text_events("two", "Recovered")),
+    ])
+    .await;
+    let provider = provider(&server);
+    let mut context = context("same");
+    collect(&provider, &context).await;
+    context.push_assistant_turn("Hello", crate::AssistantReasoning::default(), vec![]);
+    context.add_message(ChatMessage::user("next"));
+    let responses = collect(&provider, &context).await;
+    assert_eq!(responses.iter().filter(|response| matches!(response, LlmResponse::Start { .. })).count(), 1);
+    let first = server.captured().await;
+    let rejected = server.captured().await;
+    let recovered = server.captured().await;
+    assert_eq!(first.connection, rejected.connection);
+    assert_ne!(rejected.connection, recovered.connection);
+    assert!(recovered.body.get("previous_response_id").is_none());
+    assert_eq!(recovered.body["input"].as_array().unwrap().len(), 3);
+}
+
+#[tokio::test]
+async fn recovery_is_not_repeated_or_attempted_after_creation() {
+    for created in [false, true] {
+        let rejection = serde_json::json!({"type":"error","status":400,"error":{"code":"websocket_connection_limit_reached","message":"limit"}});
+        let first = if created {
+            vec![
+                serde_json::json!({"type":"response.created","response":{"id":"one"}}),
+                serde_json::json!({"type":"response.output_text.delta","delta":"partial"}),
+                rejection.clone(),
+            ]
+        } else {
+            vec![rejection.clone()]
+        };
+        let mut server =
+            FakeResponsesWebsocketServer::start(vec![Reply::events(first), Reply::events(vec![rejection])]).await;
+        let provider = provider(&server);
+        let responses = provider.stream_response(&context("same")).collect::<Vec<_>>().await;
+        let error = responses.last().unwrap().as_ref().unwrap_err().provider().unwrap();
+        assert_eq!(error.kind, crate::ProviderErrorKind::StreamInterrupted);
+        assert_eq!(error.code.as_deref(), Some("websocket_connection_limit_reached"));
+        assert_eq!(responses.len(), if created { 3 } else { 1 });
+        let first = server.captured().await;
+        if !created {
+            assert_ne!(first.connection, server.captured().await.connection);
+        }
+    }
+}

--- a/crates/llm/src/providers/codex/tests/errors.rs
+++ b/crates/llm/src/providers/codex/tests/errors.rs
@@ -1,0 +1,108 @@
+use super::test_server::{FakeResponsesWebsocketServer, Reply};
+use super::{context, provider, provider_at};
+use crate::StreamingModelProvider;
+use futures::StreamExt;
+
+#[tokio::test]
+async fn classified_frame_errors_keep_status_code_and_request_id() {
+    for (status, code, kind) in [
+        (401, "invalid_api_key", crate::ProviderErrorKind::Authentication),
+        (403, "invalid_authentication", crate::ProviderErrorKind::Authentication),
+        (429, "rate_limit_exceeded", crate::ProviderErrorKind::RateLimit),
+        (500, "server_error", crate::ProviderErrorKind::Server),
+    ] {
+        for wrapped in [true, false] {
+            let error = serde_json::json!({"code":code,"message":"rejected"});
+            let frame = if wrapped {
+                serde_json::json!({"type":"error","status":status,"error":error,"headers":{"X-Request-ID":["req-1"]}})
+            } else {
+                serde_json::json!({"type":"error","status":status,"code":code,"message":"rejected","headers":{"x-request-id":"req-1"}})
+            };
+            let server = FakeResponsesWebsocketServer::start(vec![Reply::events(vec![frame])]).await;
+            let responses = provider(&server).stream_response(&context("same")).collect::<Vec<_>>().await;
+            assert_eq!(responses.len(), 1);
+            let error = responses[0].as_ref().unwrap_err().provider().unwrap();
+            assert_eq!(error.kind, kind);
+            assert_eq!(error.http_status, Some(status));
+            assert_eq!(error.code.as_deref(), Some(code));
+            assert_eq!(error.request_id.as_deref(), Some("req-1"));
+        }
+    }
+}
+
+#[tokio::test]
+async fn statusless_errors_use_explicit_codes_and_status_takes_precedence() {
+    for (code, kind) in [
+        ("invalid_api_key", crate::ProviderErrorKind::Authentication),
+        ("invalid_authentication", crate::ProviderErrorKind::Authentication),
+        ("authentication_error", crate::ProviderErrorKind::Authentication),
+        ("token_expired", crate::ProviderErrorKind::Authentication),
+        ("rate_limit_exceeded", crate::ProviderErrorKind::RateLimit),
+        ("server_error", crate::ProviderErrorKind::Server),
+        ("unclassified", crate::ProviderErrorKind::Unknown),
+    ] {
+        for status in [None, Some(400)] {
+            let frame = serde_json::json!({"type":"error","status":status,"error":{"code":code,"message":"rejected"}});
+            let server = FakeResponsesWebsocketServer::start(vec![Reply::events(vec![frame])]).await;
+            let responses = provider(&server).stream_response(&context("same")).collect::<Vec<_>>().await;
+            assert_eq!(
+                responses[0].as_ref().unwrap_err().provider().unwrap().kind,
+                if status.is_some() { crate::ProviderErrorKind::Api } else { kind }
+            );
+        }
+    }
+}
+
+#[tokio::test]
+async fn failed_response_preserves_frame_and_connection_diagnostics() {
+    for headers in [serde_json::json!({"X-Request-Id":["frame-request"]}), serde_json::json!({})] {
+        let frame = serde_json::json!({"type":"response.failed","status":429,"headers":headers,"response":{"error":{"code":"quota","message":"Try later"}}});
+        let server = FakeResponsesWebsocketServer::start(vec![Reply::events(vec![frame])]).await;
+        let responses = provider(&server).stream_response(&context("same")).collect::<Vec<_>>().await;
+        let error = responses[0].as_ref().unwrap_err().provider().unwrap();
+        assert_eq!(error.kind, crate::ProviderErrorKind::RateLimit);
+        assert_eq!(error.http_status, Some(429));
+        assert_eq!(error.code.as_deref(), Some("quota"));
+        assert_eq!(error.message, "Try later");
+        assert_eq!(
+            error.request_id.as_deref(),
+            Some(if headers.as_object().unwrap().is_empty() { "upgrade-request" } else { "frame-request" })
+        );
+    }
+}
+
+#[tokio::test]
+async fn upgrade_rejections_have_diagnostics_and_never_fall_back_to_post() {
+    for (status, kind) in [
+        (401, crate::ProviderErrorKind::Authentication),
+        (403, crate::ProviderErrorKind::Authentication),
+        (429, crate::ProviderErrorKind::RateLimit),
+        (500, crate::ProviderErrorKind::Server),
+        (426, crate::ProviderErrorKind::Api),
+    ] {
+        let server = FakeResponsesWebsocketServer::start(vec![]).await;
+        let provider = provider_at(&format!("{}/reject/{status}", server.base_url));
+        let responses = provider.stream_response(&context("same")).collect::<Vec<_>>().await;
+        assert_eq!(responses.len(), 1);
+        let error = responses[0].as_ref().unwrap_err().provider().unwrap();
+        assert_eq!(error.kind, kind);
+        assert_eq!(error.http_status, Some(status));
+        assert_eq!(error.code.as_deref(), Some("rejected"));
+        assert_eq!(error.request_id.as_deref(), Some("upgrade-rejected"));
+    }
+}
+
+#[tokio::test]
+async fn upgrade_rejection_diagnostics_are_bounded_and_non_json_is_safe() {
+    for mode in ["large", "text"] {
+        let server = FakeResponsesWebsocketServer::start(vec![]).await;
+        let provider = provider_at(&format!("{}/reject-body/{mode}", server.base_url));
+        let responses = provider.stream_response(&context("same")).collect::<Vec<_>>().await;
+        let error = responses[0].as_ref().unwrap_err().provider().unwrap();
+        assert_eq!(error.kind, crate::ProviderErrorKind::RateLimit);
+        assert_eq!(error.http_status, Some(429));
+        assert_eq!(error.request_id.as_deref(), Some("upgrade-rejected"));
+        assert_eq!(error.code, None);
+        assert!(!error.message.contains("sensitive"));
+    }
+}

--- a/crates/llm/src/providers/codex/tests/mod.rs
+++ b/crates/llm/src/providers/codex/tests/mod.rs
@@ -1,0 +1,59 @@
+//! Behavioral tests for the Codex WebSocket transport, run against an
+//! in-memory fake Responses server.
+
+mod continuation;
+mod errors;
+mod reuse;
+mod wire;
+
+use super::CodexProvider;
+use super::test_server::{self, FakeResponsesWebsocketServer};
+use crate::providers::openai_responses::mappers::{ResponsesRequestPolicy, build_wire_request};
+use crate::{ChatMessage, Context, LlmResponse, ProviderConnectionConfig, StreamingModelProvider};
+use aether_auth::{FakeOAuthCredentialStore, OAuthCredential};
+use base64::{Engine, engine::general_purpose::URL_SAFE_NO_PAD};
+use futures::StreamExt;
+use std::sync::Arc;
+
+const MODEL: &str = "gpt-5.6-luna";
+
+/// The `input` items a request would carry without continuation.
+fn full_history(context: &Context) -> Vec<serde_json::Value> {
+    let request = build_wire_request(MODEL, context, &ResponsesRequestPolicy::codex()).unwrap();
+    request["input"].as_array().cloned().unwrap()
+}
+
+async fn collect(provider: &CodexProvider, context: &Context) -> Vec<LlmResponse> {
+    provider.stream_response(context).collect::<Vec<_>>().await.into_iter().map(Result::unwrap).collect()
+}
+
+fn context(key: &str) -> Context {
+    let mut context = Context::new(vec![ChatMessage::user("Hi")], vec![]);
+    context.set_session_affinity_key(Some(key.into()));
+    context.set_turn_id(Some("turn-1".into()));
+    context
+}
+
+fn credential(account: &str) -> OAuthCredential {
+    let payload = URL_SAFE_NO_PAD
+        .encode(serde_json::json!({"https://api.openai.com/auth":{"chatgpt_account_id":account}}).to_string());
+    OAuthCredential {
+        client_id: "test".into(),
+        access_token: format!("e30.{payload}.signature"),
+        refresh_token: None,
+        expires_at: Some(u64::MAX),
+    }
+}
+
+fn provider(server: &FakeResponsesWebsocketServer) -> CodexProvider {
+    provider_at(&server.base_url)
+}
+
+fn provider_at(base_url: &str) -> CodexProvider {
+    let store = Arc::new(FakeOAuthCredentialStore::new().with_credential("codex", credential("account-1")));
+    CodexProvider::new(store, connection(base_url), MODEL).unwrap()
+}
+
+fn connection(base_url: &str) -> ProviderConnectionConfig {
+    ProviderConnectionConfig { base_url: Some(base_url.into()), ..Default::default() }
+}

--- a/crates/llm/src/providers/codex/tests/reuse.rs
+++ b/crates/llm/src/providers/codex/tests/reuse.rs
@@ -1,0 +1,364 @@
+use super::test_server::{FakeResponsesWebsocketServer, Reply, text_events};
+use super::{MODEL, collect, connection, context, credential, provider};
+use crate::providers::codex::CodexProvider;
+use crate::{LlmResponse, ProviderConnectionConfig, StreamingModelProvider};
+use aether_auth::FakeOAuthCredentialStore;
+use axum::extract::ws::Message;
+use futures::StreamExt;
+use std::sync::Arc;
+use tokio::sync::oneshot;
+
+#[test]
+fn provider_and_unpolled_stream_do_not_require_a_runtime() {
+    let store = Arc::new(FakeOAuthCredentialStore::new().with_credential("codex", credential("account-1")));
+    let provider = CodexProvider::new(store, ProviderConnectionConfig::default(), MODEL).unwrap();
+    let stream = provider.stream_response(&context("lazy"));
+    drop(provider);
+    drop(stream);
+}
+
+#[tokio::test]
+async fn one_provider_cannot_be_rebound_to_another_conversation() {
+    let mut server = FakeResponsesWebsocketServer::start(vec![]).await;
+    let provider = provider(&server);
+    collect(&provider, &context("one")).await;
+    let first = server.captured().await;
+    let mut rejected = provider.stream_response(&context("two"));
+    let error = rejected.next().await.unwrap().unwrap_err();
+    assert!(!error.is_retryable());
+    assert!(error.to_string().contains("conversation"));
+    collect(&provider, &context("one")).await;
+    assert_eq!(server.captured().await.connection, first.connection);
+    assert!(rejected.next().await.is_none());
+}
+
+#[tokio::test]
+async fn server_completion_does_not_release_session_before_consumer_done() {
+    let mut server = FakeResponsesWebsocketServer::start(vec![Reply::events(text_events("one", "Hello"))]).await;
+    let provider = provider(&server);
+    let mut stream = provider.stream_response(&context("same"));
+    assert!(matches!(stream.next().await.unwrap().unwrap(), LlmResponse::Start { .. }));
+    let first = server.captured().await;
+
+    let mut queued = provider.clone().stream_response(&context("same"));
+    assert!(futures::poll!(queued.next()).is_pending());
+    drop(stream);
+    assert!(queued.collect::<Vec<_>>().await.iter().all(Result::is_ok));
+    assert_ne!(server.captured().await.connection, first.connection);
+}
+
+#[tokio::test]
+async fn dropping_stream_closes_silent_socket_without_another_request() {
+    let reply = Reply::events(vec![serde_json::json!({
+        "type": "response.created", "response": {"id": "silent"}
+    })]);
+    let mut server = FakeResponsesWebsocketServer::start(vec![reply]).await;
+    let provider = provider(&server);
+    let mut stream = provider.stream_response(&context("same"));
+    assert!(matches!(stream.next().await.unwrap().unwrap(), LlmResponse::Start { .. }));
+    let first = server.captured().await;
+    drop(stream);
+    assert_eq!(server.closed().await, first.connection);
+}
+
+#[tokio::test]
+async fn completed_requests_reuse_socket_before_done_is_yielded() {
+    let mut server = FakeResponsesWebsocketServer::start(vec![]).await;
+    let provider = provider(&server);
+    let context = context("same");
+    let mut stream = provider.stream_response(&context);
+    while !matches!(stream.next().await.unwrap().unwrap(), LlmResponse::Done { .. }) {}
+    let first = server.captured().await;
+    let second = provider.clone().stream_response(&context).collect::<Vec<_>>().await;
+    assert!(second.iter().all(Result::is_ok));
+    assert_eq!(first.connection, server.captured().await.connection);
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn dropping_stream_after_done_preserves_reuse() {
+    let mut server = FakeResponsesWebsocketServer::start(vec![]).await;
+    let provider = provider(&server);
+    let mut first_connection = None;
+    for _ in 0..16 {
+        let mut stream = provider.stream_response(&context("same"));
+        while !matches!(stream.next().await.unwrap().unwrap(), LlmResponse::Done { .. }) {}
+        drop(stream);
+        let request = server.captured().await;
+        assert_eq!(request.connection, *first_connection.get_or_insert(request.connection));
+    }
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn completion_usage_does_not_allow_reuse_until_done_is_consumed() {
+    for consume_done in [false, true] {
+        let mut events = text_events("one", "Hello");
+        events[2]["response"]["usage"] = serde_json::json!({
+            "input_tokens": 2, "input_tokens_details": {"cached_tokens": 0},
+            "output_tokens": 1, "output_tokens_details": {"reasoning_tokens": 0},
+            "total_tokens": 3
+        });
+        let mut server = FakeResponsesWebsocketServer::start(vec![Reply::events(events)]).await;
+        let provider = provider(&server);
+        let mut context = context("same");
+        let mut stream = provider.stream_response(&context);
+        while !matches!(stream.next().await.unwrap().unwrap(), LlmResponse::Usage { .. }) {}
+        let first = server.captured().await;
+        context.push_assistant_turn("Hello", crate::AssistantReasoning::default(), vec![]);
+        context.add_message(crate::ChatMessage::user("next"));
+        let mut queued = provider.stream_response(&context);
+        assert!(futures::poll!(queued.next()).is_pending());
+        if consume_done {
+            assert!(matches!(stream.next().await.unwrap().unwrap(), LlmResponse::Done { .. }));
+        }
+        drop(stream);
+        if !consume_done {
+            assert_eq!(server.closed().await, first.connection);
+        }
+        assert!(queued.collect::<Vec<_>>().await.iter().all(Result::is_ok));
+        let second = server.captured().await;
+        assert_eq!(first.connection == second.connection, consume_done);
+        assert_eq!(second.body.get("previous_response_id").is_some(), consume_done);
+        assert_eq!(second.effective_input, super::full_history(&context));
+    }
+}
+
+#[tokio::test]
+async fn dropping_queued_requests_preserves_the_active_connection() {
+    let mut server = FakeResponsesWebsocketServer::start(vec![]).await;
+    let provider = provider(&server);
+    let context = context("same");
+    let mut active = provider.stream_response(&context);
+    assert!(matches!(active.next().await.unwrap().unwrap(), LlmResponse::Start { .. }));
+    let first = server.captured().await;
+
+    let mut queued = provider.stream_response(&context);
+    assert!(futures::poll!(queued.next()).is_pending());
+    let mut backpressured = provider.stream_response(&context);
+    assert!(futures::poll!(backpressured.next()).is_pending());
+    drop(backpressured);
+    drop(queued);
+
+    let mut next = provider.stream_response(&context);
+    assert!(futures::poll!(next.next()).is_pending());
+    assert!(active.collect::<Vec<_>>().await.iter().all(Result::is_ok));
+    assert!(next.collect::<Vec<_>>().await.iter().all(Result::is_ok));
+    assert_eq!(server.captured().await.connection, first.connection);
+}
+
+#[tokio::test]
+async fn dropping_pending_stream_releases_session() {
+    let (release, wait) = oneshot::channel();
+    let mut reply = Reply::events(text_events("one", "Hello"));
+    reply.release = Some(wait);
+    let mut server = FakeResponsesWebsocketServer::start(vec![reply]).await;
+    let provider = provider(&server);
+    let mut stream = provider.stream_response(&context("same"));
+    let first = tokio::select! {
+        first = server.captured() => first,
+        response = stream.next() => panic!("server has not released a response: {response:?}"),
+    };
+    drop(stream);
+    release.send(()).unwrap();
+    assert_eq!(server.closed().await, first.connection);
+    collect(&provider, &context("same")).await;
+    assert_ne!(server.captured().await.connection, first.connection);
+}
+
+#[tokio::test]
+async fn separate_providers_run_concurrently_without_sharing_sockets() {
+    let (release, wait) = oneshot::channel();
+    let mut reply = Reply::events(text_events("one", "Hello"));
+    reply.release = Some(wait);
+    let mut server = FakeResponsesWebsocketServer::start(vec![reply]).await;
+    let provider = provider(&server);
+    let other = self::provider(&server);
+    let first = tokio::spawn(provider.stream_response(&context("one")).collect::<Vec<_>>());
+    let one = server.captured().await;
+    collect(&other, &context("two")).await;
+    let two = server.captured().await;
+    assert_ne!(one.connection, two.connection);
+    assert_eq!(one.headers["session-id"], "one");
+    assert_eq!(two.headers["session-id"], "two");
+    release.send(()).unwrap();
+    assert!(first.await.unwrap().iter().all(Result::is_ok));
+    for (provider, key, connection) in [(&provider, "one", one.connection), (&other, "two", two.connection)] {
+        collect(provider, &context(key)).await;
+        assert_eq!(server.captured().await.connection, connection);
+    }
+}
+
+#[tokio::test]
+async fn stream_keeps_sessions_alive_after_original_provider_is_dropped() {
+    let (release, wait) = oneshot::channel();
+    let mut reply = Reply::events(text_events("one", "Hello"));
+    reply.release = Some(wait);
+    let mut server = FakeResponsesWebsocketServer::start(vec![reply]).await;
+    let provider = provider(&server);
+    let stream = tokio::spawn(provider.stream_response(&context("one")).collect::<Vec<_>>());
+    let first = server.captured().await;
+    drop(provider);
+    release.send(()).unwrap();
+    assert!(stream.await.unwrap().iter().all(Result::is_ok));
+    assert_eq!(server.closed().await, first.connection);
+}
+
+#[tokio::test]
+async fn unkeyed_requests_reuse_one_provider_session_and_stable_routing_id() {
+    let mut server = FakeResponsesWebsocketServer::start(vec![]).await;
+    let provider = provider(&server);
+    collect(&provider, &context("")).await;
+    let first = server.captured().await;
+    collect(&provider, &context("")).await;
+    let second = server.captured().await;
+    assert_eq!(first.connection, second.connection);
+    assert_eq!(first.headers["session-id"], second.headers["session-id"]);
+
+    collect(&self::provider(&server), &context("")).await;
+    let other = server.captured().await;
+    assert_ne!(first.connection, other.connection);
+    assert_ne!(first.headers["session-id"], other.headers["session-id"]);
+}
+
+#[tokio::test]
+async fn dropping_stream_before_done_discards_connection() {
+    let mut server = FakeResponsesWebsocketServer::start(vec![]).await;
+    let provider = provider(&server);
+    let context = context("same");
+    let mut stream = provider.stream_response(&context);
+    assert!(matches!(stream.next().await.unwrap().unwrap(), LlmResponse::Start { .. }));
+    let first = server.captured().await;
+    drop(stream);
+    collect(&provider, &context).await;
+    assert_ne!(first.connection, server.captured().await.connection);
+}
+
+#[tokio::test]
+async fn incomplete_errors_and_malformed_frames_never_reuse_connections() {
+    let cases = vec![
+        vec![Message::Text("not json".into())],
+        vec![Message::Binary(vec![1, 2].into())],
+        vec![Message::Close(None)],
+        Reply::events(vec![serde_json::json!({"type":"response.output_text.delta"})]).frames,
+        Reply::events(vec![serde_json::json!({"type":"response.output_text.delta","delta":"before created"})]).frames,
+        Reply::events(vec![serde_json::json!({"type":"response.created","response":{"id":"one"}}), serde_json::json!({"type":"response.incomplete","response":{"status":"incomplete"}})]).frames,
+        Reply::events(vec![serde_json::json!({"type":"response.failed","response":{"error":{"code":"server_error","message":"failed"}}})]).frames,
+    ];
+    for frames in cases {
+        let mut server = FakeResponsesWebsocketServer::start(vec![Reply { frames, release: None }]).await;
+        let provider = provider(&server);
+        let context = context("same");
+        let responses = provider.stream_response(&context).collect::<Vec<_>>().await;
+        let incomplete = responses
+            .iter()
+            .any(|response| matches!(response, Ok(LlmResponse::Done { stop_reason: Some(crate::StopReason::Length) })));
+        assert!(incomplete || responses.last().unwrap().is_err(), "{responses:?}");
+        if !incomplete {
+            assert!(!responses.iter().any(|response| matches!(response, Ok(LlmResponse::Done { .. }))));
+        }
+        collect(&provider, &context).await;
+        assert_ne!(server.captured().await.connection, server.captured().await.connection);
+    }
+}
+
+#[tokio::test]
+async fn idle_socket_services_ping_and_provider_drop_closes_it() {
+    let mut reply = Reply::events(text_events("one", "Hello"));
+    reply.frames.push(Message::Ping(vec![1].into()));
+    let mut server = FakeResponsesWebsocketServer::start(vec![reply]).await;
+    let provider = provider(&server);
+    collect(&provider, &context("same")).await;
+    let request = server.captured().await;
+    server.pong().await;
+    drop(provider);
+    assert_eq!(server.closed().await, request.connection);
+}
+
+#[tokio::test]
+async fn idle_deadline_closes_socket_without_another_request() {
+    let mut server = FakeResponsesWebsocketServer::start(vec![]).await;
+    let provider = provider(&server);
+    collect(&provider, &context("same")).await;
+    let first = server.captured().await;
+    tokio::time::pause();
+    tokio::time::advance(std::time::Duration::from_secs(301)).await;
+    assert_eq!(server.closed().await, first.connection);
+    tokio::time::resume();
+    collect(&provider, &context("same")).await;
+    assert_ne!(server.captured().await.connection, first.connection);
+}
+
+#[tokio::test]
+async fn max_socket_age_is_bounded() {
+    let mut server = FakeResponsesWebsocketServer::start(vec![]).await;
+    let provider = provider(&server);
+    collect(&provider, &context("same")).await;
+    let first = server.captured().await;
+    for iteration in 1..=14 {
+        tokio::time::pause();
+        tokio::time::advance(std::time::Duration::from_mins(4)).await;
+        tokio::time::resume();
+        collect(&provider, &context("same")).await;
+        let request = server.captured().await;
+        if iteration < 14 {
+            assert_eq!(request.connection, first.connection);
+        } else {
+            assert_ne!(request.connection, first.connection);
+        }
+    }
+    assert_eq!(server.closed().await, first.connection);
+}
+
+#[tokio::test]
+async fn active_event_deadline_and_drop_during_backpressure_release_socket() {
+    let mut server = FakeResponsesWebsocketServer::start(vec![Reply::events(vec![
+        serde_json::json!({"type":"response.created","response":{"id":"one"}}),
+    ])])
+    .await;
+    let provider = provider(&server);
+    let mut stream = provider.stream_response(&context("same"));
+    assert!(matches!(stream.next().await.unwrap().unwrap(), LlmResponse::Start { .. }));
+    server.captured().await;
+    tokio::time::pause();
+    tokio::time::advance(std::time::Duration::from_secs(301)).await;
+    assert_eq!(stream.next().await.unwrap().unwrap_err().provider().unwrap().kind, crate::ProviderErrorKind::Timeout);
+    tokio::time::resume();
+    drop(stream);
+    server.closed().await;
+
+    let mut events = vec![serde_json::json!({"type":"response.created","response":{"id":"flood"}})];
+    events.extend((0..128).map(|_| serde_json::json!({"type":"response.output_text.delta","delta":"chunk"})));
+    let mut flood = FakeResponsesWebsocketServer::start(vec![Reply::events(events)]).await;
+    let provider = self::provider(&flood);
+    let mut stream = provider.stream_response(&context("same"));
+    assert!(matches!(stream.next().await.unwrap().unwrap(), LlmResponse::Start { .. }));
+    let first = flood.captured().await;
+    drop(stream);
+    assert_eq!(flood.closed().await, first.connection);
+    collect(&provider, &context("same")).await;
+    assert_ne!(flood.captured().await.connection, first.connection);
+}
+
+#[tokio::test]
+async fn authentication_rejection_reloads_credentials_and_invalidates_session_identity() {
+    use aether_auth::OAuthCredentialStorage;
+    let mut events = text_events("one", "Hello");
+    events.insert(1, serde_json::json!({"type":"response.metadata","headers":{"x-codex-turn-state":"old-token"}}));
+    let rejected =
+        serde_json::json!({"type":"error","status":401,"error":{"code":"invalid_api_key","message":"rejected"}});
+    let mut server =
+        FakeResponsesWebsocketServer::start(vec![Reply::events(events), Reply::events(vec![rejected])]).await;
+    let store = Arc::new(FakeOAuthCredentialStore::new().with_credential("codex", credential("account-1")));
+    let provider = CodexProvider::new(store.clone(), connection(&server.base_url), MODEL).unwrap();
+    collect(&provider, &context("one")).await;
+    let first = server.captured().await;
+    let failed = provider.stream_response(&context("one")).collect::<Vec<_>>().await;
+    assert_eq!(failed[0].as_ref().unwrap_err().provider().unwrap().kind, crate::ProviderErrorKind::Authentication);
+    server.captured().await;
+    store.save_credential("codex", credential("account-2")).await.unwrap();
+    collect(&provider, &context("one")).await;
+    let changed = server.captured().await;
+    assert_ne!(changed.connection, first.connection);
+    assert_eq!(changed.headers["chatgpt-account-id"], "account-2");
+    assert!(changed.body["client_metadata"].get("x-codex-turn-state").is_none());
+    assert!(changed.body.get("previous_response_id").is_none());
+}

--- a/crates/llm/src/providers/codex/tests/wire.rs
+++ b/crates/llm/src/providers/codex/tests/wire.rs
@@ -1,0 +1,136 @@
+use super::test_server::{FakeResponsesWebsocketServer, Reply, text_events};
+use super::{MODEL, collect, connection, context, provider, provider_at};
+use crate::providers::codex::CodexProvider;
+use crate::{LlmResponse, StreamingModelProvider};
+use aether_auth::FakeOAuthCredentialStore;
+use futures::StreamExt;
+use std::sync::Arc;
+
+#[tokio::test]
+async fn websocket_wire_contract() {
+    let mut server = FakeResponsesWebsocketServer::start(vec![]).await;
+    let provider = provider(&server);
+    let mut context = context("conversation-1");
+    context.set_system_content("You are helpful".into());
+    context.set_tools(vec![crate::ToolDefinition::new(
+        "bash",
+        "Run a command",
+        serde_json::json!({"type":"object","properties":{"cmd":{"type":"string"}}}),
+    )]);
+    context.set_reasoning_effort(Some(crate::ReasoningEffort::Max));
+    context.set_prompt_cache_key(Some("cache-1".into()));
+    let responses = provider.stream_response(&context).collect::<Vec<_>>().await;
+    assert!(responses.iter().all(Result::is_ok), "{responses:?}");
+    assert!(matches!(responses.last(), Some(Ok(LlmResponse::Done { .. }))));
+    let request = server.captured().await;
+    assert_eq!(request.uri.path(), "/responses");
+    assert_eq!(request.body["type"], "response.create");
+    assert_eq!(request.body["stream"], true);
+    assert_eq!(request.body["store"], false);
+    assert_eq!(request.body["model"], "gpt-5.6-luna");
+    assert_eq!(request.body["reasoning"]["effort"], "max");
+    assert!(request.body["reasoning"].get("context").is_none());
+    assert_eq!(request.body["instructions"], "You are helpful");
+    assert_eq!(
+        request.body["tools"],
+        serde_json::json!([{
+            "type":"function", "name":"bash", "description":"Run a command",
+            "parameters":{"type":"object","properties":{"cmd":{"type":"string"}}}
+        }])
+    );
+    assert_eq!(request.body["input"][0]["role"], "user");
+    assert_eq!(request.body["prompt_cache_key"], "cache-1");
+    assert!(request.body.get("parallel_tool_calls").is_none());
+    assert_eq!(request.headers["version"], "0.153.4");
+    assert_eq!(request.headers["originator"], "codex_cli_rs");
+    assert!(!request.headers.contains_key("x-openai-internal-codex-responses-lite"));
+    assert_eq!(request.headers["openai-beta"], "responses_websockets=2026-02-06");
+    assert_eq!(request.headers["chatgpt-account-id"], "account-1");
+    assert_eq!(request.headers["session-id"], request.headers["thread-id"]);
+    assert!(request.headers.contains_key("x-client-request-id"));
+    assert!(request.body.get("previous_response_id").is_none());
+}
+
+#[tokio::test]
+async fn default_wire_settings_and_display_name() {
+    let mut server = FakeResponsesWebsocketServer::start(vec![]).await;
+    let provider = provider(&server);
+    collect(&provider, &context("same")).await;
+    assert_eq!(server.captured().await.body["reasoning"]["effort"], "medium");
+    assert_eq!(provider.display_name(), "Codex (gpt-5.6-luna)");
+    assert_eq!(provider.context_window(), Some(272_000));
+}
+
+#[tokio::test]
+async fn routing_token_is_first_wins_and_scoped_to_turn() {
+    let mut events = text_events("one", "Hello");
+    events.insert(1, serde_json::json!({"type":"response.metadata","headers":{"X-Codex-Turn-State":[["first"]]}}));
+    events.insert(2, serde_json::json!({"type":"response.metadata","headers":{"x-codex-turn-state":"second"}}));
+    let mut server = FakeResponsesWebsocketServer::start(vec![Reply::events(events)]).await;
+    let provider = provider(&server);
+    let mut context = context("same");
+    for turn in ["turn-1", "turn-1", "turn-2"] {
+        context.set_turn_id(Some(turn.into()));
+        let responses = provider.stream_response(&context).collect::<Vec<_>>().await;
+        assert!(responses.iter().all(Result::is_ok), "{responses:?}");
+    }
+    let first = server.captured().await;
+    let second = server.captured().await;
+    let third = server.captured().await;
+    assert_eq!(first.connection, third.connection);
+    assert_eq!(second.body["client_metadata"]["x-codex-turn-state"], "first");
+    assert!(third.body["client_metadata"].get("x-codex-turn-state").is_none());
+}
+
+#[tokio::test]
+async fn handshake_token_survives_same_turn_reconnect_but_not_new_turn() {
+    let rejection =
+        serde_json::json!({"type":"error","error":{"code":"previous_response_not_found","message":"expired"}});
+    let mut server = FakeResponsesWebsocketServer::start(vec![Reply::events(vec![rejection])]).await;
+    server.handshake_token("first-token");
+    let provider = provider(&server);
+    let mut context = context("same");
+    collect(&provider, &context).await;
+    let first = server.captured().await;
+    let second = server.captured().await;
+    assert_ne!(first.connection, second.connection);
+    assert_eq!(second.body["client_metadata"]["x-codex-turn-state"], "first-token");
+    context.set_turn_id(Some("next-turn".into()));
+    collect(&provider, &context).await;
+    let third = server.captured().await;
+    assert_eq!(third.connection, second.connection);
+    assert!(third.body["client_metadata"].get("x-codex-turn-state").is_none());
+}
+
+#[tokio::test]
+async fn no_turn_id_does_not_replay_routing_tokens() {
+    let mut events = text_events("one", "Hello");
+    events.insert(1, serde_json::json!({"type":"response.metadata","headers":{"x-codex-turn-state":"token"}}));
+    let mut server = FakeResponsesWebsocketServer::start(vec![Reply::events(events)]).await;
+    let provider = provider(&server);
+    let mut context = context("same");
+    context.set_turn_id(None);
+    collect(&provider, &context).await;
+    collect(&provider, &context).await;
+    let first = server.captured().await;
+    let second = server.captured().await;
+    assert_eq!(first.connection, second.connection);
+    assert_ne!(first.body["client_metadata"]["x-codex-turn-id"], second.body["client_metadata"]["x-codex-turn-id"]);
+    assert!(second.body["client_metadata"].get("x-codex-turn-state").is_none());
+}
+
+#[tokio::test]
+async fn base_paths_and_queries_are_preserved_and_invalid_urls_rejected() {
+    let mut server = FakeResponsesWebsocketServer::start(vec![]).await;
+    collect(&provider_at(&format!("{}/base/?key=value", server.base_url)), &context("same")).await;
+    let captured = server.captured().await;
+    assert_eq!(captured.uri.path(), "/base/responses");
+    assert_eq!(captured.uri.query(), Some("key=value"));
+    let store = Arc::new(FakeOAuthCredentialStore::new());
+    for url in
+        ["ws://localhost", "https://user:password@localhost", "https://localhost/#fragment", "not-url", "file:///path"]
+    {
+        let provider = CodexProvider::new(store.clone(), connection(url), MODEL);
+        assert!(matches!(provider, Err(crate::LlmError::ProviderRequest(_))), "{url}");
+    }
+}

--- a/crates/llm/src/providers/codex/websocket.rs
+++ b/crates/llm/src/providers/codex/websocket.rs
@@ -1,0 +1,195 @@
+use async_openai::types::responses::{CreateResponse, Status};
+use futures::{SinkExt, StreamExt};
+use reqwest::{Client, Url, header::HeaderMap};
+use reqwest_websocket::{Message, Upgrade, WebSocket};
+use serde_json::{Value, json};
+use tokio::time::{Duration, Instant, timeout, timeout_at};
+
+use crate::providers::openai_responses::streaming::{ResponsesErrorEvent, ResponsesStreamEvent};
+use crate::{LlmError, ProviderError, ReasoningEffort, Result};
+
+/// How long a socket may sit idle between responses before it is closed.
+pub(super) const IDLE_LIFETIME: Duration = Duration::from_mins(5);
+/// Sockets older than this are not reused for new requests.
+pub(super) const MAX_CONNECTION_AGE: Duration = Duration::from_mins(55);
+pub(super) const OPEN_SEND_TIMEOUT: Duration = Duration::from_secs(30);
+/// How long to wait for the next model event while a response is streaming.
+pub(super) const EVENT_IDLE_TIMEOUT: Duration = Duration::from_mins(5);
+
+pub(super) struct Connection {
+    socket: WebSocket,
+    request_id: Option<String>,
+    opened: Instant,
+    phase: Phase,
+}
+
+impl Connection {
+    /// Open a socket, returning it with any routing token issued during the upgrade.
+    pub async fn open(client: &Client, url: Url, headers: HeaderMap) -> Result<(Self, Option<String>)> {
+        let deadline = Instant::now() + OPEN_SEND_TIMEOUT;
+        let upgrade = timeout_at(deadline, client.get(url).headers(headers).upgrade().send())
+            .await
+            .map_err(|_| ProviderError::timeout("Codex WebSocket upgrade deadline exceeded"))?
+            .map_err(open_error)?;
+        let request_id = header_value(upgrade.headers(), "x-request-id");
+        if upgrade.status() != reqwest::StatusCode::SWITCHING_PROTOCOLS {
+            let status = upgrade.status().as_u16();
+            let body =
+                timeout_at(deadline.min(Instant::now() + REJECTION_BODY_TIMEOUT), rejection_body(upgrade.into_inner()))
+                    .await
+                    .unwrap_or(Value::Null);
+            let mut rejection = serde_json::from_value::<ResponsesErrorEvent>(body).unwrap_or_default();
+            rejection.status = Some(status);
+            let mut error = ProviderError::from(rejection);
+            error.request_id = request_id;
+            return Err(error.into());
+        }
+        let turn_state = header_value(upgrade.headers(), "x-codex-turn-state");
+        let socket = timeout_at(deadline, upgrade.into_websocket())
+            .await
+            .map_err(|_| ProviderError::timeout("Codex WebSocket upgrade deadline exceeded"))?
+            .map_err(open_error)?;
+        let opened = Instant::now();
+        Ok((Self { socket, request_id, opened, phase: Phase::Idle(opened + IDLE_LIFETIME) }, turn_state))
+    }
+
+    /// The request ID the server assigned to the upgrade, for error diagnostics.
+    pub fn request_id(&self) -> Option<&str> {
+        self.request_id.as_deref()
+    }
+
+    pub fn reusable(&self) -> bool {
+        matches!(self.phase, Phase::Idle(until) if Instant::now() < until) && self.opened.elapsed() < MAX_CONNECTION_AGE
+    }
+
+    pub async fn send(
+        &mut self,
+        request: &CreateResponse,
+        effort: Option<ReasoningEffort>,
+        turn_id: &str,
+        routing_token: Option<&str>,
+    ) -> Result<()> {
+        let mut body = serde_json::to_value(request)?;
+        // The SDK cannot represent Codex's `max` reasoning effort.
+        if let Some(effort) = effort {
+            body["reasoning"]["effort"] = effort.as_str().into();
+        }
+        body["type"] = "response.create".into();
+        body["client_metadata"] = json!({"x-codex-turn-id": turn_id});
+        if let Some(token) = routing_token {
+            body["client_metadata"]["x-codex-turn-state"] = token.into();
+        }
+        timeout(OPEN_SEND_TIMEOUT, self.socket.send(Message::Text(body.to_string())))
+            .await
+            .map_err(|_| ProviderError::timeout("Codex WebSocket send deadline exceeded"))?
+            .map_err(|_| ProviderError::stream_interrupted("Codex WebSocket send failed"))?;
+        self.phase = Phase::Streaming(Instant::now() + EVENT_IDLE_TIMEOUT);
+        Ok(())
+    }
+
+    pub async fn receive(&mut self) -> Result<ResponsesStreamEvent> {
+        loop {
+            let event = match timeout_at(self.phase.deadline(), self.socket.next()).await {
+                Err(_) => {
+                    return Err(ProviderError::timeout("Codex WebSocket response-event idle deadline exceeded").into());
+                }
+                Ok(Some(Ok(Message::Text(text)))) => serde_json::from_str::<ResponsesStreamEvent>(&text)
+                    .map_err(|_| ProviderError::stream_interrupted("Invalid Codex WebSocket event"))?,
+                Ok(Some(Ok(Message::Ping(_) | Message::Pong(_)))) => {
+                    timeout(OPEN_SEND_TIMEOUT, self.socket.flush())
+                        .await
+                        .map_err(|_| ProviderError::timeout("Codex WebSocket ping deadline exceeded"))?
+                        .map_err(|_| ProviderError::stream_interrupted("Codex WebSocket ping failed"))?;
+                    continue;
+                }
+                Ok(Some(Ok(Message::Binary(_)))) => {
+                    return Err(ProviderError::stream_interrupted("Unexpected binary Codex WebSocket frame").into());
+                }
+                Ok(None | Some(Ok(Message::Close { .. }) | Err(_))) => {
+                    return Err(
+                        ProviderError::stream_interrupted("Codex WebSocket closed before terminal response").into()
+                    );
+                }
+            };
+            match &event {
+                ResponsesStreamEvent::Metadata(_) => {}
+                ResponsesStreamEvent::Completed(completed)
+                    if matches!(completed.response.status, Some(Status::Completed)) =>
+                {
+                    self.phase = Phase::Idle(Instant::now() + IDLE_LIFETIME);
+                }
+                _ => self.phase = Phase::Streaming(Instant::now() + EVENT_IDLE_TIMEOUT),
+            }
+            return Ok(event);
+        }
+    }
+
+    /// Service control frames while idle, returning on unexpected traffic or the idle deadline.
+    pub async fn idle(&mut self) {
+        while matches!(self.receive().await, Ok(ResponsesStreamEvent::Metadata(_))) {}
+    }
+}
+
+pub(super) fn responses_url(base: &str) -> Result<Url> {
+    let mut url = Url::parse(base).map_err(|_| LlmError::ProviderRequest("Invalid Codex endpoint URL".into()))?;
+    if !matches!(url.scheme(), "http" | "https")
+        || url.host_str().is_none()
+        || !url.username().is_empty()
+        || url.password().is_some()
+        || url.fragment().is_some()
+    {
+        return Err(LlmError::ProviderRequest(
+            "Codex endpoint requires HTTP(S), a host, and no userinfo or fragment".into(),
+        ));
+    }
+    url.path_segments_mut()
+        .map_err(|()| LlmError::ProviderRequest("Invalid Codex endpoint path".into()))?
+        .pop_if_empty()
+        .push("responses");
+    Ok(url)
+}
+
+const REJECTION_BODY_LIMIT: usize = 16 * 1024;
+const REJECTION_BODY_TIMEOUT: Duration = Duration::from_secs(2);
+
+/// Whether a response is in flight on the socket, and when waiting for it gives up.
+enum Phase {
+    /// No response in flight; the socket may be reused until the deadline.
+    Idle(Instant),
+    /// A response is streaming; the next event must arrive before the deadline.
+    Streaming(Instant),
+}
+
+impl Phase {
+    fn deadline(&self) -> Instant {
+        match self {
+            Self::Idle(deadline) | Self::Streaming(deadline) => *deadline,
+        }
+    }
+}
+
+async fn rejection_body(mut response: reqwest::Response) -> Value {
+    let mut body = Vec::new();
+    while let Ok(Some(chunk)) = response.chunk().await {
+        if body.len() + chunk.len() > REJECTION_BODY_LIMIT {
+            return Value::Null;
+        }
+        body.extend_from_slice(&chunk);
+    }
+    serde_json::from_slice(&body).unwrap_or(Value::Null)
+}
+
+fn open_error(error: reqwest_websocket::Error) -> LlmError {
+    match error {
+        reqwest_websocket::Error::Handshake(_) => ProviderError::api("Invalid Codex WebSocket upgrade handshake"),
+        reqwest_websocket::Error::Reqwest(error) if error.is_timeout() => {
+            ProviderError::timeout("Codex WebSocket opening timed out")
+        }
+        _ => ProviderError::network("Unable to open Codex WebSocket connection"),
+    }
+    .into()
+}
+
+fn header_value(headers: &HeaderMap, name: &str) -> Option<String> {
+    headers.get(name).and_then(|value| value.to_str().ok()).map(str::to_owned)
+}

--- a/crates/llm/src/providers/openai_responses/mappers.rs
+++ b/crates/llm/src/providers/openai_responses/mappers.rs
@@ -58,7 +58,7 @@ impl ResponsesRequestPolicy {
     }
 
     /// Effort to send, if any — an explicit request beats the provider default.
-    fn effort(&self, context: &Context) -> Option<ReasoningEffort> {
+    pub(crate) fn effort(&self, context: &Context) -> Option<ReasoningEffort> {
         context.reasoning_effort().or(self.default_effort)
     }
 }

--- a/crates/llm/src/providers/openai_responses/mappers.rs
+++ b/crates/llm/src/providers/openai_responses/mappers.rs
@@ -160,9 +160,6 @@ pub(crate) fn map_messages(messages: &[ChatMessage]) -> Result<(Option<String>, 
                 }));
             }
             ChatMessage::Assistant { content, tool_calls, reasoning, .. } => {
-                if !content.is_empty() {
-                    items.push(easy_message(Role::Assistant, content.clone()));
-                }
                 if let Some(encrypted) = &reasoning.encrypted_content {
                     items.push(InputItem::Item(Item::Reasoning(ReasoningItem {
                         id: Some(encrypted.id.clone()),
@@ -171,6 +168,9 @@ pub(crate) fn map_messages(messages: &[ChatMessage]) -> Result<(Option<String>, 
                         content: None,
                         status: None,
                     })));
+                }
+                if !content.is_empty() {
+                    items.push(easy_message(Role::Assistant, content.clone()));
                 }
                 for tc in tool_calls {
                     items.push(InputItem::Item(Item::FunctionCall(FunctionToolCall {
@@ -565,15 +565,16 @@ mod tests {
         }];
 
         let (_, items) = map_messages(&messages).unwrap();
-        // Should have: easy_message (text) + reasoning item = 2
         assert_eq!(items.len(), 2);
 
-        let reasoning_item = &items[1];
+        // Reasoning precedes the message, matching the order the model produced them.
+        let reasoning_item = &items[0];
         if let InputItem::Item(Item::Reasoning(r)) = reasoning_item {
             assert_eq!(r.encrypted_content.as_deref(), Some("encrypted-blob"));
         } else {
             panic!("Expected Item::Reasoning, got {reasoning_item:?}");
         }
+        assert!(matches!(&items[1], InputItem::EasyMessage(_)));
     }
 
     #[test]

--- a/crates/llm/src/providers/openai_responses/mod.rs
+++ b/crates/llm/src/providers/openai_responses/mod.rs
@@ -1,10 +1,6 @@
-//! Shared building blocks for providers that speak the `OpenAI` Responses API.
+//! Shared request mapping and event decoding for the `OpenAI` Responses API.
 //!
-//! Several endpoints serve the same `POST {base}/responses` wire contract behind
-//! different hosts and authentication schemes -- the `ChatGPT` Codex backend and
-//! the Bedrock Mantle endpoint among them. Request mapping and SSE event
-//! processing are identical across all of them, so they live here and each
-//! provider supplies only its own transport and credentials.
+//! Providers supply their own credentials and HTTP/SSE or WebSocket transport.
 
 pub(crate) mod mappers;
 pub(crate) mod streaming;

--- a/crates/llm/src/providers/openai_responses/streaming.rs
+++ b/crates/llm/src/providers/openai_responses/streaming.rs
@@ -237,7 +237,8 @@ fn process_event(
         }
         ResponsesStreamEvent::OutputItemAdded(e) => {
             if let OutputItem::FunctionCall(call) = e.item {
-                let tool_responses = tool_collector.handle_delta(e.output_index, call.id, Some(call.name), None);
+                let tool_responses =
+                    tool_collector.handle_delta(e.output_index, Some(call.call_id), Some(call.name), None);
                 responses.extend(tool_responses.into_iter().map(Ok));
             }
         }
@@ -354,15 +355,15 @@ mod tests {
 
         assert!(matches!(responses[0], LlmResponse::Start { .. }));
         assert!(
-            matches!(&responses[1], LlmResponse::ToolRequestStart { id, name } if id == "fc_1" && name == "read_file")
+            matches!(&responses[1], LlmResponse::ToolRequestStart { id, name } if id == "call_1" && name == "read_file")
         );
-        assert!(matches!(responses[2], LlmResponse::ToolRequestArg { .. }));
-        assert!(matches!(responses[3], LlmResponse::ToolRequestArg { .. }));
+        assert!(matches!(&responses[2], LlmResponse::ToolRequestArg { id, .. } if id == "call_1"));
+        assert!(matches!(&responses[3], LlmResponse::ToolRequestArg { id, .. } if id == "call_1"));
 
         let tc = responses.iter().find(|r| matches!(r, LlmResponse::ToolRequestComplete { .. }));
         assert!(tc.is_some());
         if let LlmResponse::ToolRequestComplete { tool_call } = tc.unwrap() {
-            assert_eq!(tool_call.id, "fc_1");
+            assert_eq!(tool_call.id, "call_1");
             assert_eq!(tool_call.name, "read_file");
             assert_eq!(tool_call.arguments, r#"{"path":"foo.rs"}"#);
         }

--- a/crates/llm/src/providers/openai_responses/streaming.rs
+++ b/crates/llm/src/providers/openai_responses/streaming.rs
@@ -6,7 +6,7 @@ use tokio_stream::StreamExt;
 use crate::providers::tool_call_collector::ToolCallCollector;
 use crate::{LlmResponse, ProviderError, ProviderErrorKind, Result, StopReason, TokenUsage};
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct ResponsesUsage {
     usage: ResponseUsage,
     cache_write_tokens: Option<u32>,
@@ -63,17 +63,34 @@ pub enum ResponsesStreamEvent {
     Failed(ResponsesFailedEvent),
     #[serde(rename = "error")]
     Error(ResponsesErrorEvent),
+    /// Transport metadata carrying routing headers but no response content.
+    #[serde(rename = "response.metadata", alias = "codex.response.metadata")]
+    Metadata(ResponsesMetadataEvent),
     #[serde(other)]
     Ignored,
 }
 
 impl ResponsesStreamEvent {
+    /// Whether this event ends the response, successfully or not.
+    pub fn ends_response(&self) -> bool {
+        matches!(self, Self::Completed(_) | Self::Incomplete(_) | Self::Failed(_) | Self::Error(_))
+    }
+
+    /// Split a failure the server reported as an event out of the stream.
+    pub fn into_result(self) -> std::result::Result<Self, ProviderError> {
+        match self {
+            Self::Failed(event) => Err(event.into()),
+            Self::Error(event) => Err(event.into()),
+            event => Ok(event),
+        }
+    }
+
     /// Whether this event may legitimately arrive before `response.created`:
     /// event types we ignore, and failures the endpoint reports *instead of*
     /// opening a response. Rejecting those would replace the server's own
     /// message with a generic interrupt.
     fn may_precede_creation(&self) -> bool {
-        matches!(self, Self::Ignored | Self::Error(_) | Self::Failed(_))
+        matches!(self, Self::Ignored | Self::Metadata(_) | Self::Error(_) | Self::Failed(_))
     }
 }
 
@@ -87,15 +104,78 @@ pub struct ResponsesCreated {
     pub id: String,
 }
 
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Deserialize, Default)]
 pub struct ResponsesFailedEvent {
     pub response: ResponsesFailed,
+    #[serde(default)]
+    pub status: Option<u16>,
+    #[serde(default)]
+    pub headers: ResponsesHeaders,
+}
+
+#[derive(Debug, Deserialize, Default)]
+pub struct ResponsesFailed {
+    #[serde(default)]
+    pub error: Option<ResponsesError>,
+}
+
+/// A top-level `error` event. `OpenAI` sends the error fields inline; the Codex
+/// WebSocket wraps them in an `error` object beside the HTTP status and headers.
+#[derive(Debug, Deserialize, Default)]
+pub struct ResponsesErrorEvent {
+    #[serde(default)]
+    pub error: Option<ResponsesError>,
+    #[serde(flatten)]
+    pub inline: ResponsesError,
+    #[serde(default)]
+    pub status: Option<u16>,
+    #[serde(default)]
+    pub headers: ResponsesHeaders,
+}
+
+#[derive(Debug, Deserialize, Default)]
+pub struct ResponsesError {
+    #[serde(default)]
+    pub code: Option<String>,
+    #[serde(default)]
+    pub message: Option<String>,
+    #[serde(default, rename = "type")]
+    pub kind: Option<String>,
 }
 
 #[derive(Debug, Deserialize)]
-pub struct ResponsesFailed {
+pub struct ResponsesMetadataEvent {
     #[serde(default)]
-    pub error: Option<ResponsesErrorEvent>,
+    pub headers: ResponsesHeaders,
+}
+
+/// Response headers echoed inside an event frame.
+#[derive(Debug, Deserialize, Default)]
+pub struct ResponsesHeaders(serde_json::Value);
+
+impl ResponsesHeaders {
+    /// Case-insensitive lookup that unwraps nested single-element arrays.
+    pub fn get(&self, name: &str) -> Option<&str> {
+        let (_, mut value) = self.0.as_object()?.iter().find(|(key, _)| key.eq_ignore_ascii_case(name))?;
+        while let serde_json::Value::Array(values) = value {
+            value = values.first()?;
+        }
+        value.as_str()
+    }
+}
+
+impl From<ResponsesErrorEvent> for ProviderError {
+    fn from(event: ResponsesErrorEvent) -> Self {
+        let error = event.error.unwrap_or(event.inline);
+        map_responses_error(error, event.status, &event.headers, ProviderErrorKind::Unknown)
+    }
+}
+
+impl From<ResponsesFailedEvent> for ProviderError {
+    fn from(event: ResponsesFailedEvent) -> Self {
+        let error = event.response.error.unwrap_or_default();
+        map_responses_error(error, event.status, &event.headers, ProviderErrorKind::Api)
+    }
 }
 
 #[derive(Debug, Deserialize)]
@@ -125,29 +205,16 @@ pub struct ResponsesCompletedEvent {
     pub response: ResponsesCompleted,
 }
 
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Clone, Deserialize)]
 pub struct ResponsesCompleted {
+    #[serde(default)]
+    pub id: Option<String>,
     #[serde(default)]
     pub usage: Option<ResponsesUsage>,
     #[serde(default)]
     pub status: Option<Status>,
-}
-
-#[derive(Debug, Deserialize)]
-pub struct ResponsesErrorEvent {
-    #[serde(default)]
-    pub code: Option<String>,
-    #[serde(default)]
-    pub message: String,
-}
-
-fn map_responses_error(code: Option<String>, message: String, fallback: ProviderErrorKind) -> ProviderError {
-    let kind = match code.as_deref() {
-        Some("server_error") => ProviderErrorKind::Server,
-        Some("rate_limit_exceeded") => ProviderErrorKind::RateLimit,
-        _ => fallback,
-    };
-    ProviderError::new(kind, message).with_code(code)
+    #[serde(default, deserialize_with = "deserialize_completed_output")]
+    pub output: Option<Vec<OutputItem>>,
 }
 
 /// Process an `OpenAI` Responses event stream into `LlmResponse` items.
@@ -166,7 +233,10 @@ where
             let event = match result {
                 Ok(event) => event,
                 Err(e) => {
-                    yield Err(ProviderError::stream_interrupted(e.to_string()).into());
+                    yield Err(match e {
+                        crate::LlmError::Provider(_) => e,
+                        other => ProviderError::stream_interrupted(other.to_string()).into(),
+                    });
                     return;
                 }
             };
@@ -218,6 +288,45 @@ struct ResponsesUsageExtension {
 struct ResponsesInputTokenDetailsExtension {
     #[serde(default)]
     cache_write_tokens: Option<u32>,
+}
+
+fn deserialize_completed_output<'de, D>(deserializer: D) -> std::result::Result<Option<Vec<OutputItem>>, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    let output = Option::<Vec<serde_json::Value>>::deserialize(deserializer)?;
+    // Unsupported replay metadata or malformed items disable continuation, not response delivery.
+    Ok(output.and_then(|items| {
+        items
+            .into_iter()
+            .map(|item| {
+                if ["phase", "namespace"].iter().any(|key| !item[*key].is_null()) {
+                    return None;
+                }
+                serde_json::from_value(item).ok()
+            })
+            .collect()
+    }))
+}
+
+fn map_responses_error(
+    error: ResponsesError,
+    status: Option<u16>,
+    headers: &ResponsesHeaders,
+    fallback: ProviderErrorKind,
+) -> ProviderError {
+    let kind = status
+        .map(ProviderErrorKind::from_http_status)
+        .or_else(|| error.code.as_deref().and_then(ProviderErrorKind::from_code))
+        .unwrap_or(if error.kind.as_deref() == Some("invalid_request_error") {
+            ProviderErrorKind::Api
+        } else {
+            fallback
+        });
+    let message = error.message.unwrap_or_else(|| "Responses API request failed".into());
+    ProviderError::new(kind, message)
+        .with_code(error.code)
+        .with_http_metadata(status, headers.get("x-request-id").map(str::to_owned))
 }
 
 fn process_event(
@@ -275,18 +384,10 @@ fn process_event(
                 _ => {}
             }
         }
-        ResponsesStreamEvent::Failed(e) => {
-            let error = e.response.error.map_or_else(
-                || ProviderError::new(ProviderErrorKind::Api, "Unknown Responses API failure"),
-                |e| map_responses_error(e.code, e.message, ProviderErrorKind::Api),
-            );
-            responses.push(Err(error.into()));
-        }
-        ResponsesStreamEvent::Error(e) => {
-            let message = format!("Responses API error: {}", e.message);
-            responses.push(Err(map_responses_error(e.code, message, ProviderErrorKind::Unknown).into()));
-        }
+        ResponsesStreamEvent::Failed(e) => responses.push(Err(ProviderError::from(e).into())),
+        ResponsesStreamEvent::Error(e) => responses.push(Err(ProviderError::from(e).into())),
         ResponsesStreamEvent::Ignored
+        | ResponsesStreamEvent::Metadata(_)
         | ResponsesStreamEvent::OutputTextDelta(_)
         | ResponsesStreamEvent::ReasoningSummaryTextDelta(_) => {}
     }
@@ -309,6 +410,23 @@ mod tests {
             responses.push(result.unwrap());
         }
         responses
+    }
+
+    #[tokio::test]
+    async fn classified_transport_errors_preserve_diagnostics() {
+        for (kind, status, code) in [
+            (ProviderErrorKind::Authentication, 401, "invalid_api_key"),
+            (ProviderErrorKind::RateLimit, 429, "rate_limit_exceeded"),
+        ] {
+            let expected = ProviderError::new(kind, "rejected")
+                .with_http_status(status)
+                .with_code(Some(code.into()))
+                .with_request_id(Some("req-1".into()));
+            let stream = tokio_stream::iter(vec![Err(expected.clone().into())]);
+            let responses = process_response_stream(stream).collect::<Vec<_>>().await;
+            assert_eq!(responses.len(), 1);
+            assert_eq!(responses[0].as_ref().unwrap_err().provider(), Some(&expected));
+        }
     }
 
     #[tokio::test]
@@ -371,10 +489,7 @@ mod tests {
 
     #[tokio::test]
     async fn error_event_without_code_stays_retryable() {
-        let stream = make_stream(vec![ResponsesStreamEvent::Error(ResponsesErrorEvent {
-            code: None,
-            message: "Rate limit exceeded".to_string(),
-        })]);
+        let stream = make_stream(vec![error_event(None, "Rate limit exceeded".to_string())]);
         let mut response_stream = Box::pin(process_response_stream(stream));
 
         let mut responses = Vec::new();
@@ -390,10 +505,7 @@ mod tests {
 
     #[tokio::test]
     async fn error_event_with_unknown_code_stays_retryable() {
-        let events = vec![Ok(ResponsesStreamEvent::Error(ResponsesErrorEvent {
-            code: Some("bogus".to_string()),
-            message: "boom".to_string(),
-        }))];
+        let events = vec![Ok(error_event(Some("bogus".to_string()), "boom".to_string()))];
         let responses = process_response_stream(tokio_stream::iter(events)).collect::<Vec<_>>().await;
         let err = responses[0].as_ref().expect_err("expected error to surface as Err");
         assert_eq!(err.provider().map(|provider| provider.kind), Some(ProviderErrorKind::Unknown), "got {err:?}");
@@ -402,10 +514,7 @@ mod tests {
 
     #[tokio::test]
     async fn error_event_with_rate_limit_code_is_rate_limited() {
-        let events = vec![Ok(ResponsesStreamEvent::Error(ResponsesErrorEvent {
-            code: Some("rate_limit_exceeded".to_string()),
-            message: "slow down".to_string(),
-        }))];
+        let events = vec![Ok(error_event(Some("rate_limit_exceeded".to_string()), "slow down".to_string()))];
         let responses = process_response_stream(tokio_stream::iter(events)).collect::<Vec<_>>().await;
         let err = responses[0].as_ref().expect_err("expected error to surface as Err");
         assert_eq!(err.provider().map(|provider| provider.kind), Some(ProviderErrorKind::RateLimit), "got {err:?}");
@@ -414,15 +523,9 @@ mod tests {
 
     #[tokio::test]
     async fn failed_event_with_server_error_code_is_retryable() {
-        let responses = failed_events([ResponsesFailedEvent {
-            response: ResponsesFailed {
-                error: Some(ResponsesErrorEvent {
-                    code: Some("server_error".to_string()),
-                    message: "The server had an error".to_string(),
-                }),
-            },
-        }])
-        .await;
+        let responses =
+            failed_events([failed_event(Some("server_error".to_string()), "The server had an error".to_string())])
+                .await;
         let err = responses[0].as_ref().expect_err("expected failure to surface as Err");
         assert_eq!(err.provider().map(|provider| provider.kind), Some(ProviderErrorKind::Server), "got {err:?}");
         assert!(err.is_retryable());
@@ -431,15 +534,8 @@ mod tests {
 
     #[tokio::test]
     async fn failed_event_with_rate_limit_code_is_retryable() {
-        let responses = failed_events([ResponsesFailedEvent {
-            response: ResponsesFailed {
-                error: Some(ResponsesErrorEvent {
-                    code: Some("rate_limit_exceeded".to_string()),
-                    message: "slow down".to_string(),
-                }),
-            },
-        }])
-        .await;
+        let responses =
+            failed_events([failed_event(Some("rate_limit_exceeded".to_string()), "slow down".to_string())]).await;
         let err = responses[0].as_ref().expect_err("expected failure to surface as Err");
         assert_eq!(err.provider().map(|provider| provider.kind), Some(ProviderErrorKind::RateLimit), "got {err:?}");
         assert!(err.is_retryable());
@@ -448,12 +544,7 @@ mod tests {
     #[tokio::test]
     async fn failed_event_with_unknown_code_is_terminal() {
         for code in [Some("invalid_prompt".to_string()), Some("bogus".to_string()), None] {
-            let responses = failed_events([ResponsesFailedEvent {
-                response: ResponsesFailed {
-                    error: Some(ResponsesErrorEvent { code: code.clone(), message: "bad".to_string() }),
-                },
-            }])
-            .await;
+            let responses = failed_events([failed_event(code.clone(), "bad".to_string())]).await;
             let err = responses[0].as_ref().expect_err("expected failure to surface as Err");
             assert_eq!(err.provider().map(|provider| provider.kind), Some(ProviderErrorKind::Api), "got {err:?}");
             assert!(!err.is_retryable(), "unknown/failed codes must be terminal: {err:?}");
@@ -462,10 +553,7 @@ mod tests {
 
     #[tokio::test]
     async fn error_event_with_server_error_code_is_retryable() {
-        let events = vec![Ok(ResponsesStreamEvent::Error(ResponsesErrorEvent {
-            code: Some("server_error".to_string()),
-            message: "boom".to_string(),
-        }))];
+        let events = vec![Ok(error_event(Some("server_error".to_string()), "boom".to_string()))];
         let responses = process_response_stream(tokio_stream::iter(events)).collect::<Vec<_>>().await;
         let err = responses[0].as_ref().expect_err("expected error to surface as Err");
         assert_eq!(err.provider().map(|provider| provider.kind), Some(ProviderErrorKind::Server), "got {err:?}");
@@ -517,10 +605,7 @@ mod tests {
 
     #[tokio::test]
     async fn error_event_before_creation_keeps_the_servers_message() {
-        let events = vec![Ok(ResponsesStreamEvent::Error(ResponsesErrorEvent {
-            code: None,
-            message: "Rate limit exceeded".to_string(),
-        }))];
+        let events = vec![Ok(error_event(None, "Rate limit exceeded".to_string()))];
         let responses = process_response_stream(tokio_stream::iter(events)).collect::<Vec<_>>().await;
 
         let err = responses[0].as_ref().expect_err("expected the error event to surface as Err");
@@ -530,11 +615,7 @@ mod tests {
 
     #[tokio::test]
     async fn failure_event_before_creation_keeps_the_servers_message() {
-        let events = vec![Ok(ResponsesStreamEvent::Failed(ResponsesFailedEvent {
-            response: ResponsesFailed {
-                error: Some(ResponsesErrorEvent { code: None, message: "model overloaded".to_string() }),
-            },
-        }))];
+        let events = vec![Ok(ResponsesStreamEvent::Failed(failed_event(None, "model overloaded".to_string())))];
         let responses = process_response_stream(tokio_stream::iter(events)).collect::<Vec<_>>().await;
 
         let err = responses[0].as_ref().expect_err("expected the failure event to surface as Err");
@@ -601,7 +682,6 @@ mod tests {
         assert_eq!(usage.cache_creation_tokens.map(crate::Tokens::get), Some(1024));
     }
 
-    /// Decode a captured SSE body and run it through the shared processor.
     async fn failed_events<const N: usize>(events: [ResponsesFailedEvent; N]) -> Vec<Result<LlmResponse>> {
         let events = events.into_iter().map(ResponsesStreamEvent::Failed).map(Ok);
         process_response_stream(tokio_stream::iter(events)).collect().await
@@ -707,6 +787,20 @@ mod tests {
         assert!(responses.is_empty());
     }
 
+    fn error_event(code: Option<String>, message: String) -> ResponsesStreamEvent {
+        ResponsesStreamEvent::Error(ResponsesErrorEvent {
+            inline: ResponsesError { code, message: Some(message), kind: None },
+            ..ResponsesErrorEvent::default()
+        })
+    }
+
+    fn failed_event(code: Option<String>, message: String) -> ResponsesFailedEvent {
+        ResponsesFailedEvent {
+            response: ResponsesFailed { error: Some(ResponsesError { code, message: Some(message), kind: None }) },
+            ..ResponsesFailedEvent::default()
+        }
+    }
+
     fn text_delta(delta: &str) -> ResponsesStreamEvent {
         ResponsesStreamEvent::OutputTextDelta(ResponsesTextDeltaEvent { delta: delta.to_string() })
     }
@@ -724,7 +818,7 @@ mod tests {
 
     fn completed(status: Status, usage: Option<ResponsesUsage>) -> ResponsesStreamEvent {
         ResponsesStreamEvent::Completed(ResponsesCompletedEvent {
-            response: ResponsesCompleted { usage, status: Some(status) },
+            response: ResponsesCompleted { id: None, usage, status: Some(status), output: None },
         })
     }
 

--- a/crates/llm/tests/fixtures/README.md
+++ b/crates/llm/tests/fixtures/README.md
@@ -18,6 +18,12 @@ endpoint. Used by `tests/providers/*/fixture_tests.rs` to verify that the real
 `process_*_stream` parsers extract `TokenUsage` correctly from on-the-wire
 responses.
 
+The `codex_websocket/` directory is different: it holds synthetic JSON event
+arrays, not captured SSE. The in-memory fake Responses server sends each element
+as a WebSocket text message and maintains per-connection response lineage so
+tests can compare continuation requests against full-context replay. These tests
+need no credentials and do not demonstrate live backend interoperability.
+
 ## Why these exist
 
 Hand-written tests check our *mapping* (e.g. `cached_tokens` → `cache_read_tokens`)

--- a/crates/llm/tests/fixtures/codex_websocket/reasoning_text.json
+++ b/crates/llm/tests/fixtures/codex_websocket/reasoning_text.json
@@ -1,0 +1,9 @@
+[
+  {"type":"response.created","response":{"id":"mixed-response"}},
+  {"type":"response.output_item.done","output_index":0,"item":{"type":"reasoning","id":"reasoning-1","summary":[],"encrypted_content":"opaque-content"}},
+  {"type":"response.output_text.delta","delta":"Hello"},
+  {"type":"response.completed","response":{"id":"mixed-response","status":"completed","output":[
+    {"type":"reasoning","id":"reasoning-1","summary":[],"encrypted_content":"opaque-content"},
+    {"type":"message","id":"msg_1","role":"assistant","status":"completed","content":[{"type":"output_text","text":"Hello","annotations":[]}]}
+  ]}}
+]

--- a/crates/llm/tests/fixtures/codex_websocket/tool_reasoning.json
+++ b/crates/llm/tests/fixtures/codex_websocket/tool_reasoning.json
@@ -1,0 +1,12 @@
+[
+  {"type":"response.created","response":{"id":"tool-response"}},
+  {"type":"response.reasoning_summary_text.delta","delta":"Checking"},
+  {"type":"response.output_item.done","output_index":0,"item":{"type":"reasoning","id":"reasoning-1","summary":[{"type":"summary_text","text":"Checking"}],"encrypted_content":"opaque-content"}},
+  {"type":"response.output_item.added","output_index":1,"item":{"type":"function_call","id":"fc_item_1","call_id":"call_1","name":"read","arguments":"","status":"in_progress"}},
+  {"type":"response.function_call_arguments.delta","output_index":1,"delta":"{ \"path\" : \"file\" }"},
+  {"type":"response.function_call_arguments.done","output_index":1},
+  {"type":"response.completed","response":{"id":"tool-response","status":"completed","output":[
+    {"type":"reasoning","id":"reasoning-1","summary":[{"type":"summary_text","text":"Checking"}],"encrypted_content":"opaque-content"},
+    {"type":"function_call","id":"fc_item_1","call_id":"call_1","name":"read","arguments":"{ \"path\" : \"file\" }","status":"completed"}
+  ],"usage":{"input_tokens":10,"output_tokens":5,"total_tokens":15,"input_tokens_details":{"cached_tokens":2},"output_tokens_details":{"reasoning_tokens":3}}}}
+]


### PR DESCRIPTION
## Summary

Replace Codex HTTP/SSE inference with persistent Responses WebSocket sessions.

- Give each conversation one lazily started task that permanently owns its session and socket. Serialize overlapping calls through a bounded channel without a separate semaphore.
- Preserve cancellation-safe cleanup, terminal-consumption acknowledgment, idle ping handling, connection expiry, and shutdown when callers disappear.
- Add validated incremental continuation using `previous_response_id`, with full-context recovery when server-side lineage is unavailable. Compare request settings, history, and delivered output before enabling continuation.
- Keep async-openai request/input/output types throughout session and continuation logic; isolate Codex JSON extensions and unsupported reasoning effort at the wire boundary.
- Propagate runtime-only turn identity from core through tool iterations, retries, and compaction, with fresh identities for subsequent turns.
- Preserve structured provider error diagnostics and add fake-server coverage, synthetic fixtures, lifecycle documentation, and an optional live smoke-test example.

Includes the preceding reasoning replay-order and tool-call-ID fix used by continuation.

## API changes

- Construct Codex providers with `CodexProvider::new(store, connection, model)?`.
- Clones share one conversation; concurrent calls are serialized. Consume or drop the active stream before awaiting the next one. Independent conversations require separate providers.
- Codex inference is WebSocket-only, with no HTTP/SSE fallback.
- The LLM crate declares Rust 1.98 as its minimum version.

## Validation

- [x] `just test -p aether-llm -p aether-agent-core` — 656 passed, 13 skipped
- [x] `just lint -p aether-llm -p aether-agent-core`
- [x] `just fmt-check -p aether-llm -p aether-agent-core`
- [x] `git diff --check`
- [ ] Live Codex backend smoke test — not run; WebSocket fixtures are synthetic and do not establish live interoperability
