### PR TITLE
feat: Add additional cumulative cost components for sessions

### DIFF
--- a/crates/aether-core/src/context/session_usage_tracker.rs
+++ b/crates/aether-core/src/context/session_usage_tracker.rs
@@ -128,6 +128,58 @@ mod tests {
     }
 
     #[test]
+    fn nested_samples_and_resumption_preserve_cumulative_cost_components() {
+        let model = ModelIdentity::of(Some(&priced_model()));
+        let tokens = TokenUsage {
+            cache_read_tokens: Some(20.into()),
+            cache_creation_tokens: Some(10.into()),
+            ..TokenUsage::new(100, 50)
+        };
+
+        let mut root = SessionUsageTracker::new("root");
+        root.record(LlmCallPurpose::Chat, model.clone(), tokens);
+
+        let mut child = SessionUsageTracker::new("child");
+        let child_sample = child.record(LlmCallPurpose::Chat, model.clone(), tokens);
+        root.record_child("child-task", child_sample);
+
+        let mut grandchild = SessionUsageTracker::new("grandchild");
+        let sample = grandchild.record(LlmCallPurpose::Compaction, model.clone(), tokens);
+        let sample_cost = sample.estimated_cost.unwrap();
+        let folded = child.record_child("grandchild-task", sample);
+
+        let last = root.record_child("child-task", folded);
+
+        assert_eq!(last.sequence, 3);
+        assert_eq!(last.source.agent_id, grandchild.source().agent_id);
+        assert_eq!(last.totals.tokens.input_tokens.get(), 300);
+        assert_eq!(last.estimated_cost, Some(sample_cost));
+        assert_cost_components(&last, sample_cost, 3);
+
+        let persisted = serde_json::to_string(&last).unwrap();
+        let mut resumed = SessionUsageTracker::new("root");
+        resumed.resume_from(&serde_json::from_str(&persisted).unwrap());
+        let next = resumed.record(LlmCallPurpose::Chat, model, tokens);
+        assert_eq!(next.sequence, 4);
+        assert_eq!(next.totals.tokens.input_tokens.get(), 400);
+        assert_cost_components(&next, sample_cost, 4);
+    }
+
+    fn assert_cost_components(event: &SessionUsageEvent, cost: UsageCost, samples: usize) {
+        let totals = serde_json::to_value(&event.totals).unwrap();
+        for (field, amount) in [
+            ("estimated_input_usd", cost.input_usd),
+            ("estimated_output_usd", cost.output_usd),
+            ("estimated_cache_read_usd", cost.cache_read_usd),
+            ("estimated_cache_creation_usd", cost.cache_creation_usd),
+            ("estimated_usd", cost.total_usd),
+        ] {
+            let expected = (0..samples).fold(llm::Usd::ZERO, |total, _| total + amount);
+            assert_eq!(totals[field], serde_json::json!(expected), "{field}");
+        }
+    }
+
+    #[test]
     fn child_samples_keep_lineage_they_already_carry() {
         let mut tracker = SessionUsageTracker::new("root");
         let mut grandchild = session_usage_event(1, TokenUsage::new(1, 1));

--- a/crates/aether-core/tests/agent/usage_tests.rs
+++ b/crates/aether-core/tests/agent/usage_tests.rs
@@ -44,6 +44,7 @@ async fn priced_model_costs_each_call_and_keeps_totals_priced() {
 
     let usage = session_usage(&events);
     assert_eq!(usage.len(), 2);
+    assert_cumulative_cost_components(&usage);
     let first_cost = usage[0].estimated_cost.expect("catalog model is priced").total_usd;
     let second_cost = usage[1].estimated_cost.expect("catalog model is priced").total_usd;
     assert!(first_cost.get() > 0.0 && second_cost.get() > 0.0);
@@ -57,6 +58,7 @@ async fn priced_model_costs_each_call_and_keeps_totals_priced() {
 #[tokio::test]
 async fn usage_received_before_a_stream_error_survives_the_failed_turn() {
     let events = test_agent()
+        .model(priced_model())
         .llm_result_responses(&[llm_response("msg").usage(9, 1).build_with_error(ProviderError::api("HTTP 500"))])
         .without_mcp()
         .user_text("hello")
@@ -70,12 +72,14 @@ async fn usage_received_before_a_stream_error_survives_the_failed_turn() {
     });
     assert!(usage_index < failed_index);
     assert_eq!(session_usage(&events)[0].tokens.input_tokens.get(), 9);
+    assert_cumulative_cost_components(&session_usage(&events));
 }
 
 #[tokio::test]
 async fn usage_received_before_cancellation_survives_the_cancelled_turn() {
     let release = Arc::new(Notify::new());
     let events = test_agent()
+        .model(priced_model())
         .llm_responses(&[llm_response("msg").usage(5, 3).text(&["never delivered"]).build()])
         .without_mcp()
         .pause_turn_after(0, 2, release)
@@ -96,6 +100,7 @@ async fn usage_received_before_cancellation_survives_the_cancelled_turn() {
     });
     assert!(usage_index < cancelled_index);
     assert_eq!(session_usage(&events).len(), 1);
+    assert_cumulative_cost_components(&session_usage(&events));
 }
 
 #[tokio::test]
@@ -121,6 +126,7 @@ async fn retried_attempts_without_usage_add_nothing() {
 #[tokio::test]
 async fn compaction_usage_is_recorded_once_before_the_compaction_call_ends() {
     let events = test_agent()
+        .model(priced_model())
         .llm_responses(&[
             llm_response("sum").usage(50, 10).text(&["summary"]).build(),
             llm_response("msg").usage(20, 5).text(&["hello"]).build(),
@@ -141,6 +147,7 @@ async fn compaction_usage_is_recorded_once_before_the_compaction_call_ends() {
     assert_eq!(usage[1].purpose, LlmCallPurpose::Chat);
     assert_eq!(usage[1].totals.tokens.input_tokens.get(), 70);
     assert_eq!(usage[1].totals.tokens.output_tokens.get(), 15);
+    assert_cumulative_cost_components(&usage);
 
     let compaction_usage_index = position(
         &events,
@@ -261,6 +268,26 @@ async fn alloyed_usage_is_attributed_to_the_member_that_served_the_call() {
         })
         .collect::<Vec<_>>();
     assert_eq!(started, served, "usage must name the same model as the call that produced it");
+}
+
+fn assert_cumulative_cost_components(events: &[&SessionUsageEvent]) {
+    let mut input = Usd::ZERO;
+    let mut output = Usd::ZERO;
+    let mut cache_read = Usd::ZERO;
+    let mut cache_creation = Usd::ZERO;
+    for event in events {
+        let cost = event.estimated_cost.expect("catalog model is priced");
+        input += cost.input_usd;
+        output += cost.output_usd;
+        cache_read += cost.cache_read_usd;
+        cache_creation += cost.cache_creation_usd;
+        assert_eq!(event.totals.estimated_input_usd, input);
+        assert_eq!(event.totals.estimated_output_usd, output);
+        assert_eq!(event.totals.estimated_cache_read_usd, cache_read);
+        assert_eq!(event.totals.estimated_cache_creation_usd, cache_creation);
+        let sum = input + output + cache_read + cache_creation;
+        assert!((event.totals.estimated_usd.get() - sum.get()).abs() < 1e-12);
+    }
 }
 
 fn two_distinct_models() -> [LlmModel; 2] {

--- a/crates/aether-sessions/tests/analytics.rs
+++ b/crates/aether-sessions/tests/analytics.rs
@@ -126,6 +126,7 @@ async fn session_usage_columns_are_projected_for_root_and_sub_agent_samples() {
             tokens: TokenUsage { cache_read_tokens: Some(3.into()), ..TokenUsage::new(14, 7) },
             estimated_usd: Usd::new(0.25),
             unpriced_calls: 1,
+            ..SessionUsageTotals::default()
         },
         ..session_usage_event(2, TokenUsage::new(4, 2))
     };
@@ -409,7 +410,7 @@ fn root_usage(source: &UsageSource) -> SessionUsageEvent {
         source: source.clone(),
         model: ModelIdentity { provider: Some("anthropic".into()), model_id: Some("claude".into()), pricing: None },
         estimated_cost: Some(UsageCost { total_usd: Usd::new(0.25), ..UsageCost::default() }),
-        totals: SessionUsageTotals { tokens, estimated_usd: Usd::new(0.25), unpriced_calls: 0 },
+        totals: SessionUsageTotals { tokens, estimated_usd: Usd::new(0.25), ..SessionUsageTotals::default() },
         ..session_usage_event(1, tokens)
     }
 }

--- a/crates/llm/src/usage/session.rs
+++ b/crates/llm/src/usage/session.rs
@@ -9,6 +9,14 @@ pub struct SessionUsageTotals {
     pub tokens: TokenUsage,
     /// Sum of every priced call's estimated cost.
     pub estimated_usd: Usd,
+    /// Cumulative estimated cost of non-cached input tokens, in USD.
+    pub estimated_input_usd: Usd,
+    /// Cumulative estimated cost of output tokens, in USD.
+    pub estimated_output_usd: Usd,
+    /// Cumulative estimated cost of cache-read tokens, in USD.
+    pub estimated_cache_read_usd: Usd,
+    /// Cumulative estimated cost of cache-creation tokens, in USD.
+    pub estimated_cache_creation_usd: Usd,
     /// Calls with nonzero usage but no catalog pricing, which `estimated_usd`
     /// therefore leaves out.
     pub unpriced_calls: u64,
@@ -21,7 +29,13 @@ impl SessionUsageTotals {
         }
         self.tokens += tokens;
         match estimated_cost {
-            Some(cost) => self.estimated_usd += cost.total_usd,
+            Some(cost) => {
+                self.estimated_usd += cost.total_usd;
+                self.estimated_input_usd += cost.input_usd;
+                self.estimated_output_usd += cost.output_usd;
+                self.estimated_cache_read_usd += cost.cache_read_usd;
+                self.estimated_cache_creation_usd += cost.cache_creation_usd;
+            }
             None => self.unpriced_calls += 1,
         }
     }
@@ -35,11 +49,47 @@ impl SessionUsageTotals {
 /// One provider usage sample, its estimated cost, and the totals after it.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize, JsonSchema)]
 pub struct SessionUsageEvent {
+    /// Sequence assigned by the emitting tracker, including folded child samples.
     pub sequence: u64,
+    /// Attribution of this sample, not the owner of the cumulative totals.
     pub source: UsageSource,
     pub purpose: LlmCallPurpose,
     pub model: ModelIdentity,
     pub tokens: TokenUsage,
     pub estimated_cost: Option<UsageCost>,
     pub totals: SessionUsageTotals,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn cumulative_cost_components_include_each_priced_sample_once() {
+        let mut totals = SessionUsageTotals::default();
+        let cost = UsageCost {
+            input_usd: Usd::new(0.125),
+            output_usd: Usd::new(0.25),
+            cache_read_usd: Usd::new(0.0625),
+            cache_creation_usd: Usd::new(0.0625),
+            total_usd: Usd::new(0.5),
+        };
+        totals.add(TokenUsage::new(10, 2), Some(cost));
+        totals.add(TokenUsage::new(20, 4), Some(cost));
+        totals.add(TokenUsage::new(5, 1), None);
+        totals.add(TokenUsage::default(), Some(cost));
+        totals.add(TokenUsage::default(), None);
+
+        let serialized = serde_json::to_value(&totals).unwrap();
+        assert_eq!(serialized["estimated_input_usd"], json!(0.25));
+        assert_eq!(serialized["estimated_output_usd"], json!(0.5));
+        assert_eq!(serialized["estimated_cache_read_usd"], json!(0.125));
+        assert_eq!(serialized["estimated_cache_creation_usd"], json!(0.125));
+        assert_eq!(totals.estimated_usd, Usd::new(1.0));
+        assert_eq!(totals.tokens, TokenUsage::new(35, 7));
+        assert_eq!(totals.unpriced_calls, 1);
+        assert!(!totals.is_fully_priced());
+        assert_eq!(serde_json::from_value::<SessionUsageTotals>(serialized).unwrap(), totals);
+    }
 }

--- a/packages/aether-evals/package.json
+++ b/packages/aether-evals/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aether-agent/evals",
-  "version": "0.3.2",
+  "version": "0.3.3",
   "description": "Evaluation harness for the Aether agent SDK",
   "repository": {
     "type": "git",

--- a/packages/aether-evals/src/index.ts
+++ b/packages/aether-evals/src/index.ts
@@ -63,6 +63,8 @@ export type {
   PlanMeta,
   PlanMetaEntry,
   PlanMetaStatus,
+  SessionUsageEvent,
+  SessionUsageTotals,
   StopReason,
   TokenUsage,
   ToolCallError,
@@ -73,4 +75,6 @@ export type {
   ToolResultMeta,
   TurnEvent,
   TurnOutcome,
+  UsageCost,
+  UsageSource,
 } from "@aether-agent/sdk";

--- a/packages/aether-evals/test/sessionUsage.test.ts
+++ b/packages/aether-evals/test/sessionUsage.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  Transcript,
+  TranscriptError,
+  type AgentEvent,
+  type SessionUsageEvent,
+  type SessionUsageTotals,
+} from "../src/index.js";
+
+describe("cumulative session usage", () => {
+  it("preserves the complete snapshot in a failed transcript", async () => {
+    const totals: SessionUsageTotals = {
+      tokens: { input_tokens: 100, output_tokens: 20 },
+      estimated_usd: 1,
+      estimated_input_usd: 0.25,
+      estimated_output_usd: 0.5,
+      estimated_cache_read_usd: 0.125,
+      estimated_cache_creation_usd: 0.125,
+      unpriced_calls: 1,
+    };
+
+    const usage: SessionUsageEvent = {
+      sequence: 3,
+      source: {
+        agent_id: "child",
+        parent_agent_id: "root",
+        agent_name: "Explore",
+      },
+      purpose: "chat",
+      model: {},
+      tokens: { input_tokens: 10, output_tokens: 2 },
+      estimated_cost: null,
+      totals,
+    };
+
+    const failure = new Error("provider failed");
+    async function* stream(): AsyncGenerator<AgentEvent> {
+      yield { category: "session_usage", event: usage };
+      throw failure;
+    }
+
+    const error = await Transcript.fromStream(stream()).catch(
+      (cause: unknown) => cause,
+    );
+    expect(error).toBeInstanceOf(TranscriptError);
+    if (!(error instanceof TranscriptError)) throw error;
+    expect(error.cause).toBe(failure);
+    expect(error.transcript.events).toEqual([
+      { category: "session_usage", event: usage },
+    ]);
+  });
+});

--- a/packages/aether-sdk/README.md
+++ b/packages/aether-sdk/README.md
@@ -166,8 +166,7 @@ for await (const message of session.prompt("Implement the feature")) {
 
 Costs are catalog-based USD estimates. `totals.estimated_usd` excludes calls
 whose model pricing is unknown; `totals.unpriced_calls` reports how many were
-excluded. Sub-agent usage includes agent and task identity in
-`message.usage.source`.
+excluded.
 
 ## Multi-turn usage
 

--- a/packages/aether-sdk/package.json
+++ b/packages/aether-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aether-agent/sdk",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "description": "TypeScript SDK for the Aether agent CLI",
   "repository": {
     "type": "git",

--- a/packages/aether-sdk/test/factories/sessionUsage.ts
+++ b/packages/aether-sdk/test/factories/sessionUsage.ts
@@ -42,6 +42,10 @@ export const sessionUsageFactory = Factory.define<SessionUsageEvent>(() => ({
       cache_read_tokens: 300,
     },
     estimated_usd: 400,
+    estimated_input_usd: 40,
+    estimated_output_usd: 80,
+    estimated_cache_read_usd: 120,
+    estimated_cache_creation_usd: 160,
     unpriced_calls: 10,
   },
 }));

--- a/packages/aether-sdk/test/headless.test.ts
+++ b/packages/aether-sdk/test/headless.test.ts
@@ -107,6 +107,21 @@ describe("runHeadless()", () => {
     ).toEqual(events);
   });
 
+  it("retains cumulative usage received before the process fails", async () => {
+    const usage: AgentEvent = {
+      category: "session_usage",
+      event: sessionUsageFactory.build(),
+    };
+    const received: AgentEvent[] = [];
+    await expect(
+      Array.fromAsync(
+        streamRaw(JSON.stringify(usage) + "\n", { FAKE_EXIT_CODE: "2" }),
+        (event) => received.push(event),
+      ),
+    ).rejects.toMatchObject({ code: "process_exited" });
+    expect(received).toEqual([usage]);
+  });
+
   it.each(["", "\n\r\n  \n"])(
     "accepts empty output and blank lines: %j",
     async (raw) => {

--- a/packages/website/src/content/docs/libraries/typescript-sdk.mdx
+++ b/packages/website/src/content/docs/libraries/typescript-sdk.mdx
@@ -169,7 +169,13 @@ for await (const message of session.prompt("Implement the feature")) {
 update. `totals` contains cumulative usage after that call. Costs are
 catalog-based USD estimates; `totals.estimated_usd` excludes calls whose model
 pricing is unknown, and `totals.unpriced_calls` reports how many were excluded.
-Sub-agent calls include agent and task attribution in `source`.
+
+Cumulative cost breakdowns are available via `totals.estimated_input_usd`,
+`totals.estimated_output_usd`, `totals.estimated_cache_read_usd`, and
+`totals.estimated_cache_creation_usd`.
+
+Do not sum `totals` fields across snapshots or group/filter by `source.parent_agent_id`. The root agent's stream includes sub-agent and
+compaction in its totals, even when `source` identifies a child.
 
 ## TypeScript tools
 


### PR DESCRIPTION
This PR improves cost tracking for consumers by exposing additional cumulative token/cost totals that are now broken out by type (e.g. cached vs uncached). 