### PR TITLE
feat(acp-utils): add WebSocket transport and reliable client lifecycle

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -61,6 +61,7 @@ dependencies = [
  "tempfile",
  "thiserror 2.0.20",
  "tokio",
+ "tokio-tungstenite",
  "tokio-util",
  "tracing",
 ]
@@ -2303,6 +2304,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "data-encoding"
+version = "2.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4583a4551df46e2792f82ceeac45e850d2e2d5debba0b91f102385cda5b11f06"
+
+[[package]]
 name = "dbus"
 version = "0.9.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3607,7 +3614,7 @@ dependencies = [
  "tokio",
  "tokio-rustls 0.26.5",
  "tower-service",
- "webpki-roots",
+ "webpki-roots 1.0.9",
 ]
 
 [[package]]
@@ -5819,7 +5826,7 @@ dependencies = [
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
- "webpki-roots",
+ "webpki-roots 1.0.9",
 ]
 
 [[package]]
@@ -7281,6 +7288,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-tungstenite"
+version = "0.30.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "17a073bfed563fa236697a068031408a93cd9522e08abf9933ead3e73411bd71"
+dependencies = [
+ "futures-util",
+ "log",
+ "rustls 0.23.44",
+ "rustls-pki-types",
+ "tokio",
+ "tokio-rustls 0.26.5",
+ "tungstenite",
+ "webpki-roots 0.26.11",
+]
+
+[[package]]
 name = "tokio-util"
 version = "0.7.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7807,6 +7830,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
+name = "tungstenite"
+version = "0.30.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e48ac77174b19c110a50ab2128b24215ac9cb40e0e12e093fb602d175c569d22"
+dependencies = [
+ "bytes",
+ "data-encoding",
+ "http 1.5.0",
+ "httparse",
+ "log",
+ "rand 0.10.2",
+ "rustls 0.23.44",
+ "rustls-pki-types",
+ "sha1 0.11.0",
+ "thiserror 2.0.20",
+]
+
+[[package]]
 name = "two-face"
 version = "0.5.2+bat-0.26.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8152,6 +8193,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b96554aa2acc8ccdb7e1c9a58a7a68dd5d13bccc69cd124cb09406db612a1c9b"
 dependencies = [
  "rustls-pki-types",
+]
+
+[[package]]
+name = "webpki-roots"
+version = "0.26.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "521bc38abb08001b01866da9f51eb7c5d647a19260e00054a8c7fd5f9e57f7a9"
+dependencies = [
+ "webpki-roots 1.0.9",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,6 +47,7 @@ tracing-appender = "0.2"
 
 # ACP
 agent-client-protocol = { version = "2.0.0", features = ["unstable_elicitation"] }
+tokio-tungstenite = { version = "0.30.0", features = ["rustls-tls-webpki-roots"] }
 
 # MCP and API clients
 rmcp = { version = "^3.3.0", default-features = false }

--- a/crates/acp-utils/Cargo.toml
+++ b/crates/acp-utils/Cargo.toml
@@ -28,6 +28,7 @@ default = ["client", "server"]
 client = []
 server = []
 testing = ["client"]
+websocket = ["dep:tokio-tungstenite"]
 
 [dependencies]
 agent-client-protocol = { workspace = true }
@@ -44,6 +45,7 @@ tracing = { workspace = true }
 utils = { package = "aether-utils", path = "../utils", version = "0.2.14" }
 async-trait = { workspace = true }
 thiserror = { workspace = true }
+tokio-tungstenite = { workspace = true, optional = true }
 
 [dev-dependencies]
 aether-acp-utils = { path = ".", features = ["testing"] }

--- a/crates/acp-utils/README.md
+++ b/crates/acp-utils/README.md
@@ -11,6 +11,7 @@ Utilities for the [Agent Client Protocol](https://agentclientprotocol.com/) (ACP
 - [Key Types](#key-types)
 - [Feature Flags](#feature-flags)
 - [WebSocket transport](#websocket-transport)
+- [Ordered session loading](#ordered-session-loading)
 - [License](#license)
 
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->

--- a/crates/acp-utils/README.md
+++ b/crates/acp-utils/README.md
@@ -10,6 +10,7 @@ Utilities for the [Agent Client Protocol](https://agentclientprotocol.com/) (ACP
 - [Protocol compatibility](#protocol-compatibility)
 - [Key Types](#key-types)
 - [Feature Flags](#feature-flags)
+- [WebSocket transport](#websocket-transport)
 - [License](#license)
 
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
@@ -27,6 +28,11 @@ Utilities for the [Agent Client Protocol](https://agentclientprotocol.com/) (ACP
 |---------|-------------|---------|
 | `client` | ACP client (for UIs connecting to agents) | yes |
 | `server` | ACP server (for agents accepting connections) | yes |
+| `websocket` | Message-oriented WebSocket transport | no |
+
+## WebSocket transport
+
+Enable the `websocket` feature to use ACP via websockets, via the `websocket::WebSocketTransport<S>` struct. 
 
 ## License
 

--- a/crates/acp-utils/README.md
+++ b/crates/acp-utils/README.md
@@ -7,7 +7,6 @@ Utilities for the [Agent Client Protocol](https://agentclientprotocol.com/) (ACP
 <!-- START doctoc generated TOC please keep comment here to allow auto update -->
 <!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
 
-- [Protocol compatibility](#protocol-compatibility)
 - [Key Types](#key-types)
 - [Feature Flags](#feature-flags)
 - [WebSocket transport](#websocket-transport)
@@ -33,7 +32,7 @@ Utilities for the [Agent Client Protocol](https://agentclientprotocol.com/) (ACP
 
 ## WebSocket transport
 
-Enable the `websocket` feature to use ACP via websockets, via the `websocket::WebSocketTransport<S>` struct. 
+Enable the `websocket` feature to use `websocket::WebSocketTransport<S>` with an already-established WebSocket connection.
 
 ## License
 

--- a/crates/acp-utils/src/client/event.rs
+++ b/crates/acp-utils/src/client/event.rs
@@ -1,15 +1,49 @@
 use acp::Responder;
 use acp::schema::v1::{SessionUpdate, StopReason};
 use agent_client_protocol as acp;
-use agent_client_protocol::schema::v1::{CreateElicitationRequest, CreateElicitationResponse, SessionId};
+use agent_client_protocol::schema::v1::{
+    CreateElicitationRequest, CreateElicitationResponse, SessionId, SessionNotification,
+};
 
+use crate::client::LoadedSession;
 use crate::notifications::{
     AuthMethodsUpdatedParams, ContextClearedParams, ContextCompactionParams, McpNotification, SessionUsageParams,
     SubAgentProgressParams,
 };
 
+pub enum ReplayableEvent {
+    SessionUpdate(Box<SessionNotification>),
+    ContextCleared(ContextClearedParams),
+    ContextCompaction(ContextCompactionParams),
+    SubAgentProgress(Box<SubAgentProgressParams>),
+    SessionUsage(Box<SessionUsageParams>),
+    McpNotification(McpNotification),
+}
+
+impl From<SessionNotification> for ReplayableEvent {
+    fn from(notification: SessionNotification) -> Self {
+        Self::SessionUpdate(Box::new(notification))
+    }
+}
+
+impl From<ReplayableEvent> for AcpEvent {
+    fn from(event: ReplayableEvent) -> Self {
+        match event {
+            ReplayableEvent::SessionUpdate(notification) => {
+                Self::SessionUpdate { session_id: notification.session_id, update: Box::new(notification.update) }
+            }
+            ReplayableEvent::ContextCleared(params) => Self::ContextCleared(params),
+            ReplayableEvent::ContextCompaction(params) => Self::ContextCompaction(params),
+            ReplayableEvent::SubAgentProgress(params) => Self::SubAgentProgress(*params),
+            ReplayableEvent::SessionUsage(params) => Self::SessionUsage(params),
+            ReplayableEvent::McpNotification(params) => Self::McpNotification(params),
+        }
+    }
+}
+
 /// Events forwarded from the ACP connection to the main event loop.
 pub enum AcpEvent {
+    SessionLoaded(LoadedSession),
     SessionUpdate { session_id: SessionId, update: Box<SessionUpdate> },
     ContextCleared(ContextClearedParams),
     ContextCompaction(ContextCompactionParams),

--- a/crates/acp-utils/src/client/mod.rs
+++ b/crates/acp-utils/src/client/mod.rs
@@ -4,6 +4,6 @@ mod session;
 mod tokio_agent;
 
 pub use error::AcpClientError;
-pub use event::AcpEvent;
+pub use event::{AcpEvent, ReplayableEvent};
 pub use session::{AcpClient, AcpClientHandle, LoadedSession, connect_acp_client};
 pub use tokio_agent::TokioAcpAgent;

--- a/crates/acp-utils/src/client/session.rs
+++ b/crates/acp-utils/src/client/session.rs
@@ -17,12 +17,14 @@ use agent_client_protocol::schema::v1::{
 use agent_client_protocol::{self as acp, Client, ConnectTo, ConnectionTo, JsonRpcNotification, JsonRpcRequest};
 use std::sync::{Arc, Mutex};
 use tokio::sync::{mpsc, oneshot};
+use tokio_util::sync::CancellationToken;
 use tracing::info;
 
 /// A cloneable handle for issuing typed lifecycle requests and prompt commands.
 #[derive(Clone)]
 pub struct AcpClientHandle {
     cmd_tx: mpsc::UnboundedSender<ClientCommand>,
+    connection: Arc<ClientConnection>,
 }
 
 /// An initialized ACP connection that can create and manage multiple sessions.
@@ -50,20 +52,21 @@ pub async fn connect_acp_client(
     let init_tx = Arc::new(Mutex::new(Some(init_tx)));
     let replay_state = Arc::new(Mutex::new(None));
 
-    tokio::spawn(run_client_connection(
-        agent,
-        event_tx,
-        cmd_rx,
-        Arc::clone(&init_tx),
-        init_request,
-        Arc::clone(&replay_state),
-    ));
+    let connection =
+        Arc::new(ClientConnection { shutdown: CancellationToken::new(), shutdown_complete: CancellationToken::new() });
+
+    let shutdown = connection.shutdown.clone();
+    let stopped = connection.shutdown_complete.clone();
+    tokio::spawn(async move {
+        let _stopped = stopped.drop_guard();
+        run_client_connection(agent, event_tx, cmd_rx, init_tx, init_request, replay_state, shutdown).await;
+    });
 
     let initialize_response = init_rx
         .await
         .map_err(|_| AcpClientError::AgentCrashed("ACP task died during initialization".to_string()))??;
 
-    Ok(AcpClient { initialize_response, event_rx, handle: AcpClientHandle { cmd_tx } })
+    Ok(AcpClient { initialize_response, event_rx, handle: AcpClientHandle { cmd_tx, connection } })
 }
 
 impl AcpClient {
@@ -89,10 +92,11 @@ impl AcpClient {
 }
 
 impl AcpClientHandle {
-    #[cfg(feature = "testing")]
-    pub fn detached() -> Self {
-        let (cmd_tx, _) = mpsc::unbounded_channel();
-        Self { cmd_tx }
+    /// Stop this connection and wait for its transport and response tasks to
+    /// be dropped. Does not send session/cancel or session/close.
+    pub async fn disconnect(&self) {
+        self.connection.shutdown.cancel();
+        self.connection.shutdown_complete.cancelled().await;
     }
 
     pub async fn prompt(&self, request: PromptRequest) -> Result<PromptResponse, AcpClientError> {
@@ -205,6 +209,17 @@ impl AcpClientHandle {
     }
 }
 
+struct ClientConnection {
+    shutdown: CancellationToken,
+    shutdown_complete: CancellationToken,
+}
+
+impl Drop for ClientConnection {
+    fn drop(&mut self) {
+        self.shutdown.cancel();
+    }
+}
+
 type InitializeResult = Result<InitializeResponse, AcpClientError>;
 type InitializeSender = Arc<Mutex<Option<oneshot::Sender<InitializeResult>>>>;
 type Response<T> = oneshot::Sender<Result<T, AcpClientError>>;
@@ -233,124 +248,131 @@ async fn run_client_connection(
     init_tx: InitializeSender,
     init_request: InitializeRequest,
     replay_state: Arc<Mutex<Option<ReplayState>>>,
+    shutdown: CancellationToken,
 ) {
-    let connection_result = Client
-        .builder()
-        .on_receive_request(
-            async move |req: RequestPermissionRequest, responder, _cx| {
-                responder.respond(RequestPermissionResponse::new(RequestPermissionOutcome::Selected(
-                    SelectedPermissionOutcome::new(auto_approve_option(&req)),
-                )))
-            },
-            acp::on_receive_request!(),
-        )
-        .on_receive_request(
-            {
-                let event_tx = event_tx.clone();
-                async move |params: CreateElicitationRequest, responder, _cx| {
-                    if let Err(send_err) =
-                        event_tx.send(AcpEvent::ElicitationRequest { params: Box::new(params), responder })
-                        && let AcpEvent::ElicitationRequest { responder, .. } = send_err.0
-                    {
-                        return responder.respond_with_error(acp::Error::internal_error());
-                    }
-                    Ok(())
-                }
-            },
-            acp::on_receive_request!(),
-        )
-        .on_receive_notification(
-            {
-                let event_tx = event_tx.clone();
-                let replay_state = Arc::clone(&replay_state);
-                async move |notification: SessionNotification, _cx| {
-                    let passthrough = {
-                        let mut replay = replay_state.lock().expect("replay state lock poisoned");
-                        match replay.as_mut() {
-                            Some(state) if state.session_id == notification.session_id => {
-                                state.notifications.push(notification);
-                                None
-                            }
-                            _ => Some(notification),
+    let connection_result = {
+        let connection = Client
+            .builder()
+            .on_receive_request(
+                async move |req: RequestPermissionRequest, responder, _cx| {
+                    responder.respond(RequestPermissionResponse::new(RequestPermissionOutcome::Selected(
+                        SelectedPermissionOutcome::new(auto_approve_option(&req)),
+                    )))
+                },
+                acp::on_receive_request!(),
+            )
+            .on_receive_request(
+                {
+                    let event_tx = event_tx.clone();
+                    async move |params: CreateElicitationRequest, responder, _cx| {
+                        if let Err(send_err) =
+                            event_tx.send(AcpEvent::ElicitationRequest { params: Box::new(params), responder })
+                            && let AcpEvent::ElicitationRequest { responder, .. } = send_err.0
+                        {
+                            return responder.respond_with_error(acp::Error::internal_error());
                         }
-                    };
-                    if let Some(SessionNotification { session_id, update, .. }) = passthrough {
-                        let _ = event_tx.send(AcpEvent::SessionUpdate { session_id, update: Box::new(update) });
+                        Ok(())
                     }
-                    Ok(())
-                }
-            },
-            acp::on_receive_notification!(),
-        )
-        .on_receive_notification(
-            {
+                },
+                acp::on_receive_request!(),
+            )
+            .on_receive_notification(
+                {
+                    let event_tx = event_tx.clone();
+                    let replay_state = Arc::clone(&replay_state);
+                    async move |notification: SessionNotification, _cx| {
+                        let passthrough = {
+                            let mut replay = replay_state.lock().expect("replay state lock poisoned");
+                            match replay.as_mut() {
+                                Some(state) if state.session_id == notification.session_id => {
+                                    state.notifications.push(notification);
+                                    None
+                                }
+                                _ => Some(notification),
+                            }
+                        };
+                        if let Some(SessionNotification { session_id, update, .. }) = passthrough {
+                            let _ = event_tx.send(AcpEvent::SessionUpdate { session_id, update: Box::new(update) });
+                        }
+                        Ok(())
+                    }
+                },
+                acp::on_receive_notification!(),
+            )
+            .on_receive_notification(
+                {
+                    let event_tx = event_tx.clone();
+                    async move |params: ContextCompactionParams, _cx| {
+                        let _ = event_tx.send(AcpEvent::ContextCompaction(params));
+                        Ok(())
+                    }
+                },
+                acp::on_receive_notification!(),
+            )
+            .on_receive_notification(
+                {
+                    let event_tx = event_tx.clone();
+                    async move |params: ContextClearedParams, _cx| {
+                        let _ = event_tx.send(AcpEvent::ContextCleared(params));
+                        Ok(())
+                    }
+                },
+                acp::on_receive_notification!(),
+            )
+            .on_receive_notification(
+                {
+                    let event_tx = event_tx.clone();
+                    async move |params: SubAgentProgressParams, _cx| {
+                        let _ = event_tx.send(AcpEvent::SubAgentProgress(params));
+                        Ok(())
+                    }
+                },
+                acp::on_receive_notification!(),
+            )
+            .on_receive_notification(
+                {
+                    let event_tx = event_tx.clone();
+                    async move |params: SessionUsageParams, _cx| {
+                        let _ = event_tx.send(AcpEvent::SessionUsage(Box::new(params)));
+                        Ok(())
+                    }
+                },
+                acp::on_receive_notification!(),
+            )
+            .on_receive_notification(
+                {
+                    let event_tx = event_tx.clone();
+                    async move |params: AuthMethodsUpdatedParams, _cx| {
+                        let _ = event_tx.send(AcpEvent::AuthMethodsUpdated(params));
+                        Ok(())
+                    }
+                },
+                acp::on_receive_notification!(),
+            )
+            .on_receive_notification(
+                {
+                    let event_tx = event_tx.clone();
+                    async move |params: McpNotification, _cx| {
+                        let _ = event_tx.send(AcpEvent::McpNotification(params));
+                        Ok(())
+                    }
+                },
+                acp::on_receive_notification!(),
+            )
+            .connect_with(agent, {
                 let event_tx = event_tx.clone();
-                async move |params: ContextCompactionParams, _cx| {
-                    let _ = event_tx.send(AcpEvent::ContextCompaction(params));
+                let init_tx = Arc::clone(&init_tx);
+                async move |cx: ConnectionTo<acp::Agent>| {
+                    run_main(cx, event_tx, &mut cmd_rx, Arc::clone(&init_tx), init_request, replay_state).await;
                     Ok(())
                 }
-            },
-            acp::on_receive_notification!(),
-        )
-        .on_receive_notification(
-            {
-                let event_tx = event_tx.clone();
-                async move |params: ContextClearedParams, _cx| {
-                    let _ = event_tx.send(AcpEvent::ContextCleared(params));
-                    Ok(())
-                }
-            },
-            acp::on_receive_notification!(),
-        )
-        .on_receive_notification(
-            {
-                let event_tx = event_tx.clone();
-                async move |params: SubAgentProgressParams, _cx| {
-                    let _ = event_tx.send(AcpEvent::SubAgentProgress(params));
-                    Ok(())
-                }
-            },
-            acp::on_receive_notification!(),
-        )
-        .on_receive_notification(
-            {
-                let event_tx = event_tx.clone();
-                async move |params: SessionUsageParams, _cx| {
-                    let _ = event_tx.send(AcpEvent::SessionUsage(Box::new(params)));
-                    Ok(())
-                }
-            },
-            acp::on_receive_notification!(),
-        )
-        .on_receive_notification(
-            {
-                let event_tx = event_tx.clone();
-                async move |params: AuthMethodsUpdatedParams, _cx| {
-                    let _ = event_tx.send(AcpEvent::AuthMethodsUpdated(params));
-                    Ok(())
-                }
-            },
-            acp::on_receive_notification!(),
-        )
-        .on_receive_notification(
-            {
-                let event_tx = event_tx.clone();
-                async move |params: McpNotification, _cx| {
-                    let _ = event_tx.send(AcpEvent::McpNotification(params));
-                    Ok(())
-                }
-            },
-            acp::on_receive_notification!(),
-        )
-        .connect_with(agent, {
-            let event_tx = event_tx.clone();
-            let init_tx = Arc::clone(&init_tx);
-            async move |cx: ConnectionTo<acp::Agent>| {
-                run_main(cx, event_tx, &mut cmd_rx, Arc::clone(&init_tx), init_request, replay_state).await;
-                Ok(())
-            }
-        })
-        .await;
+            });
+        tokio::pin!(connection);
+        tokio::select! {
+            result = &mut connection => result,
+            () = shutdown.cancelled() => Ok(()),
+        }
+    };
 
     if let Err(e) = connection_result {
         tracing::warn!("ACP connection exited with error: {e:?}");

--- a/crates/acp-utils/src/client/session.rs
+++ b/crates/acp-utils/src/client/session.rs
@@ -1,5 +1,5 @@
 use super::error::AcpClientError;
-use super::event::AcpEvent;
+use super::event::{AcpEvent, ReplayableEvent};
 use crate::notifications::{
     AuthMethodsUpdatedParams, ContextClearedParams, ContextCompactionParams, McpNotification, McpRequest,
     PromptSearchParams, PromptSearchResponse, SessionPreviewParams, SessionPreviewResponse, SessionUsageParams,
@@ -38,7 +38,7 @@ pub struct AcpClient {
 pub struct LoadedSession {
     pub session_id: SessionId,
     pub response: LoadSessionResponse,
-    pub replay: Vec<SessionNotification>,
+    pub replay: Vec<ReplayableEvent>,
 }
 
 /// Connect to an ACP agent and complete initialization without creating a session.
@@ -105,8 +105,8 @@ impl AcpClientHandle {
         await_response(receiver).await
     }
 
-    /// Load a session and collect its replay notifications in wire order.
-    pub async fn load_session(&self, request: LoadSessionRequest) -> Result<LoadedSession, AcpClientError> {
+    /// Load a session.
+    pub async fn load_session(&self, request: LoadSessionRequest) -> Result<LoadSessionResponse, AcpClientError> {
         let (response, receiver) = oneshot::channel();
         self.send(ClientCommand::LoadSession { request, response })?;
         await_response(receiver).await
@@ -227,13 +227,32 @@ type RequestFn = Box<dyn FnOnce(Result<&ConnectionTo<acp::Agent>, AcpClientError
 
 enum ClientCommand {
     Prompt { request: PromptRequest, response: Response<PromptResponse> },
-    LoadSession { request: LoadSessionRequest, response: Response<LoadedSession> },
+    LoadSession { request: LoadSessionRequest, response: Response<LoadSessionResponse> },
     Request { allow_during_prompt: bool, run: RequestFn },
 }
 
 struct ReplayState {
     session_id: SessionId,
-    notifications: Vec<SessionNotification>,
+    notifications: Vec<ReplayableEvent>,
+}
+
+fn send_replayable_event(
+    event_tx: &mpsc::UnboundedSender<AcpEvent>,
+    replay_state: &Mutex<Option<ReplayState>>,
+    event: ReplayableEvent,
+) {
+    let mut replay = replay_state.lock().expect("replay state lock poisoned");
+    if let Some(capture) = replay.as_mut() {
+        let matches_session = match &event {
+            ReplayableEvent::SessionUpdate(notification) => notification.session_id == capture.session_id,
+            _ => true,
+        };
+        if matches_session {
+            capture.notifications.push(event);
+            return;
+        }
+    }
+    let _ = event_tx.send(event.into());
 }
 
 async fn await_response<T>(receiver: oneshot::Receiver<Result<T, AcpClientError>>) -> Result<T, AcpClientError> {
@@ -281,19 +300,7 @@ async fn run_client_connection(
                     let event_tx = event_tx.clone();
                     let replay_state = Arc::clone(&replay_state);
                     async move |notification: SessionNotification, _cx| {
-                        let passthrough = {
-                            let mut replay = replay_state.lock().expect("replay state lock poisoned");
-                            match replay.as_mut() {
-                                Some(state) if state.session_id == notification.session_id => {
-                                    state.notifications.push(notification);
-                                    None
-                                }
-                                _ => Some(notification),
-                            }
-                        };
-                        if let Some(SessionNotification { session_id, update, .. }) = passthrough {
-                            let _ = event_tx.send(AcpEvent::SessionUpdate { session_id, update: Box::new(update) });
-                        }
+                        send_replayable_event(&event_tx, &replay_state, notification.into());
                         Ok(())
                     }
                 },
@@ -302,8 +309,9 @@ async fn run_client_connection(
             .on_receive_notification(
                 {
                     let event_tx = event_tx.clone();
+                    let replay_state = Arc::clone(&replay_state);
                     async move |params: ContextCompactionParams, _cx| {
-                        let _ = event_tx.send(AcpEvent::ContextCompaction(params));
+                        send_replayable_event(&event_tx, &replay_state, ReplayableEvent::ContextCompaction(params));
                         Ok(())
                     }
                 },
@@ -312,8 +320,9 @@ async fn run_client_connection(
             .on_receive_notification(
                 {
                     let event_tx = event_tx.clone();
+                    let replay_state = Arc::clone(&replay_state);
                     async move |params: ContextClearedParams, _cx| {
-                        let _ = event_tx.send(AcpEvent::ContextCleared(params));
+                        send_replayable_event(&event_tx, &replay_state, ReplayableEvent::ContextCleared(params));
                         Ok(())
                     }
                 },
@@ -322,8 +331,13 @@ async fn run_client_connection(
             .on_receive_notification(
                 {
                     let event_tx = event_tx.clone();
+                    let replay_state = Arc::clone(&replay_state);
                     async move |params: SubAgentProgressParams, _cx| {
-                        let _ = event_tx.send(AcpEvent::SubAgentProgress(params));
+                        send_replayable_event(
+                            &event_tx,
+                            &replay_state,
+                            ReplayableEvent::SubAgentProgress(Box::new(params)),
+                        );
                         Ok(())
                     }
                 },
@@ -332,8 +346,13 @@ async fn run_client_connection(
             .on_receive_notification(
                 {
                     let event_tx = event_tx.clone();
+                    let replay_state = Arc::clone(&replay_state);
                     async move |params: SessionUsageParams, _cx| {
-                        let _ = event_tx.send(AcpEvent::SessionUsage(Box::new(params)));
+                        send_replayable_event(
+                            &event_tx,
+                            &replay_state,
+                            ReplayableEvent::SessionUsage(Box::new(params)),
+                        );
                         Ok(())
                     }
                 },
@@ -352,8 +371,9 @@ async fn run_client_connection(
             .on_receive_notification(
                 {
                     let event_tx = event_tx.clone();
+                    let replay_state = Arc::clone(&replay_state);
                     async move |params: McpNotification, _cx| {
-                        let _ = event_tx.send(AcpEvent::McpNotification(params));
+                        send_replayable_event(&event_tx, &replay_state, ReplayableEvent::McpNotification(params));
                         Ok(())
                     }
                 },
@@ -473,13 +493,24 @@ async fn handle_command(
             let session_id = request.session_id.clone();
             *replay_state.lock().expect("replay state lock poisoned") =
                 Some(ReplayState { session_id: session_id.clone(), notifications: vec![] });
-            let result = cx.send_request(request).block_task().await.map_err(AcpClientError::Protocol);
-            let replay = replay_state
-                .lock()
-                .expect("replay state lock poisoned")
-                .take()
-                .map_or_else(Vec::new, |state| state.notifications);
-            let _ = response.send(result.map(|response| LoadedSession { session_id, response, replay }));
+            let replay_state = Arc::clone(replay_state);
+            let event_tx = event_tx.clone();
+            let (done_tx, done_rx) = oneshot::channel();
+            let _ = cx.send_request(request).on_receiving_result(move |result| async move {
+                let mut capture = replay_state.lock().expect("replay state lock poisoned");
+                let replay = capture.take().map(|capture| capture.notifications).unwrap_or_default();
+                let result = result.map_err(AcpClientError::Protocol).inspect(|metadata| {
+                    let _ = event_tx.send(AcpEvent::SessionLoaded(LoadedSession {
+                        session_id,
+                        response: metadata.clone(),
+                        replay,
+                    }));
+                });
+                let _ = response.send(result);
+                let _ = done_tx.send(());
+                Ok(())
+            });
+            let _ = done_rx.await;
         }
         ClientCommand::Request { allow_during_prompt, run } => {
             if state == ClientState::Prompting && !allow_during_prompt {

--- a/crates/acp-utils/src/lib.rs
+++ b/crates/acp-utils/src/lib.rs
@@ -11,6 +11,9 @@ pub mod elicitation;
 pub mod notifications;
 pub mod settings;
 
+#[cfg(feature = "websocket")]
+pub mod websocket;
+
 #[cfg(feature = "client")]
 pub mod client;
 

--- a/crates/acp-utils/src/websocket.rs
+++ b/crates/acp-utils/src/websocket.rs
@@ -1,0 +1,144 @@
+use agent_client_protocol::{ConnectTo, Error, Lines, Role};
+use futures::{SinkExt, StreamExt, stream};
+use std::{io, time::Duration};
+use thiserror::Error;
+use tokio::io::{AsyncRead, AsyncWrite};
+use tokio::sync::mpsc;
+use tokio::time::timeout;
+use tokio_tungstenite::WebSocketStream;
+use tokio_tungstenite::tungstenite::protocol::{CloseFrame, frame::coding::CloseCode};
+use tokio_tungstenite::tungstenite::{self, Message};
+use tokio_util::sync::PollSender;
+
+#[derive(Debug, Error)]
+pub enum WebSocketError {
+    #[error(transparent)]
+    WebSocket(#[from] tungstenite::Error),
+    #[error("unexpected raw WebSocket frame")]
+    UnexpectedFrame,
+    #[error("binary WebSocket messages are not supported")]
+    BinaryMessage,
+    #[error("WebSocket consumer cannot keep up")]
+    SlowConsumer,
+    #[error("WebSocket write deadline exceeded")]
+    WriteDeadline,
+}
+
+/// Websocket transport for ACP
+pub struct WebSocketTransport<T> {
+    socket: WebSocketStream<T>,
+}
+
+impl<T: AsyncRead + AsyncWrite + Unpin> WebSocketTransport<T> {
+    pub fn new(socket: WebSocketStream<T>) -> Self {
+        Self { socket }
+    }
+}
+
+impl<T, U> ConnectTo<U> for WebSocketTransport<T>
+where
+    T: AsyncRead + AsyncWrite + Unpin + Send + 'static,
+    U: Role,
+{
+    async fn connect_to(self, peer: impl ConnectTo<U::Counterpart>) -> Result<(), Error> {
+        let (to_tx, to_rx) = mpsc::channel::<String>(32);
+        let (from_tx, from_rx) = mpsc::channel::<io::Result<String>>(32);
+        let output = PollSender::new(to_tx).sink_map_err(|_| io::Error::from(io::ErrorKind::BrokenPipe));
+        let input = stream::unfold(from_rx, |mut rx| async { rx.recv().await.map(|item| (item, rx)) });
+        let connection_future = ConnectTo::<U>::connect_to(Lines::new(output, input), peer);
+        let socket_loop = self.run_socket_loop(to_rx, from_tx);
+        tokio::pin!(connection_future, socket_loop);
+        tokio::select! {
+            result = &mut connection_future => {
+                result?;
+                socket_loop.await.map_err(Error::into_internal_error)
+            }
+
+            result = &mut socket_loop => {
+                result.map_err(Error::into_internal_error)?;
+                connection_future.await
+            },
+        }
+    }
+}
+
+const WRITE_DEADLINE: Duration = Duration::from_secs(10);
+
+impl<T: AsyncRead + AsyncWrite + Unpin> WebSocketTransport<T> {
+    async fn run_socket_loop(
+        mut self,
+        mut to_rx: mpsc::Receiver<String>,
+        from_tx: mpsc::Sender<io::Result<String>>,
+    ) -> Result<(), WebSocketError> {
+        loop {
+            tokio::select! {
+                message = to_rx.recv() => {
+                    let Some(text) = message else {
+                        return self.finish_close().await;
+                    };
+                    self.write(Message::Text(text.into())).await?;
+                }
+                message = self.socket.next() => {
+                    match message {
+                        Some(Ok(Message::Text(text))) => {
+                            from_tx.try_send(Ok(text.to_string())).map_err(|_| WebSocketError::SlowConsumer)?;
+                        }
+                        Some(Ok(Message::Ping(_))) => {
+                            // Tungstenite queues the matching Pong; flush it even while ACP is idle.
+                            timeout(WRITE_DEADLINE, self.socket.flush()).await
+                                .map_err(|_| WebSocketError::WriteDeadline)??;
+                        }
+                        Some(Ok(Message::Pong(_))) => {},
+                        Some(Ok(Message::Close(_))) => {
+                            let _ = timeout(WRITE_DEADLINE, self.socket.flush()).await;
+                            return Ok(());
+                        }
+                        Some(Ok(Message::Binary(_))) => {
+                            self.close(CloseCode::Unsupported).await;
+                            return Err(WebSocketError::BinaryMessage);
+                        }
+                        Some(Ok(Message::Frame(_))) => return Err(WebSocketError::UnexpectedFrame),
+                        Some(Err(tungstenite::Error::ConnectionClosed | tungstenite::Error::AlreadyClosed)) | None => return Ok(()),
+                        Some(Err(error)) => {
+                            if matches!(error, tungstenite::Error::Capacity(_)) {
+                                self.close(CloseCode::Size).await;
+                            }
+                            return Err(error.into());
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    async fn finish_close(&mut self) -> Result<(), WebSocketError> {
+        timeout(WRITE_DEADLINE, async {
+            match self.socket.send(Message::Close(None)).await {
+                Ok(()) => {}
+                Err(tungstenite::Error::ConnectionClosed | tungstenite::Error::AlreadyClosed) => return Ok(()),
+                Err(error) => return Err(error.into()),
+            }
+            while let Some(message) = self.socket.next().await {
+                match message {
+                    Ok(Message::Close(_)) | Err(tungstenite::Error::ConnectionClosed) => break,
+                    Err(error) => return Err(error.into()),
+                    _ => {}
+                }
+            }
+            Ok(())
+        })
+        .await
+        .map_err(|_| WebSocketError::WriteDeadline)?
+    }
+
+    async fn write(&mut self, message: Message) -> Result<(), WebSocketError> {
+        timeout(WRITE_DEADLINE, self.socket.send(message))
+            .await
+            .map_err(|_| WebSocketError::WriteDeadline)?
+            .map_err(WebSocketError::from)
+    }
+
+    async fn close(&mut self, code: CloseCode) {
+        let _ = self.write(Message::Close(Some(CloseFrame { code, reason: "".into() }))).await;
+    }
+}

--- a/crates/acp-utils/tests/client_disconnect.rs
+++ b/crates/acp-utils/tests/client_disconnect.rs
@@ -1,0 +1,72 @@
+use acp::schema::ProtocolVersion;
+use acp::schema::v1::{
+    CancelNotification, CloseSessionRequest, CreateElicitationRequest, ElicitationFormMode, ElicitationSchema,
+    ElicitationSessionScope, InitializeRequest, InitializeResponse, PromptRequest,
+};
+use acp_utils::client::{AcpEvent, connect_acp_client};
+use acp_utils::testing::duplex_pair;
+use agent_client_protocol::{self as acp, Agent};
+use tokio::task::{LocalSet, spawn_local};
+
+#[tokio::test]
+async fn disconnect_drops_connection_before_the_ui_releases_a_pending_approval() {
+    LocalSet::new()
+        .run_until(async {
+            let (agent_transport, client_transport) = duplex_pair();
+            let agent = Agent
+                .builder()
+                .on_receive_request(
+                    async |_: InitializeRequest, responder, _cx| {
+                        responder.respond(InitializeResponse::new(ProtocolVersion::V1))
+                    },
+                    acp::on_receive_request!(),
+                )
+                .on_receive_request(
+                    async |request: PromptRequest, responder, cx| {
+                        let input = CreateElicitationRequest::new(
+                            ElicitationFormMode::new(
+                                ElicitationSessionScope::new(request.session_id),
+                                ElicitationSchema::new(),
+                            ),
+                            "Continue?",
+                        );
+                        let connection = cx.clone();
+                        cx.spawn(async move {
+                            let result = connection.send_request(input).block_task().await;
+                            assert!(result.is_err(), "detaching must not answer the approval");
+                            drop(responder);
+                            Ok(())
+                        })?;
+                        Ok(())
+                    },
+                    acp::on_receive_request!(),
+                )
+                .on_receive_notification(
+                    async |_: CancelNotification, _cx| -> Result<(), acp::Error> {
+                        panic!("disconnect must not send session/cancel");
+                    },
+                    acp::on_receive_notification!(),
+                )
+                .on_receive_request(
+                    async |_: CloseSessionRequest, _responder, _cx| -> Result<(), acp::Error> {
+                        panic!("disconnect must not send session/close");
+                    },
+                    acp::on_receive_request!(),
+                );
+            let server = spawn_local(agent.connect_to(agent_transport));
+            let mut client =
+                connect_acp_client(client_transport, InitializeRequest::new(ProtocolVersion::V1)).await.unwrap();
+            let handle = client.handle.clone();
+            let prompt = spawn_local(async move { handle.prompt(PromptRequest::new("live", vec![])).await });
+            let Some(AcpEvent::ElicitationRequest { responder, .. }) = client.event_rx.recv().await else {
+                panic!("approval must be pending before detach");
+            };
+            client.handle.disconnect().await;
+            assert!(matches!(client.event_rx.recv().await, Some(AcpEvent::ConnectionClosed)));
+            assert!(prompt.await.unwrap().is_err());
+            client.handle.disconnect().await;
+            drop(responder);
+            let _ = server.await.expect("agent connection task must not panic");
+        })
+        .await;
+}

--- a/crates/acp-utils/tests/client_session.rs
+++ b/crates/acp-utils/tests/client_session.rs
@@ -1,6 +1,6 @@
-use acp_utils::client::{AcpEvent, connect_acp_client};
+use acp_utils::client::{AcpClient, AcpClientError, AcpEvent, LoadedSession, ReplayableEvent, connect_acp_client};
 use acp_utils::notifications::{
-    PromptSearchParams, PromptSearchResponse, SessionPreviewParams, SessionPreviewResponse,
+    ContextCompactionParams, PromptSearchParams, PromptSearchResponse, SessionPreviewParams, SessionPreviewResponse,
 };
 use acp_utils::testing::duplex_pair;
 use agent_client_protocol::schema::ProtocolVersion;
@@ -11,10 +11,10 @@ use agent_client_protocol::schema::v1::{
     ResumeSessionResponse, SessionId, SessionInfo, SessionNotification, SessionUpdate, SetSessionConfigOptionRequest,
     StopReason, TextContent,
 };
-use agent_client_protocol::{self as acp, Agent};
+use agent_client_protocol::{self as acp, Agent, Builder, Client, ConnectTo, HandleDispatchFrom, NullRun};
 use std::path::PathBuf;
 use std::sync::Arc;
-use tokio::sync::Notify;
+use tokio::sync::{Notify, mpsc::error::TryRecvError};
 use tokio::task::{LocalSet, spawn_local};
 
 #[tokio::test(flavor = "current_thread")]
@@ -145,23 +145,44 @@ async fn prompt_completion_follows_session_updates_on_the_event_stream() {
         .await;
 }
 
-#[allow(clippy::too_many_lines)]
 #[tokio::test(flavor = "current_thread")]
-async fn initialized_client_manages_typed_sessions_and_collects_replay() {
+async fn loaded_snapshot_is_delivered_on_the_event_channel() -> Result<(), TestError> {
     LocalSet::new()
         .run_until(async {
-            let (agent_transport, client_transport) = duplex_pair();
-            let agent_builder = Agent
-                .builder()
-                .on_receive_request(
-                    async |_request: InitializeRequest, responder, _cx| {
-                        responder.respond(
-                            InitializeResponse::new(ProtocolVersion::V1)
-                                .agent_info(Implementation::new("Typed Fake", "1.0")),
-                        )
-                    },
-                    acp::on_receive_request!(),
-                )
+            let mut client = TestClientBuilder::default()
+                .replay_message("saved", "snapshot")
+                .live_message("saved", "live")
+                .build()
+                .await?;
+
+            client.handle.load_session(LoadSessionRequest::new("saved", "/remote")).await?;
+
+            let loaded = take_loaded_session(&mut client)?;
+            assert_eq!(loaded.session_id, SessionId::new("saved"));
+            let [ReplayableEvent::SessionUpdate(notification)] = loaded.replay.as_slice() else {
+                return Err(TestError::Unexpected("expected exactly one replayed session update"));
+            };
+            assert_eq!(notification.as_ref(), &message("saved", "snapshot"));
+            let Some(AcpEvent::SessionUpdate { session_id, update }) = client.event_rx.recv().await else {
+                return Err(TestError::Unexpected("expected live update after snapshot"));
+            };
+            assert_eq!(session_id, SessionId::new("saved"));
+            assert_eq!(*update, message("saved", "live").update);
+            Ok(())
+        })
+        .await
+}
+
+#[allow(clippy::too_many_lines)]
+#[tokio::test(flavor = "current_thread")]
+async fn initialized_client_manages_typed_sessions_and_collects_replay() -> Result<(), TestError> {
+    LocalSet::new()
+        .run_until(async {
+            let agent_builder = TestClientBuilder::default()
+                .agent_info(Implementation::new("Typed Fake", "1.0"))
+                .replay_message("other", "unrelated")
+                .replay_message("listed", "replayed")
+                .agent()
                 .on_receive_request(
                     async |_request: NewSessionRequest, responder, _cx| {
                         responder.respond(NewSessionResponse::new(SessionId::new("created")))
@@ -171,25 +192,6 @@ async fn initialized_client_manages_typed_sessions_and_collects_replay() {
                 .on_receive_request(
                     async |_request: ListSessionsRequest, responder, _cx| {
                         responder.respond(ListSessionsResponse::new(vec![SessionInfo::new("listed", "/tmp/project")]))
-                    },
-                    acp::on_receive_request!(),
-                )
-                .on_receive_request(
-                    async |request: LoadSessionRequest, responder, cx| {
-                        let session_id = request.session_id.clone();
-                        cx.send_notification(SessionNotification::new(
-                            "other",
-                            SessionUpdate::AgentMessageChunk(ContentChunk::new(ContentBlock::Text(TextContent::new(
-                                "unrelated",
-                            )))),
-                        ))?;
-                        cx.send_notification(SessionNotification::new(
-                            session_id,
-                            SessionUpdate::AgentMessageChunk(ContentChunk::new(ContentBlock::Text(TextContent::new(
-                                "replayed",
-                            )))),
-                        ))?;
-                        responder.respond(LoadSessionResponse::new())
                     },
                     acp::on_receive_request!(),
                 )
@@ -230,54 +232,138 @@ async fn initialized_client_manages_typed_sessions_and_collects_replay() {
                     },
                     acp::on_receive_request!(),
                 );
-            spawn_local(async move {
-                let _ = agent_builder.connect_to(agent_transport).await;
-            });
-
-            let mut client = connect_acp_client(client_transport, InitializeRequest::new(ProtocolVersion::V1))
-                .await
-                .expect("initialization succeeds");
+            let mut client = connect_test_agent(agent_builder).await?;
             assert_eq!(client.agent_name(), "Typed Fake");
             assert!(client.initialize_response.agent_info.is_some());
 
             let created =
-                client.handle.new_session(NewSessionRequest::new("/tmp/project")).await.expect("create succeeds");
+                client.handle.new_session(NewSessionRequest::new("/tmp/project")).await?;
             assert_eq!(created.session_id, SessionId::new("created"));
 
-            let listed = client.handle.list_sessions(ListSessionsRequest::new()).await.expect("list succeeds");
+            let listed = client.handle.list_sessions(ListSessionsRequest::new()).await?;
             assert_eq!(listed.sessions.len(), 1);
             assert_eq!(listed.sessions[0].session_id, SessionId::new("listed"));
 
-            let loaded = client
-                .handle
-                .load_session(LoadSessionRequest::new("listed", "/tmp/project"))
-                .await
-                .expect("load succeeds");
-            assert_eq!(loaded.replay.len(), 1);
-            assert_eq!(loaded.replay[0].session_id, SessionId::new("listed"));
-            let event = client.event_rx.try_recv().expect("other session remains on the event stream");
+            client.handle.load_session(LoadSessionRequest::new("listed", "/tmp/project")).await?;
+            let event = client.event_rx.try_recv()?;
             assert!(
                 matches!(event, AcpEvent::SessionUpdate { session_id, .. } if session_id == SessionId::new("other"))
             );
+            let loaded = take_loaded_session(&mut client)?;
+            assert_eq!(loaded.replay.len(), 1);
+            assert!(matches!(&loaded.replay[0], ReplayableEvent::SessionUpdate(notification) if notification.session_id == SessionId::new("listed")));
 
             client
                 .handle
                 .resume_session(ResumeSessionRequest::new("listed", "/tmp/project"))
-                .await
-                .expect("resume succeeds");
+                .await?;
             let search = client
                 .handle
                 .search_prompts(PromptSearchParams { query: "hello".to_string(), limit: Some(10) })
-                .await
-                .expect("search succeeds");
+                .await?;
             assert_eq!(search.query, "hello");
             let preview = client
                 .handle
                 .preview_session(SessionPreviewParams { session_id: "listed".to_string() })
-                .await
-                .expect("preview succeeds");
+                .await?;
             assert_eq!(preview.session_id, "listed");
-            client.handle.close_session(CloseSessionRequest::new("listed")).await.expect("close succeeds");
+            client.handle.close_session(CloseSessionRequest::new("listed")).await?;
+            Ok(())
         })
-        .await;
+        .await
+}
+
+#[derive(Default)]
+struct TestClientBuilder {
+    agent_info: Option<Implementation>,
+    replay: Vec<SessionNotification>,
+    live: Vec<SessionNotification>,
+    compaction_active: Option<bool>,
+}
+
+impl TestClientBuilder {
+    fn agent_info(mut self, info: Implementation) -> Self {
+        self.agent_info = Some(info);
+        self
+    }
+
+    fn replay_message(mut self, session_id: &str, text: &str) -> Self {
+        self.replay.push(message(session_id, text));
+        self
+    }
+
+    fn live_message(mut self, session_id: &str, text: &str) -> Self {
+        self.live.push(message(session_id, text));
+        self
+    }
+
+    fn compaction_active(mut self, active: bool) -> Self {
+        self.compaction_active = Some(active);
+        self
+    }
+
+    async fn build(self) -> Result<AcpClient, TestError> {
+        connect_test_agent(self.agent()).await
+    }
+
+    fn agent(self) -> Builder<Agent, impl HandleDispatchFrom<Client>, NullRun> {
+        Agent
+            .builder()
+            .on_receive_request(
+                async move |_: InitializeRequest, responder, _cx| {
+                    let mut response = InitializeResponse::new(ProtocolVersion::V1);
+                    response.agent_info.clone_from(&self.agent_info);
+                    responder.respond(response)
+                },
+                acp::on_receive_request!(),
+            )
+            .on_receive_request(
+                async move |_: LoadSessionRequest, responder, cx| {
+                    for notification in &self.replay {
+                        cx.send_notification(notification.clone())?;
+                    }
+                    if let Some(active) = self.compaction_active {
+                        cx.send_notification(ContextCompactionParams { active })?;
+                    }
+                    responder.respond(LoadSessionResponse::new())?;
+                    for notification in &self.live {
+                        cx.send_notification(notification.clone())?;
+                    }
+                    Ok(())
+                },
+                acp::on_receive_request!(),
+            )
+    }
+}
+
+#[derive(Debug, thiserror::Error)]
+enum TestError {
+    #[error(transparent)]
+    Client(#[from] AcpClientError),
+    #[error(transparent)]
+    Receive(#[from] TryRecvError),
+    #[error("{0}")]
+    Unexpected(&'static str),
+}
+
+async fn connect_test_agent(agent: impl ConnectTo<Client> + 'static) -> Result<AcpClient, TestError> {
+    let (agent_transport, client_transport) = duplex_pair();
+    spawn_local(async move {
+        let _ = agent.connect_to(agent_transport).await;
+    });
+    Ok(connect_acp_client(client_transport, InitializeRequest::new(ProtocolVersion::V1)).await?)
+}
+
+fn take_loaded_session(client: &mut AcpClient) -> Result<LoadedSession, TestError> {
+    let AcpEvent::SessionLoaded(loaded) = client.event_rx.try_recv()? else {
+        return Err(TestError::Unexpected("expected loaded snapshot before live events"));
+    };
+    Ok(loaded)
+}
+
+fn message(session_id: &str, text: &str) -> SessionNotification {
+    SessionNotification::new(
+        SessionId::new(session_id.to_owned()),
+        SessionUpdate::AgentMessageChunk(ContentChunk::new(ContentBlock::Text(TextContent::new(text)))),
+    )
 }

--- a/crates/acp-utils/tests/client_session.rs
+++ b/crates/acp-utils/tests/client_session.rs
@@ -151,6 +151,7 @@ async fn loaded_snapshot_is_delivered_on_the_event_channel() -> Result<(), TestE
         .run_until(async {
             let mut client = TestClientBuilder::default()
                 .replay_message("saved", "snapshot")
+                .compaction_active(true)
                 .live_message("saved", "live")
                 .build()
                 .await?;
@@ -159,10 +160,13 @@ async fn loaded_snapshot_is_delivered_on_the_event_channel() -> Result<(), TestE
 
             let loaded = take_loaded_session(&mut client)?;
             assert_eq!(loaded.session_id, SessionId::new("saved"));
-            let [ReplayableEvent::SessionUpdate(notification)] = loaded.replay.as_slice() else {
-                return Err(TestError::Unexpected("expected exactly one replayed session update"));
+            let [ReplayableEvent::SessionUpdate(notification), ReplayableEvent::ContextCompaction(compaction)] =
+                loaded.replay.as_slice()
+            else {
+                return Err(TestError::Unexpected("expected message followed by compaction in replay"));
             };
             assert_eq!(notification.as_ref(), &message("saved", "snapshot"));
+            assert!(compaction.active);
             let Some(AcpEvent::SessionUpdate { session_id, update }) = client.event_rx.recv().await else {
                 return Err(TestError::Unexpected("expected live update after snapshot"));
             };

--- a/crates/acp-utils/tests/websocket.rs
+++ b/crates/acp-utils/tests/websocket.rs
@@ -1,0 +1,243 @@
+#![cfg(feature = "websocket")]
+
+use acp_utils::client::{AcpEvent, connect_acp_client};
+use acp_utils::websocket::WebSocketTransport;
+use agent_client_protocol::schema::ProtocolVersion;
+use agent_client_protocol::schema::v1::{
+    ContentBlock, ContentChunk, CreateElicitationRequest, CreateElicitationResponse, ElicitationAction,
+    ElicitationFormMode, ElicitationSchema, ElicitationSessionScope, InitializeRequest, InitializeResponse,
+    PromptRequest, PromptResponse, SessionNotification, SessionUpdate, StopReason, TextContent,
+};
+use agent_client_protocol::{self as acp, Agent, Builder, Client, HandleDispatchFrom, NullRun};
+use futures::{SinkExt, StreamExt};
+use tokio::io::{DuplexStream, duplex};
+use tokio::net::TcpListener;
+use tokio::task::{LocalSet, spawn_local};
+use tokio_tungstenite::tungstenite::Message;
+use tokio_tungstenite::tungstenite::client::IntoClientRequest;
+use tokio_tungstenite::tungstenite::handshake::server::Request;
+use tokio_tungstenite::tungstenite::http::header::InvalidHeaderValue;
+use tokio_tungstenite::tungstenite::protocol::{
+    Role, WebSocketConfig,
+    frame::{
+        Frame,
+        coding::{Data, OpCode},
+    },
+};
+use tokio_tungstenite::{WebSocketStream, accept_hdr_async_with_config, connect_async};
+
+#[tokio::test]
+async fn acp_over_websocket_with_elicitation() -> Result<(), TestError> {
+    LocalSet::new()
+        .run_until(async {
+            let (server, client) = SocketPairBuilder::default().build().await;
+            let agent = streaming_elicitation_agent(&["hello ", "world"]);
+            let server_task = spawn_local(agent.connect_to(WebSocketTransport::new(server)));
+            let mut client =
+                connect_acp_client(WebSocketTransport::new(client), InitializeRequest::new(ProtocolVersion::V1))
+                    .await?;
+
+            let handle = client.handle.clone();
+            let prompt = spawn_local(async move {
+                handle.prompt(PromptRequest::new("session", vec![ContentBlock::Text(TextContent::new("hi"))])).await
+            });
+
+            for expected in ["hello ", "world"] {
+                let Some(AcpEvent::SessionUpdate { update, .. }) = client.event_rx.recv().await else {
+                    return Err(TestError::Unexpected("expected streamed update"));
+                };
+                let SessionUpdate::AgentMessageChunk(chunk) = *update else {
+                    return Err(TestError::Unexpected("expected agent message chunk"));
+                };
+                assert_eq!(chunk.content, ContentBlock::Text(TextContent::new(expected)));
+            }
+
+            let Some(AcpEvent::ElicitationRequest { responder, .. }) = client.event_rx.recv().await else {
+                return Err(TestError::Unexpected("expected elicitation request"));
+            };
+
+            responder.respond(CreateElicitationResponse::new(ElicitationAction::Decline))?;
+            assert_eq!(prompt.await??.stop_reason, StopReason::EndTurn);
+            assert!(matches!(client.event_rx.recv().await, Some(AcpEvent::PromptCompleted(StopReason::EndTurn))));
+            drop(client);
+            server_task.abort();
+            let _ = server_task.await;
+            Ok(())
+        })
+        .await
+}
+
+#[tokio::test]
+#[allow(clippy::result_large_err)]
+async fn caller_established_socket_supports_acp_initialization() -> Result<(), TestError> {
+    LocalSet::new()
+        .run_until(Box::pin(async {
+            let listener = TcpListener::bind("127.0.0.1:0").await?;
+            let endpoint = format!("ws://{}/custom/path?session=example", listener.local_addr()?);
+            let server = spawn_local(async move {
+                let (stream, _) = listener.accept().await?;
+                let socket = accept_hdr_async_with_config(
+                    stream,
+                    |request: &Request, response| {
+                        assert_eq!(request.uri().path_and_query().unwrap().as_str(), "/custom/path?session=example");
+                        assert_eq!(request.headers()["origin"], "https://example.com");
+                        assert_eq!(request.headers()["x-aws-proxy-auth"], "secret");
+                        assert_eq!(request.headers()["x-aws-proxy-port"], "8081");
+                        assert_eq!(
+                            request.headers().get_all("x-custom").iter().collect::<Vec<_>>(),
+                            vec!["first", "second"]
+                        );
+                        assert_eq!(request.headers()["x-empty"], "");
+                        Ok(response)
+                    },
+                    None,
+                )
+                .await?;
+                test_agent().connect_to(WebSocketTransport::new(socket)).await.map_err(TestError::from)
+            });
+            let mut request = endpoint.into_client_request()?;
+            request.headers_mut().insert("x-aws-proxy-auth", "secret".parse()?);
+            request.headers_mut().insert("x-aws-proxy-port", "8081".parse()?);
+            request.headers_mut().insert("origin", "https://example.com".parse()?);
+            request.headers_mut().append("x-custom", "first".parse()?);
+            request.headers_mut().append("x-custom", "second".parse()?);
+            request.headers_mut().insert("x-empty", "".parse()?);
+            let (socket, _) = connect_async(request).await?;
+            let client = Client
+                .builder()
+                .connect_with(WebSocketTransport::new(socket), async |cx| {
+                    let response = cx.send_request(InitializeRequest::new(ProtocolVersion::V1)).block_task().await?;
+                    assert_eq!(response.protocol_version, ProtocolVersion::V1);
+                    Ok(())
+                })
+                .await;
+            client?;
+            let error = server.await?.expect_err("SDK foreground completion drops the socket");
+            assert!(format!("{error:?}").contains("without closing handshake"), "{error:?}");
+            Ok(())
+        }))
+        .await
+}
+
+#[tokio::test]
+async fn final_response_is_not_lost_when_close_is_already_buffered() -> Result<(), TestError> {
+    LocalSet::new()
+        .run_until(async {
+            let (mut server, client_socket) = SocketPairBuilder::default().build().await;
+            let peer = spawn_local(async move {
+                let request = receive_json(&mut server).await?;
+                let response =
+                    serde_json::json!({"jsonrpc": "2.0", "id": request["id"], "result": {"protocolVersion": 1}});
+                server.feed(Message::Text(response.to_string().into())).await?;
+                server.feed(Message::Close(None)).await?;
+                server.flush().await?;
+                while server
+                    .next()
+                    .await
+                    .is_some_and(|message| matches!(message, Ok(Message::Ping(_) | Message::Pong(_))))
+                {}
+                Ok::<_, TestError>(())
+            });
+            let client =
+                connect_acp_client(WebSocketTransport::new(client_socket), InitializeRequest::new(ProtocolVersion::V1))
+                    .await;
+            assert!(client.is_ok(), "last response must be delivered before EOF");
+            peer.await??;
+            Ok(())
+        })
+        .await
+}
+
+#[tokio::test]
+async fn invalid_utf8_terminates_the_connection() -> Result<(), TestError> {
+    LocalSet::new()
+        .run_until(async {
+            let (server, mut client) = SocketPairBuilder::default().build().await;
+            let task = spawn_local(Agent.builder().connect_to(WebSocketTransport::new(server)));
+            client.send(Message::Frame(Frame::message(vec![0xff], OpCode::Data(Data::Text), true))).await?;
+            assert!(task.await?.is_err());
+            Ok(())
+        })
+        .await
+}
+
+#[derive(Default)]
+struct SocketPairBuilder {
+    server_config: Option<WebSocketConfig>,
+    client_config: Option<WebSocketConfig>,
+}
+
+impl SocketPairBuilder {
+    async fn build(self) -> (WebSocketStream<DuplexStream>, WebSocketStream<DuplexStream>) {
+        let (server, client) = duplex(64 * 1024);
+        tokio::join!(
+            WebSocketStream::from_raw_socket(server, Role::Server, self.server_config),
+            WebSocketStream::from_raw_socket(client, Role::Client, self.client_config),
+        )
+    }
+}
+
+#[derive(Debug, thiserror::Error)]
+enum TestError {
+    #[error(transparent)]
+    Client(#[from] acp_utils::client::AcpClientError),
+    #[error(transparent)]
+    Acp(#[from] acp::Error),
+    #[error(transparent)]
+    WebSocket(#[from] tokio_tungstenite::tungstenite::Error),
+    #[error(transparent)]
+    Io(#[from] std::io::Error),
+    #[error(transparent)]
+    Join(#[from] tokio::task::JoinError),
+    #[error(transparent)]
+    Json(#[from] serde_json::Error),
+    #[error(transparent)]
+    Header(#[from] InvalidHeaderValue),
+    #[error("{0}")]
+    Unexpected(&'static str),
+}
+
+async fn receive_message(socket: &mut WebSocketStream<DuplexStream>) -> Result<Message, TestError> {
+    Ok(socket.next().await.ok_or(TestError::Unexpected("socket closed before expected message"))??)
+}
+
+async fn receive_json(socket: &mut WebSocketStream<DuplexStream>) -> Result<serde_json::Value, TestError> {
+    let Message::Text(text) = receive_message(socket).await? else {
+        return Err(TestError::Unexpected("expected JSON text message"));
+    };
+    Ok(serde_json::from_str(&text)?)
+}
+
+fn test_agent() -> Builder<Agent, impl HandleDispatchFrom<Client>, NullRun> {
+    Agent.builder().on_receive_request(
+        async |_: InitializeRequest, responder, _cx| responder.respond(InitializeResponse::new(ProtocolVersion::V1)),
+        acp::on_receive_request!(),
+    )
+}
+
+fn streaming_elicitation_agent(
+    chunks: &'static [&'static str],
+) -> Builder<Agent, impl HandleDispatchFrom<Client>, NullRun> {
+    test_agent().on_receive_request(
+        async move |request: PromptRequest, responder, cx| {
+            for &text in chunks {
+                cx.send_notification(SessionNotification::new(
+                    request.session_id.clone(),
+                    SessionUpdate::AgentMessageChunk(ContentChunk::new(ContentBlock::Text(TextContent::new(text)))),
+                ))?;
+            }
+            let input = CreateElicitationRequest::new(
+                ElicitationFormMode::new(ElicitationSessionScope::new(request.session_id), ElicitationSchema::new()),
+                "Continue?",
+            );
+            let connection = cx.clone();
+            cx.spawn(async move {
+                let response = connection.send_request(input).block_task().await?;
+                assert_eq!(response.action, ElicitationAction::Decline);
+                responder.respond(PromptResponse::new(StopReason::EndTurn))
+            })?;
+            Ok(())
+        },
+        acp::on_receive_request!(),
+    )
+}

--- a/crates/wisp/src/app/acp_reducer.rs
+++ b/crates/wisp/src/app/acp_reducer.rs
@@ -17,6 +17,7 @@ impl App {
     #[allow(clippy::too_many_lines)]
     pub fn on_acp_event(&mut self, event: AcpEvent) {
         match event {
+            AcpEvent::SessionLoaded(loaded) => self.on_loaded_session(loaded),
             AcpEvent::SessionUpdate { session_id, update } => {
                 if &session_id == self.session.session_id() {
                     self.on_session_update(&update);
@@ -100,10 +101,11 @@ impl App {
     pub(super) fn on_loaded_session(&mut self, loaded: LoadedSession) {
         let LoadedSession { session_id, response, replay } = loaded;
         self.reset_turn_state();
-        for notification in replay {
-            self.on_session_update(&notification.update);
+        self.session.set_session(session_id, Vec::new());
+        for event in replay {
+            self.on_acp_event(event.into());
         }
-        self.session.set_session(session_id, response.config_options.unwrap_or_default());
+        self.session.update_config_options(response.config_options.unwrap_or_default());
         self.return_to_conversation();
         self.session.end_workspace_move();
     }

--- a/crates/wisp/src/app/mod.rs
+++ b/crates/wisp/src/app/mod.rs
@@ -234,7 +234,6 @@ impl App {
                 }
             }
             CommandResult::SessionsListed(response) => self.open_session_picker(response.sessions),
-            CommandResult::SessionLoaded(loaded) => self.on_loaded_session(loaded),
             CommandResult::NewSessionCreated(response) => {
                 self.on_new_session(response.session_id, response.config_options.unwrap_or_default());
             }

--- a/crates/wisp/src/command.rs
+++ b/crates/wisp/src/command.rs
@@ -5,7 +5,6 @@ use crate::request::RequestId;
 use crate::session::workspace_status::WorkspaceStatus;
 use crate::settings::UiSettings;
 use crate::theme::Theme;
-use acp_utils::client::LoadedSession;
 use acp_utils::notifications::{
     PromptSearchParams, PromptSearchResponse, SessionPreviewResponse, WorkspaceListResponse, WorkspaceMoveTarget,
     WorkspaceMoveResponse,
@@ -112,7 +111,6 @@ pub enum CommandResult {
     AuthenticationCompleted { method_id: String },
     AuthenticationFailed { method_id: String },
     SessionsListed(ListSessionsResponse),
-    SessionLoaded(LoadedSession),
     NewSessionCreated(NewSessionResponse),
     PromptSearchResults(PromptSearchResponse),
     PromptSearchFailed { query: String, error: String },

--- a/crates/wisp/src/runtime/agent.rs
+++ b/crates/wisp/src/runtime/agent.rs
@@ -92,7 +92,7 @@ pub(super) fn execute(
                 handle
                     .load_session(LoadSessionRequest::new(session_id, cwd))
                     .await
-                    .map_or_else(|error| failed(failure, &error), CommandResult::SessionLoaded)
+                    .map_or_else(|error| failed(failure, &error), |_| CommandResult::AgentCommandAccepted)
             });
             None
         }

--- a/crates/wisp/tests/runtime.rs
+++ b/crates/wisp/tests/runtime.rs
@@ -1,8 +1,12 @@
 #![cfg(feature = "testing")]
 
-use acp_utils::client::AcpClientHandle;
-use agent_client_protocol::schema::v1::SessionId;
+use acp_utils::client::{AcpClientError, AcpClientHandle, connect_acp_client};
+use acp_utils::testing::duplex_pair;
+use agent_client_protocol::schema::ProtocolVersion;
+use agent_client_protocol::schema::v1::{InitializeRequest, InitializeResponse, SessionId};
+use agent_client_protocol::{self as acp, Agent};
 use tempfile::TempDir;
+use tokio::task::{JoinError, LocalSet, spawn_local};
 use wisp::command::{AgentCommand, Command, CommandResult, FailedCommand, GitCommand};
 use wisp::file_index::index_files_with_limit;
 use wisp::git_review::{DiffScope, GitDiffError, GitDiffEvent};
@@ -21,8 +25,8 @@ fn file_index_limit_counts_only_indexed_files() {
 }
 
 #[tokio::test]
-async fn closed_agent_connection_becomes_a_reducer_visible_failure() {
-    let mut dispatcher = CommandDispatcher::new(AcpClientHandle::detached());
+async fn closed_agent_connection_becomes_a_reducer_visible_failure() -> Result<(), TestError> {
+    let mut dispatcher = CommandDispatcher::new(disconnected_client().await?);
 
     let result = dispatcher.dispatch(Command::Agent(AgentCommand::Cancel { session_id: SessionId::new("session") }));
 
@@ -33,12 +37,13 @@ async fn closed_agent_connection_becomes_a_reducer_visible_failure() {
         Some(CommandResult::Failed { command: FailedCommand::Other("cancel"), .. })
     ));
     dispatcher.shutdown().await;
+    Ok(())
 }
 
 #[tokio::test]
-async fn supervised_git_reads_report_completion() {
-    let mut dispatcher = CommandDispatcher::new(AcpClientHandle::detached());
-    let outside_repository = TempDir::new().unwrap();
+async fn supervised_git_reads_report_completion() -> Result<(), TestError> {
+    let mut dispatcher = CommandDispatcher::new(disconnected_client().await?);
+    let outside_repository = TempDir::new()?;
     let request_id = RequestId::from(7);
 
     assert!(
@@ -61,13 +66,14 @@ async fn supervised_git_reads_report_completion() {
         })) if actual == request_id
     ));
     assert!(!dispatcher.has_pending_tasks());
+    Ok(())
 }
 
 #[tokio::test]
-async fn superseded_workspace_reads_are_cancelled() {
-    let mut dispatcher = CommandDispatcher::new(AcpClientHandle::detached());
-    let first = TempDir::new().unwrap();
-    let second = TempDir::new().unwrap();
+async fn superseded_workspace_reads_are_cancelled() -> Result<(), TestError> {
+    let mut dispatcher = CommandDispatcher::new(disconnected_client().await?);
+    let first = TempDir::new()?;
+    let second = TempDir::new()?;
     let second_path = second.path().to_path_buf();
 
     dispatcher.dispatch(Command::ResolveWorkspace { cwd: first.path().to_path_buf() });
@@ -78,4 +84,34 @@ async fn superseded_workspace_reads_are_cancelled() {
         Some(CommandResult::WorkspaceResolved { cwd, .. }) if cwd == second_path
     ));
     assert!(!dispatcher.has_pending_tasks());
+    Ok(())
+}
+
+#[derive(Debug, thiserror::Error)]
+enum TestError {
+    #[error(transparent)]
+    Client(#[from] AcpClientError),
+    #[error(transparent)]
+    Join(#[from] JoinError),
+    #[error(transparent)]
+    Io(#[from] std::io::Error),
+}
+
+async fn disconnected_client() -> Result<AcpClientHandle, TestError> {
+    LocalSet::new()
+        .run_until(async {
+            let (agent_transport, client_transport) = duplex_pair();
+            let agent = Agent.builder().on_receive_request(
+                async |_: InitializeRequest, responder, _cx| {
+                    responder.respond(InitializeResponse::new(ProtocolVersion::V1))
+                },
+                acp::on_receive_request!(),
+            );
+            let server = spawn_local(agent.connect_to(agent_transport));
+            let client = connect_acp_client(client_transport, InitializeRequest::new(ProtocolVersion::V1)).await?;
+            client.handle.disconnect().await;
+            let _ = server.await?;
+            Ok(client.handle)
+        })
+        .await
 }

--- a/crates/wisp/tests/tui/plans.rs
+++ b/crates/wisp/tests/tui/plans.rs
@@ -190,7 +190,7 @@ fn plan_cleared_on_session_loaded() {
     ui.acp_event(plan_update(vec![plan_entry("Task", acp::PlanEntryStatus::Pending)]));
     assert!(ui.app().has_plan());
 
-    ui.deliver_result(session_loaded("other-session", Vec::new()));
+    ui.acp_event(session_loaded("other-session", Vec::new()));
     assert!(!ui.app().has_plan());
 
     ui.draw();

--- a/crates/wisp/tests/tui/scrollback.rs
+++ b/crates/wisp/tests/tui/scrollback.rs
@@ -69,7 +69,7 @@ fn session_switch_preserves_native_scrollback_without_purging() {
 
     ui.assert_history_contains("overflow-line-0");
 
-    ui.deliver_result(session_loaded("other", Vec::new()));
+    ui.acp_event(session_loaded("other", Vec::new()));
 
     ui.assert_history_contains("overflow-line-0");
 }

--- a/crates/wisp/tests/tui/sessions.rs
+++ b/crates/wisp/tests/tui/sessions.rs
@@ -304,17 +304,18 @@ fn loaded_session_replays_typed_notifications_in_order() {
     assert!(!viewport.contains("buffered message"), "buffered updates should not render yet:\n{viewport}");
     assert!(!viewport.contains("buffered agent"), "buffered updates should not render yet:\n{viewport}");
 
-    ui.deliver_result(CommandResult::SessionLoaded(LoadedSession {
+    ui.acp_event(AcpEvent::SessionLoaded(LoadedSession {
         session_id: SessionId::new("loaded"),
         response: acp::LoadSessionResponse::new().config_options(vec![select_option("model", "sonnet")]),
         replay: vec![
-            acp::SessionNotification::new(SessionId::new("loaded"), user_message_chunk("buffered message")),
+            acp::SessionNotification::new(SessionId::new("loaded"), user_message_chunk("buffered message")).into(),
             acp::SessionNotification::new(
                 SessionId::new("loaded"),
                 acp::SessionUpdate::AgentMessageChunk(acp::ContentChunk::new(acp::ContentBlock::Text(
                     acp::TextContent::new("buffered agent"),
                 ))),
-            ),
+            )
+            .into(),
         ],
     }));
 
@@ -335,7 +336,7 @@ fn updates_from_the_abandoned_session_do_not_reach_the_loaded_one() {
     ui.deliver_result(sessions_listed(vec![session_info("loaded", "/tmp/loaded", "Loaded", "2025-01-01T00:00:00Z")]));
     ui.key(key(KeyCode::Enter));
     let _ = ui.next_agent_command().unwrap();
-    ui.deliver_result(session_loaded("loaded", Vec::new()));
+    ui.acp_event(session_loaded("loaded", Vec::new()));
 
     ui.acp_event(session_update_for("test-session", user_message_chunk("late message from the old session")));
 
@@ -360,7 +361,7 @@ fn loaded_session_uses_server_config_values() {
     app.key(key(KeyCode::Enter));
     let _ = app.next_agent_command().unwrap();
 
-    app.deliver_result(session_loaded(
+    app.acp_event(session_loaded(
         "loaded",
         vec![select_option("model", "sonnet"), mode_option("code", &["code", "plan", "ask"])],
     ));

--- a/crates/wisp/tests/tui/subagents.rs
+++ b/crates/wisp/tests/tui/subagents.rs
@@ -562,7 +562,7 @@ mod progress_indicator_tests {
         let mut ui = TestUi::new();
         ui.submit("hello");
         ui.acp_event(AcpEvent::ContextCompaction(ContextCompactionParams { active: true }));
-        ui.deliver_result(session_loaded("loaded-session", Vec::new()));
+        ui.acp_event(session_loaded("loaded-session", Vec::new()));
 
         ui.draw();
         let viewport = ui.viewport_text();

--- a/crates/wisp/tests/tui/support.rs
+++ b/crates/wisp/tests/tui/support.rs
@@ -218,8 +218,8 @@ pub(crate) fn sessions_listed(sessions: Vec<acp::SessionInfo>) -> CommandResult 
     CommandResult::SessionsListed(acp::ListSessionsResponse::new(sessions))
 }
 
-pub(crate) fn session_loaded(session_id: &str, config_options: Vec<acp::SessionConfigOption>) -> CommandResult {
-    CommandResult::SessionLoaded(LoadedSession {
+pub(crate) fn session_loaded(session_id: &str, config_options: Vec<acp::SessionConfigOption>) -> AcpEvent {
+    AcpEvent::SessionLoaded(LoadedSession {
         session_id: SessionId::new(session_id),
         response: acp::LoadSessionResponse::new().config_options(config_options),
         replay: Vec::new(),

--- a/crates/wisp/tests/tui/workspace.rs
+++ b/crates/wisp/tests/tui/workspace.rs
@@ -353,7 +353,7 @@ fn workspace_move_success_updates_cwd_and_reloads_session() {
         other => panic!("expected LoadSession, got {other:?}"),
     }
 
-    ui.deliver_result(session_loaded("test-session", Vec::new()));
+    ui.acp_event(session_loaded("test-session", Vec::new()));
     assert_eq!(ui.app().workspace_move_state(), WorkspaceMoveState::Idle);
 }
 
@@ -376,13 +376,13 @@ fn workspace_move_success_replays_loaded_session_updates() {
     ui.deliver_result(workspace_moved("/home/user/code/other"));
     let _ = ui.next_agent_command().unwrap();
 
-    ui.deliver_result(CommandResult::SessionLoaded(LoadedSession {
+    ui.acp_event(AcpEvent::SessionLoaded(LoadedSession {
         session_id: SessionId::new("test-session"),
         response: acp::LoadSessionResponse::new(),
-        replay: vec![acp::SessionNotification::new(
-            SessionId::new("test-session"),
-            user_message_chunk("buffered-message"),
-        )],
+        replay: vec![
+            acp::SessionNotification::new(SessionId::new("test-session"), user_message_chunk("buffered-message"))
+                .into(),
+        ],
     }));
     assert_eq!(ui.app().workspace_move_state(), WorkspaceMoveState::Idle);
 


### PR DESCRIPTION
## Summary
This PR: 

- Adds a WebSocket ACP transport  (not used yet).
- Adds a `disconnect` method that doesn't send `session/cancel` or `session/close`.
