### PR TITLE
fix: allow empty test router with rmcp 3.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5352,9 +5352,9 @@ dependencies = [
 
 [[package]]
 name = "process-wrap"
-version = "9.1.0"
+version = "10.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e842efad9119158434d193c6682e2ebee4b44d6ad801d7b349623b3f57cdf55"
+checksum = "0e3f4237d0e4741eb50bc5584db701f1299c85fa31ff0274dd6445e79dc42d12"
 dependencies = [
  "futures",
  "indexmap 2.14.2",
@@ -5881,9 +5881,9 @@ dependencies = [
 
 [[package]]
 name = "rmcp"
-version = "3.2.0"
+version = "3.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42b6914fac0be956fe704a38239c3f44a9f841d1b06a5713d2f638065593f5b5"
+checksum = "b88db56b8ae316560e9e868b6b978ea940f27cb883323fc90e07435e44158f5c"
 dependencies = [
  "async-trait",
  "base64 0.23.1",
@@ -5913,9 +5913,9 @@ dependencies = [
 
 [[package]]
 name = "rmcp-macros"
-version = "3.2.0"
+version = "3.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cdf1c49bd4d52014b94db0877410db273c2008f01628b0252a2e9460ad9b7fda"
+checksum = "873b730df6f0a9b74b13eb514e0dca4c2db0d8b68b74af98a2e9bf3f9d436585"
 dependencies = [
  "darling 0.24.1",
  "proc-macro2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,7 +49,7 @@ tracing-appender = "0.2"
 agent-client-protocol = { version = "2.0.0", features = ["unstable_elicitation"] }
 
 # MCP and API clients
-rmcp = { version = "^3.1.1", default-features = false }
+rmcp = { version = "^3.3.0", default-features = false }
 async-openai = { version = "^0.41.0", features = ["byot", "chat-completion", "responses"] }
 reqwest = { version = "^0.13.4", default-features = false, features = ["json", "query", "rustls", "http2", "stream"] }
 oauth2 = "5.0"

--- a/crates/mcp-utils/src/tool_gateway/transport.rs
+++ b/crates/mcp-utils/src/tool_gateway/transport.rs
@@ -178,7 +178,7 @@ mod tests {
         tool_router: ToolRouter<Self>,
     }
 
-    #[tool_router]
+    #[tool_router(allow_empty)]
     impl TestServer {}
 
     #[allow(clippy::unused_async_trait_impl)]
@@ -239,6 +239,17 @@ mod tests {
         let socket = transport.path().to_path_buf();
         let _server = transport.spawn(TestServer { tool_router: TestServer::tool_router() });
         let _client = ().serve(connect(&socket).await.unwrap()).await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn connected_client_can_list_empty_tools() {
+        let path = UnixSocketPath::new().unwrap();
+        let transport = UnixSocketMcpTransport::bind(path).unwrap();
+        let socket = transport.path().to_path_buf();
+        let _server = transport.spawn(TestServer { tool_router: TestServer::tool_router() });
+        let client = ().serve(connect(&socket).await.unwrap()).await.unwrap();
+
+        assert!(client.list_all_tools().await.unwrap().is_empty());
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary
- Fix the shared test and Clippy compilation failure observed on release PR #445: rmcp 3.3 requires explicit opt-in for intentionally empty tool routers.
- Mark the transport test server with `#[tool_router(allow_empty)]`.
- Raise the rmcp minimum and lockfile to 3.3, which introduces this option.
- Add a regression test verifying a Unix-socket client can list an empty set of tools.

## Validation
- Reproduced the exact CI compilation failure with rmcp 3.3 before applying the fix.
- `just test`: 2,761 passed, 15 skipped.
- `just lint`: passed.
- `just fmt-check`: passed.
- `git diff --check`: passed.