### PR TITLE
feat(aether-sdk)!: stream headless agent events

### DIFF
--- a/packages/aether-evals/package.json
+++ b/packages/aether-evals/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aether-agent/evals",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "description": "Evaluation harness for the Aether agent SDK",
   "repository": {
     "type": "git",
@@ -25,7 +25,7 @@
     "test": "vitest run"
   },
   "dependencies": {
-    "@aether-agent/sdk": "^0.4.1",
+    "@aether-agent/sdk": "workspace:^",
     "testcontainers": "^12.1.0",
     "zod": "^4.4.3"
   },

--- a/packages/aether-evals/src/generate.ts
+++ b/packages/aether-evals/src/generate.ts
@@ -125,7 +125,7 @@ export async function generate<T extends z.ZodType>(
       ? `${prompt}\n\nRespond with ONLY valid JSON. Do not include markdown fences or explanatory prose.`
       : prompt;
 
-  const { stdout } = await runCommand(command, args, {
+  const stdout = await runCommand(command, args, {
     cwd: process.cwd(),
     env: resolveEnv(options.env),
     stdin: promptWithInstructions,

--- a/packages/aether-evals/src/git.ts
+++ b/packages/aether-evals/src/git.ts
@@ -73,13 +73,12 @@ export class GitRepo {
     signal?: AbortSignal,
   ): Promise<string> {
     const range = toCommit ? `${fromCommit}..${toCommit}` : fromCommit;
-    const result = await git(["-C", this.path, "diff", range], signal);
-    return result.stdout;
+    return git(["-C", this.path, "diff", range], signal);
   }
 }
 
-async function git(args: string[], signal?: AbortSignal) {
-  return await runCommand("git", args, {
+function git(args: string[], signal?: AbortSignal): Promise<string> {
+  return runCommand("git", args, {
     cwd: process.cwd(),
     env: processEnv,
     abortSignal: signal,

--- a/packages/aether-evals/test/fixtures/sdk-weather-agent/eval-agent.ts
+++ b/packages/aether-evals/test/fixtures/sdk-weather-agent/eval-agent.ts
@@ -21,13 +21,12 @@ const getWeather = tool({
 });
 
 await using weather = await mcp({ name: "weather", tools: [getWeather] });
-await runHeadless({
+for await (const event of runHeadless({
   binaryPath: process.env.AETHER_BIN ?? "/usr/local/bin/aether",
   prompt,
   cwd: process.env.AETHER_EVAL_CWD ?? process.cwd(),
   model: process.env.AETHER_EVAL_MODEL ?? "zai:glm-5.3",
   settings: { agents: [], mcps: [weather.spec] },
-  output: "json",
-  stdout: "inherit",
-  stderr: "inherit",
-});
+})) {
+  console.log(JSON.stringify(event));
+}

--- a/packages/aether-sdk/package.json
+++ b/packages/aether-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aether-agent/sdk",
-  "version": "0.5.1",
+  "version": "0.6.0",
   "description": "TypeScript SDK for the Aether agent CLI",
   "repository": {
     "type": "git",

--- a/packages/aether-sdk/src/childProcess.ts
+++ b/packages/aether-sdk/src/childProcess.ts
@@ -1,5 +1,7 @@
-import { spawn, type StdioOptions } from "node:child_process";
+import { spawn, type ChildProcessByStdio } from "node:child_process";
 import { addAbortListener } from "node:events";
+import type { Readable, Writable } from "node:stream";
+import { text } from "node:stream/consumers";
 
 import {
   AetherSdkError,
@@ -8,125 +10,119 @@ import {
 } from "./errors.js";
 import { stopChild } from "./agentProcess.js";
 
-export type ProcessOutputMode = "pipe" | "inherit";
-
-export interface RunCommandOutput {
-  stdout: string;
-  stderr: string;
-  exitCode: number;
+export interface CommandExit {
+  exitCode: number | null;
   signal: NodeJS.Signals | null;
+  stderr: string;
 }
 
 export interface RunCommandOptions {
   cwd: string;
   env: Record<string, string | undefined>;
   stdin?: string;
-  stdout?: ProcessOutputMode;
-  stderr?: ProcessOutputMode;
   abortSignal?: AbortSignal;
   spawnFailedMessage: string;
   exitedErrorCode: AetherSdkErrorCode;
-  exitedMessage: (result: RunCommandOutput) => string;
-  /** Called with each utf8 stdout chunk as it arrives (only when `stdout` is `"pipe"`). */
-  onStdout?: (chunk: string) => void;
-  /** Called with each utf8 stderr chunk as it arrives (only when `stderr` is `"pipe"`). */
-  onStderr?: (chunk: string) => void;
+  exitedMessage: (exit: CommandExit) => string;
 }
 
+/** Run a command to completion and return its stdout. */
 export function runCommand(
   command: string,
   args: string[],
   options: RunCommandOptions,
-): Promise<RunCommandOutput> {
+): Promise<string> {
+  return text(streamCommand(command, args, options));
+}
+
+/**
+ * Spawn a command and stream its stdout.
+ */
+export async function* streamCommand(
+  command: string,
+  args: string[],
+  options: RunCommandOptions,
+  transformStdout: (chunks: AsyncIterable<string>) => AsyncIterable<string> = (
+    chunks,
+  ) => chunks,
+): AsyncGenerator<string, void, unknown> {
   throwIfAborted(options.abortSignal);
 
-  return new Promise((resolve, reject) => {
-    const stdoutMode = options.stdout ?? "pipe";
-    const stderrMode = options.stderr ?? "pipe";
-    const stdio: StdioOptions = [
-      options.stdin === undefined ? "ignore" : "pipe",
-      stdoutMode,
-      stderrMode,
-    ];
-    let child: ReturnType<typeof spawn>;
-    try {
-      child = spawn(command, args, {
-        cwd: options.cwd,
-        env: options.env,
-        stdio,
-      });
-    } catch (err) {
-      reject(
-        new AetherSdkError(
-          "process_spawn_failed",
-          options.spawnFailedMessage,
-          err,
-        ),
-      );
-      return;
-    }
+  let child: ChildProcessByStdio<Writable | null, Readable, Readable>;
+  try {
+    const spawnOptions = { cwd: options.cwd, env: options.env };
+    child =
+      options.stdin === undefined
+        ? spawn(command, args, {
+            ...spawnOptions,
+            stdio: ["ignore", "pipe", "pipe"],
+          })
+        : spawn(command, args, { ...spawnOptions, stdio: "pipe" });
+  } catch (cause) {
+    throw spawnFailed(options, cause);
+  }
 
-    let stdout = "";
-    let stderr = "";
-    if (stdoutMode === "pipe") {
-      child.stdout?.setEncoding("utf8");
-      child.stdout?.on("data", (chunk: string) => {
-        stdout += chunk;
-        try {
-          options.onStdout?.(chunk);
-        } catch (err) {
-          void stopChild(child);
-          reject(err);
-        }
-      });
-    }
-    if (stderrMode === "pipe") {
-      child.stderr?.setEncoding("utf8");
-      child.stderr?.on("data", (chunk: string) => {
-        stderr += chunk;
-        try {
-          options.onStderr?.(chunk);
-        } catch (err) {
-          void stopChild(child);
-          reject(err);
-        }
-      });
-    }
-    if (options.stdin !== undefined) {
-      child.stdin?.end(options.stdin);
-    }
-
-    const abortCleanup = options.abortSignal
-      ? addAbortListener(options.abortSignal, () => {
-          void stopChild(child);
-          reject(new AetherSdkError("aborted", "Aborted by caller"));
-        })
-      : null;
-
-    child.on("error", (err) => {
-      abortCleanup?.[Symbol.dispose]();
-      reject(
-        new AetherSdkError(
-          "process_spawn_failed",
-          options.spawnFailedMessage,
-          err,
-        ),
-      );
-    });
-
-    child.on("close", (code, signal) => {
-      abortCleanup?.[Symbol.dispose]();
-      const result = { stdout, stderr, exitCode: code ?? -1, signal };
-      if (code === 0) {
-        resolve(result);
-      } else {
-        reject(
-          new AetherSdkError(
-            options.exitedErrorCode,
-            options.exitedMessage(result),
-          ),
-        );
-      }
-    });
+  let failure: AetherSdkError | undefined;
+  let stderr = "";
+  child.on("error", (cause) => {
+    failure = spawnFailed(options, cause);
   });
+
+  child.stderr.setEncoding("utf8");
+  child.stderr.on("data", (chunk: string) => {
+    stderr += chunk;
+  });
+
+  child.stdin?.end(options.stdin);
+  const closed = new Promise<Omit<CommandExit, "stderr">>((resolve) => {
+    child.once("close", (exitCode, signal) => resolve({ exitCode, signal }));
+  });
+
+  const abortCleanup = options.abortSignal
+    ? addAbortListener(options.abortSignal, () => void stopChild(child))
+    : undefined;
+
+  try {
+    child.stdout.setEncoding("utf8");
+    for await (const chunk of transformStdout(child.stdout)) {
+      throwIfAborted(options.abortSignal);
+      yield chunk;
+    }
+    const { exitCode, signal } = await closed;
+    throwIfAborted(options.abortSignal);
+    if (failure) throw failure;
+    if (exitCode !== 0) {
+      throw new AetherSdkError(
+        options.exitedErrorCode,
+        options.exitedMessage({ exitCode, signal, stderr }),
+      );
+    }
+  } finally {
+    abortCleanup?.[Symbol.dispose]();
+    await stopChild(child);
+    await closed;
+  }
+}
+
+export async function* splitLines(
+  chunks: AsyncIterable<string>,
+): AsyncGenerator<string, void, unknown> {
+  let pending = "";
+  for await (const chunk of chunks) {
+    const lines = (pending + chunk).split(/\r?\n/);
+    pending = lines.pop()!;
+    yield* lines;
+  }
+  if (pending) yield pending;
+}
+
+function spawnFailed(
+  options: RunCommandOptions,
+  cause: unknown,
+): AetherSdkError {
+  return new AetherSdkError(
+    "process_spawn_failed",
+    options.spawnFailedMessage,
+    cause,
+  );
 }

--- a/packages/aether-sdk/src/headless.ts
+++ b/packages/aether-sdk/src/headless.ts
@@ -1,81 +1,77 @@
 import { cwd as processCwd } from "node:process";
 
-import {
-  buildAetherCliCommand,
-  type AetherCliCommand,
-} from "./agentProcess.js";
-import { runCommand } from "./childProcess.js";
+import { buildAetherCliCommand } from "./agentProcess.js";
+import { splitLines, streamCommand } from "./childProcess.js";
 import { assertOptionInvariants, compactCliOptions } from "./cliOptions.js";
-import { throwIfAborted } from "./errors.js";
+import { AetherSdkError } from "./errors.js";
 import type { AetherHeadlessCliOptions } from "./generated/aether-headless-options.js";
+import type { AgentEvent } from "./generated/eval-types.js";
 import { resolveEnv } from "./processEnv.js";
-
-export type HeadlessOutputFormat = NonNullable<
-  AetherHeadlessCliOptions["output"]
->;
 
 export type HeadlessEventKind = NonNullable<
   AetherHeadlessCliOptions["events"]
 >[number];
 
-export type HeadlessStdioMode = "pipe" | "inherit";
-
-export interface AetherHeadlessResult {
-  stdout: string;
-  stderr: string;
-  exitCode: number;
-  signal: NodeJS.Signals | null;
-}
-
 export interface AetherHeadlessOptions extends Omit<
   AetherHeadlessCliOptions,
-  "mcpConfig" | "prompt"
+  "mcpConfig" | "prompt" | "output"
 > {
   prompt: string;
   binaryPath?: string;
   env?: Record<string, string | undefined>;
-  stdout?: HeadlessStdioMode;
-  stderr?: HeadlessStdioMode;
   abortSignal?: AbortSignal;
 }
 
-export async function runHeadless(
+/** Stream headless AgentEvents, terminating the child when iteration ends early. */
+export async function* runHeadless(
   options: AetherHeadlessOptions,
-): Promise<AetherHeadlessResult> {
-  throwIfAborted(options.abortSignal);
-  const { command, args } = buildHeadlessCommand(options);
-  return runHeadlessProcess(command, args, options);
-}
-
-function buildHeadlessCommand(
-  options: AetherHeadlessOptions,
-): AetherCliCommand {
-  const { binaryPath, stdout, stderr, abortSignal, env, ...cliOptions } =
-    options;
-
+): AsyncGenerator<AgentEvent, void, unknown> {
+  const { binaryPath, abortSignal, env, ...cliOptions } = options;
   assertOptionInvariants(cliOptions);
-
-  return buildAetherCliCommand({
+  const { command, args } = buildAetherCliCommand({
     binaryPath,
     subcommand: "headless",
-    options: compactCliOptions(cliOptions),
+    options: compactCliOptions({ ...cliOptions, output: "json" }),
   });
+  const lines = streamCommand(
+    command,
+    args,
+    {
+      cwd: options.cwd ?? processCwd(),
+      env: resolveEnv(env),
+      abortSignal,
+      spawnFailedMessage: `Failed to spawn aether headless at ${command}`,
+      exitedErrorCode: "process_exited",
+      exitedMessage: ({ exitCode, signal, stderr }) =>
+        `aether headless exited with code=${exitCode} signal=${signal}\n${stderr}`,
+    },
+    splitLines,
+  );
+  for await (const line of lines) {
+    if (line.trim()) yield parseEvent(line);
+  }
 }
 
-function runHeadlessProcess(
-  command: string,
-  args: string[],
-  options: AetherHeadlessOptions,
-): Promise<AetherHeadlessResult> {
-  return runCommand(command, args, {
-    cwd: options.cwd ?? processCwd(),
-    env: resolveEnv(options.env),
-    stdout: options.stdout,
-    stderr: options.stderr,
-    abortSignal: options.abortSignal,
-    spawnFailedMessage: `Failed to spawn aether headless at ${command}`,
-    exitedErrorCode: "process_exited",
-    exitedMessage: ({ exitCode, signal, stderr }) =>
-      `aether headless exited with code=${exitCode} signal=${signal}\n${stderr}`,
-  });
+function parseEvent(line: string): AgentEvent {
+  try {
+    const value: unknown = JSON.parse(line);
+    if (
+      !isRecord(value) ||
+      typeof value.category !== "string" ||
+      !isRecord(value.event)
+    ) {
+      throw new Error("Expected an AgentEvent envelope");
+    }
+    return value as AgentEvent;
+  } catch (cause) {
+    throw new AetherSdkError(
+      "invalid_protocol_message",
+      `Invalid headless AgentEvent: ${line}`,
+      cause,
+    );
+  }
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
 }

--- a/packages/aether-sdk/src/index.ts
+++ b/packages/aether-sdk/src/index.ts
@@ -16,13 +16,7 @@ export type {
   PermissionRequestHandler,
 } from "./session.js";
 export { runHeadless } from "./headless.js";
-export type {
-  AetherHeadlessOptions,
-  AetherHeadlessResult,
-  HeadlessEventKind,
-  HeadlessOutputFormat,
-  HeadlessStdioMode,
-} from "./headless.js";
+export type { AetherHeadlessOptions, HeadlessEventKind } from "./headless.js";
 export { tool } from "./tool.js";
 export { mcp } from "./mcp/index.js";
 export type { McpHandle, InlineMcpSource } from "./mcp/index.js";

--- a/packages/aether-sdk/test/childProcess.test.ts
+++ b/packages/aether-sdk/test/childProcess.test.ts
@@ -1,0 +1,49 @@
+import { fileURLToPath } from "node:url";
+import path from "node:path";
+
+import { describe, expect, it } from "vitest";
+
+import { runCommand } from "../src/index.js";
+
+const FAKE_COMMAND = path.resolve(
+  path.dirname(fileURLToPath(import.meta.url)),
+  "fakeCommand.mjs",
+);
+
+const options = {
+  cwd: process.cwd(),
+  env: process.env,
+  spawnFailedMessage: "spawn failed",
+  exitedErrorCode: "execution_failed",
+  exitedMessage: ({ exitCode, signal, stderr }) =>
+    `code=${exitCode} signal=${signal} stderr=${stderr}`,
+} satisfies Parameters<typeof runCommand>[2];
+
+describe("runCommand()", () => {
+  it("returns stdout and passes stdin", async () => {
+    expect(
+      await runCommand(process.execPath, [FAKE_COMMAND], {
+        ...options,
+        env: { ...process.env, FAKE_STDOUT: "out:", FAKE_ECHO_STDIN: "1" },
+        stdin: "in 🌍",
+      }),
+    ).toBe("out:in 🌍");
+  });
+
+  it("rejects nonzero exits with stderr instead of returning partial stdout", async () => {
+    await expect(
+      runCommand(process.execPath, [FAKE_COMMAND], {
+        ...options,
+        env: {
+          ...process.env,
+          FAKE_STDOUT: "partial",
+          FAKE_STDERR: "provider failed",
+          FAKE_EXIT_CODE: "2",
+        },
+      }),
+    ).rejects.toMatchObject({
+      code: "execution_failed",
+      message: "code=2 signal=null stderr=provider failed",
+    });
+  });
+});

--- a/packages/aether-sdk/test/fakeAether.mjs
+++ b/packages/aether-sdk/test/fakeAether.mjs
@@ -35,19 +35,25 @@ if (process.argv[2] === "headless") {
   const optionsIndex = args.indexOf("--options-json");
   const options =
     optionsIndex >= 0 ? JSON.parse(args[optionsIndex + 1] ?? "{}") : {};
-  const prompt = options.prompt ?? args.at(-1);
-  const output = options.output ?? args[args.indexOf("--output") + 1];
-  if (process.env.FAKE_AETHER_HEADLESS_EXIT_CODE) {
-    console.error("fake headless failed");
-    process.exit(Number(process.env.FAKE_AETHER_HEADLESS_EXIT_CODE));
-  }
-  if (output === "json") {
-    console.log(JSON.stringify({ type: "Text", chunk: prompt }));
-    console.log(JSON.stringify({ type: "Done" }));
-  } else {
-    console.log(`fake headless: ${prompt}`);
-  }
-  process.exit(0);
+  const { writeFakeOutput } = await import("./fakeCommand.mjs");
+  const events = [
+    {
+      category: "message",
+      event: {
+        type: "text",
+        message_id: "text",
+        chunk: options.prompt,
+        is_complete: true,
+      },
+    },
+    {
+      category: "turn",
+      event: { type: "ended", outcome: { status: "completed" } },
+    },
+  ];
+  await writeFakeOutput(
+    process.env.FAKE_STDOUT ?? events.map((e) => JSON.stringify(e)).join("\n"),
+  );
 }
 
 const writable = Writable.toWeb(process.stdout);

--- a/packages/aether-sdk/test/fakeCommand.mjs
+++ b/packages/aether-sdk/test/fakeCommand.mjs
@@ -1,0 +1,31 @@
+#!/usr/bin/env node
+
+import { text } from "node:stream/consumers";
+import { setImmediate } from "node:timers/promises";
+import { fileURLToPath } from "node:url";
+
+export async function writeFakeOutput(stdout) {
+  stdout = stdout.replaceAll("$PID", String(process.pid));
+  if (process.env.FAKE_ECHO_STDIN) stdout += await text(process.stdin);
+  const bytes = Buffer.from(stdout);
+  const chunkSize = Number(process.env.FAKE_CHUNK_SIZE ?? bytes.length) || 1;
+  for (let offset = 0; offset < bytes.length; offset += chunkSize) {
+    await new Promise((resolve) =>
+      process.stdout.write(bytes.subarray(offset, offset + chunkSize), resolve),
+    );
+    await setImmediate();
+  }
+  if (process.env.FAKE_STDERR) process.stderr.write(process.env.FAKE_STDERR);
+  if (process.env.FAKE_CLOSE_STDOUT) {
+    await new Promise((resolve) => process.stdout.end(resolve));
+  }
+  if (process.env.FAKE_HOLD) {
+    setInterval(() => {}, 2 ** 31 - 1);
+    await new Promise(() => {});
+  }
+  process.exit(Number(process.env.FAKE_EXIT_CODE ?? 0));
+}
+
+if (process.argv[1] === fileURLToPath(import.meta.url)) {
+  await writeFakeOutput(process.env.FAKE_STDOUT ?? "");
+}

--- a/packages/aether-sdk/test/headless.test.ts
+++ b/packages/aether-sdk/test/headless.test.ts
@@ -1,14 +1,15 @@
+import childProcess from "node:child_process";
+import { syncBuiltinESMExports } from "node:module";
 import { mkdtemp, readFile, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 
-import { afterEach, describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, onTestFinished, vi } from "vitest";
 import { z } from "zod";
 
-import { runHeadless } from "../src/headless.js";
-import { mcp } from "../src/mcp/index.js";
-import { tool } from "../src/tool.js";
+import { mcp, runHeadless, tool, type AgentEvent } from "../src/index.js";
+import { sessionUsageFactory } from "./factories/sessionUsage.js";
 import { TRACE_ID_CONTEXT } from "./traceContext.js";
 
 const FAKE_AETHER = path.resolve(
@@ -19,13 +20,15 @@ const FAKE_AETHER = path.resolve(
 let tempDirs: string[] = [];
 
 afterEach(async () => {
+  vi.restoreAllMocks();
+  syncBuiltinESMExports();
   await Promise.all(
     tempDirs.map((dir) => rm(dir, { recursive: true, force: true })),
   );
   tempDirs = [];
 });
 
-describe("runAetherHeadless()", () => {
+describe("runHeadless()", () => {
   it("passes SDK-hosted mcp() sources through to headless via settings.mcps", async () => {
     const dir = await mkdtemp(path.join(tmpdir(), "aether-sdk-headless-"));
     tempDirs.push(dir);
@@ -39,26 +42,31 @@ describe("runAetherHeadless()", () => {
 
     await using weather = await mcp({ name: "weather", tools: [submit] });
 
-    const result = await runHeadless({
-      binaryPath: FAKE_AETHER,
-      prompt: "call the tool",
-      model: "anthropic:claude-sonnet-4-5",
-      settings: { agents: [], mcps: [weather.spec] },
-      providers: {
-        bedrock: {
-          url: "http://127.0.0.1:8787",
-          auth: "none",
-          inferenceProfileArn: "arn:test",
+    const result = await Array.fromAsync(
+      runHeadless({
+        binaryPath: FAKE_AETHER,
+        prompt: "call the tool",
+        model: "anthropic:claude-sonnet-4-5",
+        settings: { agents: [], mcps: [weather.spec] },
+        providers: {
+          bedrock: {
+            url: "http://127.0.0.1:8787",
+            auth: "none",
+            inferenceProfileArn: "arn:test",
+          },
         },
-      },
-      output: "json",
-      events: ["tool_call", "turn_ended"],
-      traceContext: TRACE_ID_CONTEXT,
-      env: { ...process.env, FAKE_AETHER_LOG_FILE: logFile },
-    });
+        events: ["tool_call", "turn_ended"],
+        traceContext: TRACE_ID_CONTEXT,
+        env: { ...process.env, FAKE_AETHER_LOG_FILE: logFile },
+      }),
+    );
 
-    expect(result.exitCode).toBe(0);
-    expect(result.stdout).toContain("call the tool");
+    expect(result).toContainEqual(
+      expect.objectContaining({
+        category: "message",
+        event: expect.objectContaining({ chunk: "call the tool" }),
+      }),
+    );
 
     const log = JSON.parse((await readFile(logFile, "utf8")).trim());
     expect(log.event).toBe("headless");
@@ -88,14 +96,229 @@ describe("runAetherHeadless()", () => {
     expect(options).not.toHaveProperty("mcpConfig");
   });
 
+  it("parses each stdout line as an AgentEvent", async () => {
+    const events: AgentEvent[] = [
+      textEvent("hello 🌍"),
+      { category: "session_usage", event: sessionUsageFactory.build() },
+      turnEnded,
+    ];
+    expect(
+      await Array.fromAsync(stream(events, { FAKE_CHUNK_SIZE: "1" })),
+    ).toEqual(events);
+  });
+
+  it.each(["", "\n\r\n  \n"])(
+    "accepts empty output and blank lines: %j",
+    async (raw) => {
+      expect(await Array.fromAsync(streamRaw(raw))).toEqual([]);
+    },
+  );
+
+  it("yields events with categories it does not know", async () => {
+    const event = { category: "future", event: { type: "new" } };
+    expect(await Array.fromAsync(streamRaw(JSON.stringify(event)))).toEqual([
+      event,
+    ]);
+  });
+
+  it.each(["{", "null", "[]", "{}", '{"category":"turn"}'])(
+    "rejects malformed protocol output: %s",
+    async (raw) => {
+      await expect(Array.fromAsync(streamRaw(raw))).rejects.toMatchObject({
+        code: "invalid_protocol_message",
+      });
+    },
+  );
+
+  it.each(["", "\n", "\r\n"])(
+    "yields the final event before a nonzero exit with trailing delimiter %j",
+    async (delimiter) => {
+      const received: AgentEvent[] = [];
+      await expect(
+        Array.fromAsync(
+          streamRaw(JSON.stringify(turnEnded) + delimiter, {
+            FAKE_EXIT_CODE: "2",
+            FAKE_STDERR: "provider failed",
+          }),
+          (event) => received.push(event),
+        ),
+      ).rejects.toMatchObject({
+        code: "process_exited",
+        message: expect.stringContaining("provider failed"),
+      });
+      expect(received).toEqual([turnEnded]);
+    },
+  );
+
+  it("reports spawn failures", async () => {
+    await expect(
+      Array.fromAsync(
+        runHeadless({ binaryPath: "/nonexistent/aether", prompt: "hello" }),
+      ),
+    ).rejects.toMatchObject({ code: "process_spawn_failed" });
+  });
+
+  it("rejects an already aborted run", async () => {
+    await expect(
+      Array.fromAsync(streamRaw("", {}, AbortSignal.abort())),
+    ).rejects.toMatchObject({ code: "aborted" });
+  });
+
+  it("streams events while the child is alive and cleans up on break", async () => {
+    let pid: number;
+    for await (const event of heldStream()) {
+      pid = eventPid(event);
+      expect(() => process.kill(pid, 0)).not.toThrow();
+      break;
+    }
+    expectExited(pid);
+  });
+
+  it("cleans up when the loop body throws", async () => {
+    const failure = new Error("consumer failed");
+    let pid: number;
+    await expect(
+      (async () => {
+        for await (const event of heldStream()) {
+          pid = eventPid(event);
+          throw failure;
+        }
+      })(),
+    ).rejects.toBe(failure);
+    expectExited(pid);
+  });
+
+  it("reports signal termination as a failure", async () => {
+    const { events, pid } = await startHeld();
+    process.kill(pid, "SIGTERM");
+    await expect(Array.fromAsync(events)).rejects.toMatchObject({
+      code: "process_exited",
+      message: expect.stringContaining("signal=SIGTERM"),
+    });
+    expectExited(pid);
+  });
+
+  it("aborts a pending read without yielding an unterminated buffered event", async () => {
+    const controller = new AbortController();
+    const { events, pid } = await startHeld(
+      controller.signal,
+      JSON.stringify(turnEnded),
+    );
+    const pending = events.next();
+    controller.abort();
+    await expect(pending).rejects.toMatchObject({ code: "aborted" });
+    expectExited(pid);
+  });
+
+  it("reports cancellation after stdout EOF while waiting for the child to exit", async () => {
+    const controller = new AbortController();
+    const spawn = childProcess.spawn;
+    vi.spyOn(childProcess, "spawn").mockImplementation((...args) => {
+      const child = spawn(...args);
+      child.stdout!.once("end", () => setImmediate(() => controller.abort()));
+      return child;
+    });
+    syncBuiltinESMExports();
+    const { events, pid } = await startHeld(controller.signal, "", {
+      FAKE_CLOSE_STDOUT: "1",
+    });
+    await expect(events.next()).rejects.toMatchObject({ code: "aborted" });
+    expectExited(pid);
+  });
+
+  it("cleans up a live child when an event is malformed", async () => {
+    const { events, pid } = await startHeld(undefined, "{\n");
+    await expect(events.next()).rejects.toMatchObject({
+      code: "invalid_protocol_message",
+    });
+    expectExited(pid);
+  });
+
   it("rejects conflicting options", async () => {
     await expect(
-      runHeadless({
-        binaryPath: FAKE_AETHER,
-        prompt: "hello",
-        agent: "planner",
-        model: "anthropic:claude-sonnet-4-5",
-      } as never),
+      Array.fromAsync(
+        runHeadless({
+          binaryPath: FAKE_AETHER,
+          prompt: "hello",
+          agent: "planner",
+          model: "anthropic:claude-sonnet-4-5",
+        } as never),
+      ),
     ).rejects.toThrow(/agent and model/);
   });
 });
+
+const turnEnded: AgentEvent = {
+  category: "turn",
+  event: { type: "ended", outcome: { status: "completed" } },
+};
+
+function textEvent(chunk: string): AgentEvent {
+  return {
+    category: "message",
+    event: { type: "text", message_id: "text", chunk, is_complete: true },
+  };
+}
+
+function stream(events: AgentEvent[], env: Record<string, string> = {}) {
+  return streamRaw(
+    events.map((event) => JSON.stringify(event)).join("\r\n"),
+    env,
+  );
+}
+
+function streamRaw(
+  stdout: string,
+  env: Record<string, string> = {},
+  abortSignal?: AbortSignal,
+) {
+  return runHeadless({
+    binaryPath: FAKE_AETHER,
+    prompt: "hello",
+    env: { ...process.env, ...env, FAKE_STDOUT: stdout },
+    abortSignal,
+  });
+}
+
+function heldStream(
+  abortSignal?: AbortSignal,
+  suffix = "",
+  env: Record<string, string> = {},
+) {
+  const events = streamRaw(
+    JSON.stringify(textEvent("$PID")) + "\n" + suffix,
+    { ...env, FAKE_HOLD: "1" },
+    abortSignal,
+  );
+  onTestFinished(async () => {
+    await events.return();
+  });
+  return events;
+}
+
+async function startHeld(
+  abortSignal?: AbortSignal,
+  suffix = "",
+  env: Record<string, string> = {},
+) {
+  const events = heldStream(abortSignal, suffix, env);
+  const first = await events.next();
+  expect(first.done).toBe(false);
+  return { events, pid: eventPid(first.value as AgentEvent) };
+}
+
+function eventPid(event: AgentEvent): number {
+  if (event.category !== "message" || event.event.type !== "text") {
+    throw new Error("Expected a text event containing the child pid");
+  }
+  const pid = Number(event.event.chunk);
+  expect(pid).toBeGreaterThan(0);
+  return pid;
+}
+
+function expectExited(pid: number) {
+  expect(pid).toBeGreaterThan(0);
+  expect(() => process.kill(pid, 0)).toThrow(
+    expect.objectContaining({ code: "ESRCH" }),
+  );
+}

--- a/packages/aether-sdk/test/headless.test.ts
+++ b/packages/aether-sdk/test/headless.test.ts
@@ -165,7 +165,7 @@ describe("runHeadless()", () => {
   });
 
   it("streams events while the child is alive and cleans up on break", async () => {
-    let pid: number;
+    let pid = 0;
     for await (const event of heldStream()) {
       pid = eventPid(event);
       expect(() => process.kill(pid, 0)).not.toThrow();
@@ -176,7 +176,7 @@ describe("runHeadless()", () => {
 
   it("cleans up when the loop body throws", async () => {
     const failure = new Error("consumer failed");
-    let pid: number;
+    let pid = 0;
     await expect(
       (async () => {
         for await (const event of heldStream()) {

--- a/packages/website/src/content/docs/aether/running/headless.mdx
+++ b/packages/website/src/content/docs/aether/running/headless.mdx
@@ -152,7 +152,8 @@ Available event kinds:
 | `context_compaction_started` | Context compaction beginning.                                  |
 | `context_compaction_ended`   | Context compaction finished (completed, failed, or cancelled). |
 | `context_compaction_result`  | Context compaction completed.                                  |
-| `context_usage`              | Token usage update.                                            |
+| `context_usage`              | Current context-window usage.                                  |
+| `session_usage`              | Per-call tokens and estimated cost, plus cumulative totals.     |
 | `context_cleared`            | Context was cleared.                                           |
 | `turn_started`               | Turn processing began.                                         |
 | `turn_ended`                 | Turn completed, failed, or was cancelled.                      |

--- a/packages/website/src/content/docs/libraries/typescript-sdk.mdx
+++ b/packages/website/src/content/docs/libraries/typescript-sdk.mdx
@@ -94,32 +94,24 @@ Only one prompt can be in progress per session.
 
 ## Run a single headless prompt
 
-`runHeadless()` is the programmatic equivalent of [`aether headless`](/aether/running/headless/). It runs one prompt to completion (with no streaming iterator), captures the process output, and resolves with a result. Use it for scripts, CI jobs, and batch workflows where you want the final output rather than streamed updates.
+`runHeadless()` runs one non-interactive prompt and returns an async iterator of generated `AgentEvent` objects.
 
 ```ts
 import { runHeadless } from "@aether-agent/sdk";
 
-const result = await runHeadless({
+for await (const event of runHeadless({
   cwd: process.cwd(),
   prompt: "Summarize the architecture",
-  output: "text",
-});
-
-console.log(result.stdout);
+})) {
+  if (event.category === "message" && event.event.type === "text") {
+    console.log(event.event.chunk);
+  } else if (event.category === "session_usage") {
+    console.log("Estimated cost (USD):", event.event.totals.estimated_usd);
+  }
+}
 ```
 
-### Result
 
-`runHeadless()` resolves to an `AetherHeadlessResult`:
-
-| Field      | Type                     | Description                                                                           |
-| ---------- | ------------------------ | ------------------------------------------------------------------------------------- |
-| `stdout`   | `string`                 | Captured stdout from the `aether headless` process.                                   |
-| `stderr`   | `string`                 | Captured stderr (diagnostics/tracing).                                                |
-| `exitCode` | `number`                 | Process exit code. `0` on success; non-zero when the turn ends with a failed outcome. |
-| `signal`   | `NodeJS.Signals \| null` | Termination signal, if the process was killed instead of exiting normally.            |
-
-Because `aether headless` exits non-zero on a failed turn, `runHeadless()` **rejects** with an `AetherSdkError` (`code: "process_exited"`) in that case instead of resolving. Wrap the call in `try`/`catch` (or read the error's details) when a failed turn is an expected outcome.
 
 ### Options
 
@@ -134,15 +126,12 @@ Because `aether headless` exits non-zero on a failed turn, `runHeadless()` **rej
 | `settings`     | Inline Aether settings object. Mutually exclusive with `settingsFile`.                                                                               |
 | `settingsFile` | Path to an alternate settings JSON file.                                                                                                             |
 | `systemPrompt` | Additional system prompt text.                                                                                                                       |
-| `output`       | `"text"`, `"pretty"`, or `"json"`. Defaults to `"text"`. See [output formats](/aether/running/headless/#output-formats).                             |
-| `events`       | Event kinds to emit (applies to any output format). See [event filtering](/aether/running/headless/#event-filtering).                                |
+| `events`       | Event kinds to emit; omit to include all, including `session_usage` and `context_usage`. See [event filtering](/aether/running/headless/#event-filtering). |
 | `verbose`      | Verbose diagnostic logging to stderr.                                                                                                                |
 | `providers`    | Provider connection overrides, such as custom Bedrock endpoints or auth behavior.                                                                    |
 | `traceContext` | A remote W3C `traceparent` with optional `tracestate`, or a standalone `traceId`. See [Telemetry](/aether/settings/telemetry/#correlating-sdk-runs). |
 | `binaryPath`   | Override the bundled CLI binary with an absolute path or command available on `PATH`.                                                                |
 | `env`          | Environment variables for the spawned `aether headless` process.                                                                                     |
-| `stdout`       | `"pipe"` (capture, the default) or `"inherit"` (write directly to the parent stdio).                                                                 |
-| `stderr`       | `"pipe"` (the default) or `"inherit"`.                                                                                                               |
 | `abortSignal`  | Cancel the run and tear down the subprocess.                                                                                                         |
 
 Unlike `AetherSession.start()`, headless runs are non-interactive, so there are no permission or elicitation handlers.

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -18,8 +18,8 @@ importers:
   packages/aether-evals:
     dependencies:
       '@aether-agent/sdk':
-        specifier: ^0.4.1
-        version: 0.4.1
+        specifier: workspace:^
+        version: link:../aether-sdk
       testcontainers:
         specifier: ^12.1.0
         version: 12.1.0
@@ -149,29 +149,10 @@ importers:
 
 packages:
 
-  '@aether-agent/cli@0.7.22':
-    resolution: {integrity: sha512-/TOSPbVNXsdSB8LPJFPq+qvtN227EyzYYYrwPvPsS1J79oTmDKxTCrGQpSgOG/z+2fdqXcQu+WKlEN4FSkcMcg==}
-    engines: {node: '>=14', npm: '>=6'}
-    hasBin: true
-
-  '@aether-agent/cli@0.7.35':
-    resolution: {integrity: sha512-Xme2xrRU46zPrgXzC1HAv1LKSB2A7j35xNuMT/cLQZ+rD3Bf+fgZ7fnVQP46wWfgnuLOpmEKJNjmidVcCK6RcQ==}
-    engines: {node: '>=14', npm: '>=6'}
-    hasBin: true
-
   '@aether-agent/cli@0.8.0':
     resolution: {integrity: sha512-WQklT8QDdUSaJHMIoJcEY06Q5GXiJNaBx3fkFp8M3PYWk8w45AbJ8xRAk7Gl0+LxDdTO/2NZ+VG9+HzfO7hMiA==}
     engines: {node: '>=14', npm: '>=6'}
     hasBin: true
-
-  '@aether-agent/sdk@0.4.1':
-    resolution: {integrity: sha512-SqQrMxBTV3mD6eMzJmCYO/ZW1FsZ7x58glGvMXqGFTPyVfv8Evt/0dcpaLolBOdutQLdXGLHV6H5fKL7ebxzQg==}
-    engines: {node: '>=24'}
-
-  '@agentclientprotocol/sdk@0.25.1':
-    resolution: {integrity: sha512-jx2rF3bdpGwZ75Q/meyEDLLbYmbtxk82Uh9hDCdxDvcEedBnNSF5hZAnL/kJR5VNz56JqwOmqnAqasC84MwwkQ==}
-    peerDependencies:
-      zod: ^3.25.0 || ^4.0.0
 
   '@agentclientprotocol/sdk@1.3.0':
     resolution: {integrity: sha512-i3h/efaeuMUFAO1HSfo97QZQnnvMd7wWBYtBsdL6UMZg3a78sk3Ffya5Xu7C7tYsXomXoDXJBAzQF2PcFKAhIQ==}
@@ -794,12 +775,6 @@ packages:
     engines: {node: '>=6'}
     hasBin: true
 
-  '@hono/node-server@1.19.17':
-    resolution: {integrity: sha512-dSneS5qhiauZWGDCeK4o695Xd9nUNjviSZCMQrj10eetr8Uln1ucn6bbphOM6UynAMMtNIzZNSpL9vnASJwrPQ==}
-    engines: {node: '>=18.14.1'}
-    peerDependencies:
-      hono: ^4
-
   '@hono/node-server@2.1.0':
     resolution: {integrity: sha512-XovyyCCnBzW+zKu+z/zq8hwNs4KOR5rEMAOxo2f40Q5xoOI37IMm6MIg2COOUtUApo0i6850MTBKH2u4QLGIqg==}
     engines: {node: '>=20'}
@@ -1017,16 +992,6 @@ packages:
 
   '@mermaid-js/parser@1.2.0':
     resolution: {integrity: sha512-oYPyv8A4As1yH5Bx+04iQEQxXuIQDe0GKCNSRgao6z8AM9jixXIfP0vsppRLvGf+nKIOb9/LdpWA4YuJiVvESA==}
-
-  '@modelcontextprotocol/sdk@1.29.0':
-    resolution: {integrity: sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ==}
-    engines: {node: '>=18'}
-    peerDependencies:
-      '@cfworker/json-schema': ^4.1.1
-      zod: ^3.25 || ^4.0
-    peerDependenciesMeta:
-      '@cfworker/json-schema':
-        optional: true
 
   '@modelcontextprotocol/sdk@1.30.0':
     resolution: {integrity: sha512-xKd8OIzlqNzcqcNumGAa6g+PW2kjD5vrpcKOnfldAUPP3j7lnqMPwlTXQm8gF+UwH72z0lqaRbjr9hqGz0eITA==}
@@ -4670,28 +4635,6 @@ packages:
 
 snapshots:
 
-  '@aether-agent/cli@0.7.22':
-    dependencies:
-      axios: 1.19.0
-      axios-proxy-builder: 0.1.2
-      console.table: 0.10.0
-      detect-libc: 2.1.2
-      rimraf: 6.1.3
-    transitivePeerDependencies:
-      - debug
-      - supports-color
-
-  '@aether-agent/cli@0.7.35':
-    dependencies:
-      axios: 1.19.0
-      axios-proxy-builder: 0.1.2
-      console.table: 0.10.0
-      detect-libc: 2.1.2
-      rimraf: 6.1.3
-    transitivePeerDependencies:
-      - debug
-      - supports-color
-
   '@aether-agent/cli@0.8.0':
     dependencies:
       axios: 1.19.0
@@ -4702,22 +4645,6 @@ snapshots:
     transitivePeerDependencies:
       - debug
       - supports-color
-
-  '@aether-agent/sdk@0.4.1':
-    dependencies:
-      '@aether-agent/cli': 0.7.22
-      '@agentclientprotocol/sdk': 0.25.1(zod@4.4.3)
-      '@modelcontextprotocol/sdk': 1.29.0(zod@4.4.3)
-      express: 5.2.1
-      zod: 4.4.3
-    transitivePeerDependencies:
-      - '@cfworker/json-schema'
-      - debug
-      - supports-color
-
-  '@agentclientprotocol/sdk@0.25.1(zod@4.4.3)':
-    dependencies:
-      zod: 4.4.3
 
   '@agentclientprotocol/sdk@1.3.0(zod@4.4.3)':
     dependencies:
@@ -5276,10 +5203,6 @@ snapshots:
       protobufjs: 7.6.5
       yargs: 17.7.3
 
-  '@hono/node-server@1.19.17(hono@4.13.1)':
-    dependencies:
-      hono: 4.13.1
-
   '@hono/node-server@2.1.0(hono@4.13.1)':
     dependencies:
       hono: 4.13.1
@@ -5487,28 +5410,6 @@ snapshots:
   '@mermaid-js/parser@1.2.0':
     dependencies:
       '@chevrotain/types': 11.1.2
-
-  '@modelcontextprotocol/sdk@1.29.0(zod@4.4.3)':
-    dependencies:
-      '@hono/node-server': 1.19.17(hono@4.13.1)
-      ajv: 8.20.0
-      ajv-formats: 3.0.1(ajv@8.20.0)
-      content-type: 1.0.5
-      cors: 2.8.6
-      cross-spawn: 7.0.6
-      eventsource: 3.0.7
-      eventsource-parser: 3.1.0
-      express: 5.2.1
-      express-rate-limit: 8.6.2(express@5.2.1)
-      hono: 4.13.1
-      jose: 6.2.8
-      json-schema-typed: 8.0.2
-      pkce-challenge: 5.0.1
-      raw-body: 3.0.2
-      zod: 4.4.3
-      zod-to-json-schema: 3.25.2(zod@4.4.3)
-    transitivePeerDependencies:
-      - supports-color
 
   '@modelcontextprotocol/sdk@1.30.0(zod@4.4.3)':
     dependencies:

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -1,6 +1,7 @@
 {
   "compilerOptions": {
     "target": "ES2025",
+    "lib": ["ES2025", "ESNext.Array"],
     "module": "NodeNext",
     "moduleResolution": "NodeNext",
     "skipLibCheck": true,


### PR DESCRIPTION
## Summary
- Return an async iterator of typed `AgentEvent` objects from `runHeadless()`, with JSON envelope parsing and automatic subprocess cleanup.
- Preserve final unterminated events before exit errors, report cancellation after stdout EOF correctly, and encode piped stdout/stderr in the subprocess type without non-null assertions.
- Simplify `runCommand()` to return stdout directly; migrate eval generation, git diffs, and the weather-agent fixture to the new APIs.
- Link evals to the workspace SDK, update headless documentation, and bump SDK to **0.6.0** and evals to **0.3.2**.

## Breaking changes
- Consume `runHeadless()` with `for await...of` instead of awaiting a captured process result. The `output`, `stdout`, and `stderr` options and associated result/format types are removed.
- `runCommand()` now returns `Promise<string>` rather than a process result object; callers should no longer access `.stdout` on the result. Stdio modes and output callbacks are removed.

## Commits
1. `feat(aether-sdk)!: stream headless agent events`
2. `fix(aether-evals): migrate callers to sdk 0.6`
3. `docs(aether-sdk): document streaming headless events`

## Validation
- Confirmed lifecycle regression tests and existing eval caller tests fail before the fixes/migration.
- `pnpm --filter @aether-agent/sdk compile` — passed.
- `pnpm --filter @aether-agent/evals compile` — passed.
- `pnpm --filter @aether-agent/sdk exec vitest run` — **70 passed**, including the real-binary integration test and documentation typecheck.
- `pnpm --filter @aether-agent/evals test` — **48 passed**, **4 opt-in E2E tests skipped**.
- `pnpm fmt-check` and `git diff --check` — passed.
- Frozen-lockfile installation — passed.
