### PR TITLE
chore(deps): raise typescript sdk cli minimum to 0.8.3

### DIFF
--- a/packages/aether-sdk/package.json
+++ b/packages/aether-sdk/package.json
@@ -27,7 +27,7 @@
     "e2e": "node scripts/e2e.mjs"
   },
   "dependencies": {
-    "@aether-agent/cli": "^0.8.0",
+    "@aether-agent/cli": "^0.8.3",
     "@agentclientprotocol/sdk": "^1.3.0",
     "@modelcontextprotocol/sdk": "^1.30.0",
     "express": "^5.1.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -43,8 +43,8 @@ importers:
   packages/aether-sdk:
     dependencies:
       '@aether-agent/cli':
-        specifier: ^0.8.0
-        version: 0.8.0
+        specifier: ^0.8.3
+        version: 0.8.3
       '@agentclientprotocol/sdk':
         specifier: ^1.3.0
         version: 1.3.0(zod@4.4.3)
@@ -149,8 +149,8 @@ importers:
 
 packages:
 
-  '@aether-agent/cli@0.8.0':
-    resolution: {integrity: sha512-WQklT8QDdUSaJHMIoJcEY06Q5GXiJNaBx3fkFp8M3PYWk8w45AbJ8xRAk7Gl0+LxDdTO/2NZ+VG9+HzfO7hMiA==}
+  '@aether-agent/cli@0.8.3':
+    resolution: {integrity: sha512-WwrKUbv2PL3k3GIfjS0vrx0dVNhOUU72pGTXl7MmRQT0cZ1HIZbMzv1QCGYK1SDibbhTykXCZJUyMfGM+wlSXQ==}
     engines: {node: '>=14', npm: '>=6'}
     hasBin: true
 
@@ -4635,7 +4635,7 @@ packages:
 
 snapshots:
 
-  '@aether-agent/cli@0.8.0':
+  '@aether-agent/cli@0.8.3':
     dependencies:
       axios: 1.19.0
       axios-proxy-builder: 0.1.2


### PR DESCRIPTION
## Summary
- Raise the TypeScript SDK dependency on `@aether-agent/cli` from `^0.8.0` to `^0.8.3`.
- Update the workspace lockfile to resolve CLI `0.8.3`.
- TypeScript evals inherits the update through its workspace SDK dependency.

## Validation
- Confirmed npm latest CLI version is `0.8.3`.
- Refreshed the lockfile with `pnpm install --lockfile-only --ignore-scripts`; removed unrelated lockfile metadata churn.
- `git diff --check` passed.
- Tests not run (dependency-only update).